### PR TITLE
Implement replacement and prevention effects system (Issue #266)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,11 +3,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
-<<<<<<< HEAD
-  testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
-=======
   testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx', '**/__tests__/**/*.validation.ts'],
->>>>>>> c780945 (fix(AI): Complete combat decision tree implementation with bug fixes)
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },

--- a/src/lib/game-state/__tests__/replacement-effects.test.ts
+++ b/src/lib/game-state/__tests__/replacement-effects.test.ts
@@ -1,134 +1,565 @@
-import { replacementEffectManager, ReplacementAbility, ReplacementEvent } from '../replacement-effects';
+/**
+ * Comprehensive tests for Replacement and Prevention Effects
+ * Tests APNAP ordering, "as though" effects, and complex scenarios
+ */
 
-describe('ReplacementEffectManager', () => {
+import {
+  replacementEffectManager,
+  ReplacementAbility,
+  ReplacementEvent,
+  APNAPOrder,
+  createPreventionShield,
+  createDamageReplacementEffect,
+  createLifeGainReplacementEffect,
+  createLifeLossReplacementEffect,
+  createDrawReplacementEffect,
+  createDestroyReplacementEffect,
+  createAsThoughEffect,
+  AsThoughType,
+} from '../replacement-effects';
+
+describe('ReplacementEffectManager - APNAP Ordering', () => {
   beforeEach(() => {
     replacementEffectManager.reset();
   });
 
-  test('should apply damage prevention shield', () => {
-    const targetId = 'player1';
-    replacementEffectManager.addPreventionShield(targetId, {
-      sourceId: 'source1',
-      amount: 5,
-    });
-
-    const event: ReplacementEvent = {
-      type: 'damage' as const,
-      amount: 7,
-      timestamp: Date.now(),
-      targetId,
+  test('should apply effects in APNAP order', () => {
+    // Player1 is active player, Player2 is non-active
+    const apnapOrder: APNAPOrder = {
+      activePlayerId: 'player1',
+      playerOrder: ['player1', 'player2'],
     };
 
-    const processed = replacementEffectManager.processEvent(event);
-    expect(processed.amount).toBe(2); // 7 - 5 = 2
-    expect(replacementEffectManager.getPreventionShields(targetId)).toHaveLength(0);
-  });
-
-  test('should handle multiple prevention shields', () => {
-    const targetId = 'player1';
-    replacementEffectManager.addPreventionShield(targetId, {
-      sourceId: 'source1',
-      amount: 2,
-    });
-    replacementEffectManager.addPreventionShield(targetId, {
-      sourceId: 'source2',
-      amount: 3,
-    });
-
-    const event: ReplacementEvent = {
-      type: 'damage' as const,
-      amount: 4,
-      timestamp: Date.now(),
-      targetId,
-    };
-
-    const processed = replacementEffectManager.processEvent(event);
-    expect(processed.amount).toBe(0); // 4 - 2 - 2 = 0 (1 remains on second shield)
-    
-    const shields = replacementEffectManager.getPreventionShields(targetId);
-    expect(shields).toHaveLength(1);
-    expect(shields[0].amount).toBe(1);
-  });
-
-  test('should apply replacement effects in correct order', () => {
-    // Effect 1: If damage would be dealt, deal twice that much (Furnace of Rath)
-    const furnaceEffect: ReplacementAbility = {
-      id: 'furnace',
-      sourceCardId: 'furnace-card',
+    // Both players have effects that double damage
+    const p1Effect: ReplacementAbility = {
+      id: 'p1-double',
+      sourceCardId: 'p1-card',
       controllerId: 'player1',
-      effectType: 'damage_replacement' as const,
-      description: 'Double damage',
+      effectType: 'damage_replacement',
+      description: 'P1 doubles damage',
       layer: 5,
-      timestamp: 1,
-      canApply: (e: ReplacementEvent) => e.type === 'damage',
-      apply: (e: ReplacementEvent) => ({
+      timestamp: 100,
+      isInstead: true,
+      canApply: (e) => e.type === 'damage',
+      apply: (e) => ({
         modified: true,
         modifiedEvent: { ...e, amount: e.amount * 2 },
-        description: 'Doubled damage',
+        description: 'P1 doubled',
+        instead: true,
       }),
     };
 
-    // Effect 2: If damage would be dealt, prevent 2 of it
-    const preventEffect: ReplacementAbility = {
-      id: 'prevent2',
-      sourceCardId: 'prevent-card',
+    const p2Effect: ReplacementAbility = {
+      id: 'p2-double',
+      sourceCardId: 'p2-card',
+      controllerId: 'player2',
+      effectType: 'damage_replacement',
+      description: 'P2 doubles damage',
+      layer: 5,
+      timestamp: 200,
+      isInstead: true,
+      canApply: (e) => e.type === 'damage',
+      apply: (e) => ({
+        modified: true,
+        modifiedEvent: { ...e, amount: e.amount * 2 },
+        description: 'P2 doubled',
+        instead: true,
+      }),
+    };
+
+    replacementEffectManager.registerEffect(p1Effect);
+    replacementEffectManager.registerEffect(p2Effect);
+
+    const event: ReplacementEvent = {
+      type: 'damage',
+      amount: 3,
+      timestamp: Date.now(),
+      targetId: 'player2', // Affected player is P2
+    };
+
+    // P2's effect should apply first (affected player chooses)
+    // Then P1's effect applies
+    // 3 * 2 (P2) = 6, then 6 * 2 (P1) = 12
+    const processed = replacementEffectManager.processEvent(event, apnapOrder);
+    expect(processed.amount).toBe(12);
+  });
+
+  test('should prioritize self-replacement effects', () => {
+    const apnapOrder: APNAPOrder = {
+      activePlayerId: 'player1',
+      playerOrder: ['player1', 'player2'],
+    };
+
+    // Self-replacement effect (e.g., "If this creature would deal damage...")
+    const selfEffect: ReplacementAbility = {
+      id: 'self-replace',
+      sourceCardId: 'self-card',
       controllerId: 'player1',
-      effectType: 'damage_prevention' as const,
-      description: 'Prevent 2',
-      layer: 4, // Prevention usually applies before general replacement if configured
-      timestamp: 2,
-      canApply: (e: ReplacementEvent) => e.type === 'damage',
-      apply: (e: ReplacementEvent) => ({
+      effectType: 'damage_replacement',
+      description: 'Self replacement',
+      layer: 5,
+      timestamp: 300,
+      isSelfReplacement: true,
+      isInstead: true,
+      canApply: (e) => e.type === 'damage' && e.sourceId === 'self-card',
+      apply: (e) => ({
+        modified: true,
+        modifiedEvent: { ...e, amount: e.amount + 5 },
+        description: 'Self added 5',
+        instead: true,
+      }),
+    };
+
+    // Regular effect
+    const regularEffect: ReplacementAbility = {
+      id: 'regular',
+      sourceCardId: 'regular-card',
+      controllerId: 'player2',
+      effectType: 'damage_replacement',
+      description: 'Regular replacement',
+      layer: 5,
+      timestamp: 100,
+      isInstead: true,
+      canApply: (e) => e.type === 'damage',
+      apply: (e) => ({
+        modified: true,
+        modifiedEvent: { ...e, amount: e.amount * 2 },
+        description: 'Regular doubled',
+        instead: true,
+      }),
+    };
+
+    replacementEffectManager.registerEffect(selfEffect);
+    replacementEffectManager.registerEffect(regularEffect);
+
+    const event: ReplacementEvent = {
+      type: 'damage',
+      amount: 3,
+      timestamp: Date.now(),
+      sourceId: 'self-card',
+      targetId: 'player2',
+    };
+
+    // Self-replacement applies first: 3 + 5 = 8
+    // Then regular: 8 * 2 = 16
+    const processed = replacementEffectManager.processEvent(event, apnapOrder);
+    expect(processed.amount).toBe(16);
+  });
+
+  test('should handle layer ordering within same controller', () => {
+    // Lower layer applies first
+    const layer1Effect: ReplacementAbility = {
+      id: 'layer1',
+      sourceCardId: 'card1',
+      controllerId: 'player1',
+      effectType: 'damage_prevention',
+      description: 'Layer 1',
+      layer: 1,
+      timestamp: 100,
+      canApply: (e) => e.type === 'damage',
+      apply: (e) => ({
         modified: true,
         modifiedEvent: { ...e, amount: Math.max(0, e.amount - 2) },
         description: 'Prevented 2',
       }),
     };
 
-    replacementEffectManager.registerEffect(furnaceEffect);
-    replacementEffectManager.registerEffect(preventEffect);
+    const layer5Effect: ReplacementAbility = {
+      id: 'layer5',
+      sourceCardId: 'card2',
+      controllerId: 'player1',
+      effectType: 'damage_replacement',
+      description: 'Layer 5',
+      layer: 5,
+      timestamp: 200,
+      isInstead: true,
+      canApply: (e) => e.type === 'damage',
+      apply: (e) => ({
+        modified: true,
+        modifiedEvent: { ...e, amount: e.amount * 2 },
+        description: 'Doubled',
+        instead: true,
+      }),
+    };
+
+    replacementEffectManager.registerEffect(layer1Effect);
+    replacementEffectManager.registerEffect(layer5Effect);
 
     const event: ReplacementEvent = {
-      type: 'damage' as const,
-      amount: 3,
+      type: 'damage',
+      amount: 5,
       timestamp: Date.now(),
       targetId: 'player2',
     };
 
-    // Should apply prevent2 first (layer 4), then furnace (layer 5)
-    // (3 - 2) * 2 = 2
+    // Layer 1 applies first: 5 - 2 = 3
+    // Layer 5 applies second: 3 * 2 = 6
     const processed = replacementEffectManager.processEvent(event);
-    expect(processed.amount).toBe(2);
+    expect(processed.amount).toBe(6);
+  });
+});
+
+describe('ReplacementEffectManager - As Though Effects', () => {
+  beforeEach(() => {
+    replacementEffectManager.reset();
   });
 
-  test('should handle life gain replacement', () => {
-    // Alhammarret's Archive: If you would gain life, gain twice that much instead
-    const archiveEffect: ReplacementAbility = {
-      id: 'archive',
-      sourceCardId: 'archive-card',
-      controllerId: 'player1',
-      effectType: 'life_gain_replacement' as const,
-      description: 'Double life gain',
-      layer: 5,
-      timestamp: 1,
-      canApply: (e: ReplacementEvent) => e.type === 'life_gain' && e.targetId === 'player1',
-      apply: (e: ReplacementEvent) => ({
-        modified: true,
-        modifiedEvent: { ...e, amount: e.amount * 2 },
-        description: 'Doubled life gain',
-      }),
+  test('should register and check as though effects', () => {
+    const mockGameState = { players: new Map() };
+    
+    const flashEffect = createAsThoughEffect(
+      'veiled-source',
+      'player1',
+      'cast_flash',
+      'You may cast spells as though they had flash'
+    );
+
+    replacementEffectManager.registerAsThoughEffect(flashEffect);
+
+    expect(replacementEffectManager.checkAsThoughEffect('player1', 'cast_flash', mockGameState as any)).toBe(true);
+    expect(replacementEffectManager.checkAsThoughEffect('player2', 'cast_flash', mockGameState as any)).toBe(false);
+    expect(replacementEffectManager.checkAsThoughEffect('player1', 'attack_haste', mockGameState as any)).toBe(false);
+  });
+
+  test('should handle conditional as though effects', () => {
+    const mockGameState = { players: new Map() };
+    
+    // Effect that only applies when player has 10+ life
+    const conditionalEffect = createAsThoughEffect(
+      'conditional-source',
+      'player1',
+      'attack_haste',
+      'Creatures can attack as though they had haste if you have 10+ life',
+      (state, playerId) => {
+        // Simplified condition check
+        return true;
+      }
+    );
+
+    replacementEffectManager.registerAsThoughEffect(conditionalEffect);
+
+    expect(replacementEffectManager.checkAsThoughEffect('player1', 'attack_haste', mockGameState as any)).toBe(true);
+  });
+
+  test('should get all as though effects for a player', () => {
+    const mockGameState = { players: new Map() };
+    
+    replacementEffectManager.registerAsThoughEffect(
+      createAsThoughEffect('source1', 'player1', 'cast_flash', 'Flash effect')
+    );
+    replacementEffectManager.registerAsThoughEffect(
+      createAsThoughEffect('source2', 'player1', 'attack_haste', 'Haste effect')
+    );
+    replacementEffectManager.registerAsThoughEffect(
+      createAsThoughEffect('source3', 'player2', 'block_flying', 'Flying block effect')
+    );
+
+    const p1Effects = replacementEffectManager.getAsThoughEffects('player1', mockGameState as any);
+    expect(p1Effects).toHaveLength(2);
+    expect(p1Effects.map(e => e.asThoughType)).toContain('cast_flash');
+    expect(p1Effects.map(e => e.asThoughType)).toContain('attack_haste');
+
+    const p2Effects = replacementEffectManager.getAsThoughEffects('player2', mockGameState as any);
+    expect(p2Effects).toHaveLength(1);
+    expect(p2Effects[0].asThoughType).toBe('block_flying');
+  });
+
+  test('should remove as though effects when source leaves battlefield', () => {
+    const mockGameState = { players: new Map() };
+    
+    replacementEffectManager.registerAsThoughEffect(
+      createAsThoughEffect('temporary-source', 'player1', 'cast_flash', 'Temporary flash')
+    );
+
+    expect(replacementEffectManager.checkAsThoughEffect('player1', 'cast_flash', mockGameState as any)).toBe(true);
+
+    replacementEffectManager.removeEffectsFromSource('temporary-source');
+
+    expect(replacementEffectManager.checkAsThoughEffect('player1', 'cast_flash', mockGameState as any)).toBe(false);
+  });
+});
+
+describe('ReplacementEffectManager - Complex Scenarios', () => {
+  beforeEach(() => {
+    replacementEffectManager.reset();
+  });
+
+  test('should handle Furnace of Rath + prevention shield interaction', () => {
+    // Furnace of Rath: If damage would be dealt, deal twice that much instead
+    const furnaceEffect = createDamageReplacementEffect(
+      'furnace',
+      'player1',
+      'Furnace of Rath doubles damage',
+      (amount) => amount * 2,
+      5
+    );
+
+    replacementEffectManager.registerEffect(furnaceEffect);
+
+    // Target has prevention shield
+    replacementEffectManager.addPreventionShield('player2', {
+      sourceId: 'fog',
+      amount: 3,
+      controllerId: 'player2',
+    });
+
+    const event: ReplacementEvent = {
+      type: 'damage',
+      amount: 2,
+      timestamp: Date.now(),
+      targetId: 'player2',
     };
+
+    // Furnace doubles: 2 * 2 = 4
+    // Prevention shield prevents 3: 4 - 3 = 1
+    const processed = replacementEffectManager.processEvent(event);
+    expect(processed.amount).toBe(1);
+
+    // Shield should be depleted
+    const shields = replacementEffectManager.getPreventionShields('player2');
+    expect(shields).toHaveLength(0);
+  });
+
+  test('should handle Alhammarret\'s Archive life gain doubling', () => {
+    const archiveEffect = createLifeGainReplacementEffect(
+      'archive',
+      'player1',
+      'Alhammarret\'s Archive doubles life gain',
+      (amount) => amount * 2,
+      (targetId) => targetId === 'player1'
+    );
 
     replacementEffectManager.registerEffect(archiveEffect);
 
     const event: ReplacementEvent = {
-      type: 'life_gain' as const,
-      amount: 3,
+      type: 'life_gain',
+      amount: 5,
       timestamp: Date.now(),
       targetId: 'player1',
     };
 
     const processed = replacementEffectManager.processEvent(event);
-    expect(processed.amount).toBe(6);
+    expect(processed.amount).toBe(10);
+
+    // Should not apply to other players
+    const otherEvent: ReplacementEvent = {
+      type: 'life_gain',
+      amount: 5,
+      timestamp: Date.now(),
+      targetId: 'player2',
+    };
+
+    const otherProcessed = replacementEffectManager.processEvent(otherEvent);
+    expect(otherProcessed.amount).toBe(5);
+  });
+
+  test('should handle multiple prevention shields depleting correctly', () => {
+    replacementEffectManager.addPreventionShield('player1', {
+      sourceId: 'shield1',
+      amount: 2,
+      controllerId: 'player1',
+    });
+    replacementEffectManager.addPreventionShield('player1', {
+      sourceId: 'shield2',
+      amount: 3,
+      controllerId: 'player1',
+    });
+
+    // First damage: 4 damage, should use both shields (2 + 2 from second)
+    const event1: ReplacementEvent = {
+      type: 'damage',
+      amount: 4,
+      timestamp: Date.now(),
+      targetId: 'player1',
+    };
+
+    const processed1 = replacementEffectManager.processEvent(event1);
+    expect(processed1.amount).toBe(0);
+
+    // Second shield should have 1 remaining
+    const shields = replacementEffectManager.getPreventionShields('player1');
+    expect(shields).toHaveLength(1);
+    expect(shields[0].amount).toBe(1);
+
+    // Second damage: 2 damage, should use remaining 1 from shield2
+    const event2: ReplacementEvent = {
+      type: 'damage',
+      amount: 2,
+      timestamp: Date.now() + 1000,
+      targetId: 'player1',
+    };
+
+    const processed2 = replacementEffectManager.processEvent(event2);
+    expect(processed2.amount).toBe(1);
+
+    // All shields should be depleted
+    expect(replacementEffectManager.getPreventionShields('player1')).toHaveLength(0);
+  });
+
+  test('should handle draw replacement effects', () => {
+    const drawEffect = createDrawReplacementEffect(
+      'nefarox',
+      'player1',
+      'Nefarox draw replacement',
+      (amount) => amount + 1 // Draw one additional card
+    );
+
+    replacementEffectManager.registerEffect(drawEffect);
+
+    const event: ReplacementEvent = {
+      type: 'draw_card',
+      amount: 1,
+      timestamp: Date.now(),
+      targetId: 'player1',
+    };
+
+    const processed = replacementEffectManager.processEvent(event);
+    expect(processed.amount).toBe(2);
+  });
+
+  test('should handle destroy replacement (regeneration)', () => {
+    const regenEffect = createDestroyReplacementEffect(
+      'regeneration-shield',
+      'player1',
+      'Regeneration shield',
+      (event) => ({
+        ...event,
+        type: 'tap', // Instead of dying, creature taps
+        amount: 0,
+      }),
+      (targetId) => targetId === 'creature1'
+    );
+
+    replacementEffectManager.registerEffect(regenEffect);
+
+    const event: ReplacementEvent = {
+      type: 'destroy',
+      amount: 0,
+      timestamp: Date.now(),
+      targetId: 'creature1',
+    };
+
+    const processed = replacementEffectManager.processEvent(event);
+    expect(processed.type).toBe('tap');
+    expect(processed.amount).toBe(0);
+  });
+
+  test('should handle life loss replacement', () => {
+    const lossEffect = createLifeLossReplacementEffect(
+      'loss-reducer',
+      'player1',
+      'Half life loss',
+      (amount) => Math.ceil(amount / 2),
+      (targetId) => targetId === 'player1'
+    );
+
+    replacementEffectManager.registerEffect(lossEffect);
+
+    const event: ReplacementEvent = {
+      type: 'life_loss',
+      amount: 7,
+      timestamp: Date.now(),
+      targetId: 'player1',
+    };
+
+    const processed = replacementEffectManager.processEvent(event);
+    expect(processed.amount).toBe(4); // ceil(7/2) = 4
+  });
+});
+
+describe('ReplacementEffectManager - APNAP Order Creation', () => {
+  beforeEach(() => {
+    replacementEffectManager.reset();
+  });
+
+  test('should create correct APNAP order', () => {
+    const allPlayers = ['player1', 'player2', 'player3', 'player4'];
+    
+    // Player2 is active
+    const order = replacementEffectManager.createAPNAPOrder('player2', allPlayers);
+    
+    expect(order.activePlayerId).toBe('player2');
+    expect(order.playerOrder).toEqual(['player2', 'player3', 'player4', 'player1']);
+  });
+
+  test('should handle single player', () => {
+    const order = replacementEffectManager.createAPNAPOrder('player1', ['player1']);
+    expect(order.playerOrder).toEqual(['player1']);
+  });
+
+  test('should handle unknown active player', () => {
+    const allPlayers = ['player1', 'player2'];
+    const order = replacementEffectManager.createAPNAPOrder('unknown', allPlayers);
+    expect(order.playerOrder).toEqual(allPlayers);
+  });
+});
+
+describe('ReplacementEffectManager - Factory Functions', () => {
+  beforeEach(() => {
+    replacementEffectManager.reset();
+  });
+
+  test('createPreventionShield should create both ability and shield', () => {
+    const { ability, shield } = createPreventionShield(
+      'source',
+      'player1',
+      'player2',
+      5,
+      'Prevent 5 damage',
+      'until_end_of_turn',
+      ['combat']
+    );
+
+    expect(ability.id).toMatch(/prevent-source-\d+/);
+    expect(ability.effectType).toBe('damage_prevention');
+    expect(ability.layer).toBe(1);
+    expect(ability.preventionAmount).toBe(5);
+
+    expect(shield.sourceId).toBe('source');
+    expect(shield.amount).toBe(5);
+    expect(shield.damageTypes).toEqual(['combat']);
+    expect(shield.controllerId).toBe('player1');
+    expect(shield.expiresAt).toBeDefined();
+  });
+
+  test('createDamageReplacementEffect should create correct effect', () => {
+    const effect = createDamageReplacementEffect(
+      'furnace',
+      'player1',
+      'Double damage',
+      (amount) => amount * 2,
+      5,
+      true
+    );
+
+    expect(effect.isSelfReplacement).toBe(true);
+    expect(effect.isInstead).toBe(true);
+    expect(effect.layer).toBe(5);
+
+    const event: ReplacementEvent = {
+      type: 'damage',
+      amount: 3,
+      timestamp: Date.now(),
+    };
+
+    const result = effect.apply(event);
+    expect(result.modified).toBe(true);
+    expect(result.modifiedEvent?.amount).toBe(6);
+    expect(result.instead).toBe(true);
+  });
+
+  test('createAsThoughEffect should create correct effect', () => {
+    const effect = createAsThoughEffect(
+      'source',
+      'player1',
+      'cast_flash',
+      'Flash effect',
+      undefined,
+      'permanent'
+    );
+
+    expect(effect.asThoughType).toBe('cast_flash');
+    expect(effect.duration).toBe('permanent');
+    expect(effect.condition).toBeUndefined();
   });
 });

--- a/src/lib/game-state/index.ts
+++ b/src/lib/game-state/index.ts
@@ -143,3 +143,4 @@ export * from "./spell-casting";
 export * from "./abilities"
 
 export * from "./evergreen-keywords"
+export * from './replacement-examples';

--- a/src/lib/game-state/replacement-examples.ts
+++ b/src/lib/game-state/replacement-examples.ts
@@ -1,0 +1,284 @@
+/**
+ * Example Card Implementations - Replacement and Prevention Effects
+ * 
+ * This file demonstrates how to implement cards with replacement and prevention effects
+ * using the ReplacementEffectManager system.
+ * 
+ * Examples include:
+ * - Furnace of Rath (damage doubling)
+ * - Fog (damage prevention)
+ * - Alhammarret's Archive (life gain doubling)
+ * - Veiled Sentry (cast as though flash)
+ * - Nefarox, Overlord of Grixis (draw replacement)
+ * - Regeneration effects
+ */
+
+import {
+  replacementEffectManager,
+  ReplacementAbility,
+  createPreventionShield,
+  createDamageReplacementEffect,
+  createLifeGainReplacementEffect,
+  createDrawReplacementEffect,
+  createDestroyReplacementEffect,
+  createAsThoughEffect,
+  AsThoughType,
+} from './replacement-effects';
+import { CardInstanceId, PlayerId, GameState } from './types';
+
+/**
+ * Furnace of Rath
+ * "If damage would be dealt to any permanent or player, it deals double that damage instead."
+ * CR 614.7 example
+ */
+export function registerFurnaceOfRath(sourceCardId: CardInstanceId, controllerId: PlayerId): void {
+  const effect = createDamageReplacementEffect(
+    sourceCardId,
+    controllerId,
+    'Furnace of Rath: Damage is doubled',
+    (amount) => amount * 2,
+    5, // Layer 5 - general replacement
+    false
+  );
+  replacementEffectManager.registerEffect(effect);
+}
+
+/**
+ * Fog
+ * "Prevent all combat damage that would be dealt this turn."
+ */
+export function registerFog(sourceCardId: CardInstanceId, controllerId: PlayerId): void {
+  const { ability, shield } = createPreventionShield(
+    sourceCardId,
+    controllerId,
+    '*', // All targets - would need special handling
+    999, // Prevent a very large amount
+    'Fog: Prevent all combat damage',
+    'until_end_of_turn',
+    ['combat'] // Only combat damage
+  );
+  
+  replacementEffectManager.registerEffect(ability);
+  // Note: For "all targets", you'd need to register shields for each potential target
+}
+
+/**
+ * Holy Day
+ * "Prevent all damage that would be dealt this turn."
+ */
+export function registerHolyDay(sourceCardId: CardInstanceId, controllerId: PlayerId): void {
+  const { ability, shield } = createPreventionShield(
+    sourceCardId,
+    controllerId,
+    '*',
+    999,
+    'Holy Day: Prevent all damage',
+    'until_end_of_turn'
+    // No damageTypes = all damage
+  );
+  
+  replacementEffectManager.registerEffect(ability);
+}
+
+/**
+ * Alhammarret's Archive
+ * "If you would gain life, you gain twice that much life instead."
+ */
+export function registerAlhammarretsArchive(sourceCardId: CardInstanceId, controllerId: PlayerId): void {
+  const effect = createLifeGainReplacementEffect(
+    sourceCardId,
+    controllerId,
+    "Alhammarret's Archive: Double life gain",
+    (amount) => amount * 2,
+    (targetId) => targetId === controllerId // Only applies to controller
+  );
+  replacementEffectManager.registerEffect(effect);
+}
+
+/**
+ * Nefarox, Overlord of Grixis
+ * "If you would draw a card, draw two cards instead."
+ * (Simplified version for demonstration)
+ */
+export function registerNefarox(sourceCardId: CardInstanceId, controllerId: PlayerId): void {
+  const effect = createDrawReplacementEffect(
+    sourceCardId,
+    controllerId,
+    'Nefarox: Draw two cards instead of one',
+    (amount) => amount + 1 // Draw one additional card
+  );
+  replacementEffectManager.registerEffect(effect);
+}
+
+/**
+ * Veiled Sentry
+ * "You may cast spells as though they had flash."
+ */
+export function registerVeiledSentry(sourceCardId: CardInstanceId, controllerId: PlayerId): void {
+  const effect = createAsThoughEffect(
+    sourceCardId,
+    controllerId,
+    'cast_flash',
+    'Veiled Sentry: Cast spells as though they had flash',
+    undefined,
+    'permanent'
+  );
+  replacementEffectManager.registerAsThoughEffect(effect);
+}
+
+/**
+ * Leonin Abunas
+ * "Artifacts you control can't be the target of spells or abilities your opponents control."
+ * This is implemented as an "as though" effect that changes targeting rules
+ */
+export function registerLeoninAbunas(sourceCardId: CardInstanceId, controllerId: PlayerId): void {
+  const effect = createAsThoughEffect(
+    sourceCardId,
+    controllerId,
+    'target_anything',
+    'Leonin Abunas: Artifacts can\'t be targeted by opponents',
+    (state, playerId) => {
+      // This would check if the target is an artifact controlled by the effect's controller
+      // and if the source is controlled by an opponent
+      return true; // Simplified
+    },
+    'permanent'
+  );
+  replacementEffectManager.registerAsThoughEffect(effect);
+}
+
+/**
+ * Regeneration Effect
+ * "The next time this creature would be destroyed this turn, it isn't. Instead, tap it,
+ * remove all damage from it, and remove it from combat."
+ */
+export function registerRegenerationShield(
+  sourceCardId: CardInstanceId,
+  controllerId: PlayerId,
+  targetCreatureId: CardInstanceId
+): void {
+  const effect = createDestroyReplacementEffect(
+    sourceCardId,
+    controllerId,
+    `Regeneration shield for creature`,
+    (event) => ({
+      ...event,
+      type: 'tap', // Instead of destroy, tap the creature
+      amount: 0,
+      context: { ...event.context, regenerated: true },
+    }),
+    (targetId) => targetId === targetCreatureId
+  );
+  replacementEffectManager.registerEffect(effect);
+}
+
+/**
+ * Pariah
+ * "All damage that would be dealt to you is dealt to this creature instead."
+ */
+export function registerPariah(
+  sourceCardId: CardInstanceId,
+  controllerId: PlayerId,
+  creatureId: CardInstanceId
+): void {
+  const effect: ReplacementAbility = {
+    id: `pariah-${sourceCardId}-${Date.now()}`,
+    sourceCardId,
+    controllerId,
+    effectType: 'damage_replacement',
+    description: 'Pariah: Redirect damage to this creature',
+    layer: 4,
+    timestamp: Date.now(),
+    isInstead: true,
+    canApply: (event) => event.type === 'damage' && event.targetId === controllerId,
+    apply: (event) => ({
+      modified: true,
+      modifiedEvent: {
+        ...event,
+        targetId: creatureId, // Redirect to the creature
+      },
+      description: 'Damage redirected to Pariah creature',
+      instead: true,
+    }),
+  };
+  replacementEffectManager.registerEffect(effect);
+}
+
+/**
+ * Shiny Impetus (example of "as though" for attacking)
+ * "Target creature can attack as though it had haste."
+ */
+export function registerShinyImpetus(
+  sourceCardId: CardInstanceId,
+  controllerId: PlayerId,
+  targetCreatureId: CardInstanceId
+): void {
+  const effect = createAsThoughEffect(
+    sourceCardId,
+    controllerId,
+    'attack_haste',
+    'Shiny Impetus: Creature can attack as though it had haste',
+    (state, playerId) => {
+      // Would check if the creature is the target
+      return true;
+    },
+    'until_end_of_turn'
+  );
+  replacementEffectManager.registerAsThoughEffect(effect);
+}
+
+/**
+ * Circle of Protection: Black
+ * "You may pay 1. If you do, prevent all damage from black sources this turn."
+ */
+export function registerCircleOfProtectionBlack(
+  sourceCardId: CardInstanceId,
+  controllerId: PlayerId,
+  paidMana: boolean
+): void {
+  if (!paidMana) return;
+  
+  const { ability, shield } = createPreventionShield(
+    sourceCardId,
+    controllerId,
+    controllerId,
+    999,
+    'Circle of Protection: Black',
+    'until_end_of_turn'
+    // Would need additional filtering for black sources
+  );
+  
+  replacementEffectManager.registerEffect(ability);
+  replacementEffectManager.addPreventionShield(controllerId, shield);
+}
+
+/**
+ * Effect Removal - called when a permanent leaves the battlefield
+ */
+export function unregisterEffects(sourceCardId: CardInstanceId): void {
+  replacementEffectManager.removeEffectsFromSource(sourceCardId);
+}
+
+/**
+ * Check if a player can cast spells as though they had flash
+ * Helper function for the game engine
+ */
+export function canCastAsThoughFlash(playerId: PlayerId, gameState: GameState): boolean {
+  return replacementEffectManager.checkAsThoughEffect(playerId, 'cast_flash', gameState);
+}
+
+/**
+ * Check if a creature can attack as though it had haste
+ * Helper function for the game engine
+ */
+export function canAttackAsThoughHaste(playerId: PlayerId, gameState: GameState): boolean {
+  return replacementEffectManager.checkAsThoughEffect(playerId, 'attack_haste', gameState);
+}
+
+/**
+ * Check if a creature can block flying creatures
+ * Helper function for the game engine
+ */
+export function canBlockFlyingAsThoughReach(playerId: PlayerId, gameState: GameState): boolean {
+  return replacementEffectManager.checkAsThoughEffect(playerId, 'block_flying', gameState);
+}


### PR DESCRIPTION
## Summary
Implements the replacement effects and prevention effects system for the MTG rules engine (Phase 1.3).

## Changes
- **ReplacementEffectManager**: Main class for managing all replacement/prevention effects
- **APNAP Ordering**: Active Player, Non-Active Player priority system for multiple effects (CR 616)
- **Prevention Shields**: Track remaining prevention for damage prevention effects
- **'As Though' Effects**: Framework for effects that allow actions as though conditions were met (CR 609)
- **Factory Functions**: Easy creation of common effect types
- **Test Suite**: 19 comprehensive tests covering all scenarios

## Acceptance Criteria
- [x] Replacement effects correctly modify events
- [x] Prevention effects reduce damage/life loss as specified
- [x] Multiple effects can apply to same event with correct ordering
- [x] Integration with existing triggered abilities system

## Related
- Closes #266
- Part of Phase 1.3: Card Rules Engine