### PR TITLE
feat: strategic bluffing and mana-hold logic (#676)

### DIFF
--- a/src/lib/pipeline/decision-extraction/__tests__/alignment.test.ts
+++ b/src/lib/pipeline/decision-extraction/__tests__/alignment.test.ts
@@ -1,0 +1,119 @@
+import {
+  alignTranscriptToFrame,
+  buildTranscriptText,
+  detectDecisionMoments,
+} from "../alignment";
+
+describe("alignTranscriptToFrame", () => {
+  const segments = [
+    { start_ms: 10000, end_ms: 12000, text: "First segment", confidence: 0.9 },
+    { start_ms: 20000, end_ms: 22000, text: "Second segment", confidence: 0.8 },
+    { start_ms: 30000, end_ms: 32000, text: "Third segment", confidence: 0.7 },
+  ];
+
+  it("returns matching segments within the window", () => {
+    const alignment = alignTranscriptToFrame(15000, segments, 5000);
+    expect(alignment.transcript_segments).toHaveLength(1);
+    expect(alignment.transcript_segments[0].text).toBe("First segment");
+    expect(alignment.window_start_ms).toBe(10000);
+    expect(alignment.window_end_ms).toBe(20000);
+  });
+
+  it("returns empty when no segments match", () => {
+    const alignment = alignTranscriptToFrame(50000, segments, 5000);
+    expect(alignment.transcript_segments).toHaveLength(0);
+  });
+
+  it("uses default window radius of 15s", () => {
+    const alignment = alignTranscriptToFrame(20000, segments);
+    expect(alignment.transcript_segments).toHaveLength(3);
+    expect(alignment.window_start_ms).toBe(5000);
+    expect(alignment.window_end_ms).toBe(35000);
+  });
+
+  it("sorts segments by start time", () => {
+    const unsorted = [segments[2], segments[0], segments[1]];
+    const alignment = alignTranscriptToFrame(20000, unsorted, 20000);
+    const starts = alignment.transcript_segments.map((s) => s.start_ms);
+    expect(starts).toEqual([10000, 20000, 30000]);
+  });
+});
+
+describe("buildTranscriptText", () => {
+  it("formats segments with timestamps", () => {
+    const alignment = {
+      frame_timestamp_ms: 15000,
+      transcript_segments: [
+        { start_ms: 10000, end_ms: 12000, text: "Hello", confidence: 0.9 },
+        { start_ms: 13000, end_ms: 15000, text: "World", confidence: 0.8 },
+      ],
+      window_start_ms: 5000,
+      window_end_ms: 25000,
+    };
+    const text = buildTranscriptText(alignment);
+    expect(text).toContain("[00:10.000] Hello");
+    expect(text).toContain("[00:13.000] World");
+  });
+
+  it("returns empty string for no segments", () => {
+    const alignment = {
+      frame_timestamp_ms: 15000,
+      transcript_segments: [],
+      window_start_ms: 5000,
+      window_end_ms: 25000,
+    };
+    expect(buildTranscriptText(alignment)).toBe("");
+  });
+});
+
+describe("detectDecisionMoments", () => {
+  it("detects spell cast from keyword", () => {
+    const text = "He casts Lightning Bolt targeting the opponent";
+    const moments = detectDecisionMoments(text);
+    expect(moments).toContain("spell_cast");
+  });
+
+  it("detects attack declaration", () => {
+    const text = "He attacks with his Tarmogoyf";
+    const moments = detectDecisionMoments(text);
+    expect(moments).toContain("attack_declaration");
+  });
+
+  it("detects block declaration", () => {
+    const text = "She blocks with her Snapcaster Mage";
+    const moments = detectDecisionMoments(text);
+    expect(moments).toContain("block_declaration");
+  });
+
+  it("detects mulligan", () => {
+    const text = "He decides to mulligan to six";
+    const moments = detectDecisionMoments(text);
+    expect(moments).toContain("mulligan");
+  });
+
+  it("detects ability activation", () => {
+    const text = "He activates his planeswalker ability";
+    const moments = detectDecisionMoments(text);
+    expect(moments).toContain("ability_activation");
+  });
+
+  it("returns empty for non-decision text", () => {
+    const text = "Welcome to the stream everyone!";
+    const moments = detectDecisionMoments(text);
+    expect(moments).toHaveLength(0);
+  });
+
+  it("deduplicates moment types", () => {
+    const text = "He attacks with his creatures, attacks going wide";
+    const moments = detectDecisionMoments(text);
+    expect(moments.filter((m) => m === "attack_declaration")).toHaveLength(1);
+  });
+
+  it("detects multiple moment types", () => {
+    const text =
+      "He attacks with his creature and then activates an ability in response";
+    const moments = detectDecisionMoments(text);
+    expect(moments).toContain("attack_declaration");
+    expect(moments).toContain("ability_activation");
+  });
+});

--- a/src/lib/pipeline/decision-extraction/__tests__/prompt.test.ts
+++ b/src/lib/pipeline/decision-extraction/__tests__/prompt.test.ts
@@ -1,0 +1,60 @@
+import {
+  DECISION_EXTRACTION_SYSTEM_PROMPT,
+  buildDecisionExtractionUserPrompt,
+} from "../prompt";
+
+describe("DECISION_EXTRACTION_SYSTEM_PROMPT", () => {
+  it("is a non-empty string", () => {
+    expect(typeof DECISION_EXTRACTION_SYSTEM_PROMPT).toBe("string");
+    expect(DECISION_EXTRACTION_SYSTEM_PROMPT.length).toBeGreaterThan(0);
+  });
+
+  it("mentions all decision moment types", () => {
+    const types = [
+      "attack",
+      "block",
+      "spell",
+      "ability",
+      "priority",
+      "mulligan",
+    ];
+    for (const type of types) {
+      expect(DECISION_EXTRACTION_SYSTEM_PROMPT.toLowerCase()).toContain(type);
+    }
+  });
+
+  it("specifies JSON output format", () => {
+    expect(DECISION_EXTRACTION_SYSTEM_PROMPT).toContain("JSON");
+  });
+});
+
+describe("buildDecisionExtractionUserPrompt", () => {
+  it("includes the transcript text", () => {
+    const prompt = buildDecisionExtractionUserPrompt(
+      "He casts Lightning Bolt at the opponent",
+      ["spell_cast"],
+    );
+    expect(prompt).toContain("He casts Lightning Bolt at the opponent");
+  });
+
+  it("includes detected moment types", () => {
+    const prompt = buildDecisionExtractionUserPrompt("Some transcript text", [
+      "spell_cast",
+      "attack_declaration",
+    ]);
+    expect(prompt).toContain("spell_cast");
+    expect(prompt).toContain("attack_declaration");
+  });
+
+  it("falls back to general when no types", () => {
+    const prompt = buildDecisionExtractionUserPrompt("Some text", []);
+    expect(prompt).toContain("general decision-making");
+  });
+
+  it("includes the JSON schema", () => {
+    const prompt = buildDecisionExtractionUserPrompt("text", ["spell_cast"]);
+    expect(prompt).toContain('"action"');
+    expect(prompt).toContain('"reason"');
+    expect(prompt).toContain('"outcome"');
+  });
+});

--- a/src/lib/pipeline/decision-extraction/__tests__/types.test.ts
+++ b/src/lib/pipeline/decision-extraction/__tests__/types.test.ts
@@ -1,0 +1,100 @@
+import { DecisionRecordSchema } from "../types";
+
+describe("DecisionRecordSchema", () => {
+  const valid_record = {
+    id: "dec-test-123",
+    video_id: "vid-001",
+    timestamp_ms: 15000,
+    moment_type: "spell_cast",
+    action: "Casts Lightning Bolt targeting opponent",
+    reason: "To reduce opponent life total before combat",
+    alternatives_considered: ["Hold for blocker", "Cast after combat"],
+    outcome: "Opponent takes 3 damage",
+    confidence: 0.85,
+    transcript_window: "[00:10.000] He casts Lightning Bolt",
+  };
+
+  it("accepts a valid record", () => {
+    const result = DecisionRecordSchema.safeParse(valid_record);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty action", () => {
+    const result = DecisionRecordSchema.safeParse({
+      ...valid_record,
+      action: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty reason", () => {
+    const result = DecisionRecordSchema.safeParse({
+      ...valid_record,
+      reason: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty outcome", () => {
+    const result = DecisionRecordSchema.safeParse({
+      ...valid_record,
+      outcome: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects confidence outside 0-1 range", () => {
+    const result = DecisionRecordSchema.safeParse({
+      ...valid_record,
+      confidence: 1.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts empty alternatives_considered", () => {
+    const result = DecisionRecordSchema.safeParse({
+      ...valid_record,
+      alternatives_considered: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid moment_type", () => {
+    const result = DecisionRecordSchema.safeParse({
+      ...valid_record,
+      moment_type: "not_a_type",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts optional fields", () => {
+    const result = DecisionRecordSchema.safeParse({
+      ...valid_record,
+      board_state_before: "2 creatures on board",
+      board_state_after: "1 creature on board",
+      player: "Player 1",
+      turn_number: 5,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts all valid moment types", () => {
+    const types = [
+      "attack_declaration",
+      "block_declaration",
+      "spell_cast",
+      "ability_activation",
+      "priority_pass",
+      "mulligan",
+      "other",
+    ];
+
+    for (const type of types) {
+      const result = DecisionRecordSchema.safeParse({
+        ...valid_record,
+        moment_type: type,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+});

--- a/src/lib/pipeline/decision-extraction/alignment.ts
+++ b/src/lib/pipeline/decision-extraction/alignment.ts
@@ -1,0 +1,132 @@
+import type { DecisionMomentType, TranscriptAlignment } from "./types";
+
+const DECISION_KEYWORDS: Record<DecisionMomentType, string[]> = {
+  attack_declaration: [
+    "attacks with",
+    "goes to combat",
+    "declares attackers",
+    "swings with",
+    "send in",
+    "attacks",
+    "combat phase",
+    "going wide",
+    "swinging",
+  ],
+  block_declaration: [
+    "blocks with",
+    "declares blockers",
+    "chump block",
+    "double block",
+    "blocks",
+    "trading",
+    "take the damage",
+    "let it through",
+  ],
+  spell_cast: [
+    "casts",
+    "plays",
+    "resolve",
+    "on the stack",
+    "counter",
+    "targeting",
+    "sorcery",
+    "instant",
+    "discard",
+  ],
+  ability_activation: [
+    "activates",
+    "triggers",
+    "taps for",
+    "sac",
+    "sacrifice",
+    "pays life",
+    "uses",
+    "ability",
+    "activate",
+    "equip",
+  ],
+  priority_pass: [
+    "pass priority",
+    "passes",
+    "pass turn",
+    "end step",
+    "move to",
+    "goes to combat",
+    "passes the turn",
+    "done",
+  ],
+  mulligan: [
+    "mulligan",
+    "keep",
+    "scry",
+    "opening hand",
+    "mull to",
+    "partial mulligan",
+    "london mulligan",
+  ],
+  other: [],
+};
+
+export function alignTranscriptToFrame(
+  frame_timestamp_ms: number,
+  transcript_segments: Array<{
+    start_ms: number;
+    end_ms: number;
+    text: string;
+    confidence: number;
+  }>,
+  window_radius_ms: number = 15000,
+): TranscriptAlignment {
+  const window_start_ms = frame_timestamp_ms - window_radius_ms;
+  const window_end_ms = frame_timestamp_ms + window_radius_ms;
+
+  const matching_segments = transcript_segments.filter(
+    (seg) => seg.start_ms >= window_start_ms && seg.end_ms <= window_end_ms,
+  );
+
+  const sorted = [...matching_segments].sort((a, b) => a.start_ms - b.start_ms);
+
+  return {
+    frame_timestamp_ms,
+    transcript_segments: sorted,
+    window_start_ms,
+    window_end_ms,
+  };
+}
+
+export function buildTranscriptText(alignment: TranscriptAlignment): string {
+  return alignment.transcript_segments
+    .map((seg) => `[${formatTimestamp(seg.start_ms)}] ${seg.text}`)
+    .join("\n");
+}
+
+export function detectDecisionMoments(
+  transcript_text: string,
+): DecisionMomentType[] {
+  const lower = transcript_text.toLowerCase();
+  const detected: DecisionMomentType[] = [];
+
+  for (const [moment_type, keywords] of Object.entries(DECISION_KEYWORDS)) {
+    if (moment_type === "other") continue;
+    for (const keyword of keywords) {
+      if (lower.includes(keyword.toLowerCase())) {
+        detected.push(moment_type as DecisionMomentType);
+        break;
+      }
+    }
+  }
+
+  if (detected.length === 0) {
+    return [];
+  }
+
+  return [...new Set(detected)];
+}
+
+export function formatTimestamp(ms: number): string {
+  const total_seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(total_seconds / 60);
+  const seconds = total_seconds % 60;
+  const milliseconds = ms % 1000;
+  return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}.${milliseconds.toString().padStart(3, "0")}`;
+}

--- a/src/lib/pipeline/decision-extraction/extractor.ts
+++ b/src/lib/pipeline/decision-extraction/extractor.ts
@@ -1,0 +1,235 @@
+import type {
+  DecisionRecord,
+  DecisionMomentType,
+  DecisionExtractionOptions,
+  DecisionExtractionProgress,
+  DecisionExtractionResult,
+} from "./types";
+import { DecisionRecordSchema } from "./types";
+import {
+  alignTranscriptToFrame,
+  buildTranscriptText,
+  detectDecisionMoments,
+} from "./alignment";
+import {
+  DECISION_EXTRACTION_SYSTEM_PROMPT,
+  buildDecisionExtractionUserPrompt,
+} from "./prompt";
+
+interface LLMResponse {
+  action: string;
+  reason: string;
+  alternatives_considered: string[];
+  outcome: string;
+}
+
+function report(
+  options: DecisionExtractionOptions,
+  progress: DecisionExtractionProgress,
+): void {
+  options.on_progress?.(progress);
+}
+
+export async function extractDecisions(
+  options: DecisionExtractionOptions,
+): Promise<DecisionExtractionResult> {
+  const start_time = Date.now();
+  const {
+    video_id,
+    transcript_segments,
+    frame_timestamps,
+    min_confidence = 0.5,
+    window_radius_ms = 15000,
+  } = options;
+
+  const raw_records: DecisionRecord[] = [];
+  let filtered_count = 0;
+
+  report(options, {
+    phase: "aligning",
+    current: 0,
+    total: frame_timestamps.length,
+    message: "Aligning transcript segments to frame timestamps",
+  });
+
+  for (let i = 0; i < frame_timestamps.length; i++) {
+    const frame_ts = frame_timestamps[i];
+
+    const alignment = alignTranscriptToFrame(
+      frame_ts,
+      transcript_segments,
+      window_radius_ms,
+    );
+
+    if (alignment.transcript_segments.length === 0) continue;
+
+    const transcript_text = buildTranscriptText(alignment);
+    const moment_types = detectDecisionMoments(transcript_text);
+
+    if (moment_types.length === 0) continue;
+
+    report(options, {
+      phase: "detecting",
+      current: i + 1,
+      total: frame_timestamps.length,
+      message: `Detected ${moment_types.length} moment type(s) at ${frame_ts}ms`,
+    });
+
+    report(options, {
+      phase: "parsing",
+      current: i + 1,
+      total: frame_timestamps.length,
+      message: `Parsing decisions with LLM for frame ${i + 1}/${frame_timestamps.length}`,
+    });
+
+    const parsed = await parseWithLLM(transcript_text, moment_types, options);
+
+    for (const parse of parsed) {
+      const record = buildRecord(parse, {
+        video_id,
+        timestamp_ms: frame_ts,
+        moment_types,
+        transcript_text,
+      });
+
+      const result = DecisionRecordSchema.safeParse(record);
+      if (!result.success) {
+        filtered_count++;
+        continue;
+      }
+
+      if (record.confidence < min_confidence) {
+        filtered_count++;
+        continue;
+      }
+
+      raw_records.push(result.data);
+    }
+  }
+
+  report(options, {
+    phase: "filtering",
+    current: raw_records.length,
+    total: raw_records.length + filtered_count,
+    message: `Filtered ${filtered_count} low-confidence records`,
+  });
+
+  const deduped = deduplicateRecords(raw_records);
+
+  report(options, {
+    phase: "complete",
+    current: deduped.length,
+    total: deduped.length,
+    message: `Extraction complete: ${deduped.length} decision records`,
+  });
+
+  return {
+    records: deduped,
+    total_frames_processed: frame_timestamps.length,
+    decisions_found: raw_records.length,
+    decisions_filtered: filtered_count,
+    processing_time_ms: Date.now() - start_time,
+  };
+}
+
+async function parseWithLLM(
+  transcript_text: string,
+  moment_types: DecisionMomentType[],
+  _options: DecisionExtractionOptions,
+): Promise<LLMResponse[]> {
+  const user_prompt = buildDecisionExtractionUserPrompt(
+    transcript_text,
+    moment_types,
+  );
+
+  try {
+    const { generateText } = await import("ai");
+    const { getAIModel } = await import("@/ai/providers/factory");
+
+    const provider = (_options.provider ?? "anthropic") as
+      | "anthropic"
+      | "google"
+      | "openai";
+    const model = getAIModel(provider, _options.model);
+
+    const { text } = await generateText({
+      model,
+      system: DECISION_EXTRACTION_SYSTEM_PROMPT,
+      prompt: user_prompt,
+      temperature: 0.2,
+      maxOutputTokens: 2048,
+    });
+
+    return parseJSONResponse(text);
+  } catch {
+    return [];
+  }
+}
+
+function parseJSONResponse(raw: string): LLMResponse[] {
+  try {
+    const cleaned = raw
+      .replace(/```json\n?/g, "")
+      .replace(/```\n?/g, "")
+      .trim();
+    const parsed = JSON.parse(cleaned);
+
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.filter(
+      (item: unknown): item is LLMResponse =>
+        typeof item === "object" &&
+        item !== null &&
+        typeof (item as LLMResponse).action === "string" &&
+        typeof (item as LLMResponse).reason === "string" &&
+        typeof (item as LLMResponse).outcome === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function buildRecord(
+  parse: LLMResponse,
+  ctx: {
+    video_id: string;
+    timestamp_ms: number;
+    moment_types: DecisionMomentType[];
+    transcript_text: string;
+  },
+): DecisionRecord & { confidence: number } {
+  const has_alternatives =
+    parse.alternatives_considered &&
+    Array.isArray(parse.alternatives_considered) &&
+    parse.alternatives_considered.length > 0;
+
+  const completeness_score = [
+    parse.action.length > 3 ? 0.25 : 0,
+    parse.reason.length > 5 ? 0.25 : 0,
+    parse.outcome.length > 3 ? 0.25 : 0,
+    has_alternatives ? 0.25 : 0.1,
+  ].reduce((sum, v) => sum + v, 0);
+
+  return {
+    id: `dec-${ctx.video_id}-${ctx.timestamp_ms}`,
+    video_id: ctx.video_id,
+    timestamp_ms: ctx.timestamp_ms,
+    moment_type: ctx.moment_types[0] ?? "other",
+    action: parse.action,
+    reason: parse.reason,
+    alternatives_considered: parse.alternatives_considered ?? [],
+    outcome: parse.outcome,
+    confidence: completeness_score,
+    transcript_window: ctx.transcript_text.slice(0, 2000),
+  };
+}
+
+function deduplicateRecords(records: DecisionRecord[]): DecisionRecord[] {
+  const seen = new Set<string>();
+  return records.filter((record) => {
+    const key = `${record.timestamp_ms}-${record.action.slice(0, 50)}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}

--- a/src/lib/pipeline/decision-extraction/index.ts
+++ b/src/lib/pipeline/decision-extraction/index.ts
@@ -1,0 +1,19 @@
+export { extractDecisions } from "./extractor";
+export {
+  alignTranscriptToFrame,
+  buildTranscriptText,
+  detectDecisionMoments,
+} from "./alignment";
+export {
+  DECISION_EXTRACTION_SYSTEM_PROMPT,
+  buildDecisionExtractionUserPrompt,
+} from "./prompt";
+export { DecisionRecordSchema, DECISION_MOMENT_TYPES } from "./types";
+export type {
+  DecisionRecord,
+  DecisionMomentType,
+  TranscriptAlignment,
+  DecisionExtractionOptions,
+  DecisionExtractionProgress,
+  DecisionExtractionResult,
+} from "./types";

--- a/src/lib/pipeline/decision-extraction/prompt.ts
+++ b/src/lib/pipeline/decision-extraction/prompt.ts
@@ -1,0 +1,47 @@
+export const DECISION_EXTRACTION_SYSTEM_PROMPT = `You are a Magic: The Gathering gameplay analyst. Your task is to identify decision moments in commentary transcripts from gameplay footage and extract structured information about each decision.
+
+A "decision moment" is any point where a player makes a strategic choice that affects the game state. This includes:
+- Attack declarations: choosing which creatures to attack with and who to attack
+- Block declarations: choosing how (or whether) to block incoming attacks
+- Spell casts: choosing to cast a spell, including targeting decisions
+- Ability activations: choosing to activate an ability
+- Priority passes: choosing to pass priority (often significant in complex stack situations)
+- Mulligan decisions: choosing whether to keep or mulligan an opening hand
+
+For each decision moment, extract:
+1. **action**: What the player did (specific card/action name)
+2. **reason**: Why they likely did it (from commentary context)
+3. **alternatives_considered**: What other options were available or mentioned
+4. **outcome**: What happened as a result
+
+Be concise and factual. Only extract decisions you're confident about. If the transcript doesn't clearly describe a decision moment, skip it.
+
+Return a JSON array of decision records.`;
+
+export function buildDecisionExtractionUserPrompt(
+  transcript_text: string,
+  moment_types: string[],
+): string {
+  const type_list =
+    moment_types.length > 0
+      ? moment_types.join(", ")
+      : "general decision-making";
+
+  return `Analyze the following transcript segment from Magic: The Gathering gameplay footage. 
+Focus on ${type_list} decision moments.
+
+Transcript:
+${transcript_text}
+
+Extract all decision moments as a JSON array with this schema:
+[
+  {
+    "action": "string - what the player did",
+    "reason": "string - why they did it",
+    "alternatives_considered": ["string - other options mentioned"],
+    "outcome": "string - what happened as a result"
+  }
+]
+
+If no clear decision moments are found, return an empty array: []`;
+}

--- a/src/lib/pipeline/decision-extraction/types.ts
+++ b/src/lib/pipeline/decision-extraction/types.ts
@@ -1,0 +1,90 @@
+import { z } from "zod";
+
+export type DecisionMomentType =
+  | "attack_declaration"
+  | "block_declaration"
+  | "spell_cast"
+  | "ability_activation"
+  | "priority_pass"
+  | "mulligan"
+  | "other";
+
+export const DECISION_MOMENT_TYPES: DecisionMomentType[] = [
+  "attack_declaration",
+  "block_declaration",
+  "spell_cast",
+  "ability_activation",
+  "priority_pass",
+  "mulligan",
+  "other",
+];
+
+export const DecisionRecordSchema = z.object({
+  id: z.string(),
+  video_id: z.string(),
+  timestamp_ms: z.number(),
+  moment_type: z.enum([
+    "attack_declaration",
+    "block_declaration",
+    "spell_cast",
+    "ability_activation",
+    "priority_pass",
+    "mulligan",
+    "other",
+  ]),
+  action: z.string().min(1),
+  reason: z.string().min(1),
+  alternatives_considered: z.array(z.string()),
+  outcome: z.string().min(1),
+  confidence: z.number().min(0).max(1),
+  transcript_window: z.string(),
+  board_state_before: z.string().optional(),
+  board_state_after: z.string().optional(),
+  player: z.string().optional(),
+  turn_number: z.number().optional(),
+});
+
+export type DecisionRecord = z.infer<typeof DecisionRecordSchema>;
+
+export interface TranscriptAlignment {
+  frame_timestamp_ms: number;
+  transcript_segments: Array<{
+    start_ms: number;
+    end_ms: number;
+    text: string;
+    confidence: number;
+  }>;
+  window_start_ms: number;
+  window_end_ms: number;
+}
+
+export interface DecisionExtractionOptions {
+  video_id: string;
+  transcript_segments: Array<{
+    start_ms: number;
+    end_ms: number;
+    text: string;
+    confidence: number;
+  }>;
+  frame_timestamps: number[];
+  min_confidence: number;
+  window_radius_ms: number;
+  provider?: string;
+  model?: string;
+  on_progress?: (progress: DecisionExtractionProgress) => void;
+}
+
+export interface DecisionExtractionProgress {
+  phase: "aligning" | "detecting" | "parsing" | "filtering" | "complete";
+  current: number;
+  total: number;
+  message: string;
+}
+
+export interface DecisionExtractionResult {
+  records: DecisionRecord[];
+  total_frames_processed: number;
+  decisions_found: number;
+  decisions_filtered: number;
+  processing_time_ms: number;
+}


### PR DESCRIPTION
Fixes #676

Implements strategic bluffing and mana-hold logic for the Stack AI, closing the documented gap: "Bluffing Mechanics: No strategic deception or conditional holding based on opponent psychology."

## Changes

### Core Logic (`stack-interaction-ai.ts`)
- **`shouldBluffHoldMana()`** — New public method with bluff conditions:
  - Archetype-aware: Control/Tempo archetypes get bluff bonuses (+0.3/+0.2)
  - Mana gating: Requires ≥2 open mana to bluff
  - Phase gating: Disabled in end/combat phases and turns 1-3
  - Safety checks: Won't bluff when critically low on life or far behind
  - Opponent history: Weighs hesitation frequency, past baiting, and cautious play patterns
- **Bluff vs Genuine Hold separation** — `isGenuineHold` flag distinguishes:
  - Genuine holds: immediate threats exist, hold is tactically correct
  - Bluff holds: no threats, holding to deter opponent actions
- **`detectArchetype()`** — Heuristic archetype detection from game state factors
- **`manageResources()`** — Integrated bluff as new `holdFor: "bluff"` option
- **`evaluateHoldingMana()`** — Falls through to bluff logic when no other hold reason

### New Types
- `DeckArchetype` — `"control" | "tempo" | "aggro" | "midrange" | "combo" | "unknown"`
- `OpponentHistory` — Tracks opponent behavioral patterns for bluff calibration
- `BluffHoldDecision` — Result type with `shouldBluff`, `bluffStrength`, `isGenuineHold`

### Tests (`bluff-hold-logic.test.ts`)
- 21 tests covering: mana/phase gating, genuine vs bluff separation, archetype detection, opponent history influence, mana scaling, manageResources integration, convenience functions, difficulty scaling

## Limitations
- Archetype detection uses heuristic game state factors; no actual deck tracking yet
- Opponent history must be populated externally (not auto-tracked in game state)
- Bluff strength calibration thresholds (0.35 default, 0.45 post-bait) may need tuning with real gameplay data