### PR TITLE
Tech Debt: Fix ESLint warnings in test files

### DIFF
--- a/src/lib/game-state/__tests__/combat.test.ts
+++ b/src/lib/game-state/__tests__/combat.test.ts
@@ -23,7 +23,6 @@ import {
 import {
   createInitialGameState,
   startGame,
-  loadDeckForPlayer,
 } from '../game-state';
 import { createCardInstance } from '../card-instance';
 import { Phase } from '../types';
@@ -811,7 +810,7 @@ describe('Combat System - Utility Functions', () => {
 
   describe('getAvailableBlockers', () => {
     it('should return all creatures that can block', () => {
-      const { state, aliceId, bobId } = setupGameWithCreatures(
+      const { state, bobId } = setupGameWithCreatures(
         [],
         [
           { name: 'Can Block', power: 2, toughness: 2 },

--- a/src/lib/game-state/__tests__/layer-system.test.ts
+++ b/src/lib/game-state/__tests__/layer-system.test.ts
@@ -9,7 +9,6 @@ import {
   LayerSystem,
   Layer,
   PowerToughnessSublayer,
-  ContinuousEffect,
   createCopyEffect,
   createControlChangeEffect,
   createTextChangeEffect,
@@ -26,7 +25,6 @@ import {
   createPowerModifyEffect,
   createToughnessModifyEffect,
   createCounterEffect,
-  CharacteristicDefiningAbility,
   getLayerSystemInstance,
 } from '../layer-system';
 import { createCardInstance } from '../card-instance';

--- a/src/lib/game-state/__tests__/state-based-actions.test.ts
+++ b/src/lib/game-state/__tests__/state-based-actions.test.ts
@@ -9,7 +9,6 @@ import {
   checkStateBasedActions,
   canDraw,
   drawWithSBAChecking,
-  type StateBasedActionResult,
 } from '../state-based-actions';
 import {
   createInitialGameState,


### PR DESCRIPTION
## Description
Fixes #368

This PR fixes ESLint warnings in the test files.

## Changes Made
- Fix unused imports in combat.test.ts, layer-system.test.ts, state-based-actions.test.ts
- Fix unused variables in test helper functions
- All changes maintain test functionality while satisfying ESLint rules

## Testing
- All changes maintain test functionality
- No new errors introduced

## Checklist
- [x] All ESLint warnings in test files are fixed
- [x] No new errors introduced
- [x] Tests still pass