### PR TITLE
feat(issue-73): Implement 4-player free-for-all mode support

### DIFF
--- a/src/lib/multiplayer-layout.ts
+++ b/src/lib/multiplayer-layout.ts
@@ -1,0 +1,125 @@
+/**
+ * Multiplayer layout utilities for positioning players in game UI
+ */
+
+export type PlayerPosition = 'top' | 'bottom' | 'left' | 'right' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+export interface PlayerLayout {
+  playerIndex: number;
+  position: PlayerPosition;
+  rotation: number;
+}
+
+/**
+ * Get player layout for different player counts
+ * Returns array of positions for each player index
+ */
+export function getPlayerLayout(playerCount: number): PlayerLayout[] {
+  switch (playerCount) {
+    case 2:
+      return [
+        { playerIndex: 0, position: 'bottom', rotation: 0 },
+        { playerIndex: 1, position: 'top', rotation: 180 },
+      ];
+    
+    case 3:
+      return [
+        { playerIndex: 0, position: 'bottom', rotation: 0 },
+        { playerIndex: 1, position: 'top-right', rotation: 240 },
+        { playerIndex: 2, position: 'top-left', rotation: 120 },
+      ];
+    
+    case 4:
+      return [
+        { playerIndex: 0, position: 'bottom', rotation: 0 },
+        { playerIndex: 1, position: 'left', rotation: 90 },
+        { playerIndex: 2, position: 'top', rotation: 180 },
+        { playerIndex: 3, position: 'right', rotation: 270 },
+      ];
+    
+    default:
+      // Fallback for other counts
+      return Array.from({ length: playerCount }, (_, i) => ({
+        playerIndex: i,
+        position: 'bottom' as PlayerPosition,
+        rotation: 0,
+      }));
+  }
+}
+
+/**
+ * Get CSS class for player position
+ */
+export function getPositionClass(position: PlayerPosition): string {
+  const classes: Record<PlayerPosition, string> = {
+    top: 'top-4 left-1/2 -translate-x-1/2',
+    bottom: 'bottom-4 left-1/2 -translate-x-1/2',
+    left: 'left-4 top-1/2 -translate-y-1/2',
+    right: 'right-4 top-1/2 -translate-y-1/2',
+    'top-left': 'top-4 left-4',
+    'top-right': 'top-4 right-4',
+    'bottom-left': 'bottom-4 left-4',
+    'bottom-right': 'bottom-4 right-4',
+  };
+  return classes[position];
+}
+
+/**
+ * Get layout for team-based games (2v2)
+ */
+export function getTeamLayout(playerCount: number): PlayerLayout[] {
+  if (playerCount !== 4) {
+    return getPlayerLayout(playerCount);
+  }
+  
+  // Team layout: Team 1 (bottom-left, top-left) vs Team 2 (bottom-right, top-right)
+  return [
+    { playerIndex: 0, position: 'bottom-left', rotation: 0 },
+    { playerIndex: 1, position: 'top-left', rotation: 180 },
+    { playerIndex: 2, position: 'bottom-right', rotation: 0 },
+    { playerIndex: 3, position: 'top-right', rotation: 180 },
+  ];
+}
+
+/**
+ * Get turn indicator position
+ */
+export function getTurnIndicatorPosition(
+  activePlayerIndex: number,
+  playerCount: number
+): PlayerPosition {
+  const layout = getPlayerLayout(playerCount);
+  return layout[activePlayerIndex]?.position || 'top';
+}
+
+/**
+ * Check if a position is an opponent position (for attack arrows)
+ */
+export function isAdjacentPosition(
+  from: PlayerPosition,
+  to: PlayerPosition,
+  playerCount: number
+): boolean {
+  // In 2-player, all attacks go through
+  if (playerCount === 2) return true;
+  
+  // Define adjacency for multiplayer
+  const adjacency: Record<number, Record<PlayerPosition, PlayerPosition[]>> = {
+    3: {
+      bottom: ['top-left', 'top-right'],
+      'top-left': ['bottom', 'top-right'],
+      'top-right': ['bottom', 'top-left'],
+    },
+    4: {
+      bottom: ['left', 'right'],
+      left: ['bottom', 'top'],
+      top: ['left', 'right'],
+      right: ['top', 'bottom'],
+    },
+  };
+  
+  const playerAdjacency = adjacency[playerCount];
+  if (!playerAdjacency) return true;
+  
+  return playerAdjacency[from]?.includes(to) ?? true;
+}

--- a/src/lib/turn-order.ts
+++ b/src/lib/turn-order.ts
@@ -1,0 +1,135 @@
+/**
+ * Turn order utilities for multiplayer games
+ */
+
+export type TurnDirection = 'clockwise' | 'counterclockwise';
+
+export interface TurnOrderConfig {
+  direction: TurnDirection;
+  startPlayerIndex: number;
+}
+
+/**
+ * Get the next player in turn order based on current player index
+ */
+export function getNextPlayerIndex(
+  currentIndex: number,
+  totalPlayers: number,
+  direction: TurnDirection = 'clockwise'
+): number {
+  if (direction === 'clockwise') {
+    return (currentIndex + 1) % totalPlayers;
+  } else {
+    return (currentIndex - 1 + totalPlayers) % totalPlayers;
+  }
+}
+
+/**
+ * Calculate turn order for a multiplayer game
+ * Returns array of player indices in turn order
+ */
+export function calculateTurnOrder(
+  totalPlayers: number,
+  startPlayerIndex: number = 0,
+  direction: TurnDirection = 'clockwise'
+): number[] {
+  const order: number[] = [];
+  
+  for (let i = 0; i < totalPlayers; i++) {
+    if (direction === 'clockwise') {
+      order.push((startPlayerIndex + i) % totalPlayers);
+    } else {
+      const index = (startPlayerIndex - i + totalPlayers) % totalPlayers;
+      order.push(index);
+    }
+  }
+  
+  return order;
+}
+
+/**
+ * Get the player who goes first based on format rules
+ */
+export function determineStartingPlayer(
+  playerCount: number,
+  format: string
+): number {
+  // Random starting player for now
+  // In competitive play, could use dice roll or winner of previous game
+  return Math.floor(Math.random() * playerCount);
+}
+
+/**
+ * Check if a player is an opponent in multiplayer
+ */
+export function isOpponent(
+  playerIndex: number,
+  otherPlayerIndex: number,
+  playerCount: number,
+  teams?: Map<number, number> // Optional team assignments
+): boolean {
+  // If teams exist, check if they're on different teams
+  if (teams) {
+    const playerTeam = teams.get(playerIndex);
+    const otherTeam = teams.get(otherPlayerIndex);
+    if (playerTeam !== undefined && otherTeam !== undefined) {
+      return playerTeam !== otherTeam;
+    }
+  }
+  
+  // Otherwise, anyone not yourself is an opponent in FFA
+  return playerIndex !== otherPlayerIndex;
+}
+
+/**
+ * Get all opponents for a player
+ */
+export function getOpponents(
+  playerIndex: number,
+  playerCount: number,
+  teams?: Map<number, number>
+): number[] {
+  const opponents: number[] = [];
+  
+  for (let i = 0; i < playerCount; i++) {
+    if (i !== playerIndex && isOpponent(playerIndex, i, playerCount, teams)) {
+      opponents.push(i);
+    }
+  }
+  
+  return opponents;
+}
+
+/**
+ * Check win condition - in FFA, a player wins if all opponents have lost
+ */
+export function checkWinCondition(
+  playerIndex: number,
+  playerStatuses: boolean[], // true = still in game
+  teams?: Map<number, number>
+): boolean {
+  const playerCount = playerStatuses.length;
+  
+  // If teams exist, check if all opposing teams have lost
+  if (teams) {
+    const playerTeam = teams.get(playerIndex);
+    if (playerTeam !== undefined) {
+      // Check if any opposing team still has active players
+      for (let i = 0; i < playerCount; i++) {
+        const otherTeam = teams.get(i);
+        if (otherTeam !== undefined && otherTeam !== playerTeam && playerStatuses[i]) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+  
+  // In FFA, check if all other players have lost
+  for (let i = 0; i < playerCount; i++) {
+    if (i !== playerIndex && playerStatuses[i]) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary

Implements Issue #73: Phase 4.4: Implement 4-player free-for-all mode

## Changes

- Created `turn-order.ts` for managing turn order in multiplayer games
- Created `multiplayer-layout.ts` for positioning players in the game UI

## Features

### Turn Order
- Clockwise turn order calculation
- Support for 2, 3, and 4 player games
- Opponent detection in FFA and team games
- Win condition checking (player wins when all opponents lose)

### Player Layout
- Pre-defined positions for 2, 3, and 4 player games
- CSS positioning classes for each position
- Team layout support for 2v2 games
- Turn indicator positioning

## Player Positions

**2 Players**: Top vs Bottom
**3 Players**: Bottom, Top-Left, Top-Right
**4 Players**: Bottom, Left, Top, Right (clockwise order)

Note: This is a prototype. P2P networking (WebRTC) is not yet implemented.