### PR TITLE
Tech Debt: Replace 'any' types with proper TypeScript types

### DIFF
--- a/src/app/(app)/replay/page.tsx
+++ b/src/app/(app)/replay/page.tsx
@@ -1,9 +1,17 @@
 'use client';
 
-import { useEffect, useState, use } from 'react';
+import { useEffect, useState } from 'react';
 import { getReplayFromCurrentURL } from '@/lib/replay-sharing';
-import { replaySystem, type Replay } from '@/lib/game-state/replay';
+import { type Replay } from '@/lib/game-state/replay';
 import Link from 'next/link';
+
+// Type for player state in replay
+interface ReplayPlayerState {
+  id: string;
+  name: string;
+  life: number;
+  hand?: unknown[];
+}
 
 /**
  * Replay Viewer Page
@@ -166,7 +174,7 @@ export default function ReplayPage() {
           {/* Game state summary */}
           {currentAction?.resultingState && (
             <div className="grid grid-cols-2 gap-4 text-sm mb-4">
-              {Array.from(currentAction.resultingState.players?.values() || []).map((player: any) => (
+              {Array.from(currentAction.resultingState.players?.values() || []).map((player: ReplayPlayerState) => (
                 <div key={player.id} className="bg-slate-700 p-3 rounded">
                   <div className="font-bold">{player.name}</div>
                   <div className="text-slate-400">


### PR DESCRIPTION
## Description

This PR addresses part of issue #336 by fixing TypeScript \`any\` type warnings.

## Changes Made

- Remove unused imports from \`replay/page.tsx\` (\`use\`, \`replaySystem\`)
- Add \`ReplayPlayerState\` interface for player state typing
- Replace \`any\` type with \`ReplayPlayerState\` in player mapping

## Results

- Fixed 3 warnings in \`replay/page.tsx\`
- All changes are non-breaking
- No functional changes to the codebase

## Remaining Work

There are still many \`any\` type warnings remaining in:
- \`src/app/(app)/trade/page.tsx\`
- \`src/components/card-art.tsx\`
- \`src/components/game-board.tsx\`
- \`src/components/replay-viewer.tsx\`
- \`src/components/trade-dialog.tsx\`
- \`src/lib/game-state/\` (multiple files)

Additional PRs can continue to address these.

## Testing

- [x] Lint passes with reduced warnings
- [x] No TypeScript errors
- [x] No functional changes to test

Relates to #336