### PR TITLE
Refactor(ai): Enforce server-side proxy for all AI providers

### DIFF
--- a/src/ai/providers/google.ts
+++ b/src/ai/providers/google.ts
@@ -121,21 +121,12 @@ export interface GoogleAIChatResponse {
  * Create a Google AI client configuration
  * @param config - Configuration for the Google AI provider
  * @returns Configuration object for making API requests
- * @deprecated Server-side proxy is now the default. Direct API calls are discouraged.
+ * @deprecated Use server-side proxy instead.
  */
 export function createGoogleAIClient(config: GoogleAIProviderConfig): GoogleAIProviderConfig {
-  const apiKey = config.apiKey || process.env.GOOGLE_AI_API_KEY;
-
-  if (!apiKey) {
-    throw new Error(
-      'Google AI API key is required. Set GOOGLE_AI_API_KEY environment variable or pass it in config.'
-    );
-  }
-
   return {
     ...config,
-    apiKey,
-    baseURL: config.baseURL || process.env.NEXT_PUBLIC_GOOGLE_API_URL || DEFAULT_GOOGLE_AI_CONFIG.baseURL,
+    baseURL: config.baseURL || DEFAULT_GOOGLE_AI_CONFIG.baseURL,
     model: config.model || DEFAULT_GOOGLE_AI_CONFIG.model,
     maxOutputTokens: config.maxOutputTokens || DEFAULT_GOOGLE_AI_CONFIG.maxOutputTokens,
     temperature: config.temperature || DEFAULT_GOOGLE_AI_CONFIG.temperature,
@@ -148,17 +139,12 @@ export function createGoogleAIClient(config: GoogleAIProviderConfig): GoogleAIPr
  * @param request - Chat request
  * @returns Google AI chat completion response
  */
-export async function sendGoogleAIChat(
+export function sendGoogleAIChat(
   config: GoogleAIProviderConfig,
   request: Omit<GoogleAIChatRequest, 'model'>
 ): Promise<GoogleAIChatResponse> {
-  // Use server-side proxy by default (security best practice)
-  if (config.useProxy !== false) {
-    return sendGoogleAIChatViaProxy(config, request);
-  }
-
-  // Fallback to direct API call (deprecated, for backward compatibility)
-  return sendGoogleAIChatDirect(config, request);
+  // Use server-side proxy (security best practice)
+  return sendGoogleAIChatViaProxy(config, request);
 }
 
 /**
@@ -203,55 +189,6 @@ async function sendGoogleAIChatViaProxy(
   }
 }
 
-/**
- * Send a chat completion request to Google AI directly (deprecated)
- * @param config - Provider configuration
- * @param request - Chat request
- * @returns Google AI chat completion response
- * @deprecated Use server-side proxy instead
- */
-async function sendGoogleAIChatDirect(
-  config: GoogleAIProviderConfig,
-  request: Omit<GoogleAIChatRequest, 'model'>
-): Promise<GoogleAIChatResponse> {
-  console.warn(
-    'Direct Google AI API calls are deprecated. Please use server-side proxy (useProxy: true).'
-  );
-
-  const client = createGoogleAIClient(config);
-  const apiKey = client.apiKey;
-  const model = config.model || DEFAULT_GOOGLE_AI_CONFIG.model;
-
-  const url = `${client.baseURL}/models/${model}:generateContent?key=${apiKey}`;
-
-  const requestBody: GoogleAIChatRequest = {
-    contents: request.contents,
-    generationConfig: {
-      maxOutputTokens: config.maxOutputTokens || request.generationConfig?.maxOutputTokens,
-      temperature: config.temperature || request.generationConfig?.temperature,
-      topP: config.topP || request.generationConfig?.topP,
-      topK: config.topK || request.generationConfig?.topK,
-      stopSequences: request.generationConfig?.stopSequences,
-    },
-    safetySettings: request.safetySettings,
-    systemInstruction: request.systemInstruction,
-  };
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(requestBody),
-  });
-
-  if (!response.ok) {
-    const error = await response.text();
-    throw new Error(`Google AI API error: ${response.status} - ${error}`);
-  }
-
-  return response.json();
-}
 
 /**
  * Convert standard messages to Google AI format
@@ -359,19 +296,19 @@ export function validateGoogleAIApiKey(apiKey: string): boolean {
 }
 
 /**
- * Check if Google AI is configured and available
+ * Check if Google AI is available (via proxy)
  */
 export function isGoogleAIAvailable(): boolean {
-  return !!process.env.GOOGLE_AI_API_KEY;
+  // Availability is determined server-side
+  return true;
 }
 
 /**
  * Get Google AI provider status
  */
 export function getGoogleAIProviderStatus(): { available: boolean; configured: boolean } {
-  const hasApiKey = !!process.env.GOOGLE_AI_API_KEY;
   return {
-    available: hasApiKey,
-    configured: hasApiKey,
+    available: true,
+    configured: true,
   };
 }

--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -41,19 +41,11 @@ export const DEFAULT_OPENAI_CONFIG: Partial<OpenAIProviderConfig> = {
  * Create an OpenAI client instance
  * @param config - Configuration for the OpenAI provider
  * @returns OpenAI client instance
- * @deprecated Server-side proxy is now the default. Direct API calls are discouraged.
+ * @deprecated Use server-side proxy instead.
  */
 export function createOpenAIClient(config: OpenAIProviderConfig): Record<string, unknown> {
-  const apiKey = config.apiKey || process.env.OPENAI_API_KEY;
-
-  if (!apiKey) {
-    throw new Error(
-      'OpenAI API key is required. Set OPENAI_API_KEY environment variable or pass it in config.'
-    );
-  }
-
   // OpenAI client creation stub - package not installed
-  return { apiKey, organization: config.organization };
+  return { organization: config.organization };
 }
 
 /**
@@ -112,17 +104,12 @@ export interface OpenAIChatResponse {
  * @param request - Chat request
  * @returns OpenAI's chat completion response
  */
-export async function sendOpenAIChat(
+export function sendOpenAIChat(
   config: OpenAIProviderConfig,
   request: Omit<OpenAIChatRequest, 'model'>
 ): Promise<OpenAIChatResponse> {
-  // Use server-side proxy by default (security best practice)
-  if (config.useProxy !== false) {
-    return sendOpenAIChatViaProxy(config, request);
-  }
-
-  // Fallback to direct API call (deprecated, for backward compatibility)
-  return sendOpenAIChatDirect(config, request);
+  // Use server-side proxy (security best practice)
+  return sendOpenAIChatViaProxy(config, request);
 }
 
 /**
@@ -163,41 +150,6 @@ async function sendOpenAIChatViaProxy(
   }
 }
 
-/**
- * Send a chat completion request to OpenAI directly (deprecated)
- * @param config - Provider configuration
- * @param request - Chat request
- * @returns OpenAI's chat completion response
- * @deprecated Use server-side proxy instead
- */
-async function sendOpenAIChatDirect(
-  config: OpenAIProviderConfig,
-  request: Omit<OpenAIChatRequest, 'model'>
-): Promise<OpenAIChatResponse> {
-  console.warn(
-    'Direct OpenAI API calls are deprecated. Please use server-side proxy (useProxy: true).'
-  );
-
-  const client = createOpenAIClient(config) as {
-    chat: {
-      completions: {
-        create: (params: Record<string, unknown>) => Promise<OpenAIChatResponse>;
-      };
-    };
-  };
-
-  const response = await client.chat.completions.create({
-    model: config.model || DEFAULT_MODELS.openai,
-    max_tokens: config.maxTokens || request.maxTokens || 8192,
-    temperature: config.temperature || request.temperature || 0.7,
-    messages: request.messages,
-    tools: request.tools,
-    tool_choice: request.toolChoice,
-    response_format: request.responseFormat,
-  });
-
-  return response as OpenAIChatResponse;
-}
 
 /**
  * Convert OpenAI response to text

--- a/src/ai/providers/zaic.ts
+++ b/src/ai/providers/zaic.ts
@@ -88,21 +88,12 @@ export interface ZAIChatResponse {
  * Create a Z.ai client configuration
  * @param config - Configuration for the Z.ai provider
  * @returns Configuration object for making API requests
- * @deprecated Server-side proxy is now the default. Direct API calls are discouraged.
+ * @deprecated Use server-side proxy instead.
  */
 export function createZAIClient(config: ZAIProviderConfig): ZAIProviderConfig {
-  const apiKey = config.apiKey || process.env.ZAI_API_KEY;
-
-  if (!apiKey) {
-    throw new Error(
-      'Z.ai API key is required. Set ZAI_API_KEY environment variable or pass it in config.'
-    );
-  }
-
   return {
     ...config,
-    apiKey,
-    baseURL: config.baseURL || process.env.ZAI_BASE_URL || DEFAULT_ZAI_CONFIG.baseURL,
+    baseURL: config.baseURL || DEFAULT_ZAI_CONFIG.baseURL,
     model: config.model || DEFAULT_ZAI_CONFIG.model,
     maxTokens: config.maxTokens || DEFAULT_ZAI_CONFIG.maxTokens,
     temperature: config.temperature || DEFAULT_ZAI_CONFIG.temperature,
@@ -115,17 +106,12 @@ export function createZAIClient(config: ZAIProviderConfig): ZAIProviderConfig {
  * @param request - Chat request
  * @returns Z.ai chat completion response
  */
-export async function sendZAIChat(
+export function sendZAIChat(
   config: ZAIProviderConfig,
   request: Omit<ZAIChatRequest, 'model'>
 ): Promise<ZAIChatResponse> {
-  // Use server-side proxy by default (security best practice)
-  if (config.useProxy !== false) {
-    return sendZAIChatViaProxy(config, request);
-  }
-
-  // Fallback to direct API call (deprecated, for backward compatibility)
-  return sendZAIChatDirect(config, request);
+  // Use server-side proxy (security best practice)
+  return sendZAIChatViaProxy(config, request);
 }
 
 /**
@@ -165,47 +151,6 @@ async function sendZAIChatViaProxy(
   }
 }
 
-/**
- * Send a chat completion request to Z.ai directly (deprecated)
- * @param config - Provider configuration
- * @param request - Chat request
- * @returns Z.ai chat completion response
- * @deprecated Use server-side proxy instead
- */
-async function sendZAIChatDirect(
-  config: ZAIProviderConfig,
-  request: Omit<ZAIChatRequest, 'model'>
-): Promise<ZAIChatResponse> {
-  console.warn(
-    'Direct Z.ai API calls are deprecated. Please use server-side proxy (useProxy: true).'
-  );
-
-  const client = createZAIClient(config);
-
-  const response = await fetch(`${client.baseURL}/chat/completions`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${client.apiKey}`,
-    },
-    body: JSON.stringify({
-      model: client.model,
-      max_tokens: client.maxTokens || request.max_tokens,
-      temperature: client.temperature || request.temperature,
-      messages: request.messages,
-      top_p: request.top_p,
-      stream: false,
-      stop: request.stop,
-    }),
-  });
-
-  if (!response.ok) {
-    const error = await response.text();
-    throw new Error(`Z.ai API error: ${response.status} - ${error}`);
-  }
-
-  return response.json();
-}
 
 /**
  * Send a streaming chat completion request to Z.ai
@@ -349,19 +294,19 @@ export function formatZAIMessages(
 }
 
 /**
- * Check if Z.ai is configured and available
+ * Check if Z.ai is available (via proxy)
  */
 export function isZAIAvailable(): boolean {
-  return !!process.env.ZAI_API_KEY;
+  // Availability is determined server-side
+  return true;
 }
 
 /**
  * Get Z.ai provider status
  */
 export function getZAIProviderStatus(): { available: boolean; configured: boolean } {
-  const hasApiKey = !!process.env.ZAI_API_KEY;
   return {
-    available: hasApiKey,
-    configured: hasApiKey,
+    available: true,
+    configured: true,
   };
 }


### PR DESCRIPTION
Issue #543: Enforces usage of the server-side AI proxy and removes direct API key exposure from client-side AI providers.

## Summary by Sourcery

Enforce server-side proxy usage for all AI chat providers and remove client-side direct API integrations and key handling.

Enhancements:
- Always route Google AI, Z.ai, and OpenAI chat requests through the server-side proxy instead of allowing direct API calls.
- Simplify AI provider configuration by removing client-side API key and base URL handling and delegating availability/configuration checks to the server side.