### PR TITLE
feat: implement stack dependency/ordering analysis (#687)

### DIFF
--- a/src/ai/__tests__/stack-dependency-analysis.test.ts
+++ b/src/ai/__tests__/stack-dependency-analysis.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect } from "@jest/globals";
-import { analyzeStackDependencies, StackAction } from "../stack-interaction-ai";
+import {
+  analyzeStackDependencies,
+  StackDependencyAnalyzer,
+  StackAction,
+} from "../stack-interaction-ai";
 
 function makeAction(
   overrides: Partial<StackAction> & { id: string; name: string },
@@ -402,5 +406,570 @@ describe("analyzeStackDependencies", () => {
       (d) => d.type === "prevents",
     );
     expect(preventDeps.length).toBeGreaterThan(0);
+  });
+});
+
+describe("StackDependencyAnalyzer - 3-item cross-dependency scenarios", () => {
+  test("3-item counterwar: analyzer detects counterwar escalation", () => {
+    const stack = [
+      makeAction({
+        id: "original_spell",
+        name: "Cruel Ultimatum",
+        manaValue: 7,
+        controller: "player1",
+      }),
+      makeAction({
+        id: "opp_counter_1",
+        name: "Counterspell",
+        manaValue: 2,
+        controller: "player2",
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "our_recounter",
+        name: "Counterflux",
+        manaValue: 2,
+        controller: "player1",
+        isInstantSpeed: true,
+      }),
+    ];
+    const analyzer = new StackDependencyAnalyzer(stack);
+    const escalation = analyzer.findCounterwarEscalation();
+
+    expect(escalation.isCounterwar).toBe(true);
+    expect(escalation.depth).toBeGreaterThanOrEqual(2);
+    expect(escalation.recommendedAction).not.toBe("none");
+  });
+
+  test("3-item counterwar: dependency chains capture counter relationships", () => {
+    const stack = [
+      makeAction({
+        id: "spell_a",
+        name: "Primeval Titan",
+        manaValue: 6,
+        controller: "player1",
+      }),
+      makeAction({
+        id: "counter_b",
+        name: "Counterspell",
+        manaValue: 2,
+        controller: "player2",
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "recounter_c",
+        name: "Cancel",
+        manaValue: 3,
+        controller: "player1",
+        isInstantSpeed: true,
+      }),
+    ];
+    const analyzer = new StackDependencyAnalyzer(stack);
+    const chains = analyzer.getDependencyChains();
+
+    expect(chains.length).toBeGreaterThan(0);
+    const counterChain = chains.find((c) => c.involves_counterwar);
+    if (counterChain) {
+      expect(counterChain.chain.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  test("3-item: allow to prevent worse outcome pattern", () => {
+    const stack = [
+      makeAction({
+        id: "our_value_spell",
+        name: "Consecrated Sphinx",
+        manaValue: 5,
+        controller: "player1",
+      }),
+      makeAction({
+        id: "opp_remove",
+        name: "Abrupt Decay",
+        manaValue: 2,
+        controller: "player2",
+        isInstantSpeed: true,
+        targets: [{ playerId: "player1" }],
+      }),
+      makeAction({
+        id: "our_protect",
+        name: "Protect",
+        manaValue: 1,
+        controller: "player1",
+        isInstantSpeed: true,
+        targets: [{ playerId: "player1" }],
+      }),
+    ];
+    const analyzer = new StackDependencyAnalyzer(stack);
+    const advice = analyzer.getResolutionAdvice();
+
+    const removeItem = advice.find((a) => a.itemId === "opp_remove");
+    expect(removeItem).toBeDefined();
+    expect(removeItem!.dependencies_affected.length).toBeGreaterThan(0);
+  });
+
+  test("3-item: resolution advice returns correct priorities", () => {
+    const stack = [
+      makeAction({
+        id: "threat",
+        name: "Exsanguinate",
+        manaValue: 6,
+        controller: "player2",
+        targets: [{ playerId: "player1" }],
+      }),
+      makeAction({
+        id: "counter_response",
+        name: "Counterspell",
+        manaValue: 2,
+        controller: "player1",
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "counter_counter",
+        name: "Counterflux",
+        manaValue: 2,
+        controller: "player2",
+        isInstantSpeed: true,
+      }),
+    ];
+    const analyzer = new StackDependencyAnalyzer(stack);
+    const advice = analyzer.getResolutionAdvice();
+
+    expect(advice).toHaveLength(3);
+    const highPriority = advice.filter(
+      (a) => a.priority === "high" || a.priority === "critical",
+    );
+    expect(highPriority.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("3-item: cross-dependencies between non-adjacent items", () => {
+    const stack = [
+      makeAction({
+        id: "bottom_threat",
+        name: "Fireball",
+        manaValue: 6,
+        controller: "player2",
+        targets: [{ playerId: "player1" }],
+      }),
+      makeAction({
+        id: "middle_removal",
+        name: "Hero's Downfall",
+        manaValue: 3,
+        controller: "player1",
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "top_counter",
+        name: "Counterspell",
+        manaValue: 2,
+        controller: "player2",
+        isInstantSpeed: true,
+      }),
+    ];
+    const result = analyzeStackDependencies(stack);
+
+    const topToMiddleDeps = result.dependency_graph.filter(
+      (d) => d.source_id === "top_counter" && d.target_id === "middle_removal",
+    );
+    expect(topToMiddleDeps.length).toBeGreaterThan(0);
+  });
+
+  test("3-item: critical items include items with bidirectional deps", () => {
+    const stack = [
+      makeAction({
+        id: "original",
+        name: "Fireball",
+        manaValue: 6,
+        controller: "player1",
+        targets: [{ playerId: "player2" }],
+      }),
+      makeAction({
+        id: "counter1",
+        name: "Counterspell",
+        manaValue: 2,
+        controller: "player2",
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "counter2",
+        name: "Counterflux",
+        manaValue: 2,
+        controller: "player1",
+        isInstantSpeed: true,
+      }),
+    ];
+    const result = analyzeStackDependencies(stack);
+
+    expect(result.critical_items.length).toBeGreaterThanOrEqual(1);
+    const counterItem = result.items.find((i) => i.action.id === "counter1");
+    expect(counterItem!.critical_path).toBe(true);
+  });
+
+  test("3-item: resolution order prioritizes critical path items", () => {
+    const stack = [
+      makeAction({ id: "s1", name: "Rampant Growth", manaValue: 2 }),
+      makeAction({
+        id: "s2",
+        name: "Counterspell",
+        manaValue: 2,
+        controller: "player2",
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "s3",
+        name: "Counterflux",
+        manaValue: 2,
+        controller: "player1",
+        isInstantSpeed: true,
+      }),
+    ];
+    const result = analyzeStackDependencies(stack);
+
+    const criticalIdx = result.resolution_order.findIndex(
+      (id) => result.items.find((i) => i.action.id === id)?.critical_path,
+    );
+    const nonCriticalIdx = result.resolution_order.findIndex((id) =>
+      result.items.find((i) => i.action.id === id && !i.critical_path),
+    );
+    if (criticalIdx >= 0 && nonCriticalIdx >= 0) {
+      expect(criticalIdx).toBeLessThan(nonCriticalIdx);
+    }
+  });
+
+  test("3-item: dependency graph has correct source/target pairs", () => {
+    const stack = [
+      makeAction({
+        id: "spell",
+        name: "Primeval Titan",
+        manaValue: 6,
+        controller: "player1",
+      }),
+      makeAction({
+        id: "counter",
+        name: "Counterspell",
+        manaValue: 2,
+        controller: "player2",
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "draw_response",
+        name: "Ancestral Recall",
+        manaValue: 1,
+        controller: "player1",
+        isInstantSpeed: true,
+      }),
+    ];
+    const result = analyzeStackDependencies(stack);
+    const counterDep = result.dependency_graph.find(
+      (d) =>
+        d.type === "counters" &&
+        d.source_id === "counter" &&
+        d.target_id === "spell",
+    );
+    expect(counterDep).toBeDefined();
+    expect(counterDep!.strength).toBeGreaterThan(0);
+  });
+
+  test("3-item: has_cross_dependencies true when items chain-link", () => {
+    const stack = [
+      makeAction({
+        id: "a",
+        name: "Ultimatum",
+        manaValue: 7,
+        controller: "player1",
+      }),
+      makeAction({
+        id: "b",
+        name: "Counterspell",
+        manaValue: 2,
+        controller: "player2",
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "c",
+        name: "Counterflux",
+        manaValue: 2,
+        controller: "player1",
+        isInstantSpeed: true,
+      }),
+    ];
+    const result = analyzeStackDependencies(stack);
+    expect(result.has_cross_dependencies).toBe(true);
+  });
+
+  test("3-item: has_cross_dependencies false with no links", () => {
+    const stack = [
+      makeAction({ id: "a", name: "Rampant Growth", manaValue: 2 }),
+      makeAction({
+        id: "b",
+        name: "Shock",
+        manaValue: 1,
+        controller: "player2",
+        targets: [{ playerId: "player1" }],
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "c",
+        name: "Giant Growth",
+        manaValue: 1,
+        controller: "player2",
+        isInstantSpeed: true,
+      }),
+    ];
+    const result = analyzeStackDependencies(stack);
+    expect(result.has_cross_dependencies).toBe(false);
+  });
+
+  test("analyzer: empty stack returns empty advice", () => {
+    const analyzer = new StackDependencyAnalyzer([]);
+    const advice = analyzer.getResolutionAdvice();
+    expect(advice).toHaveLength(0);
+  });
+
+  test("analyzer: counterwar detection with 2 counters", () => {
+    const stack = [
+      makeAction({
+        id: "spell",
+        name: "Divination",
+        manaValue: 3,
+        controller: "player1",
+      }),
+      makeAction({
+        id: "c1",
+        name: "Counterspell",
+        manaValue: 2,
+        controller: "player2",
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "c2",
+        name: "Counterspell",
+        manaValue: 2,
+        controller: "player1",
+        isInstantSpeed: true,
+      }),
+    ];
+    const analyzer = new StackDependencyAnalyzer(stack);
+    const escalation = analyzer.findCounterwarEscalation();
+
+    expect(escalation.isCounterwar).toBe(true);
+    expect(escalation.depth).toBeGreaterThanOrEqual(2);
+  });
+
+  test("analyzer: no counterwar without counters", () => {
+    const stack = [
+      makeAction({ id: "s1", name: "Grizzly Bears", manaValue: 2 }),
+      makeAction({
+        id: "s2",
+        name: "Shock",
+        manaValue: 1,
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "s3",
+        name: "Giant Growth",
+        manaValue: 1,
+        isInstantSpeed: true,
+      }),
+    ];
+    const analyzer = new StackDependencyAnalyzer(stack);
+    const escalation = analyzer.findCounterwarEscalation();
+
+    expect(escalation.isCounterwar).toBe(false);
+    expect(escalation.depth).toBe(0);
+  });
+
+  test("analyzer: dependency chains handle empty analysis", () => {
+    const analyzer = new StackDependencyAnalyzer([]);
+    const chains = analyzer.getDependencyChains();
+    expect(chains).toHaveLength(0);
+  });
+
+  test("analyzer: resolution advice has consistent length with items", () => {
+    const stack = [
+      makeAction({ id: "a", name: "Spell A", manaValue: 2 }),
+      makeAction({ id: "b", name: "Spell B", manaValue: 3 }),
+      makeAction({ id: "c", name: "Spell C", manaValue: 4 }),
+    ];
+    const analyzer = new StackDependencyAnalyzer(stack);
+    const analysis = analyzer.getAnalysis();
+    const advice = analyzer.getResolutionAdvice();
+
+    expect(advice.length).toBe(analysis.items.length);
+  });
+
+  test("analyzer: resolution advice dependencies_affected are non-empty for linked items", () => {
+    const stack = [
+      makeAction({
+        id: "threat",
+        name: "Primeval Titan",
+        manaValue: 6,
+        controller: "player1",
+      }),
+      makeAction({
+        id: "counter",
+        name: "Counterspell",
+        manaValue: 2,
+        controller: "player2",
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "response",
+        name: "Twincast",
+        manaValue: 2,
+        controller: "player1",
+        isInstantSpeed: true,
+      }),
+    ];
+    const analyzer = new StackDependencyAnalyzer(stack);
+    const advice = analyzer.getResolutionAdvice();
+
+    const counterAdvice = advice.find((a) => a.itemId === "counter");
+    expect(counterAdvice!.dependencies_affected.length).toBeGreaterThan(0);
+  });
+
+  test("3-item: copy + counter create mixed dependency types", () => {
+    const stack = [
+      makeAction({
+        id: "fireball",
+        name: "Fireball",
+        manaValue: 4,
+        controller: "player2",
+        targets: [{ playerId: "player1" }],
+      }),
+      makeAction({
+        id: "counter",
+        name: "Counterspell",
+        manaValue: 2,
+        controller: "player1",
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "copy",
+        name: "Twincast",
+        manaValue: 2,
+        controller: "player2",
+        isInstantSpeed: true,
+      }),
+    ];
+    const result = analyzeStackDependencies(stack);
+    const depTypes = new Set(result.dependency_graph.map((d) => d.type));
+    expect(depTypes.has("counters")).toBe(true);
+    expect(depTypes.has("depends_on_resolution")).toBe(true);
+  });
+
+  test("3-item: resolution order is stable across repeated calls", () => {
+    const stack = [
+      makeAction({
+        id: "x",
+        name: "Counterspell",
+        manaValue: 2,
+        controller: "player2",
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "y",
+        name: "Counterflux",
+        manaValue: 2,
+        controller: "player1",
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "z",
+        name: "Ultimatum",
+        manaValue: 7,
+        controller: "player2",
+      }),
+    ];
+    const r1 = analyzeStackDependencies([...stack]);
+    const r2 = analyzeStackDependencies([...stack]);
+    expect(r1.resolution_order).toEqual(r2.resolution_order);
+  });
+
+  test("3-item: items with no controller conflict have no counter deps", () => {
+    const stack = [
+      makeAction({
+        id: "p1_spell",
+        name: "Primeval Titan",
+        manaValue: 6,
+        controller: "player1",
+      }),
+      makeAction({
+        id: "p1_counter",
+        name: "Counterspell",
+        manaValue: 2,
+        controller: "player1",
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "p2_spell",
+        name: "Cancel",
+        manaValue: 3,
+        controller: "player2",
+        isInstantSpeed: true,
+      }),
+    ];
+    const result = analyzeStackDependencies(stack);
+    const sameControllerCounter = result.dependency_graph.find(
+      (d) =>
+        d.type === "counters" &&
+        d.source_id === "p1_counter" &&
+        d.target_id === "p1_spell",
+    );
+    expect(sameControllerCounter).toBeUndefined();
+  });
+
+  test("analyzer: escalation depth increases with more counters", () => {
+    const twoCounterStack = [
+      makeAction({
+        id: "s1",
+        name: "Ultimatum",
+        manaValue: 7,
+        controller: "player1",
+      }),
+      makeAction({
+        id: "c1",
+        name: "Counterspell",
+        manaValue: 2,
+        controller: "player2",
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "c2",
+        name: "Counterspell",
+        manaValue: 2,
+        controller: "player1",
+        isInstantSpeed: true,
+      }),
+    ];
+
+    const threeCounterStack = [
+      makeAction({
+        id: "s1",
+        name: "Ultimatum",
+        manaValue: 7,
+        controller: "player1",
+      }),
+      makeAction({
+        id: "c1",
+        name: "Counterspell",
+        manaValue: 2,
+        controller: "player2",
+        isInstantSpeed: true,
+      }),
+      makeAction({
+        id: "c2",
+        name: "Counterflux",
+        manaValue: 2,
+        controller: "player1",
+        isInstantSpeed: true,
+      }),
+    ];
+
+    const three = new StackDependencyAnalyzer(threeCounterStack);
+    const two = new StackDependencyAnalyzer(twoCounterStack);
+
+    expect(three.findCounterwarEscalation().depth).toBeGreaterThanOrEqual(
+      two.findCounterwarEscalation().depth,
+    );
   });
 });

--- a/src/ai/stack-interaction-ai.ts
+++ b/src/ai/stack-interaction-ai.ts
@@ -312,6 +312,29 @@ export interface StackDependencyAnalysis {
   summary: string;
 }
 
+export type ResolutionPriority =
+  | "critical"
+  | "high"
+  | "medium"
+  | "low"
+  | "irrelevant";
+
+export interface DependencyChain {
+  chain: string[];
+  types: DependencyType[];
+  total_strength: number;
+  involves_counterwar: boolean;
+}
+
+export interface ResolutionAdvice {
+  itemId: string;
+  priority: ResolutionPriority;
+  shouldCounter: boolean;
+  shouldAllow: boolean;
+  reasoning: string;
+  dependencies_affected: string[];
+}
+
 export function analyzeStackDependencies(
   stack: StackAction[],
 ): StackDependencyAnalysis {
@@ -677,6 +700,252 @@ function generateAnalysisSummary(
     `${items.reduce((s, i) => s + i.dependencies.length + i.dependents.length, 0) / 2} total dependency relationship(s)`,
   );
   return parts.join(" - ");
+}
+
+export class StackDependencyAnalyzer {
+  private analysis: StackDependencyAnalysis;
+
+  constructor(stack: StackAction[]) {
+    this.analysis = analyzeStackDependencies(stack);
+  }
+
+  getAnalysis(): StackDependencyAnalysis {
+    return this.analysis;
+  }
+
+  getDependencyChains(): DependencyChain[] {
+    const chains: DependencyChain[] = [];
+    const adj = new Map<
+      string,
+      { target: string; type: DependencyType; strength: number }[]
+    >();
+
+    for (const dep of this.analysis.dependency_graph) {
+      if (!adj.has(dep.source_id)) adj.set(dep.source_id, []);
+      adj.get(dep.source_id)!.push({
+        target: dep.target_id,
+        type: dep.type,
+        strength: dep.strength,
+      });
+      if (!adj.has(dep.target_id)) adj.set(dep.target_id, []);
+      adj.get(dep.target_id)!.push({
+        target: dep.source_id,
+        type: dep.type,
+        strength: dep.strength,
+      });
+    }
+
+    const visited = new Set<string>();
+
+    for (const startId of this.analysis.resolution_order) {
+      if (visited.has(startId)) continue;
+      const chain = this.buildChain(startId, adj, visited);
+      if (chain.chain.length >= 2) {
+        chains.push(chain);
+        for (const id of chain.chain) visited.add(id);
+      }
+    }
+
+    return chains.sort((a, b) => b.total_strength - a.total_strength);
+  }
+
+  private buildChain(
+    start: string,
+    adj: Map<
+      string,
+      { target: string; type: DependencyType; strength: number }[]
+    >,
+    globalVisited: Set<string>,
+  ): DependencyChain {
+    const chain: string[] = [start];
+    const types: DependencyType[] = [];
+    let totalStrength = 0;
+    let involvesCounterwar = false;
+    const localVisited = new Set<string>([start]);
+    const current = start;
+
+    const neighbors = adj.get(current) || [];
+    for (const edge of neighbors) {
+      if (!localVisited.has(edge.target) && !globalVisited.has(edge.target)) {
+        chain.push(edge.target);
+        types.push(edge.type);
+        totalStrength += edge.strength;
+        if (edge.type === "counters") involvesCounterwar = true;
+
+        const nextNeighbors = adj.get(edge.target) || [];
+        for (const next of nextNeighbors) {
+          if (
+            !localVisited.has(next.target) &&
+            !globalVisited.has(next.target)
+          ) {
+            chain.push(next.target);
+            types.push(next.type);
+            totalStrength += next.strength;
+            if (next.type === "counters") involvesCounterwar = true;
+            break;
+          }
+        }
+        break;
+      }
+    }
+
+    return {
+      chain,
+      types,
+      total_strength: totalStrength,
+      involves_counterwar: involvesCounterwar,
+    };
+  }
+
+  getResolutionAdvice(): ResolutionAdvice[] {
+    return this.analysis.items.map((item) => {
+      const { action, priority, reason } = this.evaluateItem(item);
+      return {
+        itemId: item.action.id,
+        priority,
+        shouldCounter: action === "counter",
+        shouldAllow: action === "allow",
+        reasoning: reason,
+        dependencies_affected: [
+          ...item.dependencies.map((d) => d.target_id),
+          ...item.dependents.map((d) => d.source_id),
+        ],
+      };
+    });
+  }
+
+  private evaluateItem(item: StackItemAnalysis): {
+    action: "counter" | "allow" | "monitor";
+    priority: ResolutionPriority;
+    reason: string;
+  } {
+    if (item.critical_path) {
+      const counterDeps = item.dependencies.filter(
+        (d) => d.type === "counters",
+      );
+      const counterDependents = item.dependents.filter(
+        (d) => d.type === "counters",
+      );
+
+      if (counterDeps.length > 0 && counterDependents.length > 0) {
+        return {
+          action: "counter",
+          priority: "critical",
+          reason:
+            "Counterwar escalation point - countering this resolves the chain",
+        };
+      }
+
+      if (counterDeps.length > 0) {
+        return {
+          action: "counter",
+          priority: "high",
+          reason: "This item is being countered and sits on critical path",
+        };
+      }
+    }
+
+    const preventsDeps = item.dependencies.filter((d) => d.type === "prevents");
+    if (preventsDeps.length > 0 && item.resolution_impact > 0.4) {
+      return {
+        action: "counter",
+        priority: "high",
+        reason: "Preventing a high-impact item from being removed",
+      };
+    }
+
+    if (this.shouldAllowToPreventWorse(item)) {
+      return {
+        action: "allow",
+        priority: "medium",
+        reason: "Allowing this to resolve blocks a worse outcome below",
+      };
+    }
+
+    if (item.resolution_impact > 0.6) {
+      return {
+        action: "monitor",
+        priority: "high",
+        reason: "High resolution impact - monitor for responses",
+      };
+    }
+
+    if (item.resolution_impact > 0.3) {
+      return {
+        action: "monitor",
+        priority: "medium",
+        reason: "Moderate impact item",
+      };
+    }
+
+    if (item.dependencies.length === 0 && item.dependents.length === 0) {
+      return {
+        action: "allow",
+        priority: "low",
+        reason: "No dependencies - safe to resolve",
+      };
+    }
+
+    return {
+      action: "monitor",
+      priority: "medium",
+      reason: "Standard monitoring",
+    };
+  }
+
+  private shouldAllowToPreventWorse(item: StackItemAnalysis): boolean {
+    const preventsDeps = item.dependents.filter(
+      (d) => d.type === "prevents" && d.strength >= 0.5,
+    );
+    if (preventsDeps.length === 0) return false;
+
+    const itemsBelow = this.analysis.items.filter(
+      (i) => i.position < item.position,
+    );
+    const threatBelow = itemsBelow.some(
+      (i) =>
+        i.dependencies.some(
+          (d) => d.type === "prevents" || d.type === "targets",
+        ) && i.resolution_impact > 0.4,
+    );
+
+    return threatBelow;
+  }
+
+  findCounterwarEscalation(): {
+    isCounterwar: boolean;
+    depth: number;
+    recommendedAction: string;
+  } {
+    const counters = this.analysis.items.filter((i) =>
+      i.action.name.toLowerCase().includes("counter"),
+    );
+    if (counters.length < 2) {
+      return { isCounterwar: false, depth: 0, recommendedAction: "none" };
+    }
+
+    const counterDeps = this.analysis.dependency_graph.filter(
+      (d) => d.type === "counters",
+    );
+    const uniqueCounterItems = new Set(counterDeps.map((d) => d.source_id));
+
+    if (uniqueCounterItems.size >= 2) {
+      return {
+        isCounterwar: true,
+        depth: uniqueCounterItems.size,
+        recommendedAction:
+          uniqueCounterItems.size >= 3
+            ? "resolve_original_and_hold"
+            : "recounter_top",
+      };
+    }
+
+    return {
+      isCounterwar: true,
+      depth: counters.length,
+      recommendedAction: "evaluate_mana_efficiency",
+    };
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #687

- Add StackDependencyAnalyzer with analyzeStackDependencies function
- Model stack as ordered list with dependency tracking
- Handle counter-response and resolution-order patterns
- Add tests for 3-item cross-dependency scenarios