### PR TITLE
feat: integrate Gemini Vision for board-state recognition (#664)

### DIFF
--- a/src/lib/pipeline/__tests__/board-state-vision.test.ts
+++ b/src/lib/pipeline/__tests__/board-state-vision.test.ts
@@ -1,0 +1,247 @@
+import {
+  RecognizedBoardStateSchema,
+  BoardCardSchema,
+} from "@/lib/pipeline/board-state-vision-types";
+import {
+  validateCardNames,
+} from "@/lib/pipeline/card-name-validator";
+import {
+  BOARD_STATE_SYSTEM_PROMPT,
+  BOARD_STATE_VALIDATION_PROMPT,
+} from "@/lib/pipeline/board-state-prompt";
+
+
+describe("RecognizedBoardStateSchema", () => {
+  it("parses a minimal valid board state", () => {
+    const input = {
+      player_life: 20,
+      opponent_life: 20,
+    };
+    const result = RecognizedBoardStateSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.player_life).toBe(20);
+      expect(result.data.opponent_life).toBe(20);
+      expect(result.data.battlefield_player).toEqual([]);
+      expect(result.data.hand_size).toBe(0);
+      expect(result.data.phase).toBe("main");
+      expect(result.data.turn_number).toBe(0);
+    }
+  });
+
+  it("parses a full board state", () => {
+    const input = {
+      player_life: 15,
+      opponent_life: 8,
+      battlefield_player: [
+        { name: "Sol Ring", is_tapped: true, power: 0, toughness: 0 },
+        { name: "Grizzly Bears", is_tapped: false, power: 2, toughness: 2 },
+      ],
+      battlefield_opponent: [
+        { name: "Counterspell" },
+      ],
+      hand_size: 5,
+      graveyard: ["Lightning Bolt", "Forest"],
+      stack: ["Counterspell"],
+      phase: "combat",
+      turn_number: 7,
+    };
+    const result = RecognizedBoardStateSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.player_life).toBe(15);
+      expect(result.data.battlefield_player).toHaveLength(2);
+      expect(result.data.battlefield_player[0].name).toBe("Sol Ring");
+      expect(result.data.battlefield_player[0].is_tapped).toBe(true);
+      expect(result.data.battlefield_opponent).toHaveLength(1);
+      expect(result.data.hand_size).toBe(5);
+      expect(result.data.graveyard).toHaveLength(2);
+      expect(result.data.stack).toHaveLength(1);
+      expect(result.data.phase).toBe("combat");
+      expect(result.data.turn_number).toBe(7);
+    }
+  });
+
+  it("coerces string numbers to integers", () => {
+    const input = {
+      player_life: "20",
+      opponent_life: "18",
+      hand_size: "6",
+      turn_number: "3",
+    };
+    const result = RecognizedBoardStateSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.player_life).toBe(20);
+      expect(result.data.opponent_life).toBe(18);
+      expect(result.data.hand_size).toBe(6);
+      expect(result.data.turn_number).toBe(3);
+    }
+  });
+
+  it("rejects completely invalid input", () => {
+    const input = { invalid: "data" };
+    const result = RecognizedBoardStateSchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts face-down cards", () => {
+    const input = {
+      player_life: 20,
+      opponent_life: 20,
+      battlefield_player: [{ name: "Unknown Card", is_face_down: true }],
+    };
+    const result = RecognizedBoardStateSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.battlefield_player[0].is_face_down).toBe(true);
+    }
+  });
+
+  it("accepts cards with counters", () => {
+    const input = {
+      player_life: 20,
+      opponent_life: 20,
+      battlefield_player: [
+        { name: "Questing Beast", counters: { "+1/+1": 2, loyalty: 1 } },
+      ],
+    };
+    const result = RecognizedBoardStateSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.battlefield_player[0].counters).toEqual({
+        "+1/+1": 2,
+        loyalty: 1,
+      });
+    }
+  });
+});
+
+describe("BoardCardSchema", () => {
+  it("defaults is_tapped to false", () => {
+    const result = BoardCardSchema.safeParse({ name: "Sol Ring" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.is_tapped).toBe(false);
+    }
+  });
+});
+
+describe("validateCardNames", () => {
+  const cardDatabase = new Map<string, string[]>([
+    ["sol ring", ["Sol Ring", "Ring of Sol"]],
+    ["lightning bolt", ["Lightning Bolt", "Bolt"]],
+    ["counterspell", ["Counterspell"]],
+    ["grizzly bears", ["Grizzly Bears"]],
+    ["forest", ["Forest"]],
+    ["island", ["Island"]],
+    ["mountain", ["Mountain"]],
+    ["plains", ["Plains"]],
+    ["swamp", ["Swamp"]],
+    ["questing beast", ["Questing Beast"]],
+  ]);
+
+  function makeBoardState(overrides: Record<string, unknown> = {}) {
+    return RecognizedBoardStateSchema.parse({
+      player_life: 20,
+      opponent_life: 20,
+      battlefield_player: [],
+      battlefield_opponent: [],
+      hand_size: 0,
+      graveyard: [],
+      stack: [],
+      phase: "main",
+      turn_number: 1,
+      ...overrides,
+    });
+  }
+
+  it("validates exact match card names", () => {
+    const boardState = makeBoardState({
+      battlefield_player: [{ name: "Sol Ring" }],
+    });
+
+    const results = validateCardNames(boardState, cardDatabase);
+    expect(results).toHaveLength(1);
+    expect(results[0].name).toBe("Sol Ring");
+    expect(results[0].valid).toBe(true);
+  });
+
+  it("suggests corrections for misspelled cards", () => {
+    const boardState = makeBoardState({
+      battlefield_player: [{ name: "Grizzli Bears" }],
+    });
+
+    const results = validateCardNames(boardState, cardDatabase);
+    expect(results).toHaveLength(1);
+    expect(results[0].valid).toBe(false);
+    expect(results[0].suggestion).toBeTruthy();
+  });
+
+  it("handles Unknown Card as invalid", () => {
+    const boardState = makeBoardState({
+      battlefield_player: [{ name: "Unknown Card", is_face_down: true }],
+    });
+
+    const results = validateCardNames(boardState, cardDatabase);
+    expect(results).toHaveLength(1);
+    expect(results[0].valid).toBe(false);
+  });
+
+  it("deduplicates card names across zones", () => {
+    const boardState = makeBoardState({
+      battlefield_player: [{ name: "Sol Ring" }],
+      graveyard: ["Sol Ring"],
+    });
+
+    const results = validateCardNames(boardState, cardDatabase);
+    expect(results).toHaveLength(1);
+    expect(results[0].valid).toBe(true);
+  });
+
+  it("works without a card database", () => {
+    const boardState = makeBoardState({
+      battlefield_player: [{ name: "Sol Ring" }],
+    });
+
+    const results = validateCardNames(boardState);
+    expect(results).toHaveLength(1);
+    expect(results[0].name).toBe("Sol Ring");
+  });
+
+  it("collects cards from all zones", () => {
+    const boardState = makeBoardState({
+      battlefield_player: [{ name: "Sol Ring" }],
+      battlefield_opponent: [{ name: "Forest" }],
+      graveyard: ["Lightning Bolt"],
+      stack: ["Counterspell"],
+    });
+
+    const results = validateCardNames(boardState, cardDatabase);
+    expect(results).toHaveLength(4);
+    const validCount = results.filter((r) => r.valid).length;
+    expect(validCount).toBe(4);
+  });
+});
+
+describe("BOARD_STATE_SYSTEM_PROMPT", () => {
+  it("contains required extraction instructions", () => {
+    expect(BOARD_STATE_SYSTEM_PROMPT).toContain("life totals");
+    expect(BOARD_STATE_SYSTEM_PROMPT).toContain("tapped");
+    expect(BOARD_STATE_SYSTEM_PROMPT).toContain("power");
+    expect(BOARD_STATE_SYSTEM_PROMPT).toContain("toughness");
+    expect(BOARD_STATE_SYSTEM_PROMPT).toContain("phase");
+    expect(BOARD_STATE_SYSTEM_PROMPT).toContain("JSON");
+    expect(BOARD_STATE_SYSTEM_PROMPT).toContain("hand_size");
+    expect(BOARD_STATE_SYSTEM_PROMPT).toContain("graveyard");
+    expect(BOARD_STATE_SYSTEM_PROMPT).toContain("stack");
+  });
+});
+
+describe("BOARD_STATE_VALIDATION_PROMPT", () => {
+  it("contains validation instructions", () => {
+    expect(BOARD_STATE_VALIDATION_PROMPT).toContain("valid");
+    expect(BOARD_STATE_VALIDATION_PROMPT).toContain("suggested_name");
+    expect(BOARD_STATE_VALIDATION_PROMPT).toContain("JSON");
+  });
+});

--- a/src/lib/pipeline/board-state-prompt.ts
+++ b/src/lib/pipeline/board-state-prompt.ts
@@ -1,0 +1,54 @@
+export const BOARD_STATE_SYSTEM_PROMPT = `You are an expert card game board state analyst. Your task is to analyze a screenshot of a digital card game (Magic: The Gathering / Planar Nexus) and extract structured board state information.
+
+## Rules
+
+1. Examine the screenshot carefully for all visible game elements.
+2. Identify life totals displayed for each player.
+3. List all cards visible on the battlefield, grouped by controlling player (bottom = player, top = opponent).
+4. For each card, extract:
+   - Full card name (exact spelling from the card art)
+   - Whether it is tapped (rotated 90 degrees)
+   - Power/toughness for creatures
+   - Any visible counters (+1/+1, charge, etc.)
+5. Determine the current phase and turn number from any UI indicators.
+6. Count visible cards in hand if shown.
+7. List card names visible in graveyards.
+
+## Output Format
+
+You MUST respond with valid JSON matching this exact schema:
+{
+  "player_life": <number>,
+  "opponent_life": <number>,
+  "battlefield_player": [
+    {
+      "name": "<exact card name>",
+      "is_tapped": <boolean>,
+      "power": <number or omitted>,
+      "toughness": <number or omitted>,
+      "counters": {"+1/+1": <number>} or omitted,
+      "is_face_down": <boolean>
+    }
+  ],
+  "battlefield_opponent": [...],
+  "hand_size": <number>,
+  "graveyard": ["<card name>", ...],
+  "stack": ["<card or ability name>", ...],
+  "phase": "<main|combat|beginning|end|draw|upkeep|cleanup>",
+  "turn_number": <number>
+}
+
+## Important Notes
+- Use exact card names as they appear in the game.
+- If you cannot identify a card name with confidence, use "Unknown Card" as the name.
+- For face-down cards, set is_face_down to true and name to "Unknown Card".
+- If no cards are visible in a zone, use an empty array [].
+- Respond with ONLY the JSON object, no other text.`;
+
+export const BOARD_STATE_VALIDATION_PROMPT = `Given this card name extracted from a game screenshot, determine if it is a valid card name. Return a JSON object with:
+{
+  "is_valid": <boolean>,
+  "suggested_name": "<corrected card name or null>"
+}
+
+Card name: `;

--- a/src/lib/pipeline/board-state-vision-types.ts
+++ b/src/lib/pipeline/board-state-vision-types.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+export const BoardCardSchema = z.object({
+  name: z.string(),
+  is_tapped: z.boolean().default(false),
+  power: z.coerce.number().optional(),
+  toughness: z.coerce.number().optional(),
+  counters: z.record(z.string(), z.coerce.number()).optional(),
+  is_face_down: z.boolean().default(false),
+  zone: z.string().default("battlefield"),
+});
+
+export type BoardCard = z.infer<typeof BoardCardSchema>;
+
+export const RecognizedBoardStateSchema = z.object({
+  player_life: z.coerce.number(),
+  opponent_life: z.coerce.number(),
+  battlefield_player: z.array(BoardCardSchema).default([]),
+  battlefield_opponent: z.array(BoardCardSchema).default([]),
+  hand_size: z.coerce.number().default(0),
+  graveyard: z.array(z.string()).default([]),
+  stack: z.array(z.string()).default([]),
+  phase: z.string().default("main"),
+  turn_number: z.coerce.number().default(0),
+});
+
+export type RecognizedBoardState = z.infer<typeof RecognizedBoardStateSchema>;
+
+export interface VisionProcessingOptions {
+  model?: string;
+  temperature?: number;
+  maxRetries?: number;
+  includeCardArtContext?: boolean;
+  confidenceThreshold?: number;
+}
+
+export interface VisionProcessingResult {
+  success: boolean;
+  boardState: RecognizedBoardState | null;
+  rawResponse: string | null;
+  validatedCards: { name: string; valid: boolean; suggestion?: string }[];
+  error?: string;
+  processingTimeMs: number;
+  modelUsed: string;
+  tokensUsed?: { input: number; output: number };
+}
+
+export interface BatchProcessingResult {
+  results: VisionProcessingResult[];
+  totalFrames: number;
+  successfulFrames: number;
+  failedFrames: number;
+  averageCardAccuracy: number;
+  totalProcessingTimeMs: number;
+}

--- a/src/lib/pipeline/board-state-vision.ts
+++ b/src/lib/pipeline/board-state-vision.ts
@@ -1,0 +1,254 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { generateText } from "ai";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import {
+  BOARD_STATE_SYSTEM_PROMPT,
+} from "./board-state-prompt";
+import {
+  RecognizedBoardStateSchema,
+  type VisionProcessingOptions,
+  type VisionProcessingResult,
+  type BatchProcessingResult,
+} from "./board-state-vision-types";
+import { validateCardNames } from "./card-name-validator";
+
+const DEFAULT_MODEL = "gemini-2.0-flash";
+const DEFAULT_TEMPERATURE = 0.1;
+const DEFAULT_MAX_RETRIES = 2;
+
+function readImageAsBase64(imagePath: string): Promise<string> {
+  return fs.readFile(imagePath).then((buf) => buf.toString("base64"));
+}
+
+function guessMimeType(imagePath: string): string {
+  const ext = path.extname(imagePath).toLowerCase();
+  if (ext === ".png") return "image/png";
+  if (ext === ".webp") return "image/webp";
+  return "image/jpeg";
+}
+
+export async function analyzeFrame(
+  framePath: string,
+  cardDatabase?: Map<string, string[]>,
+  options?: VisionProcessingOptions,
+): Promise<VisionProcessingResult> {
+  const startTime = Date.now();
+  const modelId = options?.model ?? DEFAULT_MODEL;
+  const temperature = options?.temperature ?? DEFAULT_TEMPERATURE;
+  const maxRetries = options?.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const confidenceThreshold = options?.confidenceThreshold ?? 0.0;
+
+  const apiKey =
+    process.env.GOOGLE_AI_API_KEY ?? process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+  if (!apiKey) {
+    return {
+      success: false,
+      boardState: null,
+      rawResponse: null,
+      validatedCards: [],
+      error: "GOOGLE_AI_API_KEY not configured",
+      processingTimeMs: Date.now() - startTime,
+      modelUsed: modelId,
+    };
+  }
+
+  let base64Image: string;
+  try {
+    base64Image = await readImageAsBase64(framePath);
+  } catch {
+    return {
+      success: false,
+      boardState: null,
+      rawResponse: null,
+      validatedCards: [],
+      error: `Failed to read image: ${framePath}`,
+      processingTimeMs: Date.now() - startTime,
+      modelUsed: modelId,
+    };
+  }
+
+  const mimeType = guessMimeType(framePath);
+  const dataUri = `data:${mimeType};base64,${base64Image}`;
+
+  let lastError: Error | null = null;
+  let rawResponse: string | null = null;
+  let tokensUsed: { input: number; output: number } | undefined;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const google = createGoogleGenerativeAI({ apiKey });
+      const model = google(modelId);
+
+      const result = await generateText({
+        model,
+        system: BOARD_STATE_SYSTEM_PROMPT,
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "image", image: dataUri },
+              {
+                type: "text",
+                text: "Analyze this game board screenshot and extract the board state as JSON.",
+              },
+            ],
+          },
+        ],
+        temperature,
+      });
+
+      rawResponse = result.text;
+      const usage = await result.usage;
+      tokensUsed = {
+        input: usage.inputTokens ?? 0,
+        output: usage.outputTokens ?? 0,
+      };
+      break;
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      if (attempt < maxRetries) {
+        await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)));
+      }
+    }
+  }
+
+  if (!rawResponse) {
+    return {
+      success: false,
+      boardState: null,
+      rawResponse,
+      validatedCards: [],
+      error: lastError?.message ?? "Unknown error",
+      processingTimeMs: Date.now() - startTime,
+      modelUsed: modelId,
+      tokensUsed,
+    };
+  }
+
+  const jsonMatch = rawResponse.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    return {
+      success: false,
+      boardState: null,
+      rawResponse,
+      validatedCards: [],
+      error: "No JSON object found in response",
+      processingTimeMs: Date.now() - startTime,
+      modelUsed: modelId,
+      tokensUsed,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonMatch[0]);
+  } catch {
+    return {
+      success: false,
+      boardState: null,
+      rawResponse,
+      validatedCards: [],
+      error: "Invalid JSON in response",
+      processingTimeMs: Date.now() - startTime,
+      modelUsed: modelId,
+      tokensUsed,
+    };
+  }
+
+  const result = RecognizedBoardStateSchema.safeParse(parsed);
+  if (!result.success) {
+    return {
+      success: false,
+      boardState: null,
+      rawResponse,
+      validatedCards: [],
+      error: `Schema validation failed: ${result.error.message}`,
+      processingTimeMs: Date.now() - startTime,
+      modelUsed: modelId,
+      tokensUsed,
+    };
+  }
+
+  const boardState = result.data;
+  const validatedCards = validateCardNames(boardState, cardDatabase);
+
+  const validCount = validatedCards.filter((c) => c.valid).length;
+  const totalCount = validatedCards.length;
+  const accuracy = totalCount > 0 ? validCount / totalCount : 1;
+
+  if (accuracy < confidenceThreshold && confidenceThreshold > 0) {
+    return {
+      success: false,
+      boardState,
+      rawResponse,
+      validatedCards,
+      error: `Card accuracy ${accuracy.toFixed(2)} below threshold ${confidenceThreshold}`,
+      processingTimeMs: Date.now() - startTime,
+      modelUsed: modelId,
+      tokensUsed,
+    };
+  }
+
+  return {
+    success: true,
+    boardState,
+    rawResponse,
+    validatedCards,
+    processingTimeMs: Date.now() - startTime,
+    modelUsed: modelId,
+    tokensUsed,
+  };
+}
+
+export async function analyzeFramesBatch(
+  frames: string[],
+  cardDatabase?: Map<string, string[]>,
+  options?: VisionProcessingOptions & {
+    concurrency?: number;
+    onProgress?: (current: number, total: number) => void;
+  },
+): Promise<BatchProcessingResult> {
+  const concurrency = options?.concurrency ?? 3;
+  const onProgress = options?.onProgress;
+  const results: VisionProcessingResult[] = [];
+
+  let completed = 0;
+  const total = frames.length;
+
+  async function processFrame(framePath: string): Promise<VisionProcessingResult> {
+    const result = await analyzeFrame(framePath, cardDatabase, options);
+    completed++;
+    onProgress?.(completed, total);
+    return result;
+  }
+
+  for (let i = 0; i < frames.length; i += concurrency) {
+    const batch = frames.slice(i, i + concurrency);
+    const batchResults = await Promise.all(batch.map(processFrame));
+    results.push(...batchResults);
+  }
+
+  const successfulFrames = results.filter((r) => r.success).length;
+  const failedFrames = results.filter((r) => !r.success).length;
+  const totalProcessingTimeMs = results.reduce((sum, r) => sum + r.processingTimeMs, 0);
+
+  let totalValid = 0;
+  let totalCards = 0;
+  for (const r of results) {
+    for (const vc of r.validatedCards) {
+      totalCards++;
+      if (vc.valid) totalValid++;
+    }
+  }
+  const averageCardAccuracy = totalCards > 0 ? totalValid / totalCards : 0;
+
+  return {
+    results,
+    totalFrames: total,
+    successfulFrames,
+    failedFrames,
+    averageCardAccuracy,
+    totalProcessingTimeMs,
+  };
+}

--- a/src/lib/pipeline/card-name-validator.ts
+++ b/src/lib/pipeline/card-name-validator.ts
@@ -1,0 +1,144 @@
+import type { RecognizedBoardState } from "./board-state-vision-types";
+
+const COMMON_CORRECTIONS: Record<string, string> = {
+  "sol ring": "Sol Ring",
+  "lightning bolt": "Lightning Bolt",
+  "counterspell": "Counterspell",
+  "dark ritual": "Dark Ritual",
+  "forest": "Forest",
+  "island": "Island",
+  "mountain": "Mountain",
+  "plains": "Plains",
+  "swamp": "Swamp",
+  "unknown card": "Unknown Card",
+};
+
+function normalizeForMatch(name: string): string {
+  return name.toLowerCase().trim().replace(/['']/g, "'").replace(/\s+/g, " ");
+}
+
+function findBestMatch(
+  query: string,
+  database: Map<string, string[]>,
+): { match: string | null; exact: boolean } {
+  const normalized = normalizeForMatch(query);
+
+  if (normalized === "unknown card" || normalized === "") {
+    return { match: null, exact: false };
+  }
+
+  for (const [normalizedName, aliases] of database) {
+    if (normalizedName === normalized) {
+      return { match: normalizedName, exact: true };
+    }
+    if (aliases.some((a) => normalizeForMatch(a) === normalized)) {
+      return { match: normalizedName, exact: true };
+    }
+  }
+
+  let bestMatch: string | null = null;
+  let bestDistance = Infinity;
+  const threshold = 3;
+
+  for (const [normalizedName] of database) {
+    const dist = levenshteinDistance(normalized, normalized);
+    if (dist < bestDistance && dist <= threshold) {
+      bestDistance = dist;
+      bestMatch = normalizedName;
+    }
+  }
+
+  return { match: bestMatch, exact: false };
+}
+
+function levenshteinDistance(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () =>
+    new Array(n + 1).fill(0),
+  );
+
+  for (let i = 0; i <= m; i++) dp[i][0] = i;
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (a[i - 1] === b[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1];
+      } else {
+        dp[i][j] =
+          1 + Math.min(dp[i - 1][j - 1], dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  return dp[m][n];
+}
+
+export interface ValidatedCard {
+  name: string;
+  valid: boolean;
+  suggestion?: string;
+}
+
+export function validateCardNames(
+  boardState: RecognizedBoardState,
+  cardDatabase?: Map<string, string[]>,
+): ValidatedCard[] {
+  const allNames: string[] = [];
+
+  for (const card of boardState.battlefield_player) {
+    allNames.push(card.name);
+  }
+  for (const card of boardState.battlefield_opponent) {
+    allNames.push(card.name);
+  }
+  for (const name of boardState.graveyard) {
+    allNames.push(name);
+  }
+  for (const name of boardState.stack) {
+    allNames.push(name);
+  }
+
+  if (!cardDatabase || cardDatabase.size === 0) {
+    return allNames.map((name) => ({
+      name,
+      valid: name !== "Unknown Card",
+      suggestion: COMMON_CORRECTIONS[normalizeForMatch(name)],
+    }));
+  }
+
+  const seen = new Set<string>();
+  const results: ValidatedCard[] = [];
+
+  for (const name of allNames) {
+    if (seen.has(name)) continue;
+    seen.add(name);
+
+    const { match, exact } = findBestMatch(name, cardDatabase);
+    const isKnownCard = name !== "Unknown Card";
+
+    if (exact) {
+      results.push({ name, valid: true });
+    } else if (match && !exact && isKnownCard) {
+      const capitalized = capitalizeWords(match);
+      results.push({ name, valid: false, suggestion: capitalized });
+    } else {
+      const commonCorrection = COMMON_CORRECTIONS[normalizeForMatch(name)];
+      results.push({
+        name,
+        valid: isKnownCard ? (commonCorrection !== undefined) : false,
+        suggestion: commonCorrection,
+      });
+    }
+  }
+
+  return results;
+}
+
+function capitalizeWords(str: string): string {
+  return str
+    .split(" ")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}

--- a/src/lib/pipeline/card-name-validator.ts
+++ b/src/lib/pipeline/card-name-validator.ts
@@ -3,13 +3,13 @@ import type { RecognizedBoardState } from "./board-state-vision-types";
 const COMMON_CORRECTIONS: Record<string, string> = {
   "sol ring": "Sol Ring",
   "lightning bolt": "Lightning Bolt",
-  "counterspell": "Counterspell",
+  counterspell: "Counterspell",
   "dark ritual": "Dark Ritual",
-  "forest": "Forest",
-  "island": "Island",
-  "mountain": "Mountain",
-  "plains": "Plains",
-  "swamp": "Swamp",
+  forest: "Forest",
+  island: "Island",
+  mountain: "Mountain",
+  plains: "Plains",
+  swamp: "Swamp",
   "unknown card": "Unknown Card",
 };
 
@@ -41,7 +41,7 @@ function findBestMatch(
   const threshold = 3;
 
   for (const [normalizedName] of database) {
-    const dist = levenshteinDistance(normalized, normalized);
+    const dist = levenshteinDistance(normalized, normalizedName);
     if (dist < bestDistance && dist <= threshold) {
       bestDistance = dist;
       bestMatch = normalizedName;
@@ -66,8 +66,7 @@ function levenshteinDistance(a: string, b: string): number {
       if (a[i - 1] === b[j - 1]) {
         dp[i][j] = dp[i - 1][j - 1];
       } else {
-        dp[i][j] =
-          1 + Math.min(dp[i - 1][j - 1], dp[i - 1][j], dp[i][j - 1]);
+        dp[i][j] = 1 + Math.min(dp[i - 1][j - 1], dp[i - 1][j], dp[i][j - 1]);
       }
     }
   }
@@ -127,7 +126,7 @@ export function validateCardNames(
       const commonCorrection = COMMON_CORRECTIONS[normalizeForMatch(name)];
       results.push({
         name,
-        valid: isKnownCard ? (commonCorrection !== undefined) : false,
+        valid: isKnownCard ? commonCorrection !== undefined : false,
         suggestion: commonCorrection,
       });
     }

--- a/src/lib/pipeline/index.ts
+++ b/src/lib/pipeline/index.ts
@@ -9,6 +9,12 @@ export {
   buildMetadata,
   mergeWithSceneChanges,
 } from "./transcript-aligner";
+export { analyzeFrame, analyzeFramesBatch } from "./board-state-vision";
+export { validateCardNames } from "./card-name-validator";
+export {
+  BOARD_STATE_SYSTEM_PROMPT,
+  BOARD_STATE_VALIDATION_PROMPT,
+} from "./board-state-prompt";
 export type {
   FrameMetadata,
   TranscriptSegment,
@@ -44,3 +50,11 @@ export {
   crossReferenceWithEngine,
   buildTriageList,
 } from "./sentiment-analyzer";
+
+export type {
+  RecognizedBoardState,
+  BoardCard,
+  VisionProcessingOptions,
+  VisionProcessingResult,
+  BatchProcessingResult,
+} from "./board-state-vision-types";


### PR DESCRIPTION
## Summary
- Add Gemini 2.0 Flash Vision integration for board-state recognition from extracted video frames
- Implement structured JSON output schema (`RecognizedBoardState`) matching the issue #664 spec with Zod validation
- Create configurable prompt templates for board state extraction and card name validation
- Add card name validator with fuzzy matching (Levenshtein distance) against existing card database
- Support batch processing of frames with configurable concurrency and retry logic

## New Files
| File | Purpose |
|------|---------|
| `src/lib/pipeline/board-state-vision-types.ts` | Zod schemas and TypeScript types for vision output |
| `src/lib/pipeline/board-state-prompt.ts` | System prompt templates for Gemini Vision |
| `src/lib/pipeline/board-state-vision.ts` | `analyzeFrame()` and `analyzeFramesBatch()` using `@ai-sdk/google` |
| `src/lib/pipeline/card-name-validator.ts` | Fuzzy card name validation against database |
| `src/lib/pipeline/__tests__/board-state-vision.test.ts` | 15 unit tests |

## Integration
- New modules exported from `src/lib/pipeline/index.ts`
- Uses existing `@ai-sdk/google` dependency (already in `package.json`)
- Follows the same provider pattern as `src/ai/providers/factory.ts`
- Reads frames produced by the existing `ffmpeg-frame-extractor.ts` (Stage 1)

## Output Schema
```json
{
  "player_life": 20,
  "opponent_life": 15,
  "battlefield_player": [{"name": "Sol Ring", "is_tapped": true}],
  "battlefield_opponent": [{"name": "Grizzly Bears", "power": 2, "toughness": 2}],
  "hand_size": 5,
  "graveyard": ["Lightning Bolt"],
  "stack": ["Counterspell"],
  "phase": "combat",
  "turn_number": 7
}
```

Fixes #664