### PR TITLE
Tech Debt: Fix ESLint warnings in lib files (partial)

### DIFF
--- a/src/lib/action-broadcast.ts
+++ b/src/lib/action-broadcast.ts
@@ -14,7 +14,6 @@
 
 import { z } from 'zod';
 import type { 
-  DeterministicAction, 
   SequenceNumber, 
   PeerId,
   GameSyncMessage,

--- a/src/lib/desync-logger.ts
+++ b/src/lib/desync-logger.ts
@@ -6,7 +6,6 @@
 import type { 
   HashDiscrepancy, 
   ConflictResolution, 
-  DeterministicAction,
   PeerId,
   SequenceNumber,
 } from './game-state/deterministic-sync';


### PR DESCRIPTION
## Description

This PR partially addresses ESLint warnings in lib files as tracked in #341.

## Changes Made

- **action-broadcast.ts**: Removed unused `DeterministicAction` import
- **desync-logger.ts**: Removed unused `DeterministicAction` import

## Note

This is a partial fix. Additional lib files still have ESLint warnings that can be addressed in follow-up PRs. The remaining warnings are primarily in:
- Test files (__tests__/*.test.ts)
- Game state files (game-state/*.ts)
- Firebase files (firebase/*.ts)

## Related

Partially addresses #341

## Summary by Sourcery

Enhancements:
- Remove unused DeterministicAction imports from lib action broadcasting and desync logging modules to reduce ESLint warnings.