### PR TITLE
Fix #520: Remove build error suppression settings

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -45,14 +45,6 @@ const nextConfig: NextConfig = {
   // Ensure trailing slashes for static hosting
   trailingSlash: true,
 
-  // TypeScript and ESLint settings
-  typescript: {
-    ignoreBuildErrors: true,
-  },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
-
   // Set base path for deployment
   basePath: '',
 };


### PR DESCRIPTION
Fixes #520

## Summary
- Remove ignoreBuildErrors: true from typescript config
- Remove ignoreDuringBuilds: true from eslint config

## Impact
- Build and lint will now fail on errors as expected
- Ensures production builds contain no TypeScript errors or ESLint violations
- Prevents technical debt from accumulating unnoticed

## Dependencies
- Depends on #516 (TypeScript types in AI flows) being fixed first
- Other TypeScript/ESLint issues should be addressed separately

## Testing
After merging, run:
- npm run build (should fail if TypeScript errors exist)
- npm run lint (should fail if ESLint errors exist)

## Summary by Sourcery

Enforce TypeScript and ESLint errors to fail Next.js production builds by removing build-time error suppression.

Build:
- Remove Next.js TypeScript ignoreBuildErrors setting so builds fail on type errors.
- Remove Next.js ESLint ignoreDuringBuilds setting so builds fail on lint errors.