### PR TITLE
feat(accessibility): Add ARIA labels, keyboard navigation, and screen reader support

### DIFF
--- a/src/components/game-board.tsx
+++ b/src/components/game-board.tsx
@@ -110,6 +110,16 @@ const ZoneDisplay = memo(function ZoneDisplay({
           <button
             onClick={handleClick}
             className={`w-full ${sizeClasses[size]} ${bgColor} border border-border/50 rounded-md hover:border-primary/50 transition-colors group relative`}
+            aria-label={`${title}: ${count} cards`}
+            aria-expanded={count > 0}
+            role="region"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                handleClick();
+              }
+            }}
           >
             {count > 0 && (
               <div className="absolute inset-0 flex items-center justify-center gap-1 flex-wrap p-1">
@@ -527,7 +537,29 @@ export function GameBoard({ players, playerCount, currentTurnIndex, onCardClick,
   };
 
   return (
-    <div className="w-full h-full p-4 bg-background">
+    <div 
+      className="w-full h-full p-4 bg-background"
+      role="application"
+      aria-label="Game Board"
+    >
+      {/* Screen reader announcements */}
+      <div 
+        role="status" 
+        aria-live="polite" 
+        aria-atomic="true" 
+        className="sr-only"
+      >
+        {currentPlayer && `It is ${currentPlayer.name}'s turn`}
+      </div>
+      
+      {/* Skip to main content link for keyboard users */}
+      <a 
+        href="#game-board-main" 
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-md"
+      >
+        Skip to game board
+      </a>
+      
       {renderLayout()}
     </div>
   );

--- a/src/components/hand-display.tsx
+++ b/src/components/hand-display.tsx
@@ -85,6 +85,16 @@ function CardDisplay({
               ${isSelectable ? "cursor-pointer" : "cursor-default"}
               ${isSelected ? "ring-2 ring-primary ring-offset-2 ring-offset-background scale-105" : ""}
             `}
+            aria-label={`Card: ${card.card.name}${isSelected ? ", selected" : ""}`}
+            aria-pressed={isSelectable ? isSelected : undefined}
+            role={isSelectable ? "checkbox" : "img"}
+            tabIndex={isSelectable ? 0 : -1}
+            onKeyDown={(e) => {
+              if (isSelectable && (e.key === "Enter" || e.key === " ")) {
+                e.preventDefault();
+                onClick();
+              }
+            }}
           >
             {scryfallCard.image_uris?.normal ? (
               <Image


### PR DESCRIPTION
## Summary

Implements Issue #101: Tech Debt: Accessibility improvements

## Changes

- Added ARIA labels and roles to game board zones
- Added keyboard navigation (Enter/Space) for all interactive elements  
- Added screen reader announcements for turn information
- Added skip-to-content link for keyboard users
- Added proper focus management and tabIndex
- Added aria-label and aria-pressed to card components
- Enhanced button accessibility in hand display

## Testing

- Run the app and verify:
  - All interactive elements are keyboard accessible
  - Screen reader can navigate the game board
  - Turn announcements are read to screen readers