### PR TITLE
feat(legal): Add legal disclaimers and trademark notices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,44 @@
+MIT License
+
+Copyright (c) 2024 Planar Nexus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## Legal Notices and Disclaimers
+
+**Trademark Notice**: Magic: The Gathering, Magic, MTG, "Commander," "Legendary," 
+and all related characters and elements are trademarks of Wizards of the Coast, LLC. 
+This project is not affiliated with, endorsed by, or connected to Wizards of the Coast.
+
+**Copyright Notice**: All card images, text, and game rules are property of Wizards of the Coast. 
+This project uses the Scryfall API for card data but does not host any copyrighted materials.
+
+**No Affiliation**: This project is not affiliated with, endorsed by, or connected to 
+Wizards of the Coast. It is an independent, non-commercial project created for 
+educational and entertainment purposes.
+
+**Disclaimer**: Planar Nexus is provided "as is" without warranty of any kind. 
+The developers make no representations or warranties of any kind, express or implied, 
+about the completeness, reliability, accuracy, or availability of the content.
+
+This software is for educational and entertainment purposes only. It is not intended 
+to replace or replicate the official Magic: The Gathering game. Please support 
+the official product by purchasing authentic cards and using official WotC services.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Planar Nexus
 
+**Disclaimer**: Planar Nexus is not affiliated with, endorsed by, or connected to Wizards of the Coast, Magic: The Gathering, or any of their affiliates. All Magic: The Gathering content is trademarked and copyrighted by Wizards of the Coast. This project is provided for educational and entertainment purposes only.
+
 A digital Magic: The Gathering tabletop experience with deck building, AI coaching, and multiplayer functionality.
 
 ## Project Overview
@@ -203,6 +205,18 @@ To start development, take a look at `src/app/page.tsx` and `CLAUDE.md` for deve
 - [ ] Accessibility improvements (screen reader support, keyboard navigation)
 - [ ] Mobile responsiveness improvements
 - [ ] Offline mode (PWA with local caching)
+
+---
+
+---
+
+## Legal Notices
+
+**Trademark Notice**: Magic: The Gathering, Magic, MTG, and all related characters and elements are trademarks of Wizards of the Coast, LLC.
+
+**Copyright Notice**: All card images, text, and game rules are property of Wizards of the Coast. This project uses the Scryfall API for card data but does not host any copyrighted materials.
+
+**No Affiliation**: This project is not affiliated with, endorsed by, or connected to Wizards of the Coast. It is an independent, non-commercial project created for educational and entertainment purposes.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "nextn",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/anchapin/planar-nexus/issues"
+  },
   "scripts": {
     "dev": "next dev --turbopack -p 9002",
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,5 +1,6 @@
 import { Sidebar, SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
 import { AppSidebar } from '@/components/app-sidebar';
+import { AppFooter } from '@/components/app-footer';
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -10,6 +11,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       <SidebarInset>
         <div className="min-h-svh flex flex-col">
           {children}
+          <AppFooter />
         </div>
       </SidebarInset>
     </SidebarProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import { Toaster } from '@/components/ui/toaster';
 import { ServiceWorkerRegistration } from '@/components/service-worker-registration';
+import { LandingFooter } from '@/components/landing-footer';
 
 export const metadata: Metadata = {
   title: 'Planar Nexus',
@@ -50,6 +51,7 @@ export default function RootLayout({
       <body className="font-body antialiased" suppressHydrationWarning>
         <ServiceWorkerRegistration />
         {children}
+        <LandingFooter />
         <Toaster />
       </body>
     </html>

--- a/src/components/app-footer.tsx
+++ b/src/components/app-footer.tsx
@@ -1,0 +1,10 @@
+export function AppFooter() {
+  return (
+    <footer className="border-t bg-muted/10 py-2 px-4">
+      <div className="flex flex-col md:flex-row justify-between items-center gap-2 text-xs text-muted-foreground">
+        <p>Planar Nexus - Not affiliated with WotC</p>
+        <p>Magic: The Gathering is a trademark of Wizards of the Coast</p>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/landing-footer.tsx
+++ b/src/components/landing-footer.tsx
@@ -1,0 +1,30 @@
+export function LandingFooter() {
+  return (
+    <footer className="border-t bg-muted/20 py-8 mt-auto">
+      <div className="container mx-auto px-4">
+        <div className="flex flex-col md:flex-row justify-between items-center gap-4 text-sm text-muted-foreground">
+          <div className="flex flex-col items-center md:items-start gap-1">
+            <p className="font-medium text-foreground">Planar Nexus</p>
+            <p>Not affiliated with Wizards of the Coast</p>
+          </div>
+          
+          <div className="flex flex-col items-center md:items-end gap-1">
+            <p>Magic: The Gathering is a trademark of Wizards of the Coast</p>
+            <a 
+              href="https://company.wizards.com/en/legal" 
+              target="_blank" 
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              WotC Legal Policy
+            </a>
+          </div>
+        </div>
+        
+        <div className="mt-4 pt-4 border-t text-center text-xs text-muted-foreground">
+          <p>This project is for educational and entertainment purposes only.</p>
+        </div>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary

Add proper legal disclaimers, trademark notices, and copyright notices to the Planar Nexus project to demonstrate good faith compliance with Wizards of the Coast (WotC) intellectual property policies.

## Changes

- **LICENSE file**: Created with MIT license and additional WotC disclaimers
- **README.md**: Added disclaimer at top and legal notices section
- **package.json**: Added license field
- **Landing page footer**: New component with WotC legal policy link
- **App footer**: Persistent disclaimer in app layout

## Related Issue

Closes #181