### PR TITLE
fix: ZoneType compatibility in game-board components (Issue #216)

### DIFF
--- a/src/app/(app)/game-board/page.tsx
+++ b/src/app/(app)/game-board/page.tsx
@@ -99,7 +99,7 @@ function generateMockPlayer(
               name: "Commander",
               color_identity: [],
             },
-            zone: "command" as ZoneType,
+            zone: "commandZone" as ZoneType,
             playerId: id,
           },
         ]
@@ -189,7 +189,35 @@ export default function GameBoardPage() {
 
   const handleZoneClick = (zone: ZoneType, playerId: string) => {
     const player = players.find((p) => p.id === playerId);
-    const zoneData = player?.[zone === "command" ? "commandZone" : zone];
+    let zoneData: any[] = [];
+    
+    // Map ZoneType to PlayerState properties
+    switch (zone) {
+      case "commandZone":
+        zoneData = player?.commandZone || [];
+        break;
+      case "battlefield":
+        zoneData = player?.battlefield || [];
+        break;
+      case "hand":
+        zoneData = player?.hand || [];
+        break;
+      case "graveyard":
+        zoneData = player?.graveyard || [];
+        break;
+      case "exile":
+        zoneData = player?.exile || [];
+        break;
+      case "library":
+        zoneData = player?.library || [];
+        break;
+      case "stack":
+      case "sideboard":
+      case "anticipate":
+        // These zones don't exist in PlayerState yet
+        zoneData = [];
+        break;
+    }
 
     toast({
       title: `${zone.charAt(0).toUpperCase() + zone.slice(1)} Zone`,

--- a/src/components/game-board.tsx
+++ b/src/components/game-board.tsx
@@ -47,8 +47,11 @@ const ZONE_ICONS: Record<ZoneType, React.ReactNode> = {
   graveyard: <Skull className="h-3 w-3" />,
   exile: <Ban className="h-3 w-3" />,
   library: <Library className="h-3 w-3" />,
-  command: <Crown className="h-3 w-3" />,
+  commandZone: <Crown className="h-3 w-3" />,
   companion: <Crown className="h-3 w-3" />,
+  stack: null,
+  sideboard: null,
+  anticipate: null,
 };
 
 interface GameBoardProps {
@@ -131,8 +134,11 @@ const ZoneDisplay = memo(function ZoneDisplay({
     graveyard: <Skull className="h-3 w-3" />,
     exile: <Ban className="h-3 w-3" />,
     library: <Library className="h-3 w-3" />,
-    command: <Crown className="h-3 w-3" />,
+    commandZone: <Crown className="h-3 w-3" />,
     companion: <Crown className="h-3 w-3" />,
+    stack: null,
+    sideboard: null,
+    anticipate: null,
   }), []);
 
   return (
@@ -282,8 +288,11 @@ function PlayerArea({ player, isCurrentTurn, position, onCardClick, onZoneClick,
     graveyard: <Skull className="h-3 w-3" />,
     exile: <Ban className="h-3 w-3" />,
     library: <Library className="h-3 w-3" />,
-    command: <Crown className="h-3 w-3" />,
+    commandZone: <Crown className="h-3 w-3" />,
     companion: <Crown className="h-3 w-3" />,
+    stack: null,
+    sideboard: null,
+    anticipate: null,
   }), []);
 
   // Local ZoneDisplay wrapper for backward compatibility
@@ -322,7 +331,7 @@ function PlayerArea({ player, isCurrentTurn, position, onCardClick, onZoneClick,
       {/* Command Zone - always visible for Commander format */}
       {player.commandZone.length > 0 && (
         <ZoneDisplayLocal
-          zone="command"
+          zone="commandZone"
           title="Command Zone"
           count={player.commandZone.length}
           cards={player.commandZone}


### PR DESCRIPTION
## Summary

This PR fixes the ZoneType compatibility issues in the game-board components as described in Issue #216.

## Changes Made

1. **Updated ZoneType in `src/types/game.ts`**:
   - Added `commandZone`, `companion`, `stack`, `sideboard`, `anticipate` to the ZoneType union
   - This aligns ZoneType with PlayerState properties

2. **Fixed `src/components/game-board.tsx`**:
   - Updated `ZONE_ICONS` constant to include all ZoneType values
   - Fixed `zoneIcons` in both ZoneDisplay and PlayerArea components
   - Changed usage from `zone="command"` to `zone="commandZone"` 

3. **Fixed `src/app/(app)/game-board/page.tsx`**:
   - Updated `handleZoneClick` to properly map ZoneType to PlayerState properties
   - Updated mock player generator to use `"commandZone"` instead of `"command"`

## Testing

- TypeScript type checking passes for game-board components
- The component properly handles all zone types including commandZone, companion, stack, sideboard, and anticipate

Closes #216