### PR TITLE
Fix: Auto-save slot management now correctly replaces existing saves

### DIFF
--- a/src/lib/saved-games.ts
+++ b/src/lib/saved-games.ts
@@ -139,9 +139,16 @@ class SavedGamesManager {
     replay: Replay | null,
     slot: number = 0
   ): SavedGame {
+    // First, delete any existing auto-save in this slot
+    const existingAutoSaves = this.getAutoSaves();
+    const existingInSlot = existingAutoSaves.find(g => g.autoSaveSlot === slot);
+    if (existingInSlot) {
+      this.deleteGame(existingInSlot.id);
+    }
+
     const now = Date.now();
     const autoSave: SavedGame = {
-      id: `${AUTO_SAVE_PREFIX}${now}`,
+      id: `${AUTO_SAVE_PREFIX}${slot}_${now}`,
       name: `Auto-Save ${slot + 1}`,
       format: 'unknown', // Would be stored in gameState
       playerNames: Array.from(gameState.players.values()).map(p => p.name),


### PR DESCRIPTION
## Summary
Fixes #400

Fixed the auto-save slot management to properly handle multiple auto-saves and slot rotation.

## Problem
The `saveToAutoSave` method was creating new auto-saves without removing existing ones in the same slot, causing multiple auto-saves to accumulate instead of properly rotating through slots 0, 1, 2.

## Solution
Modified `saveToAutoSave` to delete any existing auto-save in the target slot before creating a new one. This ensures:
- Calling `autoSave()` 3 times creates saves in slots 0, 1, 2
- Calling `autoSave()` a 4th time replaces the oldest save
- Max auto-save limit (3) is properly enforced

## Changes
- Added logic to delete existing auto-save in target slot before saving new one
- Updated ID format to include slot number for better debugging

## Testing
All 393 tests pass, including the 5 previously failing auto-save tests:
- ✓ should use slot rotation by default
- ✓ should reuse oldest slot when max auto-saves reached
- ✓ should sort auto-saves by slot number
- ✓ should rotate through auto-save slots
- ✓ should overwrite oldest slot when max is reached

## Checklist
- [x] Code compiles correctly
- [x] All tests pass
- [x] Fix verified with test suite