### PR TITLE
Bug: Fix failing unit tests in auto-save module

### DIFF
--- a/src/lib/auto-save-config.ts
+++ b/src/lib/auto-save-config.ts
@@ -68,7 +68,7 @@ const STORAGE_KEY = 'planar_nexus_auto_save_config';
  * Get auto-save configuration from localStorage
  */
 export function getAutoSaveConfig(): AutoSaveConfig {
-  if (typeof window === 'undefined') {
+  if (typeof localStorage === 'undefined') {
     return DEFAULT_AUTO_SAVE_CONFIG;
   }
 
@@ -93,7 +93,7 @@ export function getAutoSaveConfig(): AutoSaveConfig {
  * Save auto-save configuration to localStorage
  */
 export function setAutoSaveConfig(config: Partial<AutoSaveConfig>): void {
-  if (typeof window === 'undefined') {
+  if (typeof localStorage === 'undefined') {
     return;
   }
 
@@ -130,7 +130,7 @@ export function toggleTrigger(trigger: AutoSaveTrigger): void {
  * Reset auto-save configuration to defaults
  */
 export function resetAutoSaveConfig(): void {
-  if (typeof window !== 'undefined') {
+  if (typeof localStorage !== 'undefined') {
     localStorage.removeItem(STORAGE_KEY);
   }
 }


### PR DESCRIPTION
## Summary
Fixes #382

This PR fixes the failing auto-save tests by correcting the environment check in the auto-save configuration module.

## Problem
The tests were failing because the code checked \`typeof window === 'undefined'\` to determine if localStorage is available. However, in Jest tests, \`window\` is undefined while \`localStorage\` is mocked separately.

## Solution
Changed the environment check from \`typeof window === 'undefined'\` to \`typeof localStorage === 'undefined'\` in:
- \`getAutoSaveConfig()\`
- \`setAutoSaveConfig()\`
- \`resetAutoSaveConfig()\`

## Testing
All 18 auto-save tests now pass:
- getAutoSaveConfig: 5 tests ✓
- setAutoSaveConfig: 3 tests ✓
- isTriggerEnabled: 3 tests ✓
- toggleTrigger: 3 tests ✓
- resetAutoSaveConfig: 1 test ✓
- default configuration: 3 tests ✓

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass
- [x] No breaking changes