### PR TITLE
feat: Add E2E tests for game scenarios (Issue #99)

### DIFF
--- a/e2e/basic-navigation.spec.ts
+++ b/e2e/basic-navigation.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Basic Navigation', () => {
+  test('should load the dashboard', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveTitle(/Planar Nexus/i);
+  });
+
+  test('should navigate to deck builder', async ({ page }) => {
+    await page.goto('/');
+    await page.click('text=Deck Builder');
+    await expect(page).toHaveURL(/.*deck-builder/);
+  });
+
+  test('should navigate to single player', async ({ page }) => {
+    await page.goto('/');
+    await page.click('text=Single Player');
+    await expect(page).toHaveURL(/.*single-player/);
+  });
+
+  test('should navigate to multiplayer', async ({ page }) => {
+    await page.goto('/');
+    await page.click('text=Multiplayer');
+    await expect(page).toHaveURL(/.*multiplayer/);
+  });
+
+  test('should navigate to deck coach', async ({ page }) => {
+    await page.goto('/');
+    await page.click('text=Deck Coach');
+    await expect(page).toHaveURL(/.*deck-coach/);
+  });
+});

--- a/e2e/deck-builder.spec.ts
+++ b/e2e/deck-builder.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Deck Builder', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/deck-builder');
+  });
+
+  test('should load the deck builder page', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText(/Deck/i);
+  });
+
+  test('should show card search input', async ({ page }) => {
+    const searchInput = page.locator('input[placeholder*="Search"], input[type="text"]').first();
+    await expect(searchInput).toBeVisible();
+  });
+
+  test('should have format selector', async ({ page }) => {
+    // Look for format-related elements
+    const formatSelectors = page.locator('select, [role="combobox"]');
+    const count = await formatSelectors.count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test('should show deck list section', async ({ page }) => {
+    // Look for any list or table that would contain deck cards
+    const deckListArea = page.locator('ul, table, [class*="deck"], [data-testid="deck-list"]');
+    await expect(deckListArea.first()).toBeVisible();
+  });
+});

--- a/e2e/multiplayer-lobby.spec.ts
+++ b/e2e/multiplayer-lobby.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Multiplayer Lobby', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/multiplayer');
+  });
+
+  test('should load multiplayer page', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText(/Multiplayer/i);
+  });
+
+  test('should show host game option', async ({ page }) => {
+    const hostButton = page.locator('text=Host, a[href*="host"]').first();
+    await expect(hostButton).toBeVisible();
+  });
+
+  test('should show join game option', async ({ page }) => {
+    const joinButton = page.locator('text=Join, a[href*="browse"]').first();
+    await expect(joinButton).toBeVisible();
+  });
+
+  test('should navigate to host page', async ({ page }) => {
+    await page.click('text=Host');
+    await expect(page).toHaveURL(/.*multiplayer\/host/);
+  });
+
+  test('should navigate to browse page', async ({ page }) => {
+    await page.click('text=Join');
+    await expect(page).toHaveURL(/.*multiplayer\/browse/);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.3",
         "@jest/globals": "^30.2.0",
+        "@playwright/test": "^1.58.2",
         "@types/node": "^20",
         "@types/react": "^19.2.1",
         "@types/react-dom": "^19.2.1",
@@ -6313,6 +6314,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -16495,6 +16512,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "NODE_ENV=production next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@genkit-ai/google-genai": "^1.28.0",
@@ -58,6 +59,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",
     "@jest/globals": "^30.2.0",
+    "@playwright/test": "^1.58.2",
     "@types/node": "^20",
     "@types/react": "^19.2.1",
     "@types/react-dom": "^19.2.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:9002',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:9002',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});


### PR DESCRIPTION
## Summary
This PR adds end-to-end testing infrastructure to Planar Nexus using Playwright.

## Changes
- Install Playwright test framework (`@playwright/test`)
- Create `playwright.config.ts` with Next.js dev server configuration
- Add E2E test files:
  - `e2e/basic-navigation.spec.ts` - Tests for dashboard navigation
  - `e2e/deck-builder.spec.ts` - Tests for deck builder functionality  
  - `e2e/multiplayer-lobby.spec.ts` - Tests for multiplayer lobby
- Add `test:e2e` npm script to run tests

## Testing
Tests can be run with: `npm run test:e2e`

## Related Issue
- Closes #99

## Labels
- tech-debt
- component:testing