### PR TITLE
Bug: Fix empty test suites in AI validation files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx', '**/__tests__/**/*.validation.ts'],
+  testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },


### PR DESCRIPTION
## Summary
Fixes #383

This PR fixes the empty test suite errors by removing the validation.ts pattern from Jest's testMatch configuration.

## Problem
The Jest configuration included \`**/__tests__/**/*.validation.ts\` in the testMatch pattern. However, these files are validation utilities that export functions for manual testing, not Jest test files. They don't contain any Jest test blocks (it, test, describe), causing Jest to fail with:
\`Your test suite must contain at least one test.\`

## Solution
Removed the \`**/__tests__/**/*.validation.ts\` pattern from the Jest testMatch configuration.

## Affected Files
- \`src/ai/decision-making/__tests__/combat-ai.validation.ts\`
- \`src/ai/__tests__/game-state-evaluator.validation.ts\`

These files are now excluded from Jest test runs but remain available as validation utilities.

## Testing
- Failed test suites reduced from 9 to 7
- The validation.ts files are still available for manual testing/import

## Checklist
- [x] Code follows project style guidelines
- [x] No breaking changes
- [x] Test suite configuration improved