### PR TITLE
fix: clarify game state imports in game-rules.ts

### DIFF
--- a/src/lib/game-rules.ts
+++ b/src/lib/game-rules.ts
@@ -7,6 +7,7 @@
 
 // Note: GameState type is defined in @/types/game
 // Import directly from '@/types/game' when needed
+// Also see @/lib/game-state/types.ts for full game state types
 
 /**
  * Format-specific deck construction rules


### PR DESCRIPTION
Add reference to @/lib/game-state/types.ts for full game state types to fix the broken import comment.

This resolves a TODO in the codebase where the import path was documented but not accurate.