### PR TITLE
Add life counter adjustment props to PlayerInfo

### DIFF
--- a/src/components/game-board.tsx
+++ b/src/components/game-board.tsx
@@ -193,15 +193,23 @@ const ZoneDisplay = memo(function ZoneDisplay({
 });
 
 // Memoized PlayerInfo component for performance optimization
-const PlayerInfo = memo(function PlayerInfo({ 
-  player, 
-  isCurrentTurn,
-  isVertical 
-}: { 
+interface PlayerInfoProps {
   player: PlayerState;
   isCurrentTurn: boolean;
   isVertical: boolean;
-}) {
+  onLifeAdjust?: (playerId: string, amount: number) => void;
+  onPoisonAdjust?: (playerId: string, amount: number) => void;
+  showControls?: boolean;
+}
+
+const PlayerInfo = memo(function PlayerInfo({
+  player,
+  isCurrentTurn,
+  isVertical,
+  onLifeAdjust,
+  onPoisonAdjust,
+  showControls = false
+}: PlayerInfoProps) {
   return (
     <div className={`flex items-center gap-2 ${isVertical ? "flex-col" : ""}`}>
       <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

This PR adds support for life and poison counter adjustment to the PlayerInfo component, addressing part of Issue #23 (Implement life total and counter tracking).

### Changes:

**src/components/game-board.tsx:**
- Added `PlayerInfoProps` interface with new callback props:
  - `onLifeAdjust?: (playerId: string, amount: number) => void` - callback for life adjustment
  - `onPoisonAdjust?: (playerId: string, amount: number) => void` - callback for poison counter adjustment  
  - `showControls?: boolean` - controls whether to show adjustment controls

The component now supports receiving callbacks that can be used by parent components to implement life/poison adjustment functionality. This provides the foundation for the full life counter UI implementation.

### Related Issue:
- Issue #23: Phase 2.1: Implement life total and counter tracking