### PR TITLE
fix: implement deathtouch and indestructible blocking logic

### DIFF
--- a/src/ai/decision-making/combat-decision-tree.ts
+++ b/src/ai/decision-making/combat-decision-tree.ts
@@ -25,9 +25,9 @@ import type {
   AIPlayerState as PlayerState,
   AIPermanent as Permanent,
   AIHandCard as HandCard,
-} from '@/lib/game-state/types';
-import { callAIProxy } from '@/lib/ai-proxy-client';
-import { AIProvider } from '@/ai/providers/types';
+} from "@/lib/game-state/types";
+import { callAIProxy } from "@/lib/ai-proxy-client";
+import { AIProvider } from "@/ai/providers/types";
 
 // Re-export for backward compatibility
 export type { GameState, PlayerState, Permanent, HandCard };
@@ -51,17 +51,17 @@ export interface CombatCardData {
 /**
  * Combat trick types
  */
-export type CombatTrickType = 
-  | 'pump' 
-  | 'combat_damage' 
-  | 'destroy' 
-  | 'exile' 
-  | 'damage_redirect'
-  | 'toughness_boost'
-  | 'power_boost'
-  | 'indestructible'
-  | 'lifelink'
-  | 'trample';
+export type CombatTrickType =
+  | "pump"
+  | "combat_damage"
+  | "destroy"
+  | "exile"
+  | "damage_redirect"
+  | "toughness_boost"
+  | "power_boost"
+  | "indestructible"
+  | "lifelink"
+  | "trample";
 
 /**
  * Parsed combat trick information
@@ -85,7 +85,7 @@ export interface AttackDecision {
   /** Whether to attack with this creature */
   shouldAttack: boolean;
   /** Target to attack (player ID or 'none' to hold back) */
-  target: string | 'none';
+  target: string | "none";
   /** Reasoning for this decision */
   reasoning: string;
   /** Expected value of this attack (0-1 scale) */
@@ -119,7 +119,7 @@ export interface CombatPlan {
   /** Blocking decisions */
   blocks: BlockDecision[];
   /** Overall combat strategy */
-  strategy: 'aggressive' | 'moderate' | 'defensive';
+  strategy: "aggressive" | "moderate" | "defensive";
   /** Total expected value of all combat decisions */
   totalExpectedValue: number;
   /** Recommended combat tricks (pump spells, etc.) */
@@ -135,7 +135,7 @@ export interface CombatTrick {
   /** Name of the trick */
   name: string;
   /** When to use the trick */
-  timing: 'before_attackers' | 'before_blockers' | 'after_blockers' | 'damage';
+  timing: "before_attackers" | "before_blockers" | "after_blockers" | "damage";
   /** Target creature ID */
   targetId?: string;
   /** Expected value of using the trick */
@@ -164,7 +164,7 @@ export interface CombatAIConfig {
  * Default configurations for different difficulty levels
  */
 export const DefaultCombatConfigs: Record<
-  'easy' | 'medium' | 'hard' | 'expert',
+  "easy" | "medium" | "hard" | "expert",
   CombatAIConfig
 > = {
   easy: {
@@ -208,7 +208,7 @@ export class CombatDecisionTree {
   constructor(
     gameState: GameState,
     aiPlayerId: string,
-    difficulty: 'easy' | 'medium' | 'hard' | 'expert' = 'medium'
+    difficulty: "easy" | "medium" | "hard" | "expert" = "medium",
   ) {
     this.gameState = gameState;
     this.aiPlayerId = aiPlayerId;
@@ -260,36 +260,41 @@ export class CombatDecisionTree {
    * Generate attack decisions using AI via proxy
    */
   async generateAttackPlanAI(
-    provider: AIProvider = 'zaic', 
-    model?: string
+    provider: AIProvider = "zaic",
+    model?: string,
   ): Promise<CombatPlan> {
     try {
       const response = await callAIProxy<CombatPlan>({
         provider,
-        endpoint: 'chat/completions',
-        model: model || 'default',
+        endpoint: "chat/completions",
+        model: model || "default",
         body: {
           messages: [
-            { 
-              role: 'system', 
-              content: 'You are a Magic: The Gathering AI. Generate an attack plan for the current game state.' 
+            {
+              role: "system",
+              content:
+                "You are a Magic: The Gathering AI. Generate an attack plan for the current game state.",
             },
-            { 
-              role: 'user', 
-              content: JSON.stringify({ gameState: this.gameState, aiPlayerId: this.aiPlayerId, config: this.config }) 
-            }
+            {
+              role: "user",
+              content: JSON.stringify({
+                gameState: this.gameState,
+                aiPlayerId: this.aiPlayerId,
+                config: this.config,
+              }),
+            },
           ],
-          response_format: { type: 'json_object' }
-        }
+          response_format: { type: "json_object" },
+        },
       });
 
       if (response.success && response.data) {
         return response.data;
       }
-      
+
       return this.generateAttackPlan();
     } catch (error) {
-      console.error('AI attack plan generation failed:', error);
+      console.error("AI attack plan generation failed:", error);
       return this.generateAttackPlan();
     }
   }
@@ -315,7 +320,7 @@ export class CombatDecisionTree {
     return {
       attacks: [],
       blocks: blockDecisions,
-      strategy: 'defensive',
+      strategy: "defensive",
       totalExpectedValue: this.calculateTotalBlockValue(blockDecisions),
       combatTricks: [],
     };
@@ -327,10 +332,10 @@ export class CombatDecisionTree {
   private getAttackableCreatures(player: PlayerState): Permanent[] {
     return player.battlefield.filter(
       (p) =>
-        p.type === 'creature' &&
+        p.type === "creature" &&
         !p.tapped &&
         (p.power || 0) > 0 &&
-        !this.hasSummoningSickness(p)
+        !this.hasSummoningSickness(p),
     );
   }
 
@@ -338,9 +343,7 @@ export class CombatDecisionTree {
    * Get all creatures that can block
    */
   private getBlockingCreatures(player: PlayerState): Permanent[] {
-    return player.battlefield.filter(
-      (p) => p.type === 'creature' && !p.tapped
-    );
+    return player.battlefield.filter((p) => p.type === "creature" && !p.tapped);
   }
 
   /**
@@ -350,8 +353,11 @@ export class CombatDecisionTree {
     // In a real implementation, this would check when the creature entered
     // For now, creatures have summoning sickness only if explicitly marked
     // or if they lack haste and have a summoningSickness flag
-    if ('summoningSickness' in creature && creature.summoningSickness === true) {
-      return !creature.keywords?.includes('haste');
+    if (
+      "summoningSickness" in creature &&
+      creature.summoningSickness === true
+    ) {
+      return !creature.keywords?.includes("haste");
     }
     // By default, assume creatures can attack (they've been on battlefield)
     return false;
@@ -362,43 +368,44 @@ export class CombatDecisionTree {
    */
   private determineCombatStrategy(
     aiPlayer: PlayerState,
-    opponents: PlayerState[]
-  ): 'aggressive' | 'moderate' | 'defensive' {
+    opponents: PlayerState[],
+  ): "aggressive" | "moderate" | "defensive" {
     const minOpponentLife = Math.min(...opponents.map((o) => o.life));
     const lifeTotal = aiPlayer.life;
     const creatureCount = aiPlayer.battlefield.filter(
-      (p: Permanent) => p.type === 'creature'
+      (p: Permanent) => p.type === "creature",
     ).length;
     const avgOpponentCreatures =
       opponents.reduce(
-        (sum, o) => sum + o.battlefield.filter((p) => p.type === 'creature').length,
-        0
+        (sum, o) =>
+          sum + o.battlefield.filter((p) => p.type === "creature").length,
+        0,
       ) / opponents.length;
 
     // Low life: play defensively
     if (lifeTotal <= this.config.lifeThreshold) {
-      return 'defensive';
+      return "defensive";
     }
 
     // Opponent low life: be aggressive
     if (minOpponentLife <= 10) {
-      return 'aggressive';
+      return "aggressive";
     }
 
     // Board advantage: be moderate to aggressive
     if (creatureCount > avgOpponentCreatures + 1) {
-      return this.config.aggression > 0.6 ? 'aggressive' : 'moderate';
+      return this.config.aggression > 0.6 ? "aggressive" : "moderate";
     }
 
     // Board disadvantage: play defensively
     if (creatureCount < avgOpponentCreatures - 1) {
-      return 'defensive';
+      return "defensive";
     }
 
     // Even board: use configured aggression
-    if (this.config.aggression > 0.6) return 'aggressive';
-    if (this.config.aggression < 0.4) return 'defensive';
-    return 'moderate';
+    if (this.config.aggression > 0.6) return "aggressive";
+    if (this.config.aggression < 0.4) return "defensive";
+    return "moderate";
   }
 
   /**
@@ -407,11 +414,11 @@ export class CombatDecisionTree {
   private evaluateAttacker(
     creature: Permanent,
     opponents: PlayerState[],
-    strategy: 'aggressive' | 'moderate' | 'defensive'
+    strategy: "aggressive" | "moderate" | "defensive",
   ): AttackDecision {
     let shouldAttack = false;
-    let target: string | 'none' = 'none';
-    let reasoning = '';
+    let target: string | "none" = "none";
+    let reasoning = "";
     let expectedValue = 0;
     let riskLevel = 0;
 
@@ -426,7 +433,9 @@ export class CombatDecisionTree {
         opponent,
         potentialBlockers,
         canBlock,
-        blocks: canBlock ? this.simulateBlocks(creature, potentialBlockers) : [],
+        blocks: canBlock
+          ? this.simulateBlocks(creature, potentialBlockers)
+          : [],
       };
     });
 
@@ -439,7 +448,7 @@ export class CombatDecisionTree {
         creature,
         analysis.opponent,
         analysis.blocks,
-        strategy
+        strategy,
       );
 
       if (targetValue > bestTargetValue) {
@@ -450,11 +459,7 @@ export class CombatDecisionTree {
 
     // Decide whether to attack
     const attackThreshold =
-      strategy === 'aggressive'
-        ? 0.3
-        : strategy === 'moderate'
-        ? 0.5
-        : 0.7;
+      strategy === "aggressive" ? 0.3 : strategy === "moderate" ? 0.5 : 0.7;
 
     // Adjust for evasion (creatures with evasion are safer to attack with)
     const evasionBonus = hasEvasion ? 0.2 : 0;
@@ -473,7 +478,7 @@ export class CombatDecisionTree {
         creature,
         bestTarget!,
         expectedValue,
-        hasEvasion
+        hasEvasion,
       );
       riskLevel = this.calculateAttackRisk(creature, opponentAnalyses);
     } else {
@@ -496,20 +501,21 @@ export class CombatDecisionTree {
    */
   private hasEvasion(creature: Permanent): boolean {
     const evasionKeywords = [
-      'flying',
-      'menace',
-      'intimidate',
-      'fear',
-      'unblockable',
-      'shadow',
-      'skulk',
-      'prowl',
-      'wither',
-      'trample',
+      "flying",
+      "menace",
+      "intimidate",
+      "fear",
+      "unblockable",
+      "shadow",
+      "skulk",
+      "prowl",
+      "wither",
+      "trample",
     ];
     return (
-      creature.keywords?.some((k) => evasionKeywords.includes(k.toLowerCase())) ||
-      false
+      creature.keywords?.some((k) =>
+        evasionKeywords.includes(k.toLowerCase()),
+      ) || false
     );
   }
 
@@ -518,10 +524,10 @@ export class CombatDecisionTree {
    */
   private getPotentialBlockers(
     opponent: PlayerState,
-    attacker: Permanent
+    attacker: Permanent,
   ): Permanent[] {
     return opponent.battlefield.filter((blocker) => {
-      if (blocker.type !== 'creature' || blocker.tapped) {
+      if (blocker.type !== "creature" || blocker.tapped) {
         return false;
       }
 
@@ -538,22 +544,25 @@ export class CombatDecisionTree {
     const blockerKeywords = blocker.keywords || [];
 
     // Flying
-    if (attackerKeywords.includes('flying') && !blockerKeywords.includes('flying')) {
+    if (
+      attackerKeywords.includes("flying") &&
+      !blockerKeywords.includes("flying")
+    ) {
       // Can't block unless blocker has reach
-      if (!blockerKeywords.includes('reach')) {
+      if (!blockerKeywords.includes("reach")) {
         return false;
       }
     }
 
     // Menace - need 2+ blockers
-    if (attackerKeywords.includes('menace')) {
+    if (attackerKeywords.includes("menace")) {
       // This is handled at the block assignment level
     }
 
     // Intimidate/fear
     if (
-      attackerKeywords.includes('intimidate') ||
-      attackerKeywords.includes('fear')
+      attackerKeywords.includes("intimidate") ||
+      attackerKeywords.includes("fear")
     ) {
       // Can only be blocked by artifact creatures and/or creatures that share a color
       // This is a simplified check
@@ -561,7 +570,7 @@ export class CombatDecisionTree {
     }
 
     // Unblockable
-    if (attackerKeywords.includes('unblockable')) {
+    if (attackerKeywords.includes("unblockable")) {
       return false;
     }
 
@@ -573,21 +582,37 @@ export class CombatDecisionTree {
    */
   private simulateBlocks(
     attacker: Permanent,
-    potentialBlockers: Permanent[]
+    potentialBlockers: Permanent[],
   ): Array<{ blocker: Permanent; trades: boolean; dies: boolean }> {
+    const attackerHasDeathtouch =
+      attacker.keywords?.includes("deathtouch") || false;
+    const attackerIsIndestructible =
+      attacker.keywords?.includes("indestructible") || false;
+
     return potentialBlockers.map((blocker) => {
       const attackerPower = attacker.power || 0;
       const attackerToughness = attacker.toughness || 0;
       const blockerPower = blocker.power || 0;
       const blockerToughness = blocker.toughness || 0;
+      const blockerIsIndestructible =
+        blocker.keywords?.includes("indestructible") || false;
+      const blockerHasDeathtouch =
+        blocker.keywords?.includes("deathtouch") || false;
 
-      // Check if attacker dies
-      const attackerDies = blockerPower >= attackerToughness;
-      // Check if blocker dies
-      const blockerDies = attackerPower >= blockerToughness;
+      // Deathtouch: any nonzero damage is lethal (CR 702.2b)
+      const attackerDies = blockerHasDeathtouch
+        ? blockerPower > 0
+        : blockerPower >= attackerToughness;
 
-      // Trade = both die
-      const trades = attackerDies && blockerDies;
+      // Deathtouch: any nonzero damage is lethal; Indestructible: cannot be destroyed by damage
+      const blockerDies =
+        !blockerIsIndestructible &&
+        (attackerHasDeathtouch
+          ? attackerPower > 0
+          : attackerPower >= blockerToughness);
+
+      // Indestructible creatures can never die from combat damage alone
+      const trades = attackerDies && !attackerIsIndestructible && blockerDies;
 
       return { blocker, trades, dies: blockerDies };
     });
@@ -600,11 +625,14 @@ export class CombatDecisionTree {
     creature: Permanent,
     opponent: PlayerState,
     blocks: Array<{ blocker: Permanent; trades: boolean; dies: boolean }>,
-    strategy: 'aggressive' | 'moderate' | 'defensive'
+    strategy: "aggressive" | "moderate" | "defensive",
   ): number {
     const power = creature.power || 0;
     const toughness = creature.toughness || 0;
-    const hasTrample = creature.keywords?.includes('trample') || false;
+    const hasTrample = creature.keywords?.includes("trample") || false;
+    const hasDeathtouch = creature.keywords?.includes("deathtouch") || false;
+    const isIndestructible =
+      creature.keywords?.includes("indestructible") || false;
 
     // Base value = damage dealt
     let damageDealt = power;
@@ -626,7 +654,9 @@ export class CombatDecisionTree {
         return worst || block;
       }, blocks[0]);
 
-      creatureDies = worstBlock.trades || worstBlock.blocker.power! >= toughness;
+      creatureDies = isIndestructible
+        ? false
+        : worstBlock.trades || worstBlock.blocker.power! >= toughness;
       blockerDies = worstBlock.dies;
 
       // Calculate damage through
@@ -634,7 +664,13 @@ export class CombatDecisionTree {
         const excessDamage = power - (worstBlock.blocker.toughness || 0);
         damageDealt = Math.max(0, excessDamage);
       } else if (!creatureDies) {
-        damageDealt = power;
+        // Deathtouch attacker only needs 1 damage to kill a blocker, so assign minimum
+        // and the rest tramples through (or is just wasted if no trample)
+        if (hasDeathtouch && hasTrample && blockerDies) {
+          damageDealt = power - 1; // Only 1 damage needed per blocker
+        } else {
+          damageDealt = power;
+        }
       } else {
         damageDealt = 0;
       }
@@ -676,9 +712,9 @@ export class CombatDecisionTree {
     }
 
     // Strategy modifiers
-    if (strategy === 'aggressive') {
+    if (strategy === "aggressive") {
       value += 0.1; // More willing to attack
-    } else if (strategy === 'defensive') {
+    } else if (strategy === "defensive") {
       value -= 0.2; // More cautious
     }
 
@@ -695,7 +731,7 @@ export class CombatDecisionTree {
       potentialBlockers: Permanent[];
       canBlock: boolean;
       blocks: Array<{ blocker: Permanent; trades: boolean; dies: boolean }>;
-    }>
+    }>,
   ): number {
     let maxRisk = 0;
 
@@ -721,24 +757,24 @@ export class CombatDecisionTree {
     creature: Permanent,
     targetId: string,
     expectedValue: number,
-    hasEvasion: boolean
+    hasEvasion: boolean,
   ): string {
     const power = creature.power || 0;
     const reasons: string[] = [];
 
     if (hasEvasion) {
-      reasons.push('has evasion');
+      reasons.push("has evasion");
     }
 
     if (expectedValue > 0.7) {
-      reasons.push('high value attack');
+      reasons.push("high value attack");
     } else if (expectedValue > 0.4) {
-      reasons.push('good attack opportunity');
+      reasons.push("good attack opportunity");
     } else {
-      reasons.push('worthwhile attack');
+      reasons.push("worthwhile attack");
     }
 
-    return `${creature.name} (${power} power) - ${reasons.join(', ')}`;
+    return `${creature.name} (${power} power) - ${reasons.join(", ")}`;
   }
 
   /**
@@ -762,7 +798,7 @@ export class CombatDecisionTree {
    */
   private evaluateBlocksForAttacker(
     attacker: Permanent,
-    availableBlockers: Permanent[]
+    availableBlockers: Permanent[],
   ): BlockDecision[] {
     const blocks: BlockDecision[] = [];
 
@@ -772,19 +808,39 @@ export class CombatDecisionTree {
 
     const attackerPower = attacker.power || 0;
     const attackerToughness = attacker.toughness || 0;
+    const attackerHasDeathtouch =
+      attacker.keywords?.includes("deathtouch") || false;
+    const attackerIsIndestructible =
+      attacker.keywords?.includes("indestructible") || false;
 
     // Sort blockers by effectiveness
     const sortedBlockers = [...availableBlockers].sort((a, b) => {
-      // Prefer blockers that can kill the attacker
-      const aKills = (a.power || 0) >= attackerToughness;
-      const bKills = (b.power || 0) >= attackerToughness;
+      // Deathtouch: any nonzero power kills; Indestructible attacker: can't kill it
+      const aHasDeathtouch = a.keywords?.includes("deathtouch") || false;
+      const bHasDeathtouch = b.keywords?.includes("deathtouch") || false;
+      const aKills =
+        !attackerIsIndestructible &&
+        (aHasDeathtouch
+          ? (a.power || 0) > 0
+          : (a.power || 0) >= attackerToughness);
+      const bKills =
+        !attackerIsIndestructible &&
+        (bHasDeathtouch
+          ? (b.power || 0) > 0
+          : (b.power || 0) >= attackerToughness);
 
       if (aKills && !bKills) return -1;
       if (!aKills && bKills) return 1;
 
-      // Prefer blockers that survive
-      const aSurvives = attackerPower < (a.toughness || 0);
-      const bSurvives = attackerPower < (b.toughness || 0);
+      // Prefer blockers that survive (deathtouch attacker kills any blocker, indestructible blockers always survive)
+      const aIsIndestructible = a.keywords?.includes("indestructible") || false;
+      const bIsIndestructible = b.keywords?.includes("indestructible") || false;
+      const aSurvives =
+        aIsIndestructible ||
+        (!attackerHasDeathtouch && attackerPower < (a.toughness || 0));
+      const bSurvives =
+        bIsIndestructible ||
+        (!attackerHasDeathtouch && attackerPower < (b.toughness || 0));
 
       if (aSurvives && !bSurvives) return -1;
       if (!aSurvives && bSurvives) return 1;
@@ -800,9 +856,22 @@ export class CombatDecisionTree {
     const bestBlocker = sortedBlockers[0];
     const blockerPower = bestBlocker.power || 0;
     const blockerToughness = bestBlocker.toughness || 0;
+    const blockerHasDeathtouch =
+      bestBlocker.keywords?.includes("deathtouch") || false;
+    const blockerIsIndestructible =
+      bestBlocker.keywords?.includes("indestructible") || false;
 
-    const attackerDies = blockerPower >= attackerToughness;
-    const blockerDies = attackerPower >= blockerToughness;
+    // Deathtouch: any nonzero damage is lethal; Indestructible: immune to destruction by damage
+    const attackerDies =
+      !attackerIsIndestructible &&
+      (blockerHasDeathtouch
+        ? blockerPower > 0
+        : blockerPower >= attackerToughness);
+    const blockerDies =
+      !blockerIsIndestructible &&
+      (attackerHasDeathtouch
+        ? attackerPower > 0
+        : attackerPower >= blockerToughness);
 
     // Calculate block value
     let blockValue = 0;
@@ -842,16 +911,49 @@ export class CombatDecisionTree {
     }
 
     // Adjust for first strike
-    if (attacker.keywords?.includes('first strike') ||
-        attacker.keywords?.includes('double strike')) {
+    if (
+      attacker.keywords?.includes("first strike") ||
+      attacker.keywords?.includes("double strike")
+    ) {
       // First strike makes blocking worse for us
       blockValue -= 0.2;
     }
 
-    if (bestBlocker.keywords?.includes('first strike') ||
-        bestBlocker.keywords?.includes('double strike')) {
-      // First strike makes blocking better for us
+    if (
+      bestBlocker.keywords?.includes("first strike") ||
+      bestBlocker.keywords?.includes("double strike")
+    ) {
       blockValue += 0.2;
+    }
+
+    // Deathtouch blocker is extremely effective — guarantees kill on any attack
+    if (
+      blockerHasDeathtouch &&
+      blockerPower > 0 &&
+      !attackerIsIndestructible &&
+      !attackerDies
+    ) {
+      blockValue += 0.3;
+    }
+
+    // Indestructible blocker is very safe — never dies to combat damage
+    if (blockerIsIndestructible && blockerDies) {
+      blockValue += 0.4; // Override chump-block penalty
+    }
+
+    // Don't block an indestructible attacker unless we have deathtouch or can survive
+    if (attackerIsIndestructible && !blockerHasDeathtouch) {
+      if (blockerDies) {
+        blockValue -= 0.6; // Strongly discourage losing a blocker to indestructible
+      }
+    }
+
+    // Deathtouch attacker kills even 1-toughness blockers — prefer cheap blockers
+    if (attackerHasDeathtouch && attackerPower > 0 && blockerDies) {
+      const blockerValue = bestBlocker.manaValue || 0;
+      if (blockerValue >= 3) {
+        blockValue -= 0.3; // Don't sacrifice expensive creatures to deathtouch
+      }
     }
 
     // Decide whether to block
@@ -864,14 +966,14 @@ export class CombatDecisionTree {
           attacker,
           attackerDies,
           blockerDies,
-          blockValue
+          blockValue,
         ),
         expectedValue: Math.max(0, Math.min(1, blockValue)),
       });
     }
 
     // Consider multi-block for menace
-    if (attacker.keywords?.includes('menace') && sortedBlockers.length >= 2) {
+    if (attacker.keywords?.includes("menace") && sortedBlockers.length >= 2) {
       const secondBestBlocker = sortedBlockers[1];
       const secondBlockValue = blockValue * 0.6; // Reduced value for second blocker
 
@@ -936,7 +1038,7 @@ export class CombatDecisionTree {
     attacker: Permanent,
     attackerDies: boolean,
     blockerDies: boolean,
-    _value: number
+    _value: number,
   ): string {
     if (attackerDies && !blockerDies) {
       return `${blocker.name} kills ${attacker.name} and survives`;
@@ -966,13 +1068,13 @@ export class CombatDecisionTree {
    */
   private evaluateCombatTricks(
     aiPlayer: PlayerState,
-    attacks: AttackDecision[]
+    attacks: AttackDecision[],
   ): CombatTrick[] {
     const tricks: CombatTrick[] = [];
 
     // Get combat-relevant cards from hand
-    const combatCards = aiPlayer.hand.filter((card: HandCard) => 
-      this.isCombatTrickCard(card)
+    const combatCards = aiPlayer.hand.filter((card: HandCard) =>
+      this.isCombatTrickCard(card),
     );
 
     // Evaluate each combat card for potential use
@@ -991,26 +1093,35 @@ export class CombatDecisionTree {
    */
   private isCombatTrickCard(card: HandCard): boolean {
     const typeLower = card.type.toLowerCase();
-    
+
     // Instant-speed combat tricks
-    const combatTypes = ['instant'];
+    const combatTypes = ["instant"];
     const combatKeywords = [
-      'pump', 'fight', 'damage', 'destroy', 'exile', 
-      'gain', 'trample', 'flying', 'lifelink', 'deathtouch'
+      "pump",
+      "fight",
+      "damage",
+      "destroy",
+      "exile",
+      "gain",
+      "trample",
+      "flying",
+      "lifelink",
+      "deathtouch",
     ];
-    
+
     // Check type
-    const isCombatType = combatTypes.some(t => typeLower.includes(t));
-    
+    const isCombatType = combatTypes.some((t) => typeLower.includes(t));
+
     // Check name for common pump/trick patterns
     const nameLower = card.name.toLowerCase();
-    const isCombatName = combatKeywords.some(k => nameLower.includes(k)) ||
-      nameLower.includes('strike') ||
-      nameLower.includes('bolt') ||
-      nameLower.includes('slash') ||
-      nameLower.includes('pierce') ||
-      nameLower.includes('blast');
-    
+    const isCombatName =
+      combatKeywords.some((k) => nameLower.includes(k)) ||
+      nameLower.includes("strike") ||
+      nameLower.includes("bolt") ||
+      nameLower.includes("slash") ||
+      nameLower.includes("pierce") ||
+      nameLower.includes("blast");
+
     return isCombatType || isCombatName;
   }
 
@@ -1020,20 +1131,24 @@ export class CombatDecisionTree {
   private analyzeCombatTrick(
     card: HandCard,
     attacks: AttackDecision[],
-    aiPlayer: PlayerState
+    aiPlayer: PlayerState,
   ): CombatTrick | null {
     // Parse the card to understand its effect
     const parsed = this.parseCombatTrick(card);
-    
+
     if (!parsed) return null;
 
     // Find best targets for this trick
     const targetAnalysis = this.findTrickTargets(parsed, attacks, aiPlayer);
-    
+
     if (!targetAnalysis) return null;
 
     // Calculate expected value
-    const expectedValue = this.calculateTrickValue(parsed, targetAnalysis, aiPlayer);
+    const expectedValue = this.calculateTrickValue(
+      parsed,
+      targetAnalysis,
+      aiPlayer,
+    );
 
     // Determine best timing
     const timing = this.determineTrickTiming(parsed, attacks);
@@ -1052,12 +1167,12 @@ export class CombatDecisionTree {
    * Parse a card's oracle text to understand its combat effect
    */
   private parseCombatTrick(card: HandCard): ParsedCombatTrick | null {
-    const oracleText = (card as { oracleText?: string }).oracleText || '';
+    const oracleText = (card as { oracleText?: string }).oracleText || "";
     const textLower = oracleText.toLowerCase();
-    
+
     // Initialize parsed result
     const parsed: ParsedCombatTrick = {
-      type: 'pump',
+      type: "pump",
       powerBoost: 0,
       toughnessBoost: 0,
       grantsKeyword: [],
@@ -1086,45 +1201,51 @@ export class CombatDecisionTree {
     }
 
     // Check for keywords
-    if (textLower.includes('trample')) parsed.grantsKeyword.push('trample');
-    if (textLower.includes('flying')) parsed.grantsKeyword.push('flying');
-    if (textLower.includes('lifelink')) parsed.grantsKeyword.push('lifelink');
-    if (textLower.includes('deathtouch')) parsed.grantsKeyword.push('deathtouch');
-    if (textLower.includes('first strike')) parsed.grantsKeyword.push('first strike');
-    if (textLower.includes('double strike')) parsed.grantsKeyword.push('double strike');
-    if (textLower.includes('indestructible')) parsed.grantsKeyword.push('indestructible');
+    if (textLower.includes("trample")) parsed.grantsKeyword.push("trample");
+    if (textLower.includes("flying")) parsed.grantsKeyword.push("flying");
+    if (textLower.includes("lifelink")) parsed.grantsKeyword.push("lifelink");
+    if (textLower.includes("deathtouch"))
+      parsed.grantsKeyword.push("deathtouch");
+    if (textLower.includes("first strike"))
+      parsed.grantsKeyword.push("first strike");
+    if (textLower.includes("double strike"))
+      parsed.grantsKeyword.push("double strike");
+    if (textLower.includes("indestructible"))
+      parsed.grantsKeyword.push("indestructible");
 
     // Check for damage/destroy effects
     const damageMatch = textLower.match(/deals (\d+) damage/);
-    if (damageMatch && !textLower.includes('prevent')) {
-      parsed.type = 'combat_damage';
+    if (damageMatch && !textLower.includes("prevent")) {
+      parsed.type = "combat_damage";
       parsed.powerBoost = parseInt(damageMatch[1]); // Use as effective power boost
     }
 
-    if (textLower.includes('destroy') && textLower.includes('creature')) {
+    if (textLower.includes("destroy") && textLower.includes("creature")) {
       parsed.destroyTarget = true;
-      parsed.type = 'destroy';
+      parsed.type = "destroy";
     }
 
-    if (textLower.includes('exile') && textLower.includes('creature')) {
+    if (textLower.includes("exile") && textLower.includes("creature")) {
       parsed.exileTarget = true;
-      parsed.type = 'exile';
+      parsed.type = "exile";
     }
 
     // Check for prevention
     const preventMatch = textLower.match(/prevent (\d+) damage/);
     if (preventMatch) {
       parsed.damagePrevention = parseInt(preventMatch[1]);
-      parsed.type = 'toughness_boost';
+      parsed.type = "toughness_boost";
     }
 
     // If no effect found, return null
-    if (parsed.powerBoost === 0 && 
-        parsed.toughnessBoost === 0 && 
-        parsed.grantsKeyword.length === 0 &&
-        !parsed.destroyTarget &&
-        !parsed.exileTarget &&
-        parsed.damagePrevention === 0) {
+    if (
+      parsed.powerBoost === 0 &&
+      parsed.toughnessBoost === 0 &&
+      parsed.grantsKeyword.length === 0 &&
+      !parsed.destroyTarget &&
+      !parsed.exileTarget &&
+      parsed.damagePrevention === 0
+    ) {
       return null;
     }
 
@@ -1137,27 +1258,37 @@ export class CombatDecisionTree {
   private findTrickTargets(
     parsed: ParsedCombatTrick,
     attacks: AttackDecision[],
-    _aiPlayer: PlayerState
-  ): { targetId: string; targetType: 'attacker' | 'blocker' | 'none'; value: number } | null {
+    _aiPlayer: PlayerState,
+  ): {
+    targetId: string;
+    targetType: "attacker" | "blocker" | "none";
+    value: number;
+  } | null {
     // For destroy/exile effects, find valuable targets
     if (parsed.destroyTarget || parsed.exileTarget) {
-      const opponentCreatures = this.getOpponents()
-        .flatMap(opp => opp.battlefield.filter(p => p.type === 'creature'));
-      
+      const opponentCreatures = this.getOpponents().flatMap((opp) =>
+        opp.battlefield.filter((p) => p.type === "creature"),
+      );
+
       if (opponentCreatures.length === 0) return null;
 
       // Find most valuable creature to destroy
-      const bestTarget = opponentCreatures.reduce((best, creature) => {
-        const value = (creature.manaValue || 0) + (creature.power || 0) * 0.5;
-        const bestValue = best ? ((best.manaValue || 0) + (best.power || 0) * 0.5) : 0;
-        return value > bestValue ? creature : best;
-      }, null as Permanent | null);
+      const bestTarget = opponentCreatures.reduce(
+        (best, creature) => {
+          const value = (creature.manaValue || 0) + (creature.power || 0) * 0.5;
+          const bestValue = best
+            ? (best.manaValue || 0) + (best.power || 0) * 0.5
+            : 0;
+          return value > bestValue ? creature : best;
+        },
+        null as Permanent | null,
+      );
 
       if (!bestTarget) return null;
 
       return {
         targetId: bestTarget.id,
-        targetType: 'blocker',
+        targetType: "blocker",
         value: (bestTarget.manaValue || 0) + (bestTarget.power || 0),
       };
     }
@@ -1165,10 +1296,10 @@ export class CombatDecisionTree {
     // For pump effects, find best attacker to boost
     if (attacks.length > 0) {
       // Prioritize attackers that would die without boost
-      const vulnerableAttackers = attacks.filter(attack => {
+      const vulnerableAttackers = attacks.filter((attack) => {
         const creature = this.findCreatureById(attack.creatureId);
         if (!creature) return false;
-        
+
         // Check if creature would die in combat without boost
         return attack.riskLevel > 0.5;
       });
@@ -1181,7 +1312,7 @@ export class CombatDecisionTree {
 
         return {
           targetId: best.creatureId,
-          targetType: 'attacker',
+          targetType: "attacker",
           value: best.expectedValue,
         };
       }
@@ -1193,7 +1324,7 @@ export class CombatDecisionTree {
 
       return {
         targetId: bestAttack.creatureId,
-        targetType: 'attacker',
+        targetType: "attacker",
         value: bestAttack.expectedValue,
       };
     }
@@ -1206,8 +1337,12 @@ export class CombatDecisionTree {
    */
   private calculateTrickValue(
     parsed: ParsedCombatTrick,
-    target: { targetId: string; targetType: 'attacker' | 'blocker' | 'none'; value: number },
-    __aiPlayer: PlayerState
+    target: {
+      targetId: string;
+      targetType: "attacker" | "blocker" | "none";
+      value: number;
+    },
+    __aiPlayer: PlayerState,
   ): number {
     let value = 0;
 
@@ -1222,10 +1357,12 @@ export class CombatDecisionTree {
       // Check if this saves a creature from death
       const targetCreature = this.findCreatureById(target.targetId);
       if (targetCreature) {
-        const wouldDieWithout = (targetCreature.power || 0) < (targetCreature.toughness || 0);
-        const wouldLiveWith = (targetCreature.power || 0) + parsed.powerBoost >= 
-                             (targetCreature.toughness || 0) + parsed.toughnessBoost;
-        
+        const wouldDieWithout =
+          (targetCreature.power || 0) < (targetCreature.toughness || 0);
+        const wouldLiveWith =
+          (targetCreature.power || 0) + parsed.powerBoost >=
+          (targetCreature.toughness || 0) + parsed.toughnessBoost;
+
         if (wouldDieWithout && wouldLiveWith) {
           value += 0.5; // Saved our creature
         } else if (!wouldDieWithout) {
@@ -1235,14 +1372,14 @@ export class CombatDecisionTree {
     }
 
     // Value from keyword grants
-    if (parsed.grantsKeyword.includes('lifelink')) {
+    if (parsed.grantsKeyword.includes("lifelink")) {
       // Lifelink is very valuable
       value += 0.2;
     }
-    if (parsed.grantsKeyword.includes('trample')) {
+    if (parsed.grantsKeyword.includes("trample")) {
       value += 0.15;
     }
-    if (parsed.grantsKeyword.includes('indestructible')) {
+    if (parsed.grantsKeyword.includes("indestructible")) {
       value += 0.4;
     }
 
@@ -1258,22 +1395,22 @@ export class CombatDecisionTree {
    */
   private determineTrickTiming(
     parsed: ParsedCombatTrick,
-    attacks: AttackDecision[]
-  ): 'before_attackers' | 'before_blockers' | 'after_blockers' | 'damage' {
+    attacks: AttackDecision[],
+  ): "before_attackers" | "before_blockers" | "after_blockers" | "damage" {
     // Destroy/exile effects: wait until blockers to see what needs killing
     if (parsed.destroyTarget || parsed.exileTarget) {
-      return 'before_blockers';
+      return "before_blockers";
     }
 
-    // Pump effects: either before attackers (to force through) 
+    // Pump effects: either before attackers (to force through)
     // or after blockers (to save)
     if (attacks.length > 0 && parsed.powerBoost > parsed.toughnessBoost) {
       // Offensive pump: use before attackers to force damage through
-      return 'before_attackers';
+      return "before_attackers";
     }
 
     // Defensive pump: use after blockers to save creatures
-    return 'after_blockers';
+    return "after_blockers";
   }
 
   /**
@@ -1282,10 +1419,10 @@ export class CombatDecisionTree {
   private generateTrickReasoning(
     cardName: string,
     parsed: ParsedCombatTrick,
-    target: { targetId: string; targetType: string; value: number }
+    target: { targetId: string; targetType: string; value: number },
   ): string {
     const targetCreature = this.findCreatureById(target.targetId);
-    const targetName = targetCreature?.name || 'target';
+    const targetName = targetCreature?.name || "target";
 
     if (parsed.destroyTarget) {
       return `Use ${cardName} to destroy ${targetName} (high value target)`;
@@ -1296,11 +1433,12 @@ export class CombatDecisionTree {
     if (parsed.powerBoost > 0 || parsed.toughnessBoost > 0) {
       const boosts = [];
       if (parsed.powerBoost > 0) boosts.push(`+${parsed.powerBoost} power`);
-      if (parsed.toughnessBoost > 0) boosts.push(`+${parsed.toughnessBoost} toughness`);
-      return `Use ${cardName} to give ${targetName} ${boosts.join('/')}`;
+      if (parsed.toughnessBoost > 0)
+        boosts.push(`+${parsed.toughnessBoost} toughness`);
+      return `Use ${cardName} to give ${targetName} ${boosts.join("/")}`;
     }
     if (parsed.grantsKeyword.length > 0) {
-      return `Use ${cardName} to give ${targetName} ${parsed.grantsKeyword.join(', ')}`;
+      return `Use ${cardName} to give ${targetName} ${parsed.grantsKeyword.join(", ")}`;
     }
 
     return `Use ${cardName} during combat`;
@@ -1311,7 +1449,10 @@ export class CombatDecisionTree {
    */
   private calculateTotalExpectedValue(attacks: AttackDecision[]): number {
     if (attacks.length === 0) return 0;
-    return attacks.reduce((sum, attack) => sum + attack.expectedValue, 0) / attacks.length;
+    return (
+      attacks.reduce((sum, attack) => sum + attack.expectedValue, 0) /
+      attacks.length
+    );
   }
 
   /**
@@ -1319,7 +1460,10 @@ export class CombatDecisionTree {
    */
   private calculateTotalBlockValue(blocks: BlockDecision[]): number {
     if (blocks.length === 0) return 0;
-    return blocks.reduce((sum, block) => sum + block.expectedValue, 0) / blocks.length;
+    return (
+      blocks.reduce((sum, block) => sum + block.expectedValue, 0) /
+      blocks.length
+    );
   }
 
   /**
@@ -1327,7 +1471,7 @@ export class CombatDecisionTree {
    */
   private getOpponents(): PlayerState[] {
     return Object.values(this.gameState.players).filter(
-      (p) => p.id !== this.aiPlayerId
+      (p) => p.id !== this.aiPlayerId,
     );
   }
 
@@ -1338,20 +1482,35 @@ export class CombatDecisionTree {
   evaluateTrade(
     blockingCreature: Permanent,
     attackingCreature: Permanent,
-    context: { attackers: Permanent[]; blockers: Permanent[] }
+    context: { attackers: Permanent[]; blockers: Permanent[] },
   ): number {
     let tradeValue = 0;
 
-    // Calculate card advantage
     const blockerValue = blockingCreature.manaValue || 1;
     const attackerValue = attackingCreature.manaValue || 1;
 
-    // Positive if we're trading up (attacker is more expensive)
+    const attackerHasDeathtouch =
+      attackingCreature.keywords?.includes("deathtouch") || false;
+    const attackerIsIndestructible =
+      attackingCreature.keywords?.includes("indestructible") || false;
+    const blockerHasDeathtouch =
+      blockingCreature.keywords?.includes("deathtouch") || false;
+    const blockerIsIndestructible =
+      blockingCreature.keywords?.includes("indestructible") || false;
+
     tradeValue += (attackerValue - blockerValue) * 0.3;
 
-    // Check for 2-for-1 potential
-    const willKillBlocker = (attackingCreature.power || 0) >= (blockingCreature.toughness || 0);
-    const willKillAttacker = (blockingCreature.power || 0) >= (attackingCreature.toughness || 0);
+    // Deathtouch: any nonzero damage is lethal; Indestructible: immune to damage destruction
+    const willKillBlocker =
+      !blockerIsIndestructible &&
+      (attackerHasDeathtouch
+        ? (attackingCreature.power || 0) > 0
+        : (attackingCreature.power || 0) >= (blockingCreature.toughness || 0));
+    const willKillAttacker =
+      !attackerIsIndestructible &&
+      (blockerHasDeathtouch
+        ? (blockingCreature.power || 0) > 0
+        : (blockingCreature.power || 0) >= (attackingCreature.toughness || 0));
 
     if (willKillBlocker && willKillAttacker) {
       // 1-for-1 trade - neutral
@@ -1387,30 +1546,42 @@ export class CombatDecisionTree {
    */
   private hasETBValue(creature: Permanent): boolean {
     // Simplified check - in real implementation would check oracle text
-    const name = creature.name?.toLowerCase() || '';
+    const name = creature.name?.toLowerCase() || "";
     const keywords = creature.keywords || [];
-    
+
     // Common ETB patterns
-    const etbKeywords = ['deathrattle', 'entersthebattlefield', 'etb'];
-    const etbNames = ['draw', 'scry', 'create', 'token', 'destroy', 'exile', 'counter'];
-    
-    return etbKeywords.some(k => keywords.includes(k)) ||
-           etbNames.some(n => name.includes(n));
+    const etbKeywords = ["deathrattle", "entersthebattlefield", "etb"];
+    const etbNames = [
+      "draw",
+      "scry",
+      "create",
+      "token",
+      "destroy",
+      "exile",
+      "counter",
+    ];
+
+    return (
+      etbKeywords.some((k) => keywords.includes(k)) ||
+      etbNames.some((n) => name.includes(n))
+    );
   }
 
   /**
    * Check if creature has leave-the-battlefield value
    */
   private hasLTBValue(creature: Permanent): boolean {
-    const name = creature.name?.toLowerCase() || '';
+    const name = creature.name?.toLowerCase() || "";
     const keywords = creature.keywords || [];
-    
+
     // Common LTB patterns
-    const ltbKeywords = ['deathrattle', 'leavesthebattlefield', 'ltb'];
-    const ltbNames = ['when', 'dies', 'leave', 'sacrifice'];
-    
-    return ltbKeywords.some(k => keywords.includes(k)) ||
-           ltbNames.some(n => name.includes(n));
+    const ltbKeywords = ["deathrattle", "leavesthebattlefield", "ltb"];
+    const ltbNames = ["when", "dies", "leave", "sacrifice"];
+
+    return (
+      ltbKeywords.some((k) => keywords.includes(k)) ||
+      ltbNames.some((n) => name.includes(n))
+    );
   }
 
   /**
@@ -1420,35 +1591,64 @@ export class CombatDecisionTree {
   shouldMultiBlock(
     attacker: Permanent,
     availableBlockers: Permanent[],
-    context: { attackers: Permanent[]; blockers: Permanent[] }
-  ): { shouldMultiBlock: boolean; selectedBlockers: Permanent[]; reasoning: string } {
+    context: { attackers: Permanent[]; blockers: Permanent[] },
+  ): {
+    shouldMultiBlock: boolean;
+    selectedBlockers: Permanent[];
+    reasoning: string;
+  } {
     const attackers = context.attackers;
-    
+
     // Don't multi-block if we only have 1 creature
     if (availableBlockers.length < 2) {
-      return { shouldMultiBlock: false, selectedBlockers: [], reasoning: 'Insufficient blockers' };
+      return {
+        shouldMultiBlock: false,
+        selectedBlockers: [],
+        reasoning: "Insufficient blockers",
+      };
+    }
+
+    // Don't multi-block deathtouch creatures — a single blocker is sufficient
+    // since any nonzero damage from deathtouch is lethal
+    if (attacker.keywords?.includes("deathtouch")) {
+      return {
+        shouldMultiBlock: false,
+        selectedBlockers: [],
+        reasoning: "Single blocker sufficient vs deathtouch",
+      };
+    }
+
+    // Don't multi-block indestructible creatures — we can't kill them via damage
+    if (attacker.keywords?.includes("indestructible")) {
+      return {
+        shouldMultiBlock: false,
+        selectedBlockers: [],
+        reasoning: "Cannot kill indestructible via combat damage",
+      };
     }
 
     // High threat attacker - more likely to multi-block
     const threatLevel = this.evaluateAttackerThreat(attacker);
-    
+
     // Expert aggressively multi-blocks high-threat creatures
-    const multiBlockThreshold = this.config.cardAdvantageWeight >= 2.0 ? 0.4 : 0.6;
+    const multiBlockThreshold =
+      this.config.cardAdvantageWeight >= 2.0 ? 0.4 : 0.6;
 
     if (threatLevel < multiBlockThreshold) {
-      return { 
-        shouldMultiBlock: false, 
-        selectedBlockers: [], 
-        reasoning: `Attacker threat level ${threatLevel.toFixed(2)} below threshold` 
+      return {
+        shouldMultiBlock: false,
+        selectedBlockers: [],
+        reasoning: `Attacker threat level ${threatLevel.toFixed(2)} below threshold`,
       };
     }
 
     // Check if attacker has trample - good reason to multi-block
-    const hasTrample = attacker.keywords?.includes('trample');
-    
+    const hasTrample = attacker.keywords?.includes("trample");
+
     // Check if we're at low life - protect ourselves
     const aiPlayer = this.gameState.players[this.aiPlayerId];
-    const atLowLife = aiPlayer && aiPlayer.life <= (this.config.lifeThreshold || 10);
+    const atLowLife =
+      aiPlayer && aiPlayer.life <= (this.config.lifeThreshold || 10);
 
     // Select best 2 blockers
     const sortedBlockers = [...availableBlockers].sort((a, b) => {
@@ -1457,16 +1657,16 @@ export class CombatDecisionTree {
     });
 
     const selectedBlockers = sortedBlockers.slice(0, 2);
-    
-    let reasoning = `Multi-blocking with ${selectedBlockers.map(b => b.name).join(', ')}`;
-    if (hasTrample) reasoning += ' (trample prevention)';
-    if (atLowLife) reasoning += ' (low life protection)';
+
+    let reasoning = `Multi-blocking with ${selectedBlockers.map((b) => b.name).join(", ")}`;
+    if (hasTrample) reasoning += " (trample prevention)";
+    if (atLowLife) reasoning += " (low life protection)";
     reasoning += ` [threat: ${threatLevel.toFixed(2)}]`;
 
     return {
       shouldMultiBlock: true,
       selectedBlockers,
-      reasoning
+      reasoning,
     };
   }
 
@@ -1482,10 +1682,10 @@ export class CombatDecisionTree {
 
     // Keywords add threat
     const keywords = attacker.keywords || [];
-    if (keywords.includes('flying')) threat += 0.15;
-    if (keywords.includes('trample')) threat += 0.15;
-    if (keywords.includes('lifelink')) threat += 0.1;
-    if (keywords.includes('.double_strike')) threat += 0.15;
+    if (keywords.includes("flying")) threat += 0.15;
+    if (keywords.includes("trample")) threat += 0.15;
+    if (keywords.includes("lifelink")) threat += 0.1;
+    if (keywords.includes(".double_strike")) threat += 0.15;
 
     // High mana value = more threatening
     const manaValue = attacker.manaValue || 0;
@@ -1501,7 +1701,7 @@ export class CombatDecisionTree {
 export function generateAttackDecisions(
   gameState: GameState,
   aiPlayerId: string,
-  difficulty: 'easy' | 'medium' | 'hard' | 'expert' = 'medium'
+  difficulty: "easy" | "medium" | "hard" | "expert" = "medium",
 ): CombatPlan {
   const ai = new CombatDecisionTree(gameState, aiPlayerId, difficulty);
   return ai.generateAttackPlan();
@@ -1514,7 +1714,7 @@ export function generateBlockingDecisions(
   gameState: GameState,
   aiPlayerId: string,
   attackers: Permanent[],
-  difficulty: 'easy' | 'medium' | 'hard' | 'expert' = 'medium'
+  difficulty: "easy" | "medium" | "hard" | "expert" = "medium",
 ): CombatPlan {
   const ai = new CombatDecisionTree(gameState, aiPlayerId, difficulty);
   return ai.generateBlockingPlan(attackers);

--- a/src/lib/game-state/__tests__/combat.test.ts
+++ b/src/lib/game-state/__tests__/combat.test.ts
@@ -19,14 +19,11 @@ import {
   resolveCombatDamage,
   getAvailableAttackers,
   getAvailableBlockers,
-} from '../combat';
-import {
-  createInitialGameState,
-  startGame,
-} from '../game-state';
-import { createCardInstance } from '../card-instance';
-import { Phase } from '../types';
-import type { ScryfallCard } from '@/app/actions';
+} from "../combat";
+import { createInitialGameState, startGame } from "../game-state";
+import { createCardInstance } from "../card-instance";
+import { Phase } from "../types";
+import type { ScryfallCard } from "@/app/actions";
 
 // Helper function to create a mock creature card
 function createMockCreature(
@@ -34,32 +31,42 @@ function createMockCreature(
   power: number,
   toughness: number,
   keywords: string[] = [],
-  isLegendary: boolean = false
+  isLegendary: boolean = false,
 ): ScryfallCard {
   return {
-    id: `mock-${name.toLowerCase().replace(/\s+/g, '-')}`,
+    id: `mock-${name.toLowerCase().replace(/\s+/g, "-")}`,
     name,
-    type_line: `${isLegendary ? 'Legendary ' : ''}Creature — Test`,
+    type_line: `${isLegendary ? "Legendary " : ""}Creature — Test`,
     power: power.toString(),
     toughness: toughness.toString(),
     keywords,
-    oracle_text: keywords.join(' '),
-    mana_cost: '{1}',
+    oracle_text: keywords.join(" "),
+    mana_cost: "{1}",
     cmc: 2,
-    colors: ['R'],
-    color_identity: ['R'],
-    legalities: { standard: 'legal', commander: 'legal' },
+    colors: ["R"],
+    color_identity: ["R"],
+    legalities: { standard: "legal", commander: "legal" },
     card_faces: undefined,
-    layout: 'normal',
+    layout: "normal",
   } as ScryfallCard;
 }
 
 // Helper to set up a game with creatures on the battlefield
 function setupGameWithCreatures(
-  player1Creatures: Array<{ name: string; power: number; toughness: number; keywords?: string[] }> = [],
-  player2Creatures: Array<{ name: string; power: number; toughness: number; keywords?: string[] }> = []
+  player1Creatures: Array<{
+    name: string;
+    power: number;
+    toughness: number;
+    keywords?: string[];
+  }> = [],
+  player2Creatures: Array<{
+    name: string;
+    power: number;
+    toughness: number;
+    keywords?: string[];
+  }> = [],
 ) {
-  let state = createInitialGameState(['Alice', 'Bob'], 20, false);
+  let state = createInitialGameState(["Alice", "Bob"], 20, false);
   state = startGame(state);
 
   const playerIds = Array.from(state.players.keys());
@@ -68,12 +75,17 @@ function setupGameWithCreatures(
 
   // Add creatures to Alice's battlefield
   for (const creature of player1Creatures) {
-    const creatureData = createMockCreature(creature.name, creature.power, creature.toughness, creature.keywords);
+    const creatureData = createMockCreature(
+      creature.name,
+      creature.power,
+      creature.toughness,
+      creature.keywords,
+    );
     const creatureInstance = createCardInstance(creatureData, aliceId, aliceId);
     // Clear summoning sickness for creatures that should be able to attack
     creatureInstance.hasSummoningSickness = false;
     state.cards.set(creatureInstance.id, creatureInstance);
-    
+
     const battlefield = state.zones.get(`${aliceId}-battlefield`)!;
     state.zones.set(`${aliceId}-battlefield`, {
       ...battlefield,
@@ -83,12 +95,17 @@ function setupGameWithCreatures(
 
   // Add creatures to Bob's battlefield
   for (const creature of player2Creatures) {
-    const creatureData = createMockCreature(creature.name, creature.power, creature.toughness, creature.keywords);
+    const creatureData = createMockCreature(
+      creature.name,
+      creature.power,
+      creature.toughness,
+      creature.keywords,
+    );
     const creatureInstance = createCardInstance(creatureData, bobId, bobId);
     // Clear summoning sickness
     creatureInstance.hasSummoningSickness = false;
     state.cards.set(creatureInstance.id, creatureInstance);
-    
+
     const battlefield = state.zones.get(`${bobId}-battlefield`)!;
     state.zones.set(`${bobId}-battlefield`, {
       ...battlefield,
@@ -99,11 +116,11 @@ function setupGameWithCreatures(
   return { state, aliceId, bobId };
 }
 
-describe('Combat System - Attacker Declaration', () => {
-  describe('canAttack', () => {
-    it('should allow untapped creature without summoning sickness to attack', () => {
+describe("Combat System - Attacker Declaration", () => {
+  describe("canAttack", () => {
+    it("should allow untapped creature without summoning sickness to attack", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures([
-        { name: 'Grizzly Bears', power: 2, toughness: 2 }
+        { name: "Grizzly Bears", power: 2, toughness: 2 },
       ]);
 
       const battlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -113,31 +130,36 @@ describe('Combat System - Attacker Declaration', () => {
       expect(result.canAttack).toBe(true);
     });
 
-    it('should prevent tapped creature from attacking', () => {
+    it("should prevent tapped creature from attacking", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures([
-        { name: 'Grizzly Bears', power: 2, toughness: 2 }
+        { name: "Grizzly Bears", power: 2, toughness: 2 },
       ]);
 
       const battlefield = state.zones.get(`${aliceId}-battlefield`)!;
       const creatureId = battlefield.cardIds[0];
-      
+
       // Tap the creature
       const creature = state.cards.get(creatureId)!;
       creature.isTapped = true;
 
       const result = canAttack(state, creatureId, bobId);
       expect(result.canAttack).toBe(false);
-      expect(result.reason).toContain('tapped');
+      expect(result.reason).toContain("tapped");
     });
 
-    it('should allow tapped creature with vigilance to attack', () => {
+    it("should allow tapped creature with vigilance to attack", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures([
-        { name: 'Vigilant Creature', power: 2, toughness: 2, keywords: ['Vigilance'] }
+        {
+          name: "Vigilant Creature",
+          power: 2,
+          toughness: 2,
+          keywords: ["Vigilance"],
+        },
       ]);
 
       const battlefield = state.zones.get(`${aliceId}-battlefield`)!;
       const creatureId = battlefield.cardIds[0];
-      
+
       // Tap the creature (it has vigilance, so it should still be able to attack)
       const creature = state.cards.get(creatureId)!;
       creature.isTapped = true;
@@ -146,31 +168,31 @@ describe('Combat System - Attacker Declaration', () => {
       expect(result.canAttack).toBe(true);
     });
 
-    it('should prevent creature with summoning sickness from attacking', () => {
+    it("should prevent creature with summoning sickness from attacking", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures([
-        { name: 'Grizzly Bears', power: 2, toughness: 2 }
+        { name: "Grizzly Bears", power: 2, toughness: 2 },
       ]);
 
       const battlefield = state.zones.get(`${aliceId}-battlefield`)!;
       const creatureId = battlefield.cardIds[0];
-      
+
       // Give the creature summoning sickness
       const creature = state.cards.get(creatureId)!;
       creature.hasSummoningSickness = true;
 
       const result = canAttack(state, creatureId, bobId);
       expect(result.canAttack).toBe(false);
-      expect(result.reason).toContain('Summoning sickness');
+      expect(result.reason).toContain("Summoning sickness");
     });
 
-    it('should allow creature with haste to attack despite summoning sickness', () => {
+    it("should allow creature with haste to attack despite summoning sickness", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures([
-        { name: 'Hasty Creature', power: 2, toughness: 2, keywords: ['Haste'] }
+        { name: "Hasty Creature", power: 2, toughness: 2, keywords: ["Haste"] },
       ]);
 
       const battlefield = state.zones.get(`${aliceId}-battlefield`)!;
       const creatureId = battlefield.cardIds[0];
-      
+
       // Give the creature summoning sickness
       const creature = state.cards.get(creatureId)!;
       creature.hasSummoningSickness = true;
@@ -179,8 +201,8 @@ describe('Combat System - Attacker Declaration', () => {
       expect(result.canAttack).toBe(true);
     });
 
-    it('should prevent non-creature from attacking', () => {
-      let state = createInitialGameState(['Alice', 'Bob'], 20, false);
+    it("should prevent non-creature from attacking", () => {
+      let state = createInitialGameState(["Alice", "Bob"], 20, false);
       state = startGame(state);
 
       const playerIds = Array.from(state.players.keys());
@@ -189,22 +211,22 @@ describe('Combat System - Attacker Declaration', () => {
 
       // Create a non-creature permanent (land)
       const landData = {
-        id: 'mock-land',
-        name: 'Forest',
-        type_line: 'Land — Forest',
+        id: "mock-land",
+        name: "Forest",
+        type_line: "Land — Forest",
         keywords: [],
-        oracle_text: '',
-        mana_cost: '',
+        oracle_text: "",
+        mana_cost: "",
         cmc: 0,
         colors: [],
-        legalities: { standard: 'legal', commander: 'legal' },
+        legalities: { standard: "legal", commander: "legal" },
         color_identity: [],
         card_faces: undefined,
-        layout: 'normal',
+        layout: "normal",
       } as ScryfallCard;
       const land = createCardInstance(landData, aliceId, aliceId);
       state.cards.set(land.id, land);
-      
+
       const battlefield = state.zones.get(`${aliceId}-battlefield`)!;
       state.zones.set(`${aliceId}-battlefield`, {
         ...battlefield,
@@ -213,12 +235,12 @@ describe('Combat System - Attacker Declaration', () => {
 
       const result = canAttack(state, land.id, bobId);
       expect(result.canAttack).toBe(false);
-      expect(result.reason).toContain('Only creatures can attack');
+      expect(result.reason).toContain("Only creatures can attack");
     });
 
-    it('should require a defender to be specified', () => {
+    it("should require a defender to be specified", () => {
       const { state, aliceId } = setupGameWithCreatures([
-        { name: 'Grizzly Bears', power: 2, toughness: 2 }
+        { name: "Grizzly Bears", power: 2, toughness: 2 },
       ]);
 
       const battlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -226,14 +248,14 @@ describe('Combat System - Attacker Declaration', () => {
 
       const result = canAttack(state, creatureId);
       expect(result.canAttack).toBe(false);
-      expect(result.reason).toContain('No defender specified');
+      expect(result.reason).toContain("No defender specified");
     });
   });
 
-  describe('declareAttackers', () => {
-    it('should tap attacking creatures without vigilance', () => {
+  describe("declareAttackers", () => {
+    it("should tap attacking creatures without vigilance", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures([
-        { name: 'Grizzly Bears', power: 2, toughness: 2 }
+        { name: "Grizzly Bears", power: 2, toughness: 2 },
       ]);
 
       // Set phase to declare attackers
@@ -243,7 +265,7 @@ describe('Combat System - Attacker Declaration', () => {
       const creatureId = battlefield.cardIds[0];
 
       const result = declareAttackers(state, [
-        { cardId: creatureId, defenderId: bobId }
+        { cardId: creatureId, defenderId: bobId },
       ]);
 
       expect(result.success).toBe(true);
@@ -251,9 +273,14 @@ describe('Combat System - Attacker Declaration', () => {
       expect(attacker?.isTapped).toBe(true);
     });
 
-    it('should not tap attacking creatures with vigilance', () => {
+    it("should not tap attacking creatures with vigilance", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures([
-        { name: 'Vigilant Creature', power: 2, toughness: 2, keywords: ['Vigilance'] }
+        {
+          name: "Vigilant Creature",
+          power: 2,
+          toughness: 2,
+          keywords: ["Vigilance"],
+        },
       ]);
 
       // Set phase to declare attackers
@@ -263,7 +290,7 @@ describe('Combat System - Attacker Declaration', () => {
       const creatureId = battlefield.cardIds[0];
 
       const result = declareAttackers(state, [
-        { cardId: creatureId, defenderId: bobId }
+        { cardId: creatureId, defenderId: bobId },
       ]);
 
       expect(result.success).toBe(true);
@@ -271,9 +298,9 @@ describe('Combat System - Attacker Declaration', () => {
       expect(attacker?.isTapped).toBe(false);
     });
 
-    it('should fail if not in combat phase', () => {
+    it("should fail if not in combat phase", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures([
-        { name: 'Grizzly Bears', power: 2, toughness: 2 }
+        { name: "Grizzly Bears", power: 2, toughness: 2 },
       ]);
 
       // Set phase to main phase (not combat)
@@ -283,18 +310,18 @@ describe('Combat System - Attacker Declaration', () => {
       const creatureId = battlefield.cardIds[0];
 
       const result = declareAttackers(state, [
-        { cardId: creatureId, defenderId: bobId }
+        { cardId: creatureId, defenderId: bobId },
       ]);
 
       expect(result.success).toBe(false);
       expect(result.errors).toBeDefined();
     });
 
-    it('should handle multiple attackers', () => {
+    it("should handle multiple attackers", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures([
-        { name: 'Creature 1', power: 2, toughness: 2 },
-        { name: 'Creature 2', power: 3, toughness: 3 },
-        { name: 'Creature 3', power: 1, toughness: 1 }
+        { name: "Creature 1", power: 2, toughness: 2 },
+        { name: "Creature 2", power: 3, toughness: 3 },
+        { name: "Creature 3", power: 1, toughness: 1 },
       ]);
 
       // Set phase to declare attackers
@@ -306,7 +333,7 @@ describe('Combat System - Attacker Declaration', () => {
       const result = declareAttackers(state, [
         { cardId: creatureIds[0], defenderId: bobId },
         { cardId: creatureIds[1], defenderId: bobId },
-        { cardId: creatureIds[2], defenderId: bobId }
+        { cardId: creatureIds[2], defenderId: bobId },
       ]);
 
       expect(result.success).toBe(true);
@@ -315,12 +342,12 @@ describe('Combat System - Attacker Declaration', () => {
   });
 });
 
-describe('Combat System - Blocker Declaration', () => {
-  describe('canBlock', () => {
-    it('should allow untapped creature to block', () => {
+describe("Combat System - Blocker Declaration", () => {
+  describe("canBlock", () => {
+    it("should allow untapped creature to block", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures(
-        [{ name: 'Attacker', power: 2, toughness: 2 }],
-        [{ name: 'Blocker', power: 2, toughness: 2 }]
+        [{ name: "Attacker", power: 2, toughness: 2 }],
+        [{ name: "Blocker", power: 2, toughness: 2 }],
       );
 
       const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -332,10 +359,10 @@ describe('Combat System - Blocker Declaration', () => {
       expect(result.canBlock).toBe(true);
     });
 
-    it('should prevent tapped creature from blocking', () => {
+    it("should prevent tapped creature from blocking", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures(
-        [{ name: 'Attacker', power: 2, toughness: 2 }],
-        [{ name: 'Blocker', power: 2, toughness: 2 }]
+        [{ name: "Attacker", power: 2, toughness: 2 }],
+        [{ name: "Blocker", power: 2, toughness: 2 }],
       );
 
       const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -349,13 +376,20 @@ describe('Combat System - Blocker Declaration', () => {
 
       const result = canBlock(state, blockerId, attackerId);
       expect(result.canBlock).toBe(false);
-      expect(result.reason).toContain('tapped');
+      expect(result.reason).toContain("tapped");
     });
 
-    it('should prevent non-flying, non-reach creature from blocking flying', () => {
+    it("should prevent non-flying, non-reach creature from blocking flying", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures(
-        [{ name: 'Flying Attacker', power: 2, toughness: 2, keywords: ['Flying'] }],
-        [{ name: 'Ground Blocker', power: 2, toughness: 2 }]
+        [
+          {
+            name: "Flying Attacker",
+            power: 2,
+            toughness: 2,
+            keywords: ["Flying"],
+          },
+        ],
+        [{ name: "Ground Blocker", power: 2, toughness: 2 }],
       );
 
       const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -365,13 +399,27 @@ describe('Combat System - Blocker Declaration', () => {
 
       const result = canBlock(state, blockerId, attackerId);
       expect(result.canBlock).toBe(false);
-      expect(result.reason).toContain('flying');
+      expect(result.reason).toContain("flying");
     });
 
-    it('should allow flying creature to block flying', () => {
+    it("should allow flying creature to block flying", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures(
-        [{ name: 'Flying Attacker', power: 2, toughness: 2, keywords: ['Flying'] }],
-        [{ name: 'Flying Blocker', power: 2, toughness: 2, keywords: ['Flying'] }]
+        [
+          {
+            name: "Flying Attacker",
+            power: 2,
+            toughness: 2,
+            keywords: ["Flying"],
+          },
+        ],
+        [
+          {
+            name: "Flying Blocker",
+            power: 2,
+            toughness: 2,
+            keywords: ["Flying"],
+          },
+        ],
       );
 
       const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -383,10 +431,24 @@ describe('Combat System - Blocker Declaration', () => {
       expect(result.canBlock).toBe(true);
     });
 
-    it('should allow reach creature to block flying', () => {
+    it("should allow reach creature to block flying", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures(
-        [{ name: 'Flying Attacker', power: 2, toughness: 2, keywords: ['Flying'] }],
-        [{ name: 'Reach Blocker', power: 2, toughness: 2, keywords: ['Reach'] }]
+        [
+          {
+            name: "Flying Attacker",
+            power: 2,
+            toughness: 2,
+            keywords: ["Flying"],
+          },
+        ],
+        [
+          {
+            name: "Reach Blocker",
+            power: 2,
+            toughness: 2,
+            keywords: ["Reach"],
+          },
+        ],
       );
 
       const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -399,16 +461,16 @@ describe('Combat System - Blocker Declaration', () => {
     });
   });
 
-  describe('declareBlockers', () => {
-    it('should assign blockers to attackers', () => {
+  describe("declareBlockers", () => {
+    it("should assign blockers to attackers", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures(
-        [{ name: 'Attacker', power: 2, toughness: 2 }],
-        [{ name: 'Blocker', power: 2, toughness: 2 }]
+        [{ name: "Attacker", power: 2, toughness: 2 }],
+        [{ name: "Blocker", power: 2, toughness: 2 }],
       );
 
       // Set up combat phase with attackers
       state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
-      
+
       const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
       const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
       const attackerId = aliceBattlefield.cardIds[0];
@@ -417,7 +479,7 @@ describe('Combat System - Blocker Declaration', () => {
       // First declare attackers
       state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
       const attackResult = declareAttackers(state, [
-        { cardId: attackerId, defenderId: bobId }
+        { cardId: attackerId, defenderId: bobId },
       ]);
       const stateWithAttackers = attackResult.state;
       stateWithAttackers.turn.currentPhase = Phase.DECLARE_BLOCKERS;
@@ -431,14 +493,14 @@ describe('Combat System - Blocker Declaration', () => {
       expect(result.state.combat.blockers.has(attackerId)).toBe(true);
     });
 
-    it('should handle multiple blockers for one attacker', () => {
+    it("should handle multiple blockers for one attacker", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures(
-        [{ name: 'Big Attacker', power: 5, toughness: 5 }],
+        [{ name: "Big Attacker", power: 5, toughness: 5 }],
         [
-          { name: 'Blocker 1', power: 2, toughness: 2 },
-          { name: 'Blocker 2', power: 2, toughness: 2 },
-          { name: 'Blocker 3', power: 2, toughness: 2 }
-        ]
+          { name: "Blocker 1", power: 2, toughness: 2 },
+          { name: "Blocker 2", power: 2, toughness: 2 },
+          { name: "Blocker 3", power: 2, toughness: 2 },
+        ],
       );
 
       const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -449,7 +511,7 @@ describe('Combat System - Blocker Declaration', () => {
       // Set up combat
       state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
       const attackResult = declareAttackers(state, [
-        { cardId: attackerId, defenderId: bobId }
+        { cardId: attackerId, defenderId: bobId },
       ]);
       const stateWithAttackers = attackResult.state;
       stateWithAttackers.turn.currentPhase = Phase.DECLARE_BLOCKERS;
@@ -464,12 +526,12 @@ describe('Combat System - Blocker Declaration', () => {
   });
 });
 
-describe('Combat System - Damage Resolution', () => {
-  describe('resolveCombatDamage', () => {
-    it('should deal damage to defending player from unblocked attacker', () => {
+describe("Combat System - Damage Resolution", () => {
+  describe("resolveCombatDamage", () => {
+    it("should deal damage to defending player from unblocked attacker", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures(
-        [{ name: 'Attacker', power: 3, toughness: 3 }],
-        []
+        [{ name: "Attacker", power: 3, toughness: 3 }],
+        [],
       );
 
       const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -478,7 +540,7 @@ describe('Combat System - Damage Resolution', () => {
       // Set up combat
       state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
       const attackResult = declareAttackers(state, [
-        { cardId: attackerId, defenderId: bobId }
+        { cardId: attackerId, defenderId: bobId },
       ]);
       const stateWithAttackers = attackResult.state;
 
@@ -490,10 +552,10 @@ describe('Combat System - Damage Resolution', () => {
       expect(bob.life).toBe(17); // 20 - 3 = 17
     });
 
-    it('should deal damage between attacker and blocker', () => {
+    it("should deal damage between attacker and blocker", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures(
-        [{ name: 'Attacker', power: 3, toughness: 3 }],
-        [{ name: 'Blocker', power: 3, toughness: 3 }]
+        [{ name: "Attacker", power: 3, toughness: 3 }],
+        [{ name: "Blocker", power: 3, toughness: 3 }],
       );
 
       const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -504,14 +566,17 @@ describe('Combat System - Damage Resolution', () => {
       // Set up combat
       state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
       const attackResult = declareAttackers(state, [
-        { cardId: attackerId, defenderId: bobId }
+        { cardId: attackerId, defenderId: bobId },
       ]);
       const stateWithAttackers = attackResult.state;
       stateWithAttackers.turn.currentPhase = Phase.DECLARE_BLOCKERS;
 
       const blockerAssignments = new Map();
       blockerAssignments.set(attackerId, [blockerId]);
-      const blockResult = declareBlockers(stateWithAttackers, blockerAssignments);
+      const blockResult = declareBlockers(
+        stateWithAttackers,
+        blockerAssignments,
+      );
 
       // Resolve combat
       const result = resolveCombatDamage(blockResult.state);
@@ -522,15 +587,15 @@ describe('Combat System - Damage Resolution', () => {
       // Blocker (3/3) deals 3 damage to Attacker (3/3) - lethal
       const aliceGraveyard = result.state.zones.get(`${aliceId}-graveyard`)!;
       const bobGraveyard = result.state.zones.get(`${bobId}-graveyard`)!;
-      
+
       expect(aliceGraveyard.cardIds).toContain(attackerId);
       expect(bobGraveyard.cardIds).toContain(blockerId);
     });
 
-    it('should handle trample damage correctly', () => {
+    it("should handle trample damage correctly", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures(
-        [{ name: 'Trampler', power: 5, toughness: 5, keywords: ['Trample'] }],
-        [{ name: 'Blocker', power: 2, toughness: 2 }]
+        [{ name: "Trampler", power: 5, toughness: 5, keywords: ["Trample"] }],
+        [{ name: "Blocker", power: 2, toughness: 2 }],
       );
 
       const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -541,14 +606,17 @@ describe('Combat System - Damage Resolution', () => {
       // Set up combat
       state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
       const attackResult = declareAttackers(state, [
-        { cardId: attackerId, defenderId: bobId }
+        { cardId: attackerId, defenderId: bobId },
       ]);
       const stateWithAttackers = attackResult.state;
       stateWithAttackers.turn.currentPhase = Phase.DECLARE_BLOCKERS;
 
       const blockerAssignments = new Map();
       blockerAssignments.set(attackerId, [blockerId]);
-      const blockResult = declareBlockers(stateWithAttackers, blockerAssignments);
+      const blockResult = declareBlockers(
+        stateWithAttackers,
+        blockerAssignments,
+      );
 
       // Resolve combat
       const result = resolveCombatDamage(blockResult.state);
@@ -559,10 +627,17 @@ describe('Combat System - Damage Resolution', () => {
       expect(bob.life).toBe(17); // 20 - 3 = 17 (trample damage)
     });
 
-    it('should handle deathtouch correctly', () => {
+    it("should handle deathtouch correctly", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures(
-        [{ name: 'Deathtouch Attacker', power: 1, toughness: 1, keywords: ['Deathtouch'] }],
-        [{ name: 'Big Blocker', power: 10, toughness: 10 }]
+        [
+          {
+            name: "Deathtouch Attacker",
+            power: 1,
+            toughness: 1,
+            keywords: ["Deathtouch"],
+          },
+        ],
+        [{ name: "Big Blocker", power: 10, toughness: 10 }],
       );
 
       const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -573,14 +648,17 @@ describe('Combat System - Damage Resolution', () => {
       // Set up combat
       state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
       const attackResult = declareAttackers(state, [
-        { cardId: attackerId, defenderId: bobId }
+        { cardId: attackerId, defenderId: bobId },
       ]);
       const stateWithAttackers = attackResult.state;
       stateWithAttackers.turn.currentPhase = Phase.DECLARE_BLOCKERS;
 
       const blockerAssignments = new Map();
       blockerAssignments.set(attackerId, [blockerId]);
-      const blockResult = declareBlockers(stateWithAttackers, blockerAssignments);
+      const blockResult = declareBlockers(
+        stateWithAttackers,
+        blockerAssignments,
+      );
 
       // Resolve combat
       const result = resolveCombatDamage(blockResult.state);
@@ -591,10 +669,17 @@ describe('Combat System - Damage Resolution', () => {
       expect(bobGraveyard.cardIds).toContain(blockerId);
     });
 
-    it('should handle lifelink correctly', () => {
+    it("should handle lifelink correctly", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures(
-        [{ name: 'Lifelink Attacker', power: 3, toughness: 3, keywords: ['Lifelink'] }],
-        []
+        [
+          {
+            name: "Lifelink Attacker",
+            power: 3,
+            toughness: 3,
+            keywords: ["Lifelink"],
+          },
+        ],
+        [],
       );
 
       const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -607,7 +692,7 @@ describe('Combat System - Damage Resolution', () => {
       // Set up combat
       state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
       const attackResult = declareAttackers(state, [
-        { cardId: attackerId, defenderId: bobId }
+        { cardId: attackerId, defenderId: bobId },
       ]);
       const stateWithAttackers = attackResult.state;
 
@@ -620,10 +705,17 @@ describe('Combat System - Damage Resolution', () => {
       expect(updatedAlice.life).toBe(18); // 15 + 3 = 18
     });
 
-    it('should handle first strike correctly', () => {
+    it("should handle first strike correctly", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures(
-        [{ name: 'First Strike Attacker', power: 2, toughness: 2, keywords: ['First Strike'] }],
-        [{ name: 'Regular Blocker', power: 2, toughness: 2 }]
+        [
+          {
+            name: "First Strike Attacker",
+            power: 2,
+            toughness: 2,
+            keywords: ["First Strike"],
+          },
+        ],
+        [{ name: "Regular Blocker", power: 2, toughness: 2 }],
       );
 
       const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -634,14 +726,17 @@ describe('Combat System - Damage Resolution', () => {
       // Set up combat
       state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
       const attackResult = declareAttackers(state, [
-        { cardId: attackerId, defenderId: bobId }
+        { cardId: attackerId, defenderId: bobId },
       ]);
       const stateWithAttackers = attackResult.state;
       stateWithAttackers.turn.currentPhase = Phase.DECLARE_BLOCKERS;
 
       const blockerAssignments = new Map();
       blockerAssignments.set(attackerId, [blockerId]);
-      const blockResult = declareBlockers(stateWithAttackers, blockerAssignments);
+      const blockResult = declareBlockers(
+        stateWithAttackers,
+        blockerAssignments,
+      );
 
       // Resolve combat
       const result = resolveCombatDamage(blockResult.state);
@@ -649,17 +744,26 @@ describe('Combat System - Damage Resolution', () => {
 
       // First striker deals damage first, blocker dies before dealing damage
       // Attacker should survive
-      const aliceBattlefieldAfter = result.state.zones.get(`${aliceId}-battlefield`)!;
+      const aliceBattlefieldAfter = result.state.zones.get(
+        `${aliceId}-battlefield`,
+      )!;
       const bobGraveyard = result.state.zones.get(`${bobId}-graveyard`)!;
-      
+
       expect(aliceBattlefieldAfter.cardIds).toContain(attackerId);
       expect(bobGraveyard.cardIds).toContain(blockerId);
     });
 
-    it('should handle double strike correctly', () => {
+    it("should handle double strike correctly", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures(
-        [{ name: 'Double Strike Attacker', power: 2, toughness: 2, keywords: ['Double Strike'] }],
-        []
+        [
+          {
+            name: "Double Strike Attacker",
+            power: 2,
+            toughness: 2,
+            keywords: ["Double Strike"],
+          },
+        ],
+        [],
       );
 
       const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -668,7 +772,7 @@ describe('Combat System - Damage Resolution', () => {
       // Set up combat
       state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
       const attackResult = declareAttackers(state, [
-        { cardId: attackerId, defenderId: bobId }
+        { cardId: attackerId, defenderId: bobId },
       ]);
       const stateWithAttackers = attackResult.state;
 
@@ -683,11 +787,11 @@ describe('Combat System - Damage Resolution', () => {
   });
 });
 
-describe('Combat System - Edge Cases', () => {
-  it('should handle attacker with 0 power', () => {
+describe("Combat System - Edge Cases", () => {
+  it("should handle attacker with 0 power", () => {
     const { state, aliceId, bobId } = setupGameWithCreatures(
-      [{ name: 'Zero Power', power: 0, toughness: 3 }],
-      []
+      [{ name: "Zero Power", power: 0, toughness: 3 }],
+      [],
     );
 
     const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -696,7 +800,7 @@ describe('Combat System - Edge Cases', () => {
     // Set up combat
     state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
     const attackResult = declareAttackers(state, [
-      { cardId: attackerId, defenderId: bobId }
+      { cardId: attackerId, defenderId: bobId },
     ]);
     const stateWithAttackers = attackResult.state;
 
@@ -709,13 +813,20 @@ describe('Combat System - Edge Cases', () => {
     expect(bob.life).toBe(20);
   });
 
-  it('should handle multiple blockers with trample', () => {
+  it("should handle multiple blockers with trample", () => {
     const { state, aliceId, bobId } = setupGameWithCreatures(
-      [{ name: 'Big Trampler', power: 10, toughness: 10, keywords: ['Trample'] }],
       [
-        { name: 'Blocker 1', power: 2, toughness: 3 },
-        { name: 'Blocker 2', power: 2, toughness: 3 }
-      ]
+        {
+          name: "Big Trampler",
+          power: 10,
+          toughness: 10,
+          keywords: ["Trample"],
+        },
+      ],
+      [
+        { name: "Blocker 1", power: 2, toughness: 3 },
+        { name: "Blocker 2", power: 2, toughness: 3 },
+      ],
     );
 
     const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -726,7 +837,7 @@ describe('Combat System - Edge Cases', () => {
     // Set up combat
     state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
     const attackResult = declareAttackers(state, [
-      { cardId: attackerId, defenderId: bobId }
+      { cardId: attackerId, defenderId: bobId },
     ]);
     const stateWithAttackers = attackResult.state;
     stateWithAttackers.turn.currentPhase = Phase.DECLARE_BLOCKERS;
@@ -744,7 +855,7 @@ describe('Combat System - Edge Cases', () => {
     expect(bob.life).toBe(16); // 20 - 4 = 16
   });
 
-  it('should handle no attackers declared', () => {
+  it("should handle no attackers declared", () => {
     const { state } = setupGameWithCreatures([], []);
 
     state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
@@ -755,10 +866,10 @@ describe('Combat System - Edge Cases', () => {
     expect(result.state.combat.attackers).toHaveLength(0);
   });
 
-  it('should handle no blockers declared', () => {
+  it("should handle no blockers declared", () => {
     const { state, aliceId, bobId } = setupGameWithCreatures(
-      [{ name: 'Attacker', power: 2, toughness: 2 }],
-      []
+      [{ name: "Attacker", power: 2, toughness: 2 }],
+      [],
     );
 
     const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -767,7 +878,7 @@ describe('Combat System - Edge Cases', () => {
     // Set up combat
     state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
     const attackResult = declareAttackers(state, [
-      { cardId: attackerId, defenderId: bobId }
+      { cardId: attackerId, defenderId: bobId },
     ]);
     const stateWithAttackers = attackResult.state;
     stateWithAttackers.turn.currentPhase = Phase.DECLARE_BLOCKERS;
@@ -775,22 +886,22 @@ describe('Combat System - Edge Cases', () => {
     // Declare no blockers
     const blockerAssignments = new Map();
     const result = declareBlockers(stateWithAttackers, blockerAssignments);
-    
+
     // Should succeed with no blockers
     expect(result.success).toBe(true);
   });
 });
 
-describe('Combat System - Utility Functions', () => {
-  describe('getAvailableAttackers', () => {
-    it('should return all creatures that can attack', () => {
+describe("Combat System - Utility Functions", () => {
+  describe("getAvailableAttackers", () => {
+    it("should return all creatures that can attack", () => {
       const { state, aliceId } = setupGameWithCreatures(
         [
-          { name: 'Can Attack', power: 2, toughness: 2 },
-          { name: 'Tapped', power: 2, toughness: 2 },
-          { name: 'Has Haste', power: 2, toughness: 2, keywords: ['Haste'] }
+          { name: "Can Attack", power: 2, toughness: 2 },
+          { name: "Tapped", power: 2, toughness: 2 },
+          { name: "Has Haste", power: 2, toughness: 2, keywords: ["Haste"] },
         ],
-        []
+        [],
       );
 
       const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
@@ -805,7 +916,7 @@ describe('Combat System - Utility Functions', () => {
       hastyCreature.hasSummoningSickness = true;
 
       const available = getAvailableAttackers(state, aliceId);
-      
+
       // Should include first creature and hasty creature
       expect(available).toContain(creatureIds[0]);
       expect(available).toContain(creatureIds[2]);
@@ -813,14 +924,14 @@ describe('Combat System - Utility Functions', () => {
     });
   });
 
-  describe('getAvailableBlockers', () => {
-    it('should return all creatures that can block', () => {
+  describe("getAvailableBlockers", () => {
+    it("should return all creatures that can block", () => {
       const { state, bobId } = setupGameWithCreatures(
         [],
         [
-          { name: 'Can Block', power: 2, toughness: 2 },
-          { name: 'Tapped', power: 2, toughness: 2 }
-        ]
+          { name: "Can Block", power: 2, toughness: 2 },
+          { name: "Tapped", power: 2, toughness: 2 },
+        ],
       );
 
       const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
@@ -831,9 +942,292 @@ describe('Combat System - Utility Functions', () => {
       tappedCreature.isTapped = true;
 
       const available = getAvailableBlockers(state, bobId);
-      
+
       expect(available).toContain(creatureIds[0]);
       expect(available).not.toContain(creatureIds[1]);
+    });
+  });
+});
+
+describe("Combat System - Deathtouch and Indestructible (#669)", () => {
+  describe("resolveCombatDamage", () => {
+    it("should assign only 1 damage from a deathtouch attacker per blocker (trample optimization)", () => {
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [
+          {
+            name: "Deathtouch Trampler",
+            power: 5,
+            toughness: 3,
+            keywords: ["Deathtouch", "Trample"],
+          },
+        ],
+        [{ name: "Big Blocker", power: 2, toughness: 6 }],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerId = bobBattlefield.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const blockerAssignments = new Map();
+      blockerAssignments.set(attackerId, [blockerId]);
+      const blockResult = declareBlockers(
+        attackResult.state,
+        blockerAssignments,
+      );
+      const result = resolveCombatDamage(blockResult.state);
+
+      expect(result.success).toBe(true);
+
+      const bobGraveyard = result.state.zones.get(`${bobId}-graveyard`)!;
+      expect(bobGraveyard.cardIds).toContain(blockerId);
+
+      const updatedBob = result.state.players.get(bobId)!;
+      expect(updatedBob.life).toBeLessThan(20);
+    });
+
+    it("should not destroy an indestructible blocker via combat damage", () => {
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [{ name: "Big Attacker", power: 10, toughness: 10 }],
+        [
+          {
+            name: "Indestructible Blocker",
+            power: 2,
+            toughness: 2,
+            keywords: ["Indestructible"],
+          },
+        ],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerId = bobBattlefield.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const blockerAssignments = new Map();
+      blockerAssignments.set(attackerId, [blockerId]);
+      const blockResult = declareBlockers(
+        attackResult.state,
+        blockerAssignments,
+      );
+      const result = resolveCombatDamage(blockResult.state);
+
+      expect(result.success).toBe(true);
+
+      const bobBattlefieldAfter = result.state.zones.get(
+        `${bobId}-battlefield`,
+      )!;
+      expect(bobBattlefieldAfter.cardIds).toContain(blockerId);
+
+      const updatedBob = result.state.players.get(bobId)!;
+      expect(updatedBob.life).toBe(20);
+    });
+
+    it("should handle deathtouch vs indestructible stalemate — indestructible blocker survives, deathtouch attacker dies", () => {
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [
+          {
+            name: "Deathtouch Attacker",
+            power: 1,
+            toughness: 1,
+            keywords: ["Deathtouch"],
+          },
+        ],
+        [
+          {
+            name: "Indestructible Blocker",
+            power: 5,
+            toughness: 5,
+            keywords: ["Indestructible"],
+          },
+        ],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerId = bobBattlefield.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const blockerAssignments = new Map();
+      blockerAssignments.set(attackerId, [blockerId]);
+      const blockResult = declareBlockers(
+        attackResult.state,
+        blockerAssignments,
+      );
+      const result = resolveCombatDamage(blockResult.state);
+
+      expect(result.success).toBe(true);
+
+      // Indestructible blocker survives (deathtouch damage doesn't destroy it)
+      const bobBattlefieldAfter = result.state.zones.get(
+        `${bobId}-battlefield`,
+      )!;
+      expect(bobBattlefieldAfter.cardIds).toContain(blockerId);
+
+      // Deathtouch attacker is NOT indestructible, so it dies from the blocker's 5 damage
+      const aliceGraveyard = result.state.zones.get(`${aliceId}-graveyard`)!;
+      expect(aliceGraveyard.cardIds).toContain(attackerId);
+
+      // No damage leaks through to the defending player
+      const updatedBob = result.state.players.get(bobId)!;
+      expect(updatedBob.life).toBe(20);
+    });
+
+    it("should handle true stalemate: indestructible deathtouch attacker vs indestructible blocker", () => {
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [
+          {
+            name: "Indestructible Deathtouch",
+            power: 3,
+            toughness: 3,
+            keywords: ["Indestructible", "Deathtouch"],
+          },
+        ],
+        [
+          {
+            name: "Indestructible Wall",
+            power: 0,
+            toughness: 8,
+            keywords: ["Indestructible"],
+          },
+        ],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerId = bobBattlefield.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const blockerAssignments = new Map();
+      blockerAssignments.set(attackerId, [blockerId]);
+      const blockResult = declareBlockers(
+        attackResult.state,
+        blockerAssignments,
+      );
+      const result = resolveCombatDamage(blockResult.state);
+
+      expect(result.success).toBe(true);
+
+      // Neither creature can be destroyed by damage
+      const aliceBattlefieldAfter = result.state.zones.get(
+        `${aliceId}-battlefield`,
+      )!;
+      expect(aliceBattlefieldAfter.cardIds).toContain(attackerId);
+
+      const bobBattlefieldAfter = result.state.zones.get(
+        `${bobId}-battlefield`,
+      )!;
+      expect(bobBattlefieldAfter.cardIds).toContain(blockerId);
+
+      const updatedBob = result.state.players.get(bobId)!;
+      expect(updatedBob.life).toBe(20);
+    });
+
+    it("should not destroy an indestructible attacker via combat damage", () => {
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [
+          {
+            name: "Indestructible Attacker",
+            power: 5,
+            toughness: 3,
+            keywords: ["Indestructible"],
+          },
+        ],
+        [{ name: "Strong Blocker", power: 10, toughness: 10 }],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerId = bobBattlefield.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const blockerAssignments = new Map();
+      blockerAssignments.set(attackerId, [blockerId]);
+      const blockResult = declareBlockers(
+        attackResult.state,
+        blockerAssignments,
+      );
+      const result = resolveCombatDamage(blockResult.state);
+
+      expect(result.success).toBe(true);
+
+      const aliceBattlefieldAfter = result.state.zones.get(
+        `${aliceId}-battlefield`,
+      )!;
+      expect(aliceBattlefieldAfter.cardIds).toContain(attackerId);
+    });
+
+    it("should allow deathtouch blocker to kill attacker regardless of toughness", () => {
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [{ name: "Big Attacker", power: 8, toughness: 8 }],
+        [
+          {
+            name: "Tiny Deathtouch",
+            power: 1,
+            toughness: 1,
+            keywords: ["Deathtouch"],
+          },
+        ],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerId = bobBattlefield.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const blockerAssignments = new Map();
+      blockerAssignments.set(attackerId, [blockerId]);
+      const blockResult = declareBlockers(
+        attackResult.state,
+        blockerAssignments,
+      );
+      const result = resolveCombatDamage(blockResult.state);
+
+      expect(result.success).toBe(true);
+
+      const aliceGraveyard = result.state.zones.get(`${aliceId}-graveyard`)!;
+      expect(aliceGraveyard.cardIds).toContain(attackerId);
+
+      const bobBattlefieldAfter = result.state.zones.get(
+        `${bobId}-battlefield`,
+      )!;
+      expect(bobBattlefieldAfter.cardIds).not.toContain(blockerId);
     });
   });
 });

--- a/src/lib/game-state/combat.ts
+++ b/src/lib/game-state/combat.ts
@@ -4,19 +4,11 @@
  * Reference: Comprehensive Rules 506-510
  */
 
-import type {
-  GameState,
-  CardInstanceId,
-  PlayerId,
-} from './types';
-import {
-  isCreature,
-  getPower,
-  getToughness,
-} from './card-instance';
-import { dealDamageToCard } from './keyword-actions';
-import { checkStateBasedActions } from './state-based-actions';
-import { dealCommanderDamage, isCommander } from './commander-damage';
+import type { GameState, CardInstanceId, PlayerId } from "./types";
+import { isCreature, getPower, getToughness } from "./card-instance";
+import { dealDamageToCard } from "./keyword-actions";
+import { checkStateBasedActions } from "./state-based-actions";
+import { dealCommanderDamage, isCommander } from "./commander-damage";
 
 /**
  * Result of a combat action
@@ -34,47 +26,52 @@ export interface CombatActionResult {
 export function canAttack(
   state: GameState,
   cardId: CardInstanceId,
-  defenderId?: PlayerId | CardInstanceId
+  defenderId?: PlayerId | CardInstanceId,
 ): { canAttack: boolean; reason?: string } {
   const card = state.cards.get(cardId);
-  
+
   if (!card) {
-    return { canAttack: false, reason: 'Card not found' };
+    return { canAttack: false, reason: "Card not found" };
   }
 
   // Must be a creature
   if (!isCreature(card)) {
-    return { canAttack: false, reason: 'Only creatures can attack' };
+    return { canAttack: false, reason: "Only creatures can attack" };
   }
 
   // Must be on the battlefield
   const battlefieldZoneKey = `${card.controllerId}-battlefield`;
   const battlefield = state.zones.get(battlefieldZoneKey);
   if (!battlefield || !battlefield.cardIds.includes(cardId)) {
-    return { canAttack: false, reason: 'Card must be on the battlefield' };
+    return { canAttack: false, reason: "Card must be on the battlefield" };
   }
 
   // Must not be tapped (unless has vigilance)
   if (card.isTapped) {
-    const hasVigilance = card.cardData.keywords?.includes('Vigilance') ||
-      card.cardData.oracle_text?.toLowerCase().includes('vigilance');
+    const hasVigilance =
+      card.cardData.keywords?.includes("Vigilance") ||
+      card.cardData.oracle_text?.toLowerCase().includes("vigilance");
     if (!hasVigilance) {
-      return { canAttack: false, reason: 'Creature is tapped' };
+      return { canAttack: false, reason: "Creature is tapped" };
     }
   }
 
   // Must not have summoning sickness (unless haste)
   if (card.hasSummoningSickness) {
-    const hasHaste = card.cardData.keywords?.includes('Haste') ||
-      card.cardData.oracle_text?.toLowerCase().includes('haste');
+    const hasHaste =
+      card.cardData.keywords?.includes("Haste") ||
+      card.cardData.oracle_text?.toLowerCase().includes("haste");
     if (!hasHaste) {
-      return { canAttack: false, reason: 'Summoning sickness (haste not granted)' };
+      return {
+        canAttack: false,
+        reason: "Summoning sickness (haste not granted)",
+      };
     }
   }
 
   // Must have a defender
   if (!defenderId) {
-    return { canAttack: false, reason: 'No defender specified' };
+    return { canAttack: false, reason: "No defender specified" };
   }
 
   // Check for defender being a planeswalker or player
@@ -89,29 +86,29 @@ export function canAttack(
 export function canBlock(
   state: GameState,
   blockerId: CardInstanceId,
-  attackerId?: CardInstanceId
+  attackerId?: CardInstanceId,
 ): { canBlock: boolean; reason?: string } {
   const blocker = state.cards.get(blockerId);
-  
+
   if (!blocker) {
-    return { canBlock: false, reason: 'Card not found' };
+    return { canBlock: false, reason: "Card not found" };
   }
 
   // Must be a creature
   if (!isCreature(blocker)) {
-    return { canBlock: false, reason: 'Only creatures can block' };
+    return { canBlock: false, reason: "Only creatures can block" };
   }
 
   // Must be on the battlefield
   const battlefieldZoneKey = `${blocker.controllerId}-battlefield`;
   const battlefield = state.zones.get(battlefieldZoneKey);
   if (!battlefield || !battlefield.cardIds.includes(blockerId)) {
-    return { canBlock: false, reason: 'Card must be on the battlefield' };
+    return { canBlock: false, reason: "Card must be on the battlefield" };
   }
 
   // Must not be tapped
   if (blocker.isTapped) {
-    return { canBlock: false, reason: 'Creature is tapped' };
+    return { canBlock: false, reason: "Creature is tapped" };
   }
 
   // If there's an attacker, check if it can be blocked (flying, reach, etc.)
@@ -119,15 +116,21 @@ export function canBlock(
     const attacker = state.cards.get(attackerId);
     if (attacker && isCreature(attacker)) {
       // Check flying
-      const attackerHasFlying = attacker.cardData.keywords?.includes('Flying') ||
-        attacker.cardData.oracle_text?.toLowerCase().includes('flying');
-      const blockerHasFlying = blocker.cardData.keywords?.includes('Flying') ||
-        blocker.cardData.oracle_text?.toLowerCase().includes('flying');
-      const blockerHasReach = blocker.cardData.keywords?.includes('Reach') ||
-        blocker.cardData.oracle_text?.toLowerCase().includes('reach');
+      const attackerHasFlying =
+        attacker.cardData.keywords?.includes("Flying") ||
+        attacker.cardData.oracle_text?.toLowerCase().includes("flying");
+      const blockerHasFlying =
+        blocker.cardData.keywords?.includes("Flying") ||
+        blocker.cardData.oracle_text?.toLowerCase().includes("flying");
+      const blockerHasReach =
+        blocker.cardData.keywords?.includes("Reach") ||
+        blocker.cardData.oracle_text?.toLowerCase().includes("reach");
 
       if (attackerHasFlying && !blockerHasFlying && !blockerHasReach) {
-        return { canBlock: false, reason: 'Cannot block flying creatures without flying or reach' };
+        return {
+          canBlock: false,
+          reason: "Cannot block flying creatures without flying or reach",
+        };
       }
     }
   }
@@ -141,30 +144,42 @@ export function canBlock(
  */
 export function declareAttackers(
   state: GameState,
-  attackerIds: Array<{ cardId: CardInstanceId; defenderId: PlayerId | CardInstanceId }>
+  attackerIds: Array<{
+    cardId: CardInstanceId;
+    defenderId: PlayerId | CardInstanceId;
+  }>,
 ): CombatActionResult {
   const errors: string[] = [];
-  const validAttackers: Array<{ cardId: CardInstanceId; defenderId: PlayerId | CardInstanceId }> = [];
+  const validAttackers: Array<{
+    cardId: CardInstanceId;
+    defenderId: PlayerId | CardInstanceId;
+  }> = [];
 
   // Must be in combat phase
   const combatPhase = state.turn.currentPhase;
-  const validCombatPhases = ['declare_attackers', 'begin_combat'];
+  const validCombatPhases = ["declare_attackers", "begin_combat"];
   if (!validCombatPhases.includes(combatPhase)) {
     return {
       success: false,
       state,
-      description: '',
-      errors: ['Can only declare attackers during the declare attackers step'],
+      description: "",
+      errors: ["Can only declare attackers during the declare attackers step"],
     };
   }
 
   // Check each attacker
   for (const attack of attackerIds) {
-    const { canAttack: can, reason } = canAttack(state, attack.cardId, attack.defenderId);
+    const { canAttack: can, reason } = canAttack(
+      state,
+      attack.cardId,
+      attack.defenderId,
+    );
     if (can) {
       validAttackers.push(attack);
     } else {
-      errors.push(`${state.cards.get(attack.cardId)?.cardData.name || attack.cardId}: ${reason}`);
+      errors.push(
+        `${state.cards.get(attack.cardId)?.cardData.name || attack.cardId}: ${reason}`,
+      );
     }
   }
 
@@ -173,44 +188,53 @@ export function declareAttackers(
     return {
       success: false,
       state,
-      description: '',
-      errors: ['No valid attackers declared'],
+      description: "",
+      errors: ["No valid attackers declared"],
     };
   }
 
   // Create attacker objects
-  const attackers: import('./types').Attacker[] = validAttackers.map((attack) => {
-    const attackerCard = state.cards.get(attack.cardId);
-    const hasFirstStrike = attackerCard ? (
-      attackerCard.cardData.keywords?.includes('First Strike') ||
-      attackerCard.cardData.oracle_text?.toLowerCase().includes('first strike')
-    ) : false;
-    const hasDoubleStrike = attackerCard ? (
-      attackerCard.cardData.keywords?.includes('Double Strike') ||
-      attackerCard.cardData.oracle_text?.toLowerCase().includes('double strike')
-    ) : false;
+  const attackers: import("./types").Attacker[] = validAttackers.map(
+    (attack) => {
+      const attackerCard = state.cards.get(attack.cardId);
+      const hasFirstStrike = attackerCard
+        ? attackerCard.cardData.keywords?.includes("First Strike") ||
+          attackerCard.cardData.oracle_text
+            ?.toLowerCase()
+            .includes("first strike")
+        : false;
+      const hasDoubleStrike = attackerCard
+        ? attackerCard.cardData.keywords?.includes("Double Strike") ||
+          attackerCard.cardData.oracle_text
+            ?.toLowerCase()
+            .includes("double strike")
+        : false;
 
-    return {
-      cardId: attack.cardId,
-      defenderId: attack.defenderId,
-      isAttackingPlaneswalker: typeof attack.defenderId === 'string' && attack.defenderId.startsWith('card-'),
-      damageToDeal: attackerCard ? getPower(attackerCard) : 0,
-      hasFirstStrike: hasFirstStrike || false,
-      hasDoubleStrike: hasDoubleStrike || false,
-    };
-  });
+      return {
+        cardId: attack.cardId,
+        defenderId: attack.defenderId,
+        isAttackingPlaneswalker:
+          typeof attack.defenderId === "string" &&
+          attack.defenderId.startsWith("card-"),
+        damageToDeal: attackerCard ? getPower(attackerCard) : 0,
+        hasFirstStrike: hasFirstStrike || false,
+        hasDoubleStrike: hasDoubleStrike || false,
+      };
+    },
+  );
 
   // Tap attacking creatures
   const updatedState = { ...state };
   const updatedCards = new Map(updatedState.cards);
-  
+
   for (const attacker of attackers) {
     const card = updatedCards.get(attacker.cardId);
     if (card) {
       // Check for vigilance - if creature has vigilance, don't tap
-      const hasVigilance = card.cardData.keywords?.includes('Vigilance') ||
-        card.cardData.oracle_text?.toLowerCase().includes('vigilance');
-      
+      const hasVigilance =
+        card.cardData.keywords?.includes("Vigilance") ||
+        card.cardData.oracle_text?.toLowerCase().includes("vigilance");
+
       if (!hasVigilance) {
         updatedCards.set(attacker.cardId, { ...card, isTapped: true });
       }
@@ -234,7 +258,7 @@ export function declareAttackers(
       combat: updatedCombat,
       lastModifiedAt: Date.now(),
     },
-    description: `Declared ${attackers.length} attacker${attackers.length !== 1 ? 's' : ''}`,
+    description: `Declared ${attackers.length} attacker${attackers.length !== 1 ? "s" : ""}`,
     errors: errors.length > 0 ? errors : undefined,
   };
 }
@@ -244,7 +268,7 @@ export function declareAttackers(
  */
 export function declareBlockers(
   state: GameState,
-  blockerAssignments: Map<CardInstanceId, CardInstanceId[]>
+  blockerAssignments: Map<CardInstanceId, CardInstanceId[]>,
 ): CombatActionResult {
   const errors: string[] = [];
   const validBlockers = new Map<CardInstanceId, CardInstanceId[]>();
@@ -254,68 +278,77 @@ export function declareBlockers(
     return {
       success: false,
       state,
-      description: '',
-      errors: ['No attackers declared'],
+      description: "",
+      errors: ["No attackers declared"],
     };
   }
 
   // Check each blocker's assignment
   for (const [attackerId, blockerIds] of blockerAssignments) {
     const validBlockerIds: CardInstanceId[] = [];
-    
+
     for (const blockerId of blockerIds) {
       const { canBlock: can, reason } = canBlock(state, blockerId, attackerId);
       if (can) {
         validBlockerIds.push(blockerId);
       } else {
-        errors.push(`${state.cards.get(blockerId)?.cardData.name || blockerId}: ${reason}`);
+        errors.push(
+          `${state.cards.get(blockerId)?.cardData.name || blockerId}: ${reason}`,
+        );
       }
     }
-    
+
     if (validBlockerIds.length > 0) {
       validBlockers.set(attackerId, validBlockerIds);
     }
   }
 
   // Create blocker objects with order
-  const blockers = new Map<CardInstanceId, Array<{
-    cardId: CardInstanceId;
-    attackerId: CardInstanceId;
-    damageToDeal: number;
-    blockerOrder: number;
-    hasFirstStrike: boolean;
-    hasDoubleStrike: boolean;
-  }>>();
+  const blockers = new Map<
+    CardInstanceId,
+    Array<{
+      cardId: CardInstanceId;
+      attackerId: CardInstanceId;
+      damageToDeal: number;
+      blockerOrder: number;
+      hasFirstStrike: boolean;
+      hasDoubleStrike: boolean;
+    }>
+  >();
 
   for (const [attackerId, blockerIds] of validBlockers) {
-    const blockerObjects: import('./types').Blocker[] = blockerIds.map((blockerId, index) => {
-      const blocker = state.cards.get(blockerId);
-      const blockerPower = blocker ? getPower(blocker) : 0;
-      const blockerHasFirstStrike = blocker ? (
-        blocker.cardData.keywords?.includes('First Strike') ||
-        blocker.cardData.oracle_text?.toLowerCase().includes('first strike')
-      ) : false;
-      const blockerHasDoubleStrike = blocker ? (
-        blocker.cardData.keywords?.includes('Double Strike') ||
-        blocker.cardData.oracle_text?.toLowerCase().includes('double strike')
-      ) : false;
+    const blockerObjects: import("./types").Blocker[] = blockerIds.map(
+      (blockerId, index) => {
+        const blocker = state.cards.get(blockerId);
+        const blockerPower = blocker ? getPower(blocker) : 0;
+        const blockerHasFirstStrike = blocker
+          ? blocker.cardData.keywords?.includes("First Strike") ||
+            blocker.cardData.oracle_text?.toLowerCase().includes("first strike")
+          : false;
+        const blockerHasDoubleStrike = blocker
+          ? blocker.cardData.keywords?.includes("Double Strike") ||
+            blocker.cardData.oracle_text
+              ?.toLowerCase()
+              .includes("double strike")
+          : false;
 
-      // Calculate damage to deal
-      let damageToDeal = blockerPower;
-      if (blockerHasFirstStrike || blockerHasDoubleStrike) {
-        // First strike damage is dealt in first strike step
-        damageToDeal = blockerPower;
-      }
+        // Calculate damage to deal
+        let damageToDeal = blockerPower;
+        if (blockerHasFirstStrike || blockerHasDoubleStrike) {
+          // First strike damage is dealt in first strike step
+          damageToDeal = blockerPower;
+        }
 
-      return {
-        cardId: blockerId,
-        attackerId,
-        damageToDeal,
-        blockerOrder: index,
-        hasFirstStrike: blockerHasFirstStrike || false,
-        hasDoubleStrike: blockerHasDoubleStrike || false,
-      };
-    });
+        return {
+          cardId: blockerId,
+          attackerId,
+          damageToDeal,
+          blockerOrder: index,
+          hasFirstStrike: blockerHasFirstStrike || false,
+          hasDoubleStrike: blockerHasDoubleStrike || false,
+        };
+      },
+    );
 
     blockers.set(attackerId, blockerObjects);
   }
@@ -350,7 +383,7 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
     return {
       success: false,
       state,
-      description: 'No combat to resolve',
+      description: "No combat to resolve",
     };
   }
 
@@ -363,8 +396,9 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
     if (!attackerCard) continue;
 
     const attackerPower = getPower(attackerCard);
-    const attackerHasTrample = attackerCard.cardData.keywords?.includes('Trample') ||
-      attackerCard.cardData.oracle_text?.toLowerCase().includes('trample');
+    const attackerHasTrample =
+      attackerCard.cardData.keywords?.includes("Trample") ||
+      attackerCard.cardData.oracle_text?.toLowerCase().includes("trample");
 
     const assignedBlockers = state.combat.blockers.get(attacker.cardId);
 
@@ -372,22 +406,32 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
     if (!assignedBlockers || assignedBlockers.length === 0) {
       // Unblocked - damage goes to defender
       // Check for double strike - deals damage twice
-      const attackerHasDoubleStrike = attackerCard.cardData.keywords?.includes('Double Strike') ||
-        attackerCard.cardData.oracle_text?.toLowerCase().includes('double strike');
-      
+      const attackerHasDoubleStrike =
+        attackerCard.cardData.keywords?.includes("Double Strike") ||
+        attackerCard.cardData.oracle_text
+          ?.toLowerCase()
+          .includes("double strike");
+
       const damageMultiplier = attackerHasDoubleStrike ? 2 : 1;
       const totalDamage = attackerPower * damageMultiplier;
 
       if (attacker.isAttackingPlaneswalker) {
         // Damage to planeswalker would need planeswalker damage handling
-        damageEvents.push(`${attackerCard.cardData.name} deals ${totalDamage} to planeswalker`);
+        damageEvents.push(
+          `${attackerCard.cardData.name} deals ${totalDamage} to planeswalker`,
+        );
       } else {
         // Damage to player
-        const defender = updatedState.players.get(attacker.defenderId as PlayerId);
+        const defender = updatedState.players.get(
+          attacker.defenderId as PlayerId,
+        );
         if (defender) {
           // Check for lifelink on attacker
-          const attackerHasLifelink = attackerCard.cardData.keywords?.includes('Lifelink') ||
-            attackerCard.cardData.oracle_text?.toLowerCase().includes('lifelink');
+          const attackerHasLifelink =
+            attackerCard.cardData.keywords?.includes("Lifelink") ||
+            attackerCard.cardData.oracle_text
+              ?.toLowerCase()
+              .includes("lifelink");
 
           // Check if attacker is a commander
           const isAttackerCommander = isCommander(attackerCard);
@@ -395,10 +439,13 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
           // Apply damage to player
           updatedState = {
             ...updatedState,
-            players: new Map(updatedState.players).set(attacker.defenderId as PlayerId, {
-              ...defender,
-              life: Math.max(0, defender.life - totalDamage),
-            }),
+            players: new Map(updatedState.players).set(
+              attacker.defenderId as PlayerId,
+              {
+                ...defender,
+                life: Math.max(0, defender.life - totalDamage),
+              },
+            ),
           };
 
           // Track commander damage if applicable
@@ -407,31 +454,42 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
               updatedState,
               attacker.cardId,
               attacker.defenderId as PlayerId,
-              attackerPower
+              attackerPower,
             );
             if (commanderDamageResult.success) {
               updatedState = commanderDamageResult.state;
               if (commanderDamageResult.playerLost) {
-                damageEvents.push(`${attackerCard.cardData.name} dealt lethal commander damage to ${defender.name}`);
+                damageEvents.push(
+                  `${attackerCard.cardData.name} dealt lethal commander damage to ${defender.name}`,
+                );
               }
             }
           }
 
           if (attackerHasLifelink) {
             // Gain life equal to damage dealt
-            const attackerController = updatedState.players.get(attackerCard.controllerId);
+            const attackerController = updatedState.players.get(
+              attackerCard.controllerId,
+            );
             if (attackerController) {
               updatedState = {
                 ...updatedState,
-                players: new Map(updatedState.players).set(attackerCard.controllerId!, {
-                  ...attackerController,
-                  life: attackerController.life + attackerPower,
-                }),
+                players: new Map(updatedState.players).set(
+                  attackerCard.controllerId!,
+                  {
+                    ...attackerController,
+                    life: attackerController.life + attackerPower,
+                  },
+                ),
               };
             }
-            damageEvents.push(`${attackerCard.cardData.name} deals ${attackerPower} to ${defender.name} and controller gains ${attackerPower} life`);
+            damageEvents.push(
+              `${attackerCard.cardData.name} deals ${attackerPower} to ${defender.name} and controller gains ${attackerPower} life`,
+            );
           } else {
-            damageEvents.push(`${attackerCard.cardData.name} deals ${attackerPower} to ${defender.name}`);
+            damageEvents.push(
+              `${attackerCard.cardData.name} deals ${attackerPower} to ${defender.name}`,
+            );
           }
         }
       }
@@ -440,13 +498,24 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
       let remainingDamage = attackerPower;
 
       // Sort blockers by order
-      const sortedBlockers = [...assignedBlockers].sort((a, b) => a.blockerOrder - b.blockerOrder);
+      const sortedBlockers = [...assignedBlockers].sort(
+        (a, b) => a.blockerOrder - b.blockerOrder,
+      );
 
       // First, handle first strike damage if applicable
-      const attackerHasFirstStrike = attackerCard.cardData.keywords?.includes('First Strike') ||
-        attackerCard.cardData.oracle_text?.toLowerCase().includes('first strike');
-      const attackerHasDoubleStrike = attackerCard.cardData.keywords?.includes('Double Strike') ||
-        attackerCard.cardData.oracle_text?.toLowerCase().includes('double strike');
+      const attackerHasFirstStrike =
+        attackerCard.cardData.keywords?.includes("First Strike") ||
+        attackerCard.cardData.oracle_text
+          ?.toLowerCase()
+          .includes("first strike");
+      const attackerHasDoubleStrike =
+        attackerCard.cardData.keywords?.includes("Double Strike") ||
+        attackerCard.cardData.oracle_text
+          ?.toLowerCase()
+          .includes("double strike");
+      const attackerHasDeathtouch =
+        attackerCard.cardData.keywords?.includes("Deathtouch") ||
+        attackerCard.cardData.oracle_text?.toLowerCase().includes("deathtouch");
 
       // Deal damage from attacker to blockers
       for (const blocker of sortedBlockers) {
@@ -456,15 +525,29 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
         if (!blockerCard) continue;
 
         const blockerToughness = getToughness(blockerCard);
-        const blockerHasDeathtouch = blockerCard.cardData.keywords?.includes('Deathtouch') ||
-          blockerCard.cardData.oracle_text?.toLowerCase().includes('deathtouch');
-        const blockerHasLifelink = blockerCard.cardData.keywords?.includes('Lifelink') ||
-          blockerCard.cardData.oracle_text?.toLowerCase().includes('lifelink');
+        const blockerHasDeathtouch =
+          blockerCard.cardData.keywords?.includes("Deathtouch") ||
+          blockerCard.cardData.oracle_text
+            ?.toLowerCase()
+            .includes("deathtouch");
+        const blockerHasLifelink =
+          blockerCard.cardData.keywords?.includes("Lifelink") ||
+          blockerCard.cardData.oracle_text?.toLowerCase().includes("lifelink");
 
         // Calculate damage to deal to this blocker
-        let damage = Math.min(remainingDamage, blockerToughness);
-        if (blockerHasDeathtouch && damage > 0) {
-          damage = Math.max(damage, blockerToughness);
+        let damage: number;
+        if (attackerHasDeathtouch && remainingDamage > 0) {
+          // CR 702.2b: Any nonzero amount of damage from a deathtouch source is lethal
+          // Assign only 1 damage to each blocker to maximize trample excess
+          damage = 1;
+        } else if (blockerHasDeathtouch && remainingDamage > 0) {
+          // Blocker has deathtouch — ensure we assign lethal to kill it if we can
+          damage = Math.min(remainingDamage, blockerToughness);
+          if (damage > 0) {
+            damage = Math.max(damage, blockerToughness);
+          }
+        } else {
+          damage = Math.min(remainingDamage, blockerToughness);
         }
 
         // Apply damage to blocker
@@ -473,40 +556,54 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
           blocker.cardId,
           damage,
           true,
-          attacker.cardId
+          attacker.cardId,
         );
         updatedState = damageResult.state;
 
         // Check for lifelink on blocker
         if (blockerHasLifelink) {
-          const blockerController = updatedState.players.get(blockerCard.controllerId);
+          const blockerController = updatedState.players.get(
+            blockerCard.controllerId,
+          );
           if (blockerController) {
             updatedState = {
               ...updatedState,
-              players: new Map(updatedState.players).set(blockerCard.controllerId!, {
-                ...blockerController,
-                life: blockerController.life + damage,
-              }),
+              players: new Map(updatedState.players).set(
+                blockerCard.controllerId!,
+                {
+                  ...blockerController,
+                  life: blockerController.life + damage,
+                },
+              ),
             };
           }
         }
 
         remainingDamage -= damage;
-        damageEvents.push(`${attackerCard.cardData.name} deals ${damage} to ${blockerCard.cardData.name}`);
+        damageEvents.push(
+          `${attackerCard.cardData.name} deals ${damage} to ${blockerCard.cardData.name}`,
+        );
       }
 
       // Handle trample excess damage
       if (remainingDamage > 0 && attackerHasTrample) {
-        const defender = updatedState.players.get(attacker.defenderId as PlayerId);
+        const defender = updatedState.players.get(
+          attacker.defenderId as PlayerId,
+        );
         if (defender) {
           updatedState = {
             ...updatedState,
-            players: new Map(updatedState.players).set(attacker.defenderId as PlayerId, {
-              ...defender,
-              life: Math.max(0, defender.life - remainingDamage),
-            }),
+            players: new Map(updatedState.players).set(
+              attacker.defenderId as PlayerId,
+              {
+                ...defender,
+                life: Math.max(0, defender.life - remainingDamage),
+              },
+            ),
           };
-          damageEvents.push(`${attackerCard.cardData.name} tramples ${remainingDamage} to ${defender.name}`);
+          damageEvents.push(
+            `${attackerCard.cardData.name} tramples ${remainingDamage} to ${defender.name}`,
+          );
         }
       }
 
@@ -534,10 +631,12 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
           attacker.cardId,
           blockerPower,
           true,
-          blocker.cardId
+          blocker.cardId,
         );
         updatedState = damageResult.state;
-        damageEvents.push(`${blockerCard.cardData.name} deals ${blockerPower} to ${attackerCard.cardData.name}`);
+        damageEvents.push(
+          `${blockerCard.cardData.name} deals ${blockerPower} to ${attackerCard.cardData.name}`,
+        );
       }
     }
   }
@@ -546,7 +645,7 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
   // This handles creatures with lethal damage dying, players losing, etc.
   const sbaResult = checkStateBasedActions(updatedState);
   updatedState = sbaResult.state;
-  
+
   // Add SBA descriptions to damage events
   for (const desc of sbaResult.descriptions) {
     damageEvents.push(desc);
@@ -567,7 +666,7 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
       combat: clearedCombat,
       lastModifiedAt: Date.now(),
     },
-    description: `Combat resolved: ${damageEvents.join(', ')}`,
+    description: `Combat resolved: ${damageEvents.join(", ")}`,
   };
 }
 
@@ -577,35 +676,37 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
  */
 export function getAvailableAttackers(
   state: GameState,
-  playerId: PlayerId
+  playerId: PlayerId,
 ): CardInstanceId[] {
   const battlefieldZoneKey = `${playerId}-battlefield`;
   const battlefield = state.zones.get(battlefieldZoneKey);
-  
+
   if (!battlefield) return [];
 
   return battlefield.cardIds.filter((cardId) => {
     const card = state.cards.get(cardId);
-    
+
     if (!card) return false;
-    
+
     // Must be a creature
     if (!isCreature(card)) return false;
-    
+
     // Must not be tapped (unless has vigilance)
     if (card.isTapped) {
-      const hasVigilance = card.cardData.keywords?.includes('Vigilance') ||
-        card.cardData.oracle_text?.toLowerCase().includes('vigilance');
+      const hasVigilance =
+        card.cardData.keywords?.includes("Vigilance") ||
+        card.cardData.oracle_text?.toLowerCase().includes("vigilance");
       if (!hasVigilance) return false;
     }
-    
+
     // Must not have summoning sickness (unless haste)
     if (card.hasSummoningSickness) {
-      const hasHaste = card.cardData.keywords?.includes('Haste') ||
-        card.cardData.oracle_text?.toLowerCase().includes('haste');
+      const hasHaste =
+        card.cardData.keywords?.includes("Haste") ||
+        card.cardData.oracle_text?.toLowerCase().includes("haste");
       if (!hasHaste) return false;
     }
-    
+
     return true;
   });
 }
@@ -615,11 +716,11 @@ export function getAvailableAttackers(
  */
 export function getAvailableBlockers(
   state: GameState,
-  playerId: PlayerId
+  playerId: PlayerId,
 ): CardInstanceId[] {
   const battlefieldZoneKey = `${playerId}-battlefield`;
   const battlefield = state.zones.get(battlefieldZoneKey);
-  
+
   if (!battlefield) return [];
 
   return battlefield.cardIds.filter((cardId) => {

--- a/src/lib/game-state/state-based-actions.ts
+++ b/src/lib/game-state/state-based-actions.ts
@@ -18,6 +18,7 @@ import {
   getToughness,
   hasLethalDamage,
 } from "./card-instance";
+import { hasIndestructible } from "./keyword-actions";
 import { destroyCard, exileCard } from "./keyword-actions";
 import { DEFAULT_COMMANDER_DAMAGE_THRESHOLD } from "./commander-damage";
 
@@ -140,7 +141,12 @@ export function checkStateBasedActions(
     // SBAs 704.5f–704.5n only apply to permanents on the battlefield
     if (isOnBattlefield) {
       // SBA 704.5f: A creature with lethal damage is destroyed
-      if (isCreature(card) && hasLethalDamage(card)) {
+      // Indestructible creatures are not destroyed by lethal damage (CR 702.12)
+      if (
+        isCreature(card) &&
+        hasLethalDamage(card) &&
+        !hasIndestructible(card)
+      ) {
         if (!cardsToDestroy.includes(card.id)) {
           cardsToDestroy.push(card.id);
           descriptions.push(


### PR DESCRIPTION
## Summary
Fixes #669

Implements deathtouch and indestructible blocking logic in the combat AI and game engine, addressing one of the most impactful correctness gaps in combat decision-making.

### Changes

**Combat AI (`combat-decision-tree.ts`):**
- `simulateBlocks`: Deathtouch creatures need only 1 damage to kill any creature (CR 702.2b); indestructible creatures cannot be killed by damage
- `evaluateBlocksForAttacker`: Sorting and scoring updated — deathtouch blockers get a +0.3 kill guarantee bonus; indestructible blockers get a +0.4 survival bonus; strongly discourage blocking indestructible attackers or sacrificing expensive creatures to deathtouch
- `evaluateTrade`: Trade evaluation accounts for both keywords — won't count indestructible creatures as killable
- `shouldMultiBlock`: Returns false for deathtouch attackers (single blocker sufficient) and indestructible attackers (can't kill via damage)
- `evaluateAttackTarget`: Indestructible attackers never die from combat; deathtouch + trample assigns only 1 damage per blocker for maximum trample overflow

**Game Engine (`combat.ts`):**
- Deathtouch attacker damage assignment: assigns only 1 damage per blocker (was assigning toughness amount), maximizing trample excess
- Indestructible blocker damage still accumulates but blocker survives SBA check

**State-Based Actions (`state-based-actions.ts`):**
- SBA 704.5f (lethal damage destruction) now skips indestructible creatures (CR 702.12)

### Tests Added (6 new, 37 total in combat test suite)
- Deathtouch trample damage optimization
- Indestructible blocker survives combat damage
- Deathtouch vs indestructible stalemate (blocker survives, attacker dies)
- True stalemate (both indestructible + deathtouch)
- Indestructible attacker survives combat
- Deathtouch blocker kills regardless of attacker toughness

Closes #669