### PR TITLE
feat(mobile): Improve mobile responsiveness

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -30,13 +30,13 @@ export function AppSidebar() {
   return (
     <>
       <SidebarHeader className="border-b border-sidebar-border">
-        <div className="flex w-full items-center gap-2">
-          <Swords className="size-8 text-primary" />
-          <h1 className="font-headline text-xl font-bold text-foreground">
+          <div className="flex w-full items-center gap-2">
+          <Swords className="size-8 text-primary shrink-0" />
+          <h1 className="font-headline text-lg md:text-xl font-bold text-foreground truncate">
             Planar Nexus
           </h1>
           <div className="grow" />
-          <SidebarTrigger />
+          <SidebarTrigger className="md:hidden" />
         </div>
       </SidebarHeader>
       <SidebarContent className="p-2">
@@ -58,16 +58,16 @@ export function AppSidebar() {
         </SidebarMenu>
       </SidebarContent>
       <SidebarFooter className="mt-auto border-t border-sidebar-border p-2">
-        <div className="flex items-center gap-3">
-            <Avatar className="size-8">
+        <div className="flex items-center gap-2 md:gap-3">
+            <Avatar className="size-8 md:size-8 shrink-0">
                 <AvatarImage src="https://picsum.photos/seed/avatar/40/40" data-ai-hint="abstract avatar" />
                 <AvatarFallback>PN</AvatarFallback>
             </Avatar>
-            <div className="flex flex-col text-sm">
-                <span className="font-semibold text-foreground">Player One</span>
-                <span className="text-xs text-sidebar-foreground">#54321</span>
+            <div className="flex flex-col text-xs md:text-sm min-w-0">
+                <span className="font-semibold text-foreground truncate">Player One</span>
+                <span className="text-xs text-sidebar-foreground hidden md:block">#54321</span>
             </div>
-            <Button variant="ghost" size="icon" className="ml-auto size-7">
+            <Button variant="ghost" size="icon" className="ml-auto size-7 shrink-0">
                 <Users className="size-4" />
             </Button>
         </div>

--- a/src/components/hand-display.tsx
+++ b/src/components/hand-display.tsx
@@ -78,13 +78,13 @@ function CardDisplay({
             onClick={onClick}
             disabled={!isSelectable}
             className={`
-              relative aspect-[5/7] w-full min-w-[80px] max-w-[120px] md:min-w-[100px] md:max-w-[140px]
+              relative aspect-[5/7] w-full min-w-[70px] max-w-[100px] sm:min-w-[80px] sm:max-w-[120px] md:min-w-[100px] md:max-w-[140px] lg:max-w-[160px]
               transform transition-all duration-200
               hover:scale-105 hover:-translate-y-1
               focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background
               ${isSelectable ? "cursor-pointer" : "cursor-default"}
               ${isSelected ? "ring-2 ring-primary ring-offset-2 ring-offset-background scale-105" : ""}
-              touch-manipulation min-h-[44px]
+              touch-manipulation min-h-[60px] sm:min-h-[80px] md:min-h-[100px]
             `}
             aria-label={`Card: ${card.card.name}${isSelected ? ", selected" : ""}`}
             aria-pressed={isSelectable ? isSelected : undefined}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -198,7 +198,7 @@ const Sidebar = React.forwardRef<
           <SheetContent
             data-sidebar="sidebar"
             data-mobile="true"
-            className="w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+            className="w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden inset-0"
             style={
               {
                 "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
@@ -206,7 +206,7 @@ const Sidebar = React.forwardRef<
             }
             side={side}
           >
-            <div className="flex h-full w-full flex-col">{children}</div>
+            <div className="flex h-full w-full flex-col overflow-hidden">{children}</div>
           </SheetContent>
         </Sheet>
       )


### PR DESCRIPTION
## Summary

Improves mobile responsiveness for Planar Nexus with touch-friendly interactions.

## Changes

- Enhanced sidebar mobile drawer with full-screen overlay
- Added touch-friendly card sizes (min 60px on mobile, scaling up)
- Improved card targets with proper min-height for touch
- Added responsive menu item sizing and text truncation
- Sidebar trigger now properly hidden on desktop
- Mobile-friendly footer with collapsible elements

## Testing

- [ ] Sidebar works on mobile devices
- [ ] Cards are easily tappable on mobile
- [ ] Layout adapts properly across breakpoints

Closes #102