### PR TITLE
feat(ai): implement AI difficulty tuning system

### DIFF
--- a/src/ai/__tests__/ai-difficulty.test.ts
+++ b/src/ai/__tests__/ai-difficulty.test.ts
@@ -1,0 +1,53 @@
+import { aiDifficultyManager, DIFFICULTY_CONFIGS, DifficultyLevel } from '../ai-difficulty';
+
+describe('AIDifficultyManager', () => {
+  test('should initialize with default difficulty (medium)', () => {
+    expect(aiDifficultyManager.getLevel()).toBe('medium');
+  });
+
+  test('should set and get difficulty level', () => {
+    aiDifficultyManager.setDifficulty('hard');
+    expect(aiDifficultyManager.getLevel()).toBe('hard');
+    expect(aiDifficultyManager.getDifficulty().level).toBe('hard');
+  });
+
+  test('should handle player-specific difficulty', () => {
+    aiDifficultyManager.setDifficulty('easy', 'player1');
+    expect(aiDifficultyManager.getDifficulty('player1').level).toBe('easy');
+    expect(aiDifficultyManager.getLevel()).toBe('hard'); // Global should remain hard
+  });
+
+  test('should return correct lookahead depth', () => {
+    aiDifficultyManager.setDifficulty('expert');
+    expect(aiDifficultyManager.getLookaheadDepth()).toBe(4);
+    
+    aiDifficultyManager.setDifficulty('easy');
+    expect(aiDifficultyManager.getLookaheadDepth()).toBe(1);
+  });
+
+  test('should apply randomness correctly', () => {
+    aiDifficultyManager.setDifficulty('expert');
+    const options = ['choice1', 'choice2', 'choice3'];
+    // Expert has very low randomness (0.02), so it should almost always pick first option
+    // (though Math.random is not mocked here, we just check it returns something from options)
+    const choice = aiDifficultyManager.applyRandomness(options);
+    expect(options).toContain(choice);
+  });
+
+  test('should identify blunder chance', () => {
+    aiDifficultyManager.setDifficulty('easy');
+    // Easy has 0.25 blunder chance. 
+    // We can't easily test the randomness without mocking Math.random
+    // but we can check if the method exists and returns a boolean
+    expect(typeof aiDifficultyManager.shouldBlunder()).toBe('boolean');
+  });
+
+  test('should provide evaluation weights', () => {
+    aiDifficultyManager.setDifficulty('medium');
+    const weights = aiDifficultyManager.getEvaluationWeights();
+    expect(weights).toBeDefined();
+    // Check for some expected weight properties
+    expect(weights).toHaveProperty('lifeScore');
+    expect(weights).toHaveProperty('creaturePower');
+  });
+});

--- a/src/app/(app)/single-player/page.tsx
+++ b/src/app/(app)/single-player/page.tsx
@@ -8,20 +8,23 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/hooks/use-toast";
-import { Swords } from "lucide-react";
+import { Swords, Info } from "lucide-react";
+import { DIFFICULTY_CONFIGS, DifficultyLevel } from "@/ai/ai-difficulty";
 
 export default function SinglePlayerPage() {
-  const [difficulty, setDifficulty] = useState("medium");
+  const [difficulty, setDifficulty] = useState<DifficultyLevel>("medium");
   const [aiTheme, setAiTheme] = useState("aggressive red");
   const { toast } = useToast();
 
   const handleStartGame = (mode: "self-play" | "ai") => {
+    const config = DIFFICULTY_CONFIGS[difficulty];
     toast({
       title: "Starting Game (Prototype)",
-      description: `Game board would be initialized for ${mode === 'ai' ? `AI opponent (${difficulty}, ${aiTheme})` : 'self-play'}.`,
+      description: `Game board would be initialized for ${mode === 'ai' ? `AI opponent (${config.displayName}, ${aiTheme})` : 'self-play'}.`,
     });
     // In a real app, you would navigate to a game board page:
-    // router.push(`/single-player/new-game?mode=${mode}&difficulty=${difficulty}...`);
+    // router.push(\"/single-player/new-game?mode=\"
+    // );
   };
 
   return (
@@ -52,26 +55,48 @@ export default function SinglePlayerPage() {
                   <Label htmlFor="ai-theme">AI Deck Theme</Label>
                   <Input 
                     id="ai-theme" 
-                    placeholder="e.g., 'token generation', 'mill'" 
+                    placeholder="e.g., 'token generation', 'mill'"
                     value={aiTheme}
                     onChange={(e) => setAiTheme(e.target.value)}
                   />
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="difficulty">Difficulty</Label>
-                  <Select value={difficulty} onValueChange={setDifficulty}>
+                  <Select 
+                    value={difficulty} 
+                    onValueChange={(value) => setDifficulty(value as DifficultyLevel)}
+                  >
                     <SelectTrigger id="difficulty">
                       <SelectValue placeholder="Select difficulty" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="easy">Easy</SelectItem>
-                      <SelectItem value="medium">Medium</SelectItem>
-                      <SelectItem value="hard">Hard</SelectItem>
+                      {Object.values(DIFFICULTY_CONFIGS).map((config) => (
+                        <SelectItem key={config.level} value={config.level}>
+                          {config.displayName}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
+                  <div className="bg-muted p-3 rounded-md flex items-start gap-3 mt-2">
+                    <Info className="h-5 w-5 text-blue-500 shrink-0 mt-0.5" />
+                    <div>
+                      <p className="text-sm font-medium">{DIFFICULTY_CONFIGS[difficulty].displayName}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {DIFFICULTY_CONFIGS[difficulty].description}
+                      </p>
+                      <div className="grid grid-cols-2 gap-2 mt-2">
+                        <div className="text-[10px] bg-background px-2 py-1 rounded">
+                          Lookahead: {DIFFICULTY_CONFIGS[difficulty].lookaheadDepth} levels
+                        </div>
+                        <div className="text-[10px] bg-background px-2 py-1 rounded">
+                          Randomness: {(DIFFICULTY_CONFIGS[difficulty].randomnessFactor * 100).toFixed(0)}%
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 </div>
-                <Button className="w-full" onClick={() => handleStartGame('ai')}>
-                  <Swords className="mr-2" />
+                <Button className="w-full" onClick={() => handleStartGame('ai')}> 
+                  <Swords className="mr-2 h-4 w-4" />
                   Battle the AI
                 </Button>
               </CardContent>
@@ -90,7 +115,7 @@ export default function SinglePlayerPage() {
                 <p className="text-sm text-muted-foreground mb-4">
                   You'll be taken to a game board with your selected deck, ready to play.
                 </p>
-                <Button className="w-full" onClick={() => handleStartGame('self-play')}>
+                <Button className="w-full" onClick={() => handleStartGame('self-play')}> 
                   Start Self Play Session
                 </Button>
               </CardContent>


### PR DESCRIPTION
Closes #252. This PR adds a comprehensive UI for selecting AI difficulty levels with descriptions and lookahead/randomness stats, along with unit tests for the difficulty manager.

## Summary by Sourcery

Integrate configurable AI difficulty levels into the single-player flow and surface their details in the UI.

New Features:
- Expose AI difficulty presets in the single-player page using a shared difficulty configuration model with typed levels.
- Display contextual information for the selected AI difficulty, including name, description, lookahead depth, and randomness in the UI.

Tests:
- Add unit test coverage for the AI difficulty configuration and management logic.