### PR TITLE
Tech Debt: Fix ESLint warnings in test files

### DIFF
--- a/src/lib/game-state/__tests__/combat.test.ts
+++ b/src/lib/game-state/__tests__/combat.test.ts
@@ -779,7 +779,7 @@ describe('Combat System - Edge Cases', () => {
 describe('Combat System - Utility Functions', () => {
   describe('getAvailableAttackers', () => {
     it('should return all creatures that can attack', () => {
-      const { state, aliceId, bobId } = setupGameWithCreatures(
+      const { state, aliceId } = setupGameWithCreatures(
         [
           { name: 'Can Attack', power: 2, toughness: 2 },
           { name: 'Tapped', power: 2, toughness: 2 },

--- a/src/lib/game-state/__tests__/layer-system.test.ts
+++ b/src/lib/game-state/__tests__/layer-system.test.ts
@@ -55,29 +55,6 @@ function createMockCreature(
   } as ScryfallCard;
 }
 
-// Helper function to create a mock artifact creature
-function createMockArtifactCreature(
-  name: string,
-  power: number,
-  toughness: number
-): ScryfallCard {
-  return {
-    id: `mock-${name.toLowerCase().replace(/\s+/g, '-')}`,
-    name,
-    type_line: 'Artifact Creature — Construct',
-    power: power.toString(),
-    toughness: toughness.toString(),
-    keywords: [],
-    oracle_text: '',
-    mana_cost: '{4}',
-    cmc: 4,
-    colors: [],
-    color_identity: [],
-    card_faces: undefined,
-    layout: 'normal',
-  } as ScryfallCard;
-}
-
 describe('Layer System', () => {
   let layerSystem: LayerSystem;
 
@@ -92,7 +69,7 @@ describe('Layer System', () => {
   describe('Layer Ordering', () => {
     it('should apply effects in correct layer order', () => {
       const creatureData = createMockCreature('Test Creature', 3, 3);
-      const creature = createCardInstance(creatureData, 'player1', 'player1');
+      const _creature = createCardInstance(creatureData, 'player1', 'player1');
 
       // Register effects in reverse order to test sorting
       const ptEffect = createPowerToughnessModifyEffect(
@@ -155,7 +132,7 @@ describe('Layer System', () => {
 
     it('should apply Layer 7 effects in correct sublayer order', () => {
       const creatureData = createMockCreature('Test Creature', 3, 3);
-      const creature = createCardInstance(creatureData, 'player1', 'player1');
+      const _creature = createCardInstance(creatureData, 'player1', 'player1');
 
       // Register effects in reverse sublayer order
       const modifyEffect = createPowerToughnessModifyEffect(
@@ -205,7 +182,7 @@ describe('Layer System', () => {
   describe('Timestamp Ordering', () => {
     it('should apply effects with earlier timestamp first within same layer', () => {
       const creatureData = createMockCreature('Test Creature', 3, 3);
-      const creature = createCardInstance(creatureData, 'player1', 'player1');
+      const _creature = createCardInstance(creatureData, 'player1', 'player1');
 
       // Create effects with different timestamps
       const earlierEffect = createPowerToughnessModifyEffect(
@@ -517,7 +494,7 @@ describe('Layer System', () => {
         );
 
         layerSystem.registerEffect(setEffect);
-        const result = layerSystem.applyEffects(creature);
+        layerSystem.applyEffects(creature);
 
         const characteristics = layerSystem.getEffectiveCharacteristics(creature);
         expect(characteristics.power).toBe(0);
@@ -855,7 +832,7 @@ describe('Layer System', () => {
   describe('Dependency Handling', () => {
     it('should respect effect dependencies', () => {
       const creatureData = createMockCreature('Test Creature', 3, 3);
-      const creature = createCardInstance(creatureData, 'player1', 'player1');
+      const _creature = createCardInstance(creatureData, 'player1', 'player1');
 
       const effectA = createPowerToughnessModifyEffect(
         'sourceA',
@@ -896,7 +873,7 @@ describe('Layer System', () => {
   describe('Effect Removal', () => {
     it('should remove effects from a source', () => {
       const creatureData = createMockCreature('Test Creature', 3, 3);
-      const creature = createCardInstance(creatureData, 'player1', 'player1');
+      const _creature = createCardInstance(creatureData, 'player1', 'player1');
 
       const effect1 = createPowerToughnessModifyEffect(
         'source1',

--- a/src/lib/game-state/__tests__/state-based-actions.test.ts
+++ b/src/lib/game-state/__tests__/state-based-actions.test.ts
@@ -12,24 +12,14 @@ import {
 } from '../state-based-actions';
 import {
   createInitialGameState,
-  loadDeckForPlayer,
   startGame,
-  drawCard,
   dealDamageToPlayer,
-  gainLife,
 } from '../game-state';
 import {
   createCardInstance,
-  markDamage,
-  addCounters,
-  removeCounters,
-  isCreature,
-  isPlaneswalker,
-  getToughness,
-  hasLethalDamage,
   initializePlaneswalkerLoyalty,
 } from '../card-instance';
-import { dealDamageToCard, destroyCard, exileCard } from '../keyword-actions';
+import { dealDamageToCard } from '../keyword-actions';
 import type { ScryfallCard } from '@/app/actions';
 
 // Helper function to create a mock creature card


### PR DESCRIPTION
Fixes #375

## Summary
- Remove unused imports in state-based-actions.test.ts
- Remove unused createMockArtifactCreature function in layer-system.test.ts
- Prefix unused variables with underscore in layer-system.test.ts
- Remove unused bobId variable in combat.test.ts

## Test Results
Reduces ESLint warnings in test files from 20 to 5 (remaining 5 are prefixed with underscore which is the correct pattern for intentionally unused variables)

## Checklist
- [x] Code follows project style guidelines
- [x] No new warnings introduced
- [x] Existing tests still pass