### PR TITLE
feat(ai): Implement Z.ai provider integration (Issue #45)

### DIFF
--- a/src/ai/providers/index.ts
+++ b/src/ai/providers/index.ts
@@ -9,14 +9,15 @@
  * The AI functionality should only be used server-side or with proper fallback handling.
  */
 
-// Re-export Claude and OpenAI providers
+// Re-export Claude, OpenAI and Z.ai providers
 export * from './claude';
 export * from './openai';
+export * from './zaic';
 
 /**
  * Supported AI providers
  */
-export type AIProvider = 'google' | 'openai' | 'anthropic' | 'custom';
+export type AIProvider = 'google' | 'openai' | 'anthropic' | 'zaic' | 'custom';
 
 /**
  * Configuration options for AI providers
@@ -36,6 +37,7 @@ export const DEFAULT_MODELS: Record<string, string> = {
   google: 'gemini-1.5-flash-latest',
   openai: 'gpt-4o-mini',
   anthropic: 'claude-3-haiku-20240307',
+  zaic: 'default',
 };
 
 /**
@@ -54,6 +56,11 @@ export const DEFAULT_CONFIGS: Record<AIProvider, Partial<AIProviderConfig>> = {
   },
   anthropic: {
     model: DEFAULT_MODELS.anthropic,
+    temperature: 0.7,
+    maxOutputTokens: 8192,
+  },
+  zaic: {
+    model: DEFAULT_MODELS.zaic,
     temperature: 0.7,
     maxOutputTokens: 8192,
   },
@@ -94,7 +101,7 @@ export function setProvider(provider: AIProvider, model?: string): void {
  * Get available providers
  */
 export function getAvailableProviders(): AIProvider[] {
-  return ['google', 'openai', 'anthropic'];
+  return ['google', 'openai', 'anthropic', 'zaic'];
 }
 
 /**
@@ -120,6 +127,9 @@ export function getModelOptions(provider: AIProvider): string[] {
     case 'anthropic':
       // Lazy import to avoid bundling issues in browser
       return getClaudeModelOptionsStatic();
+    case 'zaic':
+      // Lazy import to avoid bundling issues in browser
+      return getZAIModelOptionsStatic();
     case 'custom':
       return [DEFAULT_MODELS.google];
     default:
@@ -164,6 +174,18 @@ function getClaudeModelOptionsStatic(): string[] {
 }
 
 /**
+ * Get Z.ai model options (statically defined to avoid require)
+ */
+function getZAIModelOptionsStatic(): string[] {
+  return [
+    'default',
+    'zaiclient-7b',
+    'zaiclient-14b',
+    'zaiclient-72b',
+  ];
+}
+
+/**
  * Create a standardized model string for prompts
  * This can be used in prompt templates to make them provider-agnostic
  */
@@ -175,7 +197,7 @@ export function getModelString(): string {
  * Validate provider configuration
  */
 export function isValidProvider(provider: string): provider is AIProvider {
-  return ['google', 'openai', 'anthropic', 'custom'].includes(provider);
+  return ['google', 'openai', 'anthropic', 'zaic', 'custom'].includes(provider);
 }
 
 /**

--- a/src/ai/providers/zaic.ts
+++ b/src/ai/providers/zaic.ts
@@ -1,0 +1,289 @@
+/**
+ * Z.ai Provider
+ * Issue #45: Integrate Z.ai provider
+ * 
+ * This module provides Z.ai integration for the Planar Nexus application.
+ * Z.ai is an AI provider that offers various language models.
+ */
+
+import { AIProviderConfig, DEFAULT_MODELS } from './index';
+
+/**
+ * Z.ai provider configuration
+ */
+export interface ZAIProviderConfig extends AIProviderConfig {
+  provider: 'zaic';
+  model?: string;
+  apiKey?: string;
+  baseURL?: string;
+  maxTokens?: number;
+  temperature?: number;
+}
+
+/**
+ * Default configuration for Z.ai provider
+ * Z.ai uses OpenAI-compatible API
+ */
+export const DEFAULT_ZAI_CONFIG: Partial<ZAIProviderConfig> = {
+  model: 'default',
+  maxTokens: 8192,
+  temperature: 0.7,
+  baseURL: 'https://api.z-ai.com/v1',
+};
+
+/**
+ * Z.ai chat message format
+ */
+export interface ZAIMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+  name?: string;
+}
+
+/**
+ * Z.ai chat completion request
+ */
+export interface ZAIChatRequest {
+  model: string;
+  messages: ZAIMessage[];
+  max_tokens?: number;
+  temperature?: number;
+  top_p?: number;
+  stream?: boolean;
+  stop?: string | string[];
+}
+
+/**
+ * Z.ai chat completion response
+ */
+export interface ZAIChatResponse {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: {
+    index: number;
+    message: {
+      role: string;
+      content: string;
+    };
+    finish_reason: string;
+  }[];
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+/**
+ * Create a Z.ai client configuration
+ * @param config - Configuration for the Z.ai provider
+ * @returns Configuration object for making API requests
+ */
+export function createZAIClient(config: ZAIProviderConfig): ZAIProviderConfig {
+  const apiKey = config.apiKey || process.env.ZAI_API_KEY;
+  
+  if (!apiKey) {
+    throw new Error(
+      'Z.ai API key is required. Set ZAI_API_KEY environment variable or pass it in config.'
+    );
+  }
+
+  return {
+    ...config,
+    apiKey,
+    baseURL: config.baseURL || process.env.ZAI_BASE_URL || DEFAULT_ZAI_CONFIG.baseURL,
+    model: config.model || DEFAULT_ZAI_CONFIG.model,
+    maxTokens: config.maxTokens || DEFAULT_ZAI_CONFIG.maxTokens,
+    temperature: config.temperature || DEFAULT_ZAI_CONFIG.temperature,
+  };
+}
+
+/**
+ * Send a chat completion request to Z.ai
+ * @param config - Provider configuration
+ * @param request - Chat request
+ * @returns Z.ai chat completion response
+ */
+export async function sendZAIChat(
+  config: ZAIProviderConfig,
+  request: Omit<ZAIChatRequest, 'model'>
+): Promise<ZAIChatResponse> {
+  const client = createZAIClient(config);
+  
+  const response = await fetch(`${client.baseURL}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${client.apiKey}`,
+    },
+    body: JSON.stringify({
+      model: client.model,
+      max_tokens: client.maxTokens || request.max_tokens,
+      temperature: client.temperature || request.temperature,
+      messages: request.messages,
+      top_p: request.top_p,
+      stream: false,
+      stop: request.stop,
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Z.ai API error: ${response.status} - ${error}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Send a streaming chat completion request to Z.ai
+ * @param config - Provider configuration
+ * @param request - Chat request
+ * @returns Async iterable for streaming response
+ */
+export async function* sendZAIChatStream(
+  config: ZAIProviderConfig,
+  request: Omit<ZAIChatRequest, 'model'>
+): AsyncGenerator<string> {
+  const client = createZAIClient(config);
+  
+  const response = await fetch(`${client.baseURL}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${client.apiKey}`,
+    },
+    body: JSON.stringify({
+      model: client.model,
+      max_tokens: client.maxTokens || request.max_tokens,
+      temperature: client.temperature || request.temperature,
+      messages: request.messages,
+      top_p: request.top_p,
+      stream: true,
+      stop: request.stop,
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Z.ai API error: ${response.status} - ${error}`);
+  }
+
+  if (!response.body) {
+    throw new Error('Z.ai API response has no body');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    
+    if (done) break;
+    
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() || '';
+    
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || !trimmed.startsWith('data: ')) continue;
+      
+      const data = trimmed.slice(6);
+      if (data === '[DONE]') {
+        return;
+      }
+      
+      try {
+        const parsed = JSON.parse(data);
+        const content = parsed.choices?.[0]?.delta?.content;
+        if (content) {
+          yield content;
+        }
+      } catch {
+        // Skip invalid JSON
+      }
+    }
+  }
+}
+
+/**
+ * Convert Z.ai response to text
+ * @param response - Z.ai chat completion response
+ * @returns Text content from the response
+ */
+export function zAIResponseToText(response: ZAIChatResponse): string {
+  const message = response.choices[0]?.message;
+  
+  if (message?.content) {
+    return message.content;
+  }
+  
+  return '';
+}
+
+/**
+ * Z.ai model options
+ */
+export const ZAI_MODELS = [
+  'default',
+  'zaiclient-7b',
+  'zaiclient-14b',
+  'zaiclient-72b',
+];
+
+/**
+ * Get all available Z.ai models
+ */
+export function getZAIModelOptions(): string[] {
+  return [...ZAI_MODELS];
+}
+
+/**
+ * Check if a model is a Z.ai model
+ */
+export function isZAIModel(model: string): boolean {
+  return ZAI_MODELS.includes(model);
+}
+
+/**
+ * Validate Z.ai API key format
+ * @param apiKey - The API key to validate
+ * @returns Whether the API key appears valid
+ */
+export function validateZAIApiKey(apiKey: string): boolean {
+  // Z.ai API keys are typically longer strings
+  return apiKey.length >= 20;
+}
+
+/**
+ * Convert messages to Z.ai format
+ * @param messages - Messages in standard format
+ * @returns Messages formatted for Z.ai
+ */
+export function formatZAIMessages(
+  messages: Array<{ role: 'user' | 'assistant' | 'system'; content: string; name?: string }>
+): ZAIMessage[] {
+  return messages as ZAIMessage[];
+}
+
+/**
+ * Check if Z.ai is configured and available
+ */
+export function isZAIAvailable(): boolean {
+  return !!process.env.ZAI_API_KEY;
+}
+
+/**
+ * Get Z.ai provider status
+ */
+export function getZAIProviderStatus(): { available: boolean; configured: boolean } {
+  const hasApiKey = !!process.env.ZAI_API_KEY;
+  return {
+    available: hasApiKey,
+    configured: hasApiKey,
+  };
+}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -57,6 +57,7 @@ const PROVIDER_NAMES: Record<AIProvider, string> = {
   google: "Google AI (Gemini)",
   openai: "OpenAI",
   anthropic: "Anthropic (Claude)",
+  zaic: "Z.ai",
   custom: "Custom Provider",
 };
 
@@ -67,6 +68,7 @@ const PROVIDER_COLORS: Record<AIProvider, string> = {
   google: "bg-blue-500",
   openai: "bg-green-500",
   anthropic: "bg-purple-500",
+  zaic: "bg-orange-500",
   custom: "bg-gray-500",
 };
 
@@ -259,18 +261,21 @@ export default function SettingsPage() {
     google: "",
     openai: "",
     anthropic: "",
+    zaic: "",
     custom: "",
   });
   const [showKey, setShowKey] = useState<Record<AIProvider, boolean>>({
     google: false,
     openai: false,
     anthropic: false,
+    zaic: false,
     custom: false,
   });
   const [selectedModels, setSelectedModels] = useState<Record<AIProvider, string>>({
     google: "gemini-1.5-flash-latest",
     openai: "gpt-4o-mini",
     anthropic: "claude-3-haiku-20240307",
+    zaic: "default",
     custom: "gemini-1.5-flash-latest",
   });
   
@@ -280,12 +285,14 @@ export default function SettingsPage() {
     google: false,
     openai: false,
     anthropic: false,
+    zaic: false,
     custom: false,
   });
   const [validationResults, setValidationResults] = useState<Record<AIProvider, { valid: boolean; error?: string }>>({
     google: { valid: false },
     openai: { valid: false },
     anthropic: { valid: false },
+    zaic: { valid: false },
     custom: { valid: false },
   });
   
@@ -395,9 +402,9 @@ export default function SettingsPage() {
     }
     
     await clearAllApiKeys();
-    setKeys({ google: "", openai: "", anthropic: "", custom: "" });
+    setKeys({ google: "", openai: "", anthropic: "", zaic: "", custom: "" });
     setKeyStatus([]);
-    setValidationResults({ google: { valid: false }, openai: { valid: false }, anthropic: { valid: false }, custom: { valid: false } });
+    setValidationResults({ google: { valid: false }, openai: { valid: false }, anthropic: { valid: false }, zaic: { valid: false }, custom: { valid: false } });
     
     setSaveMessage({
       type: "success",

--- a/src/lib/api-key-storage.ts
+++ b/src/lib/api-key-storage.ts
@@ -189,7 +189,7 @@ export async function hasApiKey(provider: AIProvider): Promise<boolean> {
  * Get all providers with stored keys
  */
 export async function getProvidersWithKeys(): Promise<AIProvider[]> {
-  const providers: AIProvider[] = ['google', 'openai', 'anthropic', 'custom'];
+  const providers: AIProvider[] = ['google', 'openai', 'anthropic', 'zaic', 'custom'];
   const result: AIProvider[] = [];
   
   for (const provider of providers) {
@@ -212,6 +212,7 @@ async function getStatusStorage(): Promise<Record<AIProvider, ProviderKeyStatus>
     google: { provider: 'google', hasKey: false },
     openai: { provider: 'openai', hasKey: false },
     anthropic: { provider: 'anthropic', hasKey: false },
+    zaic: { provider: 'zaic', hasKey: false },
     custom: { provider: 'custom', hasKey: false },
   };
   
@@ -318,6 +319,25 @@ export async function validateApiKey(
       return { valid: true };
     }
     
+    // For Z.ai, test with a minimal request
+    if (provider === 'zaic') {
+      const response = await fetch(
+        'https://api.z-ai.com/v1/models',
+        {
+          headers: { 'Authorization': `Bearer ${apiKey}` },
+        }
+      );
+      
+      if (!response.ok) {
+        const error = await response.text();
+        return { 
+          valid: false, 
+          error: error || 'Invalid API key' 
+        };
+      }
+      return { valid: true };
+    }
+    
     return { valid: false, error: 'Unknown provider' };
   } catch (error) {
     return { 
@@ -331,7 +351,7 @@ export async function validateApiKey(
  * Clear all stored API keys (for logout)
  */
 export async function clearAllApiKeys(): Promise<void> {
-  const providers: AIProvider[] = ['google', 'openai', 'anthropic', 'custom'];
+  const providers: AIProvider[] = ['google', 'openai', 'anthropic', 'zaic', 'custom'];
   
   for (const provider of providers) {
     localStorage.removeItem(`${STORAGE_KEY_PREFIX}_${provider}`);


### PR DESCRIPTION
## Summary

Implements Issue #45: Integrate Z.ai provider for the Planar Nexus AI system.

## Changes

- Added new Z.ai provider at `src/ai/providers/zaic.ts` following the existing provider pattern
- Updated AIProvider type to include 'zaic' as a supported provider
- Added Z.ai to provider index with default models and configurations
- Updated `api-key-storage.ts` to support Z.ai API key validation
- Updated settings page UI to include Z.ai provider

## Implementation Details

The Z.ai provider implementation includes:
- Full provider configuration with API key and base URL support
- Chat completion requests (both streaming and non-streaming)
- Model options: default, zaiclient-7b, zaiclient-14b, zaiclient-72b
- API key validation via the Z.ai models endpoint
- OpenAI-compatible API format for easy integration

## Acceptance Criteria

- [x] Z.ai provider functional
- [x] Proper authentication via API key
- [x] Feature complete (models, validation, settings UI)

## Labels

phase:3, component:ai, priority:high