### PR TITLE
Fix TypeScript Errors: image_uris and companion zone

### DIFF
--- a/src/app/(app)/deck-builder/_components/card-search.tsx
+++ b/src/app/(app)/deck-builder/_components/card-search.tsx
@@ -82,9 +82,9 @@ export function CardSearch({ onAddCard }: CardSearchProps) {
                 title={`Add ${card.name} to deck`}
                 aria-label={`Add ${card.name} to deck`}
               >
-                {card.image_uris?.large || image_uris?.normal ? (
+                {card.image_uris?.large || card.image_uris?.normal ? (
                   <Image
-                    src={card.image_uris.normal}
+                    src={card.image_uris?.normal || ''}
                     alt={card.name}
                     fill
                     sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"

--- a/src/components/game-board.tsx
+++ b/src/components/game-board.tsx
@@ -132,6 +132,7 @@ const ZoneDisplay = memo(function ZoneDisplay({
     exile: <Ban className="h-3 w-3" />,
     library: <Library className="h-3 w-3" />,
     command: <Crown className="h-3 w-3" />,
+    companion: <Crown className="h-3 w-3" />,
   }), []);
 
   return (
@@ -274,6 +275,7 @@ function PlayerArea({ player, isCurrentTurn, position, onCardClick, onZoneClick,
     exile: <Ban className="h-3 w-3" />,
     library: <Library className="h-3 w-3" />,
     command: <Crown className="h-3 w-3" />,
+    companion: <Crown className="h-3 w-3" />,
   }), []);
 
   // Local ZoneDisplay wrapper for backward compatibility

--- a/src/components/hand-display.tsx
+++ b/src/components/hand-display.tsx
@@ -97,9 +97,9 @@ function CardDisplay({
               }
             }}
           >
-            {scryfallCard.image_uris?.large || image_uris?.normal ? (
+            {scryfallCard.image_uris?.large || scryfallCard.image_uris?.normal ? (
               <Image
-                src={scryfallCard.image_uris.normal}
+                src={scryfallCard.image_uris?.normal || ''}
                 alt={scryfallCard.name}
                 fill
                 sizes="(max-width: 120px) 100vw, 120px"
@@ -124,7 +124,7 @@ function CardDisplay({
             )}
 
             {/* Mana cost overlay */}
-            {showManaCost && manaCost && scryfallCard.image_uris?.large || image_uris?.normal && (
+            {showManaCost && manaCost && scryfallCard.image_uris?.large || scryfallCard.image_uris?.normal && (
               <div className="absolute bottom-1 left-1 rounded bg-black/70 px-1.5 py-0.5">
                 <span className="text-xs font-mono text-white">{manaCost}</span>
               </div>


### PR DESCRIPTION
## Summary

This PR fixes multiple TypeScript compilation errors in the codebase:

### Fixed Errors:

1. **card-search.tsx** - Fixed undefined `image_uris` reference
   - Was using undefined `image_uris` variable instead of `card.image_uris`
   - Changed to use proper optional chaining: `card.image_uris?.normal || ''`

2. **hand-display.tsx** - Fixed undefined `image_uris` reference  
   - Was using undefined `image_uris` variable instead of `scryfallCard.image_uris`
   - Changed to use proper optional chaining: `scryfallCard.image_uris?.normal || ''`

3. **game-board.tsx** - Added missing `companion` zone to zoneIcons
   - The ZoneType includes 'companion' but it wasn't in the zoneIcons record
   - Added companion entry to match the ZoneType definition

### Remaining Errors (out of scope):

The following errors were identified but remain unfixed as they require more complex changes:
- Test file type definitions (game-rules.test.ts) - needs @types/jest
- Game state type mismatches in lib/game-state/
- Multiplayer layout type issues
- ZoneType mismatches in zone-viewer.tsx

## Testing

Run `npx tsc --noEmit` to verify TypeScript compilation.