### PR TITLE
fix: Replace 'any' types with proper TypeScript types

### DIFF
--- a/src/ai/flows/ai-gameplay-assistance.ts
+++ b/src/ai/flows/ai-gameplay-assistance.ts
@@ -17,7 +17,7 @@ import { z } from 'genkit';
 
 // Input schema for game state analysis
 const GameStateAnalysisInputSchema = z.object({
-  gameState: z.record(z.any()).describe("Current game state including hand, board, mana, etc."),
+  gameState: z.record(z.unknown()).describe("Current game state including hand, board, mana, etc."),
   playerName: z.string().describe("The player to provide assistance for"),
 });
 
@@ -51,7 +51,7 @@ const GameStateAnalysisOutputSchema = z.object({
 
 // Input schema for specific play analysis
 const PlayAnalysisInputSchema = z.object({
-  gameState: z.record(z.any()).describe("Current game state"),
+  gameState: z.record(z.unknown()).describe("Current game state"),
   playerName: z.string().describe("The player"),
   cardName: z.string().describe("Card being considered"),
   target: z.string().optional().describe("Intended target (if any)"),
@@ -72,7 +72,7 @@ const PlayAnalysisOutputSchema = z.object({
 
 // Input schema for mana advice
 const ManaAdviceInputSchema = z.object({
-  gameState: z.record(z.any()).describe("Current game state"),
+  gameState: z.record(z.unknown()).describe("Current game state"),
   playerName: z.string().describe("The player"),
 });
 
@@ -96,7 +96,7 @@ const ManaAdviceOutputSchema = z.object({
 
 // Input schema for board evaluation
 const BoardEvaluationInputSchema = z.object({
-  gameState: z.record(z.any()).describe("Current game state"),
+  gameState: z.record(z.unknown()).describe("Current game state"),
   playerName: z.string().describe("The player to evaluate for"),
 });
 

--- a/src/ai/flows/ai-post-game-analysis.ts
+++ b/src/ai/flows/ai-post-game-analysis.ts
@@ -19,7 +19,7 @@ import { z } from 'genkit';
 
 // Input schema for game analysis
 const GameAnalysisInputSchema = z.object({
-  replay: z.record(z.any()).describe("The game replay data with actions and outcomes"),
+  replay: z.record(z.unknown()).describe("The game replay data with actions and outcomes"),
   playerName: z.string().describe("The player to analyze (get advice for)"),
 });
 
@@ -50,7 +50,7 @@ const GameAnalysisOutputSchema = z.object({
 
 // Input schema for key moments identification
 const KeyMomentsInputSchema = z.object({
-  replay: z.record(z.any()).describe("The game replay data"),
+  replay: z.record(z.unknown()).describe("The game replay data"),
   playerName: z.string().describe("The player to focus on"),
 });
 
@@ -68,7 +68,7 @@ const KeyMomentsOutputSchema = z.object({
 
 // Input schema for quick tips
 const QuickTipsInputSchema = z.object({
-  replay: z.record(z.any()).describe("The game replay data"),
+  replay: z.record(z.unknown()).describe("The game replay data"),
   playerName: z.string().describe("The player to get tips for"),
 });
 

--- a/src/lib/game-state/__tests__/state-based-actions.test.ts
+++ b/src/lib/game-state/__tests__/state-based-actions.test.ts
@@ -1060,7 +1060,8 @@ describe('State-Based Actions', () => {
 
     it('should handle planeswalkers without loyalty field', () => {
       const pwData = createMockPlaneswalker('Test Planeswalker', 0);
-      pwData.loyalty = undefined as any;
+      // Delete the loyalty property to simulate a planeswalker without loyalty
+      delete (pwData as Partial<ScryfallCard>).loyalty;
       const planeswalker = createCardInstance(pwData, 'player1', 'player1');
 
       const result = initializePlaneswalkerLoyalty(planeswalker);

--- a/src/lib/game-state/keyword-actions.ts
+++ b/src/lib/game-state/keyword-actions.ts
@@ -21,6 +21,7 @@ import type {
   CardInstanceId,
   PlayerId,
   Zone,
+  ScryfallCard,
 } from './types';
 import {
   createToken,
@@ -439,7 +440,7 @@ export function discardCards(
  */
 export function createTokenCard(
   state: GameState,
-  tokenData: any, // ScryfallCard for token
+  tokenData: ScryfallCard,
   controllerId: PlayerId,
   ownerId: PlayerId,
   count: number = 1

--- a/src/lib/game-state/layer-system.ts
+++ b/src/lib/game-state/layer-system.ts
@@ -164,6 +164,15 @@ export interface CardOverrides {
 }
 
 /**
+ * Internal interface for card instance with effective colors
+ * Used by color-changing effects to communicate color changes
+ */
+interface CardInstanceWithEffectiveColors extends CardInstance {
+  /** Internal property set by color-changing effects */
+  _effectiveColors?: string[];
+}
+
+/**
  * Manages all continuous effects and applies them in correct order
  *
  * Implements the MTG layer system (CR 613) for continuous effects.
@@ -477,10 +486,10 @@ export class LayerSystem {
 
     for (const effect of colorEffects) {
       if (effect.canApply(modified)) {
-        const result = effect.apply(modified);
+        const result = effect.apply(modified) as CardInstanceWithEffectiveColors;
         // The effect should set colors directly via _effectiveColors
-        if ((result as any)._effectiveColors) {
-          colors = (result as any)._effectiveColors;
+        if (result._effectiveColors) {
+          colors = result._effectiveColors;
         }
       }
     }


### PR DESCRIPTION
## Description

This PR addresses issue #336 by replacing all `any` type usages with proper TypeScript types.

## Changes Made

1. **keyword-actions.ts**: Replaced `tokenData: any` with `tokenData: ScryfallCard` and added the proper import
2. **layer-system.ts**: Created `CardInstanceWithEffectiveColors` interface to properly type the internal `_effectiveColors` property, removing the need for `as any` casts
3. **ai-gameplay-assistance.ts**: Replaced all `z.any()` with `z.unknown()` in Zod schemas (4 occurrences)
4. **ai-post-game-analysis.ts**: Replaced all `z.any()` with `z.unknown()` in Zod schemas (3 occurrences)
5. **state-based-actions.test.ts**: Fixed the test to use `delete` operator instead of `undefined as any` for simulating missing properties

## Testing

- TypeScript compilation passes without errors
- All 40 tests in state-based-actions.test.ts pass

## Acceptance Criteria

- [x] All \`any\` types replaced with proper types
- [x] No \`@typescript-eslint/no-explicit-any\` warnings
- [x] All tests pass after changes
- [x] TypeScript compilation succeeds

Closes #336