### PR TITLE
Fix: Remove unused bobId variable in combat.test.ts

### DIFF
--- a/src/lib/game-state/__tests__/combat.test.ts
+++ b/src/lib/game-state/__tests__/combat.test.ts
@@ -743,7 +743,7 @@ describe('Combat System - Edge Cases', () => {
   });
 
   it('should handle no attackers declared', () => {
-    const { state, bobId } = setupGameWithCreatures([], []);
+    const { state } = setupGameWithCreatures([], []);
 
     state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
 


### PR DESCRIPTION
## Summary
Fixes #399

Removes the unused `bobId` variable from the destructuring in the 'should handle no attackers declared' test case.

## Changes
- Removed unused `bobId` from destructuring in `src/lib/game-state/__tests__/combat.test.ts` line 746

## Testing
- ESLint now passes with no warnings
- All existing tests continue to pass

## Checklist
- [x] Code compiles correctly
- [x] Linting passes
- [x] Tests pass