### PR TITLE
AI Proxy Security (#562)

### DIFF
--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -104,11 +104,12 @@ export interface OpenAIChatResponse {
  * @param request - Chat request
  * @returns OpenAI's chat completion response
  */
-export function sendOpenAIChat(
+export async function sendOpenAIChat(
   config: OpenAIProviderConfig,
   request: Omit<OpenAIChatRequest, 'model'>
 ): Promise<OpenAIChatResponse> {
   // Use server-side proxy (security best practice)
+  // This ensures API keys are NOT exposed on the client
   return sendOpenAIChatViaProxy(config, request);
 }
 
@@ -243,7 +244,7 @@ export function formatOpenAIMessages(
   messages: Array<{ role: 'user' | 'assistant' | 'system' | 'tool'; content: string; name?: string }>
 ): OpenAIMessage[] {
   return messages.map(msg => ({
-    role: msg.role as 'user' | 'assistant' | 'system',
+    role: (msg.role === 'tool' ? 'assistant' : msg.role) as 'user' | 'assistant' | 'system',
     content: msg.content,
   }));
 }


### PR DESCRIPTION
Reinforce AI proxy security in src/ai/providers/openai.ts by ensuring all chat completions strictly use the server-side proxy client. This prevents direct API key exposure on the client.

## Summary by Sourcery

Ensure OpenAI chat completions always go through the server-side proxy client and normalize tool-role messages to assistant for OpenAI requests.

Enhancements:
- Make the OpenAI chat helper explicitly async while continuing to route all requests through the server-side proxy.
- Normalize messages with the 'tool' role to 'assistant' when formatting OpenAI chat messages.