### PR TITLE
Fix unnecessary escape character in draft-assistant (issue #201)

### DIFF
--- a/src/app/(app)/draft-assistant/page.tsx
+++ b/src/app/(app)/draft-assistant/page.tsx
@@ -59,7 +59,7 @@ export default function DraftAssistantPage() {
     return lines.map(line => {
       // Try to extract basic info from line
       // Format: "Card Name" or "4 Lightning Bolt" or "Card Name (Red)"
-      const match = line.match(/^(\d+)?\s*([^(\[]+)/);
+      const match = line.match(/^(\d+)?\s*([^([]+)/);
       const name = match ? match[2].trim() : line.trim();
       
       // Extract color hints from parentheses like (W) or (Red)


### PR DESCRIPTION
Fixes issue #201

## Description
The regex pattern `[^(\[]` was incorrectly escaping the `[` character inside a character class. Changed to `[^([]` since `[` doesn't need escaping inside a character class.

## Changes
- Changed regex pattern in `src/app/(app)/draft-assistant/page.tsx` line 62

## Testing
- ESLint passes with no errors for this file