### PR TITLE
Integrate damage indicators and floating combat text into game board

### DIFF
--- a/src/components/game-board.tsx
+++ b/src/components/game-board.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/dialog";
 import { PlayerState, PlayerCount, ZoneType, TeamState, TeamId } from "@/types/game";
 import { HandDisplay } from "@/components/hand-display";
+import { DamageOverlay, useDamageEvents, DamageEvent, DamageType } from "@/components/damage-indicator";
 import {
   Skull,
   Archive,
@@ -77,6 +78,9 @@ interface GameBoardProps {
     sharedBlockers: boolean;
     teamChat: boolean;
   };
+  // Damage indicator props
+  damageEvents?: DamageEvent[];
+  onDamageEventComplete?: (id: string) => void;
 }
 
 interface PlayerAreaProps {
@@ -514,11 +518,18 @@ export function GameBoard({
   hasActiveDrawOffer = false,
   hasPlayerOfferedDraw = false,
   isGameOver = false,
+  damageEvents = [],
+  onDamageEventComplete,
 }: GameBoardProps) {
   const currentPlayer = players[currentTurnIndex];
   
   // Dialog states
   const [showConcedeDialog, setShowConcedeDialog] = React.useState(false);
+
+  // Internal damage events state if not provided externally
+  const internalDamageEvents = useDamageEvents({ maxEvents: 15 });
+  const activeDamageEvents = damageEvents.length > 0 ? damageEvents : internalDamageEvents.events;
+  const handleDamageEventComplete = onDamageEventComplete || internalDamageEvents.clearEvents;
 
   // Layout strategy based on player count
   const renderLayout = () => {
@@ -759,6 +770,12 @@ export function GameBoard({
       )}
 
       {renderLayout()}
+
+      {/* Damage Indicators Overlay */}
+      <DamageOverlay 
+        events={activeDamageEvents} 
+        onEventComplete={handleDamageEventComplete} 
+      />
 
       {/* Concede Confirmation Dialog */}
       <Dialog open={showConcedeDialog} onOpenChange={setShowConcedeDialog}>


### PR DESCRIPTION
## Summary
Integrates the existing damage indicator component into the game board for visual feedback during gameplay.

## Changes
- Import DamageOverlay and useDamageEvents from damage-indicator component
- Add damageEvents and onDamageEventComplete props to GameBoardProps
- Add internal damage events state management with useDamageEvents hook
- Render DamageOverlay in the game board for visual damage feedback
- Support both external and internal damage event management

## Features
The damage indicator system provides:
- Floating damage numbers when creatures take damage
- Visual combat text for key game events
- Color-coded indicators (red for damage, green for heal, purple for poison, etc.)
- Animated floating text with fade-out effect
- Support for external event management or internal state

## Related Issue
Closes #303