### PR TITLE
Tech Debt: Fix ESLint unused variable warnings in components

### DIFF
--- a/src/components/card-art.tsx
+++ b/src/components/card-art.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo, memo, useRef } from 'react';
 import { cn } from '@/lib/utils';
-import { resolveCardImageWithFallback, getCardBackImage, getImageDirectory } from '@/lib/card-image-resolver';
+import { resolveCardImageWithFallback, getCardBackImage } from '@/lib/card-image-resolver';
 
 /**
  * Card Art Display Component

--- a/src/components/combat-animations.tsx
+++ b/src/components/combat-animations.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { cn } from '@/lib/utils';
 
 /**

--- a/src/components/combat-declaration.tsx
+++ b/src/components/combat-declaration.tsx
@@ -20,8 +20,6 @@ import {
   Shield,
   AlertTriangle,
   Check,
-  X,
-  Info,
   ArrowRight,
   GripVertical,
   RotateCcw,


### PR DESCRIPTION
## Description

This PR fixes ESLint \`@typescript-eslint/no-unused-vars\` warnings in component files.

## Changes

- **card-art.tsx**: Remove unused \`getImageDirectory\` import
- **combat-animations.tsx**: Remove unused \`useMemo\` import
- **combat-declaration.tsx**: Remove unused \`X\` and \`Info\` icon imports

## Related

Fixes #347
Part of ongoing ESLint warning cleanup (#340)