### PR TITLE
Tech Debt: Fix ESLint unused variable warnings in lib files

### DIFF
--- a/src/lib/__tests__/auto-save.test.ts
+++ b/src/lib/__tests__/auto-save.test.ts
@@ -11,7 +11,6 @@ import {
   isTriggerEnabled,
   toggleTrigger,
   DEFAULT_AUTO_SAVE_CONFIG,
-  type AutoSaveTrigger,
 } from '../auto-save-config';
 
 // Mock localStorage

--- a/src/lib/__tests__/game-rules.test.ts
+++ b/src/lib/__tests__/game-rules.test.ts
@@ -5,7 +5,6 @@
 
 import {
   formatRules,
-  formatRuleDescriptions,
   validateDeckFormat,
   validateSideboard,
   isDeckLegal,
@@ -20,7 +19,6 @@ import {
   banLists,
   vintageRestrictedList,
   type Format,
-  type FormatValidationResult,
 } from "../game-rules";
 
 describe("Game Rules - Format Rules", () => {

--- a/src/lib/action-broadcast.ts
+++ b/src/lib/action-broadcast.ts
@@ -14,7 +14,6 @@
 
 import { z } from 'zod';
 import type { 
-  SequenceNumber, 
   PeerId,
   GameSyncMessage,
   SyncMessageType,

--- a/src/lib/card-image-resolver.ts
+++ b/src/lib/card-image-resolver.ts
@@ -59,7 +59,7 @@ export function isCustomImagesEnabled(): boolean {
 export function resolveCardImage(
   card: ScryfallCard, 
   imageDir?: string | null,
-  size: 'small' | 'normal' | 'large' = 'normal'
+  _size: 'small' | 'normal' | 'large' = 'normal'
 ): string | null {
   // Use provided directory or get from storage
   const dir = imageDir ?? getImageDirectory();

--- a/src/lib/deck-analyzer.ts
+++ b/src/lib/deck-analyzer.ts
@@ -71,14 +71,6 @@ export interface DeckSuggestion {
 }
 
 // Card classification helpers
-const COLOR_KEYWORDS: Record<string, string[]> = {
-  'White': ['white', 'W', 'lifelink', 'lifetime', 'exalted'],
-  'Blue': ['blue', 'U', 'flying', 'countermagic', 'draw'],
-  'Black': ['black', 'B', 'deathtouch', 'drain', 'sacrifice'],
-  'Red': ['red', 'R', 'haste', 'burn', 'damage'],
-  'Green': ['green', 'G', 'trample', 'reach', 'growth'],
-};
-
 const RAMP_KEYWORDS = ['ramp', 'mana', 'rock', 'dork', 'cultivate', 'kodama', 'farseek', 'farseek', 'sol ring', 'arcane signet', 'darksteel ingot'];
 const REMOVAL_KEYWORDS = ['destroy', 'exile', 'damage', 'fight', 'kill', 'remove', 'counter', 'destroy target', 'exile target'];
 const CREATURE_KEYWORDS = ['creature', 'token'];

--- a/src/lib/desync-logger.ts
+++ b/src/lib/desync-logger.ts
@@ -9,7 +9,6 @@ import type {
   PeerId,
   SequenceNumber,
 } from './game-state/deterministic-sync';
-import type { GameState } from './game-state/types';
 
 /**
  * Desync event record

--- a/src/lib/format-validator.ts
+++ b/src/lib/format-validator.ts
@@ -10,7 +10,6 @@ import {
   getFormatRulesDescription,
   getFormatDisplayName,
   type Format,
-  type FormatValidationResult,
   type ValidationResult,
 } from './game-rules';
 import type { SavedDeck } from '@/app/actions';


### PR DESCRIPTION
## Description

This PR fixes ESLint \`@typescript-eslint/no-unused-vars\` warnings in the lib directory files.

## Changes

- **auto-save.test.ts**: Remove unused \`AutoSaveTrigger\` type import
- **game-rules.test.ts**: Remove unused \`formatRuleDescriptions\` and \`FormatValidationResult\` imports
- **action-broadcast.ts**: Remove unused \`SequenceNumber\` type import
- **card-image-resolver.ts**: Prefix unused \`size\` parameter with underscore
- **deck-analyzer.ts**: Remove unused \`COLOR_KEYWORDS\` constant
- **desync-logger.ts**: Remove unused \`GameState\` type import
- **format-validator.ts**: Remove unused \`FormatValidationResult\` type import

## Impact

Reduces ESLint warnings from 320 to 312 (8 warnings fixed).

## Related

Fixes #348
Part of ongoing ESLint warning cleanup (#342)