### PR TITLE
fix: Remove unused game-state import from game-rules

### DIFF
--- a/src/lib/game-rules.ts
+++ b/src/lib/game-rules.ts
@@ -5,7 +5,8 @@
  * including deck construction rules, ban/restricted lists, and validation.
  */
 
-import type { GameState } from "./game-state";
+// Note: GameState type is defined in @/types/game
+// Import directly from '@/types/game' when needed
 
 /**
  * Format-specific deck construction rules


### PR DESCRIPTION
## Summary

Removes an invalid import from `src/lib/game-rules.ts` that was importing from a non-existent file `./game-state`.

## Changes

- Removed unused import `import type { GameState } from "./game-state";` from game-rules.ts
- The GameState type is actually defined in `@/types/game` but wasn't being used in this file anyway

## Testing

TypeScript type checking passes with no errors.