### PR TITLE
Tech Debt: Fix remaining ESLint 'any' type warnings

### DIFF
--- a/src/hooks/use-lobby.ts
+++ b/src/hooks/use-lobby.ts
@@ -6,11 +6,12 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import { GameLobby, Player, HostGameConfig, LobbyStatus, PlayerStatus, TeamId, Team, TeamSettings } from '@/lib/multiplayer-types';
+import { GameLobby, Player, HostGameConfig, PlayerStatus, TeamId, Team, TeamSettings } from '@/lib/multiplayer-types';
 import { lobbyManager } from '@/lib/lobby-manager';
 import { formatGameCode } from '@/lib/game-code-generator';
 import { validateDeckForLobby } from '@/lib/format-validator';
 import { getGameModeConfig } from '@/lib/game-mode';
+import type { SavedDeck } from '@/app/actions';
 
 export interface UseLobbyReturn {
   lobby: GameLobby | null;
@@ -21,14 +22,14 @@ export interface UseLobbyReturn {
   addPlayer: (playerName: string) => Player | null;
   removePlayer: (playerId: string) => boolean;
   updatePlayerStatus: (playerId: string, status: PlayerStatus) => boolean;
-  updatePlayerDeck: (playerId: string, deckId: string, deckName: string, deck?: any) => { success: boolean; isValid: boolean; errors: string[] };
+  updatePlayerDeck: (playerId: string, deckId: string, deckName: string, deck?: SavedDeck) => { success: boolean; isValid: boolean; errors: string[] };
   canStartGame: boolean;
   canForceStart: boolean;
   startGame: () => boolean;
   forceStartGame: () => boolean;
   closeLobby: () => void;
   getGameCode: () => string;
-  validateDeckForFormat: (deck: any) => { isValid: boolean; errors: string[] };
+  validateDeckForFormat: (deck: SavedDeck) => { isValid: boolean; errors: string[] };
   // Team management
   isTeamMode: boolean;
   assignPlayerToTeam: (playerId: string, teamId: TeamId) => boolean;
@@ -96,7 +97,7 @@ export function useLobby(): UseLobbyReturn {
     return success;
   }, []);
 
-  const updatePlayerDeck = useCallback((playerId: string, deckId: string, deckName: string, deck?: any) => {
+  const updatePlayerDeck = useCallback((playerId: string, deckId: string, deckName: string, deck?: SavedDeck) => {
     const result = lobbyManager.updatePlayerDeck(playerId, deckId, deckName, deck);
     if (result.success) {
       setLobby(lobbyManager.getCurrentLobby());
@@ -142,7 +143,7 @@ export function useLobby(): UseLobbyReturn {
     return lobby ? formatGameCode(lobby.gameCode) : '';
   }, [lobby]);
 
-  const validateDeckForFormat = useCallback((deck: any) => {
+  const validateDeckForFormat = useCallback((deck: SavedDeck) => {
     if (!lobby) return { isValid: false, errors: ['No lobby found'] };
 
     const validation = validateDeckForLobby(deck, lobby.format);

--- a/src/lib/game-state/__tests__/mana.test.ts
+++ b/src/lib/game-state/__tests__/mana.test.ts
@@ -34,7 +34,7 @@ import {
 import { createCardInstance } from '../card-instance';
 import { Phase } from '../types';
 import type { ScryfallCard } from '@/app/actions';
-import type { ManaPool } from '../types';
+import type { ManaPool, StackObject } from '../types';
 
 // Helper function to create a mock land card
 function createMockLand(name: string): ScryfallCard {
@@ -339,7 +339,20 @@ describe('Land Playing', () => {
       
       state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
       state.priorityPlayerId = playerId;
-      state.stack = [{ id: 'test-spell', type: 'spell' }] as any;
+      state.stack = [{ 
+        id: 'test-spell', 
+        type: 'spell',
+        sourceCardId: null,
+        controllerId: playerId,
+        name: 'Test Spell',
+        text: '',
+        manaCost: null,
+        targets: [],
+        chosenModes: [],
+        variableValues: new Map(),
+        isCountered: false,
+        timestamp: Date.now(),
+      }] as StackObject[];
       
       expect(canPlayLand(state, playerId)).toBe(false);
     });

--- a/src/lib/game-state/__tests__/replacement-effects.test.ts
+++ b/src/lib/game-state/__tests__/replacement-effects.test.ts
@@ -15,8 +15,8 @@ import {
   createDrawReplacementEffect,
   createDestroyReplacementEffect,
   createAsThoughEffect,
-  AsThoughType,
 } from '../replacement-effects';
+import type { GameState } from '../types';
 
 describe('ReplacementEffectManager - APNAP Ordering', () => {
   beforeEach(() => {
@@ -205,7 +205,7 @@ describe('ReplacementEffectManager - As Though Effects', () => {
   });
 
   test('should register and check as though effects', () => {
-    const mockGameState = { players: new Map() };
+    const mockGameState = { players: new Map() } as GameState;
     
     const flashEffect = createAsThoughEffect(
       'veiled-source',
@@ -216,13 +216,13 @@ describe('ReplacementEffectManager - As Though Effects', () => {
 
     replacementEffectManager.registerAsThoughEffect(flashEffect);
 
-    expect(replacementEffectManager.checkAsThoughEffect('player1', 'cast_flash', mockGameState as any)).toBe(true);
-    expect(replacementEffectManager.checkAsThoughEffect('player2', 'cast_flash', mockGameState as any)).toBe(false);
-    expect(replacementEffectManager.checkAsThoughEffect('player1', 'attack_haste', mockGameState as any)).toBe(false);
+    expect(replacementEffectManager.checkAsThoughEffect('player1', 'cast_flash', mockGameState)).toBe(true);
+    expect(replacementEffectManager.checkAsThoughEffect('player2', 'cast_flash', mockGameState)).toBe(false);
+    expect(replacementEffectManager.checkAsThoughEffect('player1', 'attack_haste', mockGameState)).toBe(false);
   });
 
   test('should handle conditional as though effects', () => {
-    const mockGameState = { players: new Map() };
+    const mockGameState = { players: new Map() } as GameState;
     
     // Effect that only applies when player has 10+ life
     const conditionalEffect = createAsThoughEffect(
@@ -230,7 +230,7 @@ describe('ReplacementEffectManager - As Though Effects', () => {
       'player1',
       'attack_haste',
       'Creatures can attack as though they had haste if you have 10+ life',
-      (state, playerId) => {
+      (_state, _playerId) => {
         // Simplified condition check
         return true;
       }
@@ -238,11 +238,11 @@ describe('ReplacementEffectManager - As Though Effects', () => {
 
     replacementEffectManager.registerAsThoughEffect(conditionalEffect);
 
-    expect(replacementEffectManager.checkAsThoughEffect('player1', 'attack_haste', mockGameState as any)).toBe(true);
+    expect(replacementEffectManager.checkAsThoughEffect('player1', 'attack_haste', mockGameState)).toBe(true);
   });
 
   test('should get all as though effects for a player', () => {
-    const mockGameState = { players: new Map() };
+    const mockGameState = { players: new Map() } as GameState;
     
     replacementEffectManager.registerAsThoughEffect(
       createAsThoughEffect('source1', 'player1', 'cast_flash', 'Flash effect')
@@ -254,28 +254,28 @@ describe('ReplacementEffectManager - As Though Effects', () => {
       createAsThoughEffect('source3', 'player2', 'block_flying', 'Flying block effect')
     );
 
-    const p1Effects = replacementEffectManager.getAsThoughEffects('player1', mockGameState as any);
+    const p1Effects = replacementEffectManager.getAsThoughEffects('player1', mockGameState);
     expect(p1Effects).toHaveLength(2);
     expect(p1Effects.map(e => e.asThoughType)).toContain('cast_flash');
     expect(p1Effects.map(e => e.asThoughType)).toContain('attack_haste');
 
-    const p2Effects = replacementEffectManager.getAsThoughEffects('player2', mockGameState as any);
+    const p2Effects = replacementEffectManager.getAsThoughEffects('player2', mockGameState);
     expect(p2Effects).toHaveLength(1);
     expect(p2Effects[0].asThoughType).toBe('block_flying');
   });
 
   test('should remove as though effects when source leaves battlefield', () => {
-    const mockGameState = { players: new Map() };
+    const mockGameState = { players: new Map() } as GameState;
     
     replacementEffectManager.registerAsThoughEffect(
       createAsThoughEffect('temporary-source', 'player1', 'cast_flash', 'Temporary flash')
     );
 
-    expect(replacementEffectManager.checkAsThoughEffect('player1', 'cast_flash', mockGameState as any)).toBe(true);
+    expect(replacementEffectManager.checkAsThoughEffect('player1', 'cast_flash', mockGameState)).toBe(true);
 
     replacementEffectManager.removeEffectsFromSource('temporary-source');
 
-    expect(replacementEffectManager.checkAsThoughEffect('player1', 'cast_flash', mockGameState as any)).toBe(false);
+    expect(replacementEffectManager.checkAsThoughEffect('player1', 'cast_flash', mockGameState)).toBe(false);
   });
 });
 

--- a/src/lib/game-state/__tests__/spell-casting.test.ts
+++ b/src/lib/game-state/__tests__/spell-casting.test.ts
@@ -25,7 +25,7 @@ import {
   createInitialGameState,
   startGame,
 } from '../game-state';
-import { createCardInstance, addCounters } from '../card-instance';
+import { createCardInstance } from '../card-instance';
 import { Phase } from '../types';
 import { addMana } from '../mana';
 import type { ScryfallCard } from '@/app/actions';
@@ -170,7 +170,20 @@ describe('Spell Casting - Timing Restrictions', () => {
       state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
       state.turn.activePlayerId = aliceId;
       state.priorityPlayerId = aliceId;
-      state.stack = [{ id: 'other-spell', type: 'spell' }] as any;
+      state.stack = [{ 
+        id: 'other-spell', 
+        type: 'spell',
+        sourceCardId: null,
+        controllerId: aliceId,
+        name: 'Other Spell',
+        text: '',
+        manaCost: null,
+        targets: [],
+        chosenModes: [],
+        variableValues: new Map(),
+        isCountered: false,
+        timestamp: Date.now(),
+      }] as StackObject[];
 
       const result = canCastSpell(state, aliceId, cardId);
       expect(result.canCast).toBe(false);
@@ -196,7 +209,20 @@ describe('Spell Casting - Timing Restrictions', () => {
       state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
       state.turn.activePlayerId = aliceId;
       state.priorityPlayerId = aliceId;
-      state.stack = [{ id: 'other-spell', type: 'spell' }] as any;
+      state.stack = [{ 
+        id: 'other-spell', 
+        type: 'spell',
+        sourceCardId: null,
+        controllerId: aliceId,
+        name: 'Other Spell',
+        text: '',
+        manaCost: null,
+        targets: [],
+        chosenModes: [],
+        variableValues: new Map(),
+        isCountered: false,
+        timestamp: Date.now(),
+      }] as StackObject[];
 
       const result = canCastSpell(state, aliceId, cardId);
       expect(result.canCast).toBe(true);


### PR DESCRIPTION
## Description

This PR fixes the remaining ESLint \`@typescript-eslint/no-explicit-any\` warnings in the codebase.

## Changes

- **use-lobby.ts**: Replace \`any\` types with \`SavedDeck\` type for deck-related functions
- **mana.test.ts**: Replace \`any\` type with proper \`StackObject\` type for stack items
- **replacement-effects.test.ts**: Replace \`any\` types with \`GameState\` type for mock game state
- **spell-casting.test.ts**: Replace \`any\` types with \`StackObject\` type for stack items

## Types of Warnings Fixed

All warnings were \`@typescript-eslint/no-explicit-any\` - Use of the \`any\` type instead of a specific type.

## How Fixed

- For object types, used specific interfaces (\`SavedDeck\`, \`GameState\`, \`StackObject\`)
- For function parameters, defined the expected parameter type
- For unused parameters in callbacks, prefixed with underscore (\`_\`) to match ESLint rules

## Related

Fixes #349
Follow-up to #342 (partial fix in PR #346)