### PR TITLE
Tech Debt: Replace 'any' types with proper TypeScript types

### DIFF
--- a/src/app/(app)/multiplayer/browse/page.tsx
+++ b/src/app/(app)/multiplayer/browse/page.tsx
@@ -171,7 +171,7 @@ export default function BrowseGamesPage() {
             {/* Format Filter */}
             <div className="space-y-2">
               <label className="text-sm font-medium">Format</label>
-              <Select value={formatFilter} onValueChange={(value: any) => setFormatFilter(value)}>
+              <Select value={formatFilter} onValueChange={(value: GameFormat | 'all') => setFormatFilter(value)}>
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
@@ -194,7 +194,7 @@ export default function BrowseGamesPage() {
                 <Users className="w-4 h-4" />
                 Players
               </label>
-              <Select value={playerCountFilter} onValueChange={(value: any) => setPlayerCountFilter(value)}>
+              <Select value={playerCountFilter} onValueChange={(value: PlayerCount | 'all') => setPlayerCountFilter(value)}>
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>


### PR DESCRIPTION
## Summary
Fixes #332

This PR addresses ESLint warnings related to the use of 'any' types.

## Changes Made
- \`src/app/(app)/multiplayer/browse/page.tsx\`:
  - Replaced \`any\` type with \`GameFormat | 'all'\` for format filter Select
  - Replaced \`any\` type with \`PlayerCount | 'all'\` for player count filter Select

## Results
- Reduced 'any' type warnings by 2
- Improved type safety for filter handlers
- No breaking changes

## Testing
- Ran \`npm run lint\` to verify warning reduction
- No TypeScript errors introduced