### PR TITLE
Tech Debt: Fix ESLint warnings in components (partial)

### DIFF
--- a/src/components/collection-tracker.tsx
+++ b/src/components/collection-tracker.tsx
@@ -2,13 +2,11 @@
 
 import * as React from 'react';
 import { useCollection, CollectionCard } from '@/hooks/use-collection';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Separator } from '@/components/ui/separator';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Dialog,
   DialogContent,
@@ -32,14 +30,10 @@ import {
   Search,
   Download,
   Upload,
-  Trash2,
-  Edit,
-  MoreVertical,
   Package,
   TrendingUp,
   AlertCircle,
   CheckCircle,
-  BarChart3,
   FolderOpen,
   ArrowUpDown,
 } from 'lucide-react';
@@ -58,13 +52,9 @@ export function CollectionTracker({ className }: CollectionTrackerProps) {
     addCard,
     removeCard,
     createCollection,
-    deleteCollection,
-    renameCollection,
     importFromCSV,
     exportToCSV,
     getCollectionStats,
-    compareDeckWithCollection,
-    generateTradeList,
   } = useCollection();
 
   const [searchQuery, setSearchQuery] = React.useState('');


### PR DESCRIPTION
## Description

This PR partially addresses ESLint warnings in React components as tracked in #340.

## Changes Made

- **collection-tracker.tsx**: 
  - Removed unused imports (CardFooter, Separator, Tabs components)
  - Removed unused icon imports (Trash2, Edit, MoreVertical, BarChart3)
  - Removed unused functions from useCollection hook

## Note

This is a partial fix. Additional component files still have ESLint warnings that can be addressed in follow-up PRs:
- ability-menu.tsx
- card-art.tsx
- combat-animations.tsx
- combat-declaration.tsx
- conflict-resolution-dialog.tsx
- damage-indicator.tsx
- deck-statistics.tsx
- game-board.tsx
- game-chat.tsx
- hand-display.tsx
- judge-tools.tsx
- qr-code-display.tsx
- replay-viewer.tsx
- round-timer.tsx
- spectator-view.tsx
- spell-effects.tsx
- stack-display.tsx
- subscription-plan-display.tsx
- swiss-pairing.tsx
- sync-status-indicator.tsx
- targeting-overlay.tsx
- tournament-bracket.tsx
- trade-dialog.tsx
- trigger-dialog.tsx

## Related

Partially addresses #340