### PR TITLE
fix(mtg): address issues #751, #752, #753 - MTG rules engine fixes

### DIFF
--- a/src/lib/__tests__/validation-service.test.ts
+++ b/src/lib/__tests__/validation-service.test.ts
@@ -3,6 +3,7 @@ import {
   type Player,
   type CardInstance,
   Phase,
+  ZoneType,
 } from "@/lib/game-state/types";
 import { ValidationService } from "@/lib/validation-service";
 import { ScryfallCard } from "@/app/actions";
@@ -87,7 +88,7 @@ describe("ValidationService", () => {
         [
           `${playerId}-hand`,
           {
-            type: "hand",
+            type: ZoneType.HAND,
             playerId: playerId,
             cardIds: [cardId],
             isRevealed: false,
@@ -97,7 +98,7 @@ describe("ValidationService", () => {
         [
           `${playerId}-battlefield`,
           {
-            type: "battlefield",
+            type: ZoneType.BATTLEFIELD,
             playerId: playerId,
             cardIds: [],
             isRevealed: true,

--- a/src/lib/game-state/__tests__/abilities.test.ts
+++ b/src/lib/game-state/__tests__/abilities.test.ts
@@ -670,4 +670,77 @@ describe("Abilities System - checkTriggeredAbilities", () => {
     const result = checkTriggeredAbilities(state, "entersBattlefield");
     expect(result.abilities.length).toBe(0);
   });
+
+  it("should order triggers by APNAP order - active player first (CR 603.3a)", () => {
+    const playerIds = Array.from(state.players.keys());
+    const bobId = playerIds[1];
+
+    // Alice is active player (from startGame)
+    state.turn.activePlayerId = aliceId;
+
+    // Place card for Bob (inactive player) - will be after active
+    const bobCardId = placeCardOnBattlefield(
+      createMockCard({
+        id: "bob-trigger",
+        oracle_text: "When this creature enters the battlefield, draw a card.",
+      }),
+      bobId,
+    );
+
+    // Place card for Alice (active player) - will be first
+    const aliceCardId = placeCardOnBattlefield(
+      createMockCard({
+        id: "alice-trigger",
+        oracle_text: "When this creature enters the battlefield, gain 1 life.",
+      }),
+      aliceId,
+    );
+
+    const result = checkTriggeredAbilities(state, "entersBattlefield");
+    expect(result.abilities.length).toBe(2);
+    // Active player (Alice) should be first
+    expect(result.abilities[0].sourceCardId).toBe(aliceCardId);
+    expect(result.abilities[1].sourceCardId).toBe(bobCardId);
+  });
+
+  it("should order same-controller triggers by sourceCardTimestamp (CR 603.3b)", () => {
+    // Place first card (earlier timestamp)
+    const card1 = placeCardOnBattlefield(
+      createMockCard({
+        id: "first-trigger",
+        oracle_text: "When this creature enters the battlefield, draw a card.",
+      }),
+      aliceId,
+    );
+
+    // Place second card (later timestamp)
+    const card2 = placeCardOnBattlefield(
+      createMockCard({
+        id: "second-trigger",
+        oracle_text: "When this creature enters the battlefield, gain 1 life.",
+      }),
+      aliceId,
+    );
+
+    const result = checkTriggeredAbilities(state, "entersBattlefield");
+    expect(result.abilities.length).toBe(2);
+    // Earlier timestamp (first card) should resolve first
+    expect(result.abilities[0].sourceCardId).toBe(card1);
+    expect(result.abilities[1].sourceCardId).toBe(card2);
+  });
+
+  it("should include sourceCardTimestamp in TriggeredAbilityInstance", () => {
+    const cardId = placeCardOnBattlefield(
+      createMockCard({
+        id: "timestamp-test",
+        oracle_text: "When this creature enters the battlefield, draw a card.",
+      }),
+      aliceId,
+    );
+
+    const result = checkTriggeredAbilities(state, "entersBattlefield");
+    expect(result.abilities.length).toBe(1);
+    expect(result.abilities[0].sourceCardTimestamp).toBeDefined();
+    expect(typeof result.abilities[0].sourceCardTimestamp).toBe("number");
+  });
 });

--- a/src/lib/game-state/__tests__/replacement-effects.test.ts
+++ b/src/lib/game-state/__tests__/replacement-effects.test.ts
@@ -15,54 +15,54 @@ import {
   createDrawReplacementEffect,
   createDestroyReplacementEffect,
   createAsThoughEffect,
-} from '../replacement-effects';
-import type { GameState } from '../types';
+} from "../replacement-effects";
+import type { GameState } from "../types";
 
-describe('ReplacementEffectManager - APNAP Ordering', () => {
+describe("ReplacementEffectManager - APNAP Ordering", () => {
   beforeEach(() => {
     replacementEffectManager.reset();
   });
 
-  test('should apply effects in APNAP order', () => {
+  test("should apply effects in APNAP order", () => {
     // Player1 is active player, Player2 is non-active
     const apnapOrder: APNAPOrder = {
-      activePlayerId: 'player1',
-      playerOrder: ['player1', 'player2'],
+      activePlayerId: "player1",
+      playerOrder: ["player1", "player2"],
     };
 
     // Both players have effects that double damage
     const p1Effect: ReplacementAbility = {
-      id: 'p1-double',
-      sourceCardId: 'p1-card',
-      controllerId: 'player1',
-      effectType: 'damage_replacement',
-      description: 'P1 doubles damage',
+      id: "p1-double",
+      sourceCardId: "p1-card",
+      controllerId: "player1",
+      effectType: "damage_replacement",
+      description: "P1 doubles damage",
       layer: 5,
       timestamp: 100,
       isInstead: true,
-      canApply: (e) => e.type === 'damage',
+      canApply: (e) => e.type === "damage",
       apply: (e) => ({
         modified: true,
         modifiedEvent: { ...e, amount: e.amount * 2 },
-        description: 'P1 doubled',
+        description: "P1 doubled",
         instead: true,
       }),
     };
 
     const p2Effect: ReplacementAbility = {
-      id: 'p2-double',
-      sourceCardId: 'p2-card',
-      controllerId: 'player2',
-      effectType: 'damage_replacement',
-      description: 'P2 doubles damage',
+      id: "p2-double",
+      sourceCardId: "p2-card",
+      controllerId: "player2",
+      effectType: "damage_replacement",
+      description: "P2 doubles damage",
       layer: 5,
       timestamp: 200,
       isInstead: true,
-      canApply: (e) => e.type === 'damage',
+      canApply: (e) => e.type === "damage",
       apply: (e) => ({
         modified: true,
         modifiedEvent: { ...e, amount: e.amount * 2 },
-        description: 'P2 doubled',
+        description: "P2 doubled",
         instead: true,
       }),
     };
@@ -71,10 +71,10 @@ describe('ReplacementEffectManager - APNAP Ordering', () => {
     replacementEffectManager.registerEffect(p2Effect);
 
     const event: ReplacementEvent = {
-      type: 'damage',
+      type: "damage",
       amount: 3,
       timestamp: Date.now(),
-      targetId: 'player2', // Affected player is P2
+      targetId: "player2", // Affected player is P2
     };
 
     // P2's effect should apply first (affected player chooses)
@@ -84,47 +84,47 @@ describe('ReplacementEffectManager - APNAP Ordering', () => {
     expect(processed.amount).toBe(12);
   });
 
-  test('should prioritize self-replacement effects', () => {
+  test("should prioritize self-replacement effects", () => {
     const apnapOrder: APNAPOrder = {
-      activePlayerId: 'player1',
-      playerOrder: ['player1', 'player2'],
+      activePlayerId: "player1",
+      playerOrder: ["player1", "player2"],
     };
 
     // Self-replacement effect (e.g., "If this creature would deal damage...")
     const selfEffect: ReplacementAbility = {
-      id: 'self-replace',
-      sourceCardId: 'self-card',
-      controllerId: 'player1',
-      effectType: 'damage_replacement',
-      description: 'Self replacement',
+      id: "self-replace",
+      sourceCardId: "self-card",
+      controllerId: "player1",
+      effectType: "damage_replacement",
+      description: "Self replacement",
       layer: 5,
       timestamp: 300,
       isSelfReplacement: true,
       isInstead: true,
-      canApply: (e) => e.type === 'damage' && e.sourceId === 'self-card',
+      canApply: (e) => e.type === "damage" && e.sourceId === "self-card",
       apply: (e) => ({
         modified: true,
         modifiedEvent: { ...e, amount: e.amount + 5 },
-        description: 'Self added 5',
+        description: "Self added 5",
         instead: true,
       }),
     };
 
     // Regular effect
     const regularEffect: ReplacementAbility = {
-      id: 'regular',
-      sourceCardId: 'regular-card',
-      controllerId: 'player2',
-      effectType: 'damage_replacement',
-      description: 'Regular replacement',
+      id: "regular",
+      sourceCardId: "regular-card",
+      controllerId: "player2",
+      effectType: "damage_replacement",
+      description: "Regular replacement",
       layer: 5,
       timestamp: 100,
       isInstead: true,
-      canApply: (e) => e.type === 'damage',
+      canApply: (e) => e.type === "damage",
       apply: (e) => ({
         modified: true,
         modifiedEvent: { ...e, amount: e.amount * 2 },
-        description: 'Regular doubled',
+        description: "Regular doubled",
         instead: true,
       }),
     };
@@ -133,11 +133,11 @@ describe('ReplacementEffectManager - APNAP Ordering', () => {
     replacementEffectManager.registerEffect(regularEffect);
 
     const event: ReplacementEvent = {
-      type: 'damage',
+      type: "damage",
       amount: 3,
       timestamp: Date.now(),
-      sourceId: 'self-card',
-      targetId: 'player2',
+      sourceId: "self-card",
+      targetId: "player2",
     };
 
     // Self-replacement applies first: 3 + 5 = 8
@@ -146,38 +146,38 @@ describe('ReplacementEffectManager - APNAP Ordering', () => {
     expect(processed.amount).toBe(16);
   });
 
-  test('should handle layer ordering within same controller', () => {
+  test("should handle layer ordering within same controller", () => {
     // Lower layer applies first
     const layer1Effect: ReplacementAbility = {
-      id: 'layer1',
-      sourceCardId: 'card1',
-      controllerId: 'player1',
-      effectType: 'damage_prevention',
-      description: 'Layer 1',
+      id: "layer1",
+      sourceCardId: "card1",
+      controllerId: "player1",
+      effectType: "damage_prevention",
+      description: "Layer 1",
       layer: 1,
       timestamp: 100,
-      canApply: (e) => e.type === 'damage',
+      canApply: (e) => e.type === "damage",
       apply: (e) => ({
         modified: true,
         modifiedEvent: { ...e, amount: Math.max(0, e.amount - 2) },
-        description: 'Prevented 2',
+        description: "Prevented 2",
       }),
     };
 
     const layer5Effect: ReplacementAbility = {
-      id: 'layer5',
-      sourceCardId: 'card2',
-      controllerId: 'player1',
-      effectType: 'damage_replacement',
-      description: 'Layer 5',
+      id: "layer5",
+      sourceCardId: "card2",
+      controllerId: "player1",
+      effectType: "damage_replacement",
+      description: "Layer 5",
       layer: 5,
       timestamp: 200,
       isInstead: true,
-      canApply: (e) => e.type === 'damage',
+      canApply: (e) => e.type === "damage",
       apply: (e) => ({
         modified: true,
         modifiedEvent: { ...e, amount: e.amount * 2 },
-        description: 'Doubled',
+        description: "Doubled",
         instead: true,
       }),
     };
@@ -186,10 +186,10 @@ describe('ReplacementEffectManager - APNAP Ordering', () => {
     replacementEffectManager.registerEffect(layer5Effect);
 
     const event: ReplacementEvent = {
-      type: 'damage',
+      type: "damage",
       amount: 5,
       timestamp: Date.now(),
-      targetId: 'player2',
+      targetId: "player2",
     };
 
     // Layer 1 applies first: 5 - 2 = 3
@@ -199,115 +199,172 @@ describe('ReplacementEffectManager - APNAP Ordering', () => {
   });
 });
 
-describe('ReplacementEffectManager - As Though Effects', () => {
+describe("ReplacementEffectManager - As Though Effects", () => {
   beforeEach(() => {
     replacementEffectManager.reset();
   });
 
-  test('should register and check as though effects', () => {
+  test("should register and check as though effects", () => {
     const mockGameState = { players: new Map() } as GameState;
-    
+
     const flashEffect = createAsThoughEffect(
-      'veiled-source',
-      'player1',
-      'cast_flash',
-      'You may cast spells as though they had flash'
+      "veiled-source",
+      "player1",
+      "cast_flash",
+      "You may cast spells as though they had flash",
     );
 
     replacementEffectManager.registerAsThoughEffect(flashEffect);
 
-    expect(replacementEffectManager.checkAsThoughEffect('player1', 'cast_flash', mockGameState)).toBe(true);
-    expect(replacementEffectManager.checkAsThoughEffect('player2', 'cast_flash', mockGameState)).toBe(false);
-    expect(replacementEffectManager.checkAsThoughEffect('player1', 'attack_haste', mockGameState)).toBe(false);
+    expect(
+      replacementEffectManager.checkAsThoughEffect(
+        "player1",
+        "cast_flash",
+        mockGameState,
+      ),
+    ).toBe(true);
+    expect(
+      replacementEffectManager.checkAsThoughEffect(
+        "player2",
+        "cast_flash",
+        mockGameState,
+      ),
+    ).toBe(false);
+    expect(
+      replacementEffectManager.checkAsThoughEffect(
+        "player1",
+        "attack_haste",
+        mockGameState,
+      ),
+    ).toBe(false);
   });
 
-  test('should handle conditional as though effects', () => {
+  test("should handle conditional as though effects", () => {
     const mockGameState = { players: new Map() } as GameState;
-    
+
     // Effect that only applies when player has 10+ life
     const conditionalEffect = createAsThoughEffect(
-      'conditional-source',
-      'player1',
-      'attack_haste',
-      'Creatures can attack as though they had haste if you have 10+ life',
+      "conditional-source",
+      "player1",
+      "attack_haste",
+      "Creatures can attack as though they had haste if you have 10+ life",
       (_state, _playerId) => {
         // Simplified condition check
         return true;
-      }
+      },
     );
 
     replacementEffectManager.registerAsThoughEffect(conditionalEffect);
 
-    expect(replacementEffectManager.checkAsThoughEffect('player1', 'attack_haste', mockGameState)).toBe(true);
+    expect(
+      replacementEffectManager.checkAsThoughEffect(
+        "player1",
+        "attack_haste",
+        mockGameState,
+      ),
+    ).toBe(true);
   });
 
-  test('should get all as though effects for a player', () => {
+  test("should get all as though effects for a player", () => {
     const mockGameState = { players: new Map() } as GameState;
-    
+
     replacementEffectManager.registerAsThoughEffect(
-      createAsThoughEffect('source1', 'player1', 'cast_flash', 'Flash effect')
+      createAsThoughEffect("source1", "player1", "cast_flash", "Flash effect"),
     );
     replacementEffectManager.registerAsThoughEffect(
-      createAsThoughEffect('source2', 'player1', 'attack_haste', 'Haste effect')
+      createAsThoughEffect(
+        "source2",
+        "player1",
+        "attack_haste",
+        "Haste effect",
+      ),
     );
     replacementEffectManager.registerAsThoughEffect(
-      createAsThoughEffect('source3', 'player2', 'block_flying', 'Flying block effect')
+      createAsThoughEffect(
+        "source3",
+        "player2",
+        "block_flying",
+        "Flying block effect",
+      ),
     );
 
-    const p1Effects = replacementEffectManager.getAsThoughEffects('player1', mockGameState);
+    const p1Effects = replacementEffectManager.getAsThoughEffects(
+      "player1",
+      mockGameState,
+    );
     expect(p1Effects).toHaveLength(2);
-    expect(p1Effects.map(e => e.asThoughType)).toContain('cast_flash');
-    expect(p1Effects.map(e => e.asThoughType)).toContain('attack_haste');
+    expect(p1Effects.map((e) => e.asThoughType)).toContain("cast_flash");
+    expect(p1Effects.map((e) => e.asThoughType)).toContain("attack_haste");
 
-    const p2Effects = replacementEffectManager.getAsThoughEffects('player2', mockGameState);
+    const p2Effects = replacementEffectManager.getAsThoughEffects(
+      "player2",
+      mockGameState,
+    );
     expect(p2Effects).toHaveLength(1);
-    expect(p2Effects[0].asThoughType).toBe('block_flying');
+    expect(p2Effects[0].asThoughType).toBe("block_flying");
   });
 
-  test('should remove as though effects when source leaves battlefield', () => {
+  test("should remove as though effects when source leaves battlefield", () => {
     const mockGameState = { players: new Map() } as GameState;
-    
+
     replacementEffectManager.registerAsThoughEffect(
-      createAsThoughEffect('temporary-source', 'player1', 'cast_flash', 'Temporary flash')
+      createAsThoughEffect(
+        "temporary-source",
+        "player1",
+        "cast_flash",
+        "Temporary flash",
+      ),
     );
 
-    expect(replacementEffectManager.checkAsThoughEffect('player1', 'cast_flash', mockGameState)).toBe(true);
+    expect(
+      replacementEffectManager.checkAsThoughEffect(
+        "player1",
+        "cast_flash",
+        mockGameState,
+      ),
+    ).toBe(true);
 
-    replacementEffectManager.removeEffectsFromSource('temporary-source');
+    replacementEffectManager.removeEffectsFromSource("temporary-source");
 
-    expect(replacementEffectManager.checkAsThoughEffect('player1', 'cast_flash', mockGameState)).toBe(false);
+    expect(
+      replacementEffectManager.checkAsThoughEffect(
+        "player1",
+        "cast_flash",
+        mockGameState,
+      ),
+    ).toBe(false);
   });
 });
 
-describe('ReplacementEffectManager - Complex Scenarios', () => {
+describe("ReplacementEffectManager - Complex Scenarios", () => {
   beforeEach(() => {
     replacementEffectManager.reset();
   });
 
-  test('should handle Furnace of Rath + prevention shield interaction', () => {
+  test("should handle Furnace of Rath + prevention shield interaction", () => {
     // Furnace of Rath: If damage would be dealt, deal twice that much instead
     const furnaceEffect = createDamageReplacementEffect(
-      'furnace',
-      'player1',
-      'Furnace of Rath doubles damage',
+      "furnace",
+      "player1",
+      "Furnace of Rath doubles damage",
       (amount) => amount * 2,
-      5
+      5,
     );
 
     replacementEffectManager.registerEffect(furnaceEffect);
 
     // Target has prevention shield
-    replacementEffectManager.addPreventionShield('player2', {
-      sourceId: 'fog',
+    replacementEffectManager.addPreventionShield("player2", {
+      sourceId: "fog",
       amount: 3,
-      controllerId: 'player2',
+      controllerId: "player2",
     });
 
     const event: ReplacementEvent = {
-      type: 'damage',
+      type: "damage",
       amount: 2,
       timestamp: Date.now(),
-      targetId: 'player2',
+      targetId: "player2",
     };
 
     // Furnace doubles: 2 * 2 = 4
@@ -316,26 +373,26 @@ describe('ReplacementEffectManager - Complex Scenarios', () => {
     expect(processed.amount).toBe(1);
 
     // Shield should be depleted
-    const shields = replacementEffectManager.getPreventionShields('player2');
+    const shields = replacementEffectManager.getPreventionShields("player2");
     expect(shields).toHaveLength(0);
   });
 
-  test('should handle Alhammarret\'s Archive life gain doubling', () => {
+  test("should handle Alhammarret's Archive life gain doubling", () => {
     const archiveEffect = createLifeGainReplacementEffect(
-      'archive',
-      'player1',
-      'Alhammarret\'s Archive doubles life gain',
+      "archive",
+      "player1",
+      "Alhammarret's Archive doubles life gain",
       (amount) => amount * 2,
-      (targetId) => targetId === 'player1'
+      (targetId) => targetId === "player1",
     );
 
     replacementEffectManager.registerEffect(archiveEffect);
 
     const event: ReplacementEvent = {
-      type: 'life_gain',
+      type: "life_gain",
       amount: 5,
       timestamp: Date.now(),
-      targetId: 'player1',
+      targetId: "player1",
     };
 
     const processed = replacementEffectManager.processEvent(event);
@@ -343,123 +400,125 @@ describe('ReplacementEffectManager - Complex Scenarios', () => {
 
     // Should not apply to other players
     const otherEvent: ReplacementEvent = {
-      type: 'life_gain',
+      type: "life_gain",
       amount: 5,
       timestamp: Date.now(),
-      targetId: 'player2',
+      targetId: "player2",
     };
 
     const otherProcessed = replacementEffectManager.processEvent(otherEvent);
     expect(otherProcessed.amount).toBe(5);
   });
 
-  test('should handle multiple prevention shields depleting correctly', () => {
-    replacementEffectManager.addPreventionShield('player1', {
-      sourceId: 'shield1',
+  test("should handle multiple prevention shields depleting correctly", () => {
+    replacementEffectManager.addPreventionShield("player1", {
+      sourceId: "shield1",
       amount: 2,
-      controllerId: 'player1',
+      controllerId: "player1",
     });
-    replacementEffectManager.addPreventionShield('player1', {
-      sourceId: 'shield2',
+    replacementEffectManager.addPreventionShield("player1", {
+      sourceId: "shield2",
       amount: 3,
-      controllerId: 'player1',
+      controllerId: "player1",
     });
 
     // First damage: 4 damage, should use both shields (2 + 2 from second)
     const event1: ReplacementEvent = {
-      type: 'damage',
+      type: "damage",
       amount: 4,
       timestamp: Date.now(),
-      targetId: 'player1',
+      targetId: "player1",
     };
 
     const processed1 = replacementEffectManager.processEvent(event1);
     expect(processed1.amount).toBe(0);
 
     // Second shield should have 1 remaining
-    const shields = replacementEffectManager.getPreventionShields('player1');
+    const shields = replacementEffectManager.getPreventionShields("player1");
     expect(shields).toHaveLength(1);
     expect(shields[0].amount).toBe(1);
 
     // Second damage: 2 damage, should use remaining 1 from shield2
     const event2: ReplacementEvent = {
-      type: 'damage',
+      type: "damage",
       amount: 2,
       timestamp: Date.now() + 1000,
-      targetId: 'player1',
+      targetId: "player1",
     };
 
     const processed2 = replacementEffectManager.processEvent(event2);
     expect(processed2.amount).toBe(1);
 
     // All shields should be depleted
-    expect(replacementEffectManager.getPreventionShields('player1')).toHaveLength(0);
+    expect(
+      replacementEffectManager.getPreventionShields("player1"),
+    ).toHaveLength(0);
   });
 
-  test('should handle draw replacement effects', () => {
+  test("should handle draw replacement effects", () => {
     const drawEffect = createDrawReplacementEffect(
-      'nefarox',
-      'player1',
-      'Nefarox draw replacement',
-      (amount) => amount + 1 // Draw one additional card
+      "nefarox",
+      "player1",
+      "Nefarox draw replacement",
+      (amount) => amount + 1, // Draw one additional card
     );
 
     replacementEffectManager.registerEffect(drawEffect);
 
     const event: ReplacementEvent = {
-      type: 'draw_card',
+      type: "draw_card",
       amount: 1,
       timestamp: Date.now(),
-      targetId: 'player1',
+      targetId: "player1",
     };
 
     const processed = replacementEffectManager.processEvent(event);
     expect(processed.amount).toBe(2);
   });
 
-  test('should handle destroy replacement (regeneration)', () => {
+  test("should handle destroy replacement (regeneration)", () => {
     const regenEffect = createDestroyReplacementEffect(
-      'regeneration-shield',
-      'player1',
-      'Regeneration shield',
+      "regeneration-shield",
+      "player1",
+      "Regeneration shield",
       (event) => ({
         ...event,
-        type: 'tap', // Instead of dying, creature taps
+        type: "tap", // Instead of dying, creature taps
         amount: 0,
       }),
-      (targetId) => targetId === 'creature1'
+      (targetId) => targetId === "creature1",
     );
 
     replacementEffectManager.registerEffect(regenEffect);
 
     const event: ReplacementEvent = {
-      type: 'destroy',
+      type: "destroy",
       amount: 0,
       timestamp: Date.now(),
-      targetId: 'creature1',
+      targetId: "creature1",
     };
 
     const processed = replacementEffectManager.processEvent(event);
-    expect(processed.type).toBe('tap');
+    expect(processed.type).toBe("tap");
     expect(processed.amount).toBe(0);
   });
 
-  test('should handle life loss replacement', () => {
+  test("should handle life loss replacement", () => {
     const lossEffect = createLifeLossReplacementEffect(
-      'loss-reducer',
-      'player1',
-      'Half life loss',
+      "loss-reducer",
+      "player1",
+      "Half life loss",
       (amount) => Math.ceil(amount / 2),
-      (targetId) => targetId === 'player1'
+      (targetId) => targetId === "player1",
     );
 
     replacementEffectManager.registerEffect(lossEffect);
 
     const event: ReplacementEvent = {
-      type: 'life_loss',
+      type: "life_loss",
       amount: 7,
       timestamp: Date.now(),
-      targetId: 'player1',
+      targetId: "player1",
     };
 
     const processed = replacementEffectManager.processEvent(event);
@@ -467,69 +526,82 @@ describe('ReplacementEffectManager - Complex Scenarios', () => {
   });
 });
 
-describe('ReplacementEffectManager - APNAP Order Creation', () => {
+describe("ReplacementEffectManager - APNAP Order Creation", () => {
   beforeEach(() => {
     replacementEffectManager.reset();
   });
 
-  test('should create correct APNAP order', () => {
-    const allPlayers = ['player1', 'player2', 'player3', 'player4'];
-    
+  test("should create correct APNAP order", () => {
+    const allPlayers = ["player1", "player2", "player3", "player4"];
+
     // Player2 is active
-    const order = replacementEffectManager.createAPNAPOrder('player2', allPlayers);
-    
-    expect(order.activePlayerId).toBe('player2');
-    expect(order.playerOrder).toEqual(['player2', 'player3', 'player4', 'player1']);
+    const order = replacementEffectManager.createAPNAPOrder(
+      "player2",
+      allPlayers,
+    );
+
+    expect(order.activePlayerId).toBe("player2");
+    expect(order.playerOrder).toEqual([
+      "player2",
+      "player3",
+      "player4",
+      "player1",
+    ]);
   });
 
-  test('should handle single player', () => {
-    const order = replacementEffectManager.createAPNAPOrder('player1', ['player1']);
-    expect(order.playerOrder).toEqual(['player1']);
+  test("should handle single player", () => {
+    const order = replacementEffectManager.createAPNAPOrder("player1", [
+      "player1",
+    ]);
+    expect(order.playerOrder).toEqual(["player1"]);
   });
 
-  test('should handle unknown active player', () => {
-    const allPlayers = ['player1', 'player2'];
-    const order = replacementEffectManager.createAPNAPOrder('unknown', allPlayers);
+  test("should handle unknown active player", () => {
+    const allPlayers = ["player1", "player2"];
+    const order = replacementEffectManager.createAPNAPOrder(
+      "unknown",
+      allPlayers,
+    );
     expect(order.playerOrder).toEqual(allPlayers);
   });
 });
 
-describe('ReplacementEffectManager - Factory Functions', () => {
+describe("ReplacementEffectManager - Factory Functions", () => {
   beforeEach(() => {
     replacementEffectManager.reset();
   });
 
-  test('createPreventionShield should create both ability and shield', () => {
+  test("createPreventionShield should create both ability and shield", () => {
     const { ability, shield } = createPreventionShield(
-      'source',
-      'player1',
-      'player2',
+      "source",
+      "player1",
+      "player2",
       5,
-      'Prevent 5 damage',
-      'until_end_of_turn',
-      ['combat']
+      "Prevent 5 damage",
+      "until_end_of_turn",
+      ["combat"],
     );
 
     expect(ability.id).toMatch(/prevent-source-\d+/);
-    expect(ability.effectType).toBe('damage_prevention');
+    expect(ability.effectType).toBe("damage_prevention");
     expect(ability.layer).toBe(1);
     expect(ability.preventionAmount).toBe(5);
 
-    expect(shield.sourceId).toBe('source');
+    expect(shield.sourceId).toBe("source");
     expect(shield.amount).toBe(5);
-    expect(shield.damageTypes).toEqual(['combat']);
-    expect(shield.controllerId).toBe('player1');
+    expect(shield.damageTypes).toEqual(["combat"]);
+    expect(shield.controllerId).toBe("player1");
     expect(shield.expiresAt).toBeDefined();
   });
 
-  test('createDamageReplacementEffect should create correct effect', () => {
+  test("createDamageReplacementEffect should create correct effect", () => {
     const effect = createDamageReplacementEffect(
-      'furnace',
-      'player1',
-      'Double damage',
+      "furnace",
+      "player1",
+      "Double damage",
       (amount) => amount * 2,
       5,
-      true
+      true,
     );
 
     expect(effect.isSelfReplacement).toBe(true);
@@ -537,7 +609,7 @@ describe('ReplacementEffectManager - Factory Functions', () => {
     expect(effect.layer).toBe(5);
 
     const event: ReplacementEvent = {
-      type: 'damage',
+      type: "damage",
       amount: 3,
       timestamp: Date.now(),
     };
@@ -548,64 +620,64 @@ describe('ReplacementEffectManager - Factory Functions', () => {
     expect(result.instead).toBe(true);
   });
 
-  test('createAsThoughEffect should create correct effect', () => {
+  test("createAsThoughEffect should create correct effect", () => {
     const effect = createAsThoughEffect(
-      'source',
-      'player1',
-      'cast_flash',
-      'Flash effect',
+      "source",
+      "player1",
+      "cast_flash",
+      "Flash effect",
       undefined,
-      'permanent'
+      "permanent",
     );
 
-    expect(effect.asThoughType).toBe('cast_flash');
-    expect(effect.duration).toBe('permanent');
+    expect(effect.asThoughType).toBe("cast_flash");
+    expect(effect.duration).toBe("permanent");
     expect(effect.condition).toBeUndefined();
   });
 });
 
-describe('ReplacementEffectManager - CR 614.4 Loop Detection', () => {
+describe("ReplacementEffectManager - CR 614.4 Loop Detection", () => {
   beforeEach(() => {
     replacementEffectManager.reset();
   });
 
-  test('should detect and break a two-effect infinite loop (CR 614.4)', () => {
+  test("should detect and break a two-effect infinite loop (CR 614.4)", () => {
     // Effect A: If creature would be destroyed, instead exile it
     // Effect B: If creature would be exiled, instead return it to battlefield
     // This creates an infinite loop
 
     const effectA: ReplacementAbility = {
-      id: 'exile-on-destroy',
-      sourceCardId: 'card-a',
-      controllerId: 'player1',
-      effectType: 'destroy_replacement',
-      description: 'Exile instead of destroy',
+      id: "exile-on-destroy",
+      sourceCardId: "card-a",
+      controllerId: "player1",
+      effectType: "destroy_replacement",
+      description: "Exile instead of destroy",
       layer: 3,
       timestamp: 100,
       isInstead: true,
-      canApply: (e) => e.type === 'destroy' && e.targetId === 'creature1',
+      canApply: (e) => e.type === "destroy" && e.targetId === "creature1",
       apply: (e) => ({
         modified: true,
-        modifiedEvent: { ...e, type: 'exile' as const },
-        description: 'Exiled instead of destroyed',
+        modifiedEvent: { ...e, type: "exile" as const },
+        description: "Exiled instead of destroyed",
         instead: true,
       }),
     };
 
     const effectB: ReplacementAbility = {
-      id: 'return-on-exile',
-      sourceCardId: 'card-b',
-      controllerId: 'player1',
-      effectType: 'exile_replacement',
-      description: 'Return to battlefield instead of exile',
+      id: "return-on-exile",
+      sourceCardId: "card-b",
+      controllerId: "player1",
+      effectType: "exile_replacement",
+      description: "Return to battlefield instead of exile",
       layer: 3,
       timestamp: 200,
       isInstead: true,
-      canApply: (e) => e.type === 'exile' && e.targetId === 'creature1',
+      canApply: (e) => e.type === "exile" && e.targetId === "creature1",
       apply: (e) => ({
         modified: true,
-        modifiedEvent: { ...e, type: 'destroy' as const }, // Returns to destroy loop
-        description: 'Returned to battlefield instead of staying exiled',
+        modifiedEvent: { ...e, type: "destroy" as const }, // Returns to destroy loop
+        description: "Returned to battlefield instead of staying exiled",
         instead: true,
       }),
     };
@@ -614,10 +686,10 @@ describe('ReplacementEffectManager - CR 614.4 Loop Detection', () => {
     replacementEffectManager.registerEffect(effectB);
 
     const event: ReplacementEvent = {
-      type: 'destroy',
+      type: "destroy",
       amount: 0,
       timestamp: Date.now(),
-      targetId: 'creature1',
+      targetId: "creature1",
     };
 
     // CR 614.4: If replacement effects form an infinite loop, no objects are affected
@@ -626,42 +698,42 @@ describe('ReplacementEffectManager - CR 614.4 Loop Detection', () => {
     expect(processed.amount).toBe(0); // Loop detected, event skipped
   });
 
-  test('should NOT detect loop when effects do not create circular state changes', () => {
+  test("should NOT detect loop when effects do not create circular state changes", () => {
     // Effect A: Doubles damage (layer 5)
     // Effect B: Prevents 2 damage (layer 1 - applies first)
     // These should apply normally without looping
 
     const doubleEffect: ReplacementAbility = {
-      id: 'double-effect',
-      sourceCardId: 'double-card',
-      controllerId: 'player1',
-      effectType: 'damage_replacement',
-      description: 'Double damage',
+      id: "double-effect",
+      sourceCardId: "double-card",
+      controllerId: "player1",
+      effectType: "damage_replacement",
+      description: "Double damage",
       layer: 5,
       timestamp: 100,
       isInstead: true,
-      canApply: (e) => e.type === 'damage',
+      canApply: (e) => e.type === "damage",
       apply: (e) => ({
         modified: true,
         modifiedEvent: { ...e, amount: e.amount * 2 },
-        description: 'Doubled',
+        description: "Doubled",
         instead: true,
       }),
     };
 
     const reduceEffect: ReplacementAbility = {
-      id: 'reduce-effect',
-      sourceCardId: 'reduce-card',
-      controllerId: 'player1',
-      effectType: 'damage_prevention',
-      description: 'Reduce by 2',
+      id: "reduce-effect",
+      sourceCardId: "reduce-card",
+      controllerId: "player1",
+      effectType: "damage_prevention",
+      description: "Reduce by 2",
       layer: 1,
       timestamp: 200,
-      canApply: (e) => e.type === 'damage',
+      canApply: (e) => e.type === "damage",
       apply: (e) => ({
         modified: true,
         modifiedEvent: { ...e, amount: Math.max(0, e.amount - 2) },
-        description: 'Reduced by 2',
+        description: "Reduced by 2",
       }),
     };
 
@@ -669,10 +741,10 @@ describe('ReplacementEffectManager - CR 614.4 Loop Detection', () => {
     replacementEffectManager.registerEffect(reduceEffect);
 
     const event: ReplacementEvent = {
-      type: 'damage',
+      type: "damage",
       amount: 5,
       timestamp: Date.now(),
-      targetId: 'player2',
+      targetId: "player2",
     };
 
     // No loop: Layer 1 applies first: 5 - 2 = 3, then Layer 5: 3 * 2 = 6
@@ -680,61 +752,61 @@ describe('ReplacementEffectManager - CR 614.4 Loop Detection', () => {
     expect(processed.amount).toBe(6);
   });
 
-  test('should detect loop with three-effect cycle', () => {
+  test("should detect loop with three-effect cycle", () => {
     // Effect A: destroy -> exile
     // Effect B: exile -> tap
     // Effect C: tap -> destroy (back to start)
 
     const effectA: ReplacementAbility = {
-      id: 'cycle-a',
-      sourceCardId: 'card-a',
-      controllerId: 'player1',
-      effectType: 'destroy_replacement',
-      description: 'A: destroy->exile',
+      id: "cycle-a",
+      sourceCardId: "card-a",
+      controllerId: "player1",
+      effectType: "destroy_replacement",
+      description: "A: destroy->exile",
       layer: 3,
       timestamp: 100,
       isInstead: true,
-      canApply: (e) => e.type === 'destroy' && e.targetId === 'creature1',
+      canApply: (e) => e.type === "destroy" && e.targetId === "creature1",
       apply: (e) => ({
         modified: true,
-        modifiedEvent: { ...e, type: 'exile' as const },
-        description: 'A applied',
+        modifiedEvent: { ...e, type: "exile" as const },
+        description: "A applied",
         instead: true,
       }),
     };
 
     const effectB: ReplacementAbility = {
-      id: 'cycle-b',
-      sourceCardId: 'card-b',
-      controllerId: 'player1',
-      effectType: 'exile_replacement',
-      description: 'B: exile->tap',
+      id: "cycle-b",
+      sourceCardId: "card-b",
+      controllerId: "player1",
+      effectType: "exile_replacement",
+      description: "B: exile->tap",
       layer: 3,
       timestamp: 200,
       isInstead: true,
-      canApply: (e) => e.type === 'exile' && e.targetId === 'creature1',
+      canApply: (e) => e.type === "exile" && e.targetId === "creature1",
       apply: (e) => ({
         modified: true,
-        modifiedEvent: { ...e, type: 'tap' as const },
-        description: 'B applied',
+        modifiedEvent: { ...e, type: "tap" as const },
+        description: "B applied",
         instead: true,
       }),
     };
 
     const effectC: ReplacementAbility = {
-      id: 'cycle-c',
-      sourceCardId: 'card-c',
-      controllerId: 'player1',
-      effectType: 'exile_replacement',
-      description: 'C: tap->destroy',
+      id: "cycle-c",
+      sourceCardId: "card-c",
+      controllerId: "player1",
+      effectType: "exile_replacement",
+      description: "C: tap->destroy",
       layer: 3,
       timestamp: 300,
       isInstead: true,
-      canApply: (e) => e.type === 'tap' && e.targetId === 'creature1',
+      canApply: (e) => e.type === "tap" && e.targetId === "creature1",
       apply: (e) => ({
         modified: true,
-        modifiedEvent: { ...e, type: 'destroy' as const },
-        description: 'C applied',
+        modifiedEvent: { ...e, type: "destroy" as const },
+        description: "C applied",
         instead: true,
       }),
     };
@@ -744,10 +816,10 @@ describe('ReplacementEffectManager - CR 614.4 Loop Detection', () => {
     replacementEffectManager.registerEffect(effectC);
 
     const event: ReplacementEvent = {
-      type: 'destroy',
+      type: "destroy",
       amount: 0,
       timestamp: Date.now(),
-      targetId: 'creature1',
+      targetId: "creature1",
     };
 
     // Three-effect loop detected, CR 614.4 applies
@@ -755,41 +827,41 @@ describe('ReplacementEffectManager - CR 614.4 Loop Detection', () => {
     expect(processed.amount).toBe(0); // Loop detected, event skipped
   });
 
-  test('should use maxIterations cap as safety limit for potential infinite loops', () => {
+  test("should use maxIterations cap as safety limit for potential infinite loops", () => {
     // Create a chain of effects where each transforms back to a type that triggers the first
     // But we use low maxIterations to catch it
     const effectA: ReplacementAbility = {
-      id: 'safe-a',
-      sourceCardId: 'card-a',
-      controllerId: 'player1',
-      effectType: 'destroy_replacement',
-      description: 'A: destroy->exile',
+      id: "safe-a",
+      sourceCardId: "card-a",
+      controllerId: "player1",
+      effectType: "destroy_replacement",
+      description: "A: destroy->exile",
       layer: 3,
       timestamp: 100,
       isInstead: true,
-      canApply: (e) => e.type === 'destroy' && e.targetId === 'creature1',
+      canApply: (e) => e.type === "destroy" && e.targetId === "creature1",
       apply: (e) => ({
         modified: true,
-        modifiedEvent: { ...e, type: 'exile' as const },
-        description: 'A applied',
+        modifiedEvent: { ...e, type: "exile" as const },
+        description: "A applied",
         instead: true,
       }),
     };
 
     const effectB: ReplacementAbility = {
-      id: 'safe-b',
-      sourceCardId: 'card-b',
-      controllerId: 'player1',
-      effectType: 'exile_replacement',
-      description: 'B: exile->destroy',
+      id: "safe-b",
+      sourceCardId: "card-b",
+      controllerId: "player1",
+      effectType: "exile_replacement",
+      description: "B: exile->destroy",
       layer: 3,
       timestamp: 200,
       isInstead: true,
-      canApply: (e) => e.type === 'exile' && e.targetId === 'creature1',
+      canApply: (e) => e.type === "exile" && e.targetId === "creature1",
       apply: (e) => ({
         modified: true,
-        modifiedEvent: { ...e, type: 'destroy' as const },
-        description: 'B applied',
+        modifiedEvent: { ...e, type: "destroy" as const },
+        description: "B applied",
         instead: true,
       }),
     };
@@ -798,33 +870,33 @@ describe('ReplacementEffectManager - CR 614.4 Loop Detection', () => {
     replacementEffectManager.registerEffect(effectB);
 
     const event: ReplacementEvent = {
-      type: 'destroy',
+      type: "destroy",
       amount: 0,
       timestamp: Date.now(),
-      targetId: 'creature1',
+      targetId: "creature1",
     };
 
     // Very low maxIterations to trigger safety cap
-    const processed = replacementEffectManager.processEvent(event, undefined, 5);
+    const processed = replacementEffectManager.processEvent(event, undefined);
     expect(processed.amount).toBe(0); // Hit cap, loop broken
   });
 
-  test('should not skip event when maxIterations is high enough for non-looping effects', () => {
+  test("should not skip event when maxIterations is high enough for non-looping effects", () => {
     // Effect that doubles damage - this is safe and won't loop
     const safeEffect: ReplacementAbility = {
-      id: 'safe-effect',
-      sourceCardId: 'safe-card',
-      controllerId: 'player1',
-      effectType: 'damage_replacement',
-      description: 'Safe double',
+      id: "safe-effect",
+      sourceCardId: "safe-card",
+      controllerId: "player1",
+      effectType: "damage_replacement",
+      description: "Safe double",
       layer: 5,
       timestamp: 100,
       isInstead: true,
-      canApply: (e) => e.type === 'damage',
+      canApply: (e) => e.type === "damage",
       apply: (e) => ({
         modified: true,
         modifiedEvent: { ...e, amount: e.amount * 2 },
-        description: 'Doubled safely',
+        description: "Doubled safely",
         instead: true,
       }),
     };
@@ -832,33 +904,33 @@ describe('ReplacementEffectManager - CR 614.4 Loop Detection', () => {
     replacementEffectManager.registerEffect(safeEffect);
 
     const event: ReplacementEvent = {
-      type: 'damage',
+      type: "damage",
       amount: 5,
       timestamp: Date.now(),
-      targetId: 'player2',
+      targetId: "player2",
     };
 
     // High maxIterations should not cause false positive
-    const processed = replacementEffectManager.processEvent(event, undefined, 100);
+    const processed = replacementEffectManager.processEvent(event, undefined);
     expect(processed.amount).toBe(10); // 5 * 2 = 10
   });
 
-  test('should handle single effect that does not loop', () => {
+  test("should handle single effect that does not loop", () => {
     // A single effect that modifies but doesn't create a loop
     const singleEffect: ReplacementAbility = {
-      id: 'single-effect',
-      sourceCardId: 'single-card',
-      controllerId: 'player1',
-      effectType: 'damage_replacement',
-      description: 'Add 3 damage',
+      id: "single-effect",
+      sourceCardId: "single-card",
+      controllerId: "player1",
+      effectType: "damage_replacement",
+      description: "Add 3 damage",
       layer: 5,
       timestamp: 100,
       isInstead: true,
-      canApply: (e) => e.type === 'damage',
+      canApply: (e) => e.type === "damage",
       apply: (e) => ({
         modified: true,
         modifiedEvent: { ...e, amount: e.amount + 3 },
-        description: 'Added 3',
+        description: "Added 3",
         instead: true,
       }),
     };
@@ -866,10 +938,10 @@ describe('ReplacementEffectManager - CR 614.4 Loop Detection', () => {
     replacementEffectManager.registerEffect(singleEffect);
 
     const event: ReplacementEvent = {
-      type: 'damage',
+      type: "damage",
       amount: 5,
       timestamp: Date.now(),
-      targetId: 'player2',
+      targetId: "player2",
     };
 
     // Single effect applies once: 5 + 3 = 8

--- a/src/lib/game-state/abilities.ts
+++ b/src/lib/game-state/abilities.ts
@@ -10,7 +10,7 @@
  */
 
 import type { GameState, PlayerId, CardInstanceId, StackObject } from "./types";
-import { Phase } from "./types";
+import { Phase, ZoneType, isOnBattlefield } from "./types";
 import {
   parseOracleText,
   ParsedActivatedAbility,
@@ -46,6 +46,11 @@ export interface TriggeredAbilityInstance {
   triggerCondition: string;
   effect: string;
   timestamp: number;
+  /**
+   * Timestamp of the source card in its zone (CR 603.3b)
+   * Used for ordering abilities with the same trigger timestamp
+   */
+  sourceCardTimestamp: number;
 }
 
 /**
@@ -577,15 +582,8 @@ export function checkTriggeredAbilities(
 
   // Check each card on the battlefield for triggered abilities
   for (const [cardId, card] of state.cards) {
-    // Skip if card is not on battlefield
-    let isOnBattlefield = false;
-    for (const [zoneKey, zone] of state.zones) {
-      if (zoneKey.includes("battlefield") && zone.cardIds.includes(cardId)) {
-        isOnBattlefield = true;
-        break;
-      }
-    }
-    if (!isOnBattlefield) continue;
+    // Skip if card is not on battlefield using helper
+    if (!isOnBattlefield(state, cardId)) continue;
 
     const abilities = getTriggeredAbilities(card.cardData);
 
@@ -634,12 +632,14 @@ export function checkTriggeredAbilities(
       }
 
       if (shouldTrigger) {
+        const sourceCardTimestamp = card.enteredBattlefieldTimestamp;
         triggeredAbilities.push({
           id: generateTriggeredAbilityId(),
           sourceCardId: cardId,
           triggerCondition: ability.trigger.event,
           effect: ability.effect,
           timestamp: Date.now(),
+          sourceCardTimestamp,
         });
       }
     }
@@ -648,6 +648,36 @@ export function checkTriggeredAbilities(
   // For now, triggered abilities go on the stack
   // In a full implementation, they would be queued and put on stack at the appropriate time
   let currentState = state;
+
+  // Sort triggered abilities according to CR 603.3:
+  // 603.3a: Abilities that trigger at the same time are put on the stack in APNAP order
+  // 603.3b: Abilities with the same timestamp are ordered by the cards timestamp in the zone
+  // 603.3c: For continuous triggers, check the game state at the moment of the trigger
+  triggeredAbilities.sort((a, b) => {
+    // First: earlier timestamp resolves first (lower timestamp = earlier)
+    if (a.timestamp !== b.timestamp) {
+      return a.timestamp - b.timestamp;
+    }
+
+    // Second: APNAP order - active player's abilities resolve first
+    const aCard = state.cards.get(a.sourceCardId);
+    const bCard = state.cards.get(b.sourceCardId);
+    if (!aCard || !bCard) return 0;
+
+    const activePlayerId = state.turn.activePlayerId;
+    const aIsActive = aCard.controllerId === activePlayerId;
+    const bIsActive = bCard.controllerId === activePlayerId;
+
+    if (aIsActive && !bIsActive) return -1; // Active player first
+    if (!aIsActive && bIsActive) return 1; // Inactive player after active
+
+    // Third: same controller, order by source card's timestamp in zone
+    if (a.sourceCardTimestamp !== b.sourceCardTimestamp) {
+      return a.sourceCardTimestamp - b.sourceCardTimestamp;
+    }
+
+    return 0;
+  });
 
   for (const trigger of triggeredAbilities) {
     const card = state.cards.get(trigger.sourceCardId);

--- a/src/lib/game-state/examples.ts
+++ b/src/lib/game-state/examples.ts
@@ -59,6 +59,7 @@ import {
   getPhaseName,
   getPhaseShortName,
 } from "./turn-phases";
+import { ZoneType } from "./types";
 import { ScryfallCard } from "@/app/actions";
 
 /**
@@ -72,7 +73,11 @@ export function example1_createGame() {
   let state = createInitialGameState(["Alice", "Bob"], 20, false);
 
   console.log(`Game ID: ${state.gameId}`);
-  console.log(`Players: ${Array.from(state.players.values()).map((p) => p.name).join(", ")}`);
+  console.log(
+    `Players: ${Array.from(state.players.values())
+      .map((p) => p.name)
+      .join(", ")}`,
+  );
   console.log(`Starting life: ${Array.from(state.players.values())[0].life}`);
   console.log(`Turn: ${state.turn.turnNumber}`);
   console.log(`Current phase: ${getPhaseName(state.turn.currentPhase)}`);
@@ -166,7 +171,9 @@ export function example3_cardOperations() {
 
   // Add counters
   card = addCounters(card, "+1/+1", 2);
-  console.log(`+1/+1 counters: ${card.counters.find((c) => c.type === "+1/+1")?.count || 0}`);
+  console.log(
+    `+1/+1 counters: ${card.counters.find((c) => c.type === "+1/+1")?.count || 0}`,
+  );
 
   // Mark damage
   card = markDamage(card, 2);
@@ -182,7 +189,7 @@ export function example4_zoneOperations() {
   console.log("\nExample 4: Zone operations");
 
   // Create a zone
-  let library = createZone("library", "player-1", {
+  let library = createZone(ZoneType.LIBRARY, "player-1", {
     initialCards: ["card-1", "card-2", "card-3", "card-4", "card-5"],
   });
 
@@ -190,7 +197,7 @@ export function example4_zoneOperations() {
   console.log(`Top card: ${getTopCard(library)}`);
 
   // Draw a card
-  const hand = createZone("hand", "player-1");
+  const hand = createZone(ZoneType.HAND, "player-1");
   const topCard = getTopCard(library);
 
   if (topCard) {
@@ -253,17 +260,25 @@ export function example6_combatAndDamage() {
 
   // Deal damage to player 2
   state = dealDamageToPlayer(state, player2Id, 5);
-  console.log(`Player 2 life after damage: ${state.players.get(player2Id)?.life}`);
+  console.log(
+    `Player 2 life after damage: ${state.players.get(player2Id)?.life}`,
+  );
 
   // Player 1 gains life
   state = gainLife(state, player1Id, 3);
-  console.log(`Player 1 life after gain: ${state.players.get(player1Id)?.life}`);
+  console.log(
+    `Player 1 life after gain: ${state.players.get(player1Id)?.life}`,
+  );
 
   // Check win condition
   state = dealDamageToPlayer(state, player2Id, 20);
-  console.log(`Player 2 life after lethal: ${state.players.get(player2Id)?.life}`);
+  console.log(
+    `Player 2 life after lethal: ${state.players.get(player2Id)?.life}`,
+  );
   console.log(`Game status: ${state.status}`);
-  console.log(`Winners: ${state.winners.length > 0 ? Array.from(state.players.values()).find((p) => p.id === state.winners[0])?.name : "None"}`);
+  console.log(
+    `Winners: ${state.winners.length > 0 ? Array.from(state.players.values()).find((p) => p.id === state.winners[0])?.name : "None"}`,
+  );
 
   return state;
 }
@@ -355,8 +370,12 @@ export function example9_gameSimulation() {
   state = startGame(state);
 
   console.log("=== Game Started ===");
-  console.log(`Player 1 hand: ${getPlayerHand(state, player1Id)?.cardIds.length || 0} cards`);
-  console.log(`Player 2 hand: ${getPlayerHand(state, player2Id)?.cardIds.length || 0} cards`);
+  console.log(
+    `Player 1 hand: ${getPlayerHand(state, player1Id)?.cardIds.length || 0} cards`,
+  );
+  console.log(
+    `Player 2 hand: ${getPlayerHand(state, player2Id)?.cardIds.length || 0} cards`,
+  );
 
   // Both players pass priority for a few phases
   console.log("\n=== Passing priority through phases ===");

--- a/src/lib/game-state/spell-casting.ts
+++ b/src/lib/game-state/spell-casting.ts
@@ -16,7 +16,7 @@ import type {
   WaitingChoice,
   ChoiceOption,
 } from "./types";
-import { Phase } from "./types";
+import { Phase, ZoneType } from "./types";
 import { moveCardBetweenZones } from "./zones";
 import { spendMana, getSpellManaCost } from "./mana";
 import { ValidationService } from "./validation-service";
@@ -69,7 +69,7 @@ function executeBoardSweeper(
   if (!sourceCard) return state;
 
   for (const [zoneKey, zone] of state.zones) {
-    if (!zoneKey.includes("battlefield")) continue;
+    if (zone.type !== ZoneType.BATTLEFIELD) continue;
 
     for (const cardId of zone.cardIds) {
       const card = currentState.cards.get(cardId);
@@ -430,7 +430,7 @@ export function resolveTopOfStack(state: GameState): GameState {
         const allCreatureIds: CardInstanceId[] = [];
 
         for (const [zoneKey, zone] of updatedState.zones) {
-          if (zoneKey.includes("battlefield")) {
+          if (zone.type === ZoneType.BATTLEFIELD) {
             for (const cId of zone.cardIds) {
               const c = updatedState.cards.get(cId);
               if (

--- a/src/lib/game-state/state-based-actions.ts
+++ b/src/lib/game-state/state-based-actions.ts
@@ -12,6 +12,7 @@ import type {
   CardInstanceId,
   PlayerId,
 } from "./types";
+import { ZoneType, isOnBattlefield, parseZoneKey } from "./types";
 import {
   isCreature,
   isPlaneswalker,
@@ -87,7 +88,7 @@ export function checkStateBasedActions(
 
     // SBA 704.5c: A player attempting to draw from an empty library loses the game
     // This is tracked separately - for now, we check if library is empty
-    const libraryKey = `${playerId}-library`;
+    const libraryKey = `${playerId}-${ZoneType.LIBRARY}`;
     const library = updatedState.zones.get(libraryKey);
     if (library && library.cardIds.length === 0) {
       // Player will lose on their next draw attempt
@@ -125,12 +126,13 @@ export function checkStateBasedActions(
   for (const card of cardsToCheck) {
     // Find the card's current zone
     let currentZoneKey: string | null = null;
-    let isOnBattlefield = false;
+    let isOnBf = false;
     for (const [zoneKey, zone] of updatedState.zones) {
       if (zone.cardIds.includes(card.id)) {
         currentZoneKey = zoneKey;
-        if (zoneKey.includes("battlefield")) {
-          isOnBattlefield = true;
+        const parsed = parseZoneKey(zoneKey);
+        if (parsed.zone === ZoneType.BATTLEFIELD) {
+          isOnBf = true;
         }
         break;
       }
@@ -139,7 +141,7 @@ export function checkStateBasedActions(
     if (!currentZoneKey) continue;
 
     // SBAs 704.5f–704.5n only apply to permanents on the battlefield
-    if (isOnBattlefield) {
+    if (isOnBf) {
       // SBA 704.5f: A creature with lethal damage is destroyed
       // Indestructible creatures are not destroyed by lethal damage (CR 702.12)
       if (
@@ -190,19 +192,19 @@ export function checkStateBasedActions(
       if (isAura(card) && card.attachedToId) {
         const attachedTo = updatedState.cards.get(card.attachedToId);
         // Check if the target still exists and is on the battlefield
-        let attachedToOnBattlefield = false;
+        let attachedToOnBf = false;
         if (attachedTo) {
           for (const [zoneKey, zone] of updatedState.zones) {
-            if (
-              zoneKey.includes("battlefield") &&
-              zone.cardIds.includes(card.attachedToId!)
-            ) {
-              attachedToOnBattlefield = true;
+            if (zone.cardIds.includes(card.attachedToId!)) {
+              const parsed = parseZoneKey(zoneKey);
+              if (parsed.zone === ZoneType.BATTLEFIELD) {
+                attachedToOnBf = true;
+              }
               break;
             }
           }
         }
-        if (!attachedToOnBattlefield) {
+        if (!attachedToOnBf) {
           // Aura's target is gone - put aura in graveyard
           if (!cardsToDestroy.includes(card.id)) {
             cardsToDestroy.push(card.id);
@@ -219,28 +221,25 @@ export function checkStateBasedActions(
       if (isEquipment(card) && card.attachedToId) {
         const attachedTo = updatedState.cards.get(card.attachedToId);
         // Check if the attached object is on the battlefield
-        let attachedToOnBattlefield = false;
+        let attachedToOnBf = false;
         if (attachedTo) {
           for (const [zoneKey, zone] of updatedState.zones) {
-            if (
-              zoneKey.includes("battlefield") &&
-              zone.cardIds.includes(card.attachedToId!)
-            ) {
-              attachedToOnBattlefield = true;
+            if (zone.cardIds.includes(card.attachedToId!)) {
+              const parsed = parseZoneKey(zoneKey);
+              if (parsed.zone === ZoneType.BATTLEFIELD) {
+                attachedToOnBf = true;
+              }
               break;
             }
           }
         }
         // Equipment becomes unattached if the attached permanent leaves the battlefield
         // or if it's attached to a non-creature permanent
-        if (
-          !attachedToOnBattlefield ||
-          (attachedTo && !isCreature(attachedTo))
-        ) {
+        if (!attachedToOnBf || (attachedTo && !isCreature(attachedTo))) {
           if (!cardsToDestroy.includes(card.id)) {
             cardsToDestroy.push(card.id);
           }
-          const reason = !attachedToOnBattlefield
+          const reason = !attachedToOnBf
             ? "attached permanent left battlefield"
             : "attached to non-creature";
           descriptions.push(`${card.cardData.name} is destroyed (${reason})`);
@@ -251,7 +250,7 @@ export function checkStateBasedActions(
 
     // SBA 704.5q: If a permanent has both +1/+1 and -1/-1 counters, remove N of each
     // where N is the smaller of the two counts
-    if (isOnBattlefield) {
+    if (isOnBf) {
       const plusOneCounters = card.counters.find((c) => c.type === "+1/+1");
       const minusOneCounters = card.counters.find((c) => c.type === "-1/-1");
       if (
@@ -308,17 +307,11 @@ export function checkStateBasedActions(
   // Check for legendary rule (SBA 704.5j)
   // Two legendary permanents with the same name - keep one, destroy the rest
   const legendaryPermanents = cardsToCheck.filter((card) => {
-    // Check if card is on battlefield by looking in zones
-    let isOnBattlefield = false;
-    for (const [zoneKey, zone] of updatedState.zones) {
-      if (zoneKey.includes("battlefield") && zone.cardIds.includes(card.id)) {
-        isOnBattlefield = true;
-        break;
-      }
-    }
+    // Check if card is on battlefield using the helper
+    const isOnBf = isOnBattlefield(updatedState, card.id);
     const isLegendary =
       card.cardData.type_line?.toLowerCase().includes("legendary") ?? false;
-    return isOnBattlefield && isLegendary;
+    return isOnBf && isLegendary;
   });
 
   const nameGroups = new Map<string, CardInstanceId[]>();
@@ -349,15 +342,9 @@ export function checkStateBasedActions(
   // Check for world rule (SBA 704.5k)
   // Two world permanents exist - destroy the older one
   const worldPermanents = cardsToCheck.filter((card) => {
-    let isOnBattlefield = false;
-    for (const [zoneKey, zone] of updatedState.zones) {
-      if (zoneKey.includes("battlefield") && zone.cardIds.includes(card.id)) {
-        isOnBattlefield = true;
-        break;
-      }
-    }
+    const isOnBf = isOnBattlefield(updatedState, card.id);
     return (
-      isOnBattlefield &&
+      isOnBf &&
       (card.cardData.type_line?.toLowerCase().includes("world") ?? false)
     );
   });
@@ -394,15 +381,9 @@ export function checkStateBasedActions(
   // A player can only control one planeswalker of each type
   // Only check planeswalkers on the battlefield
   const planeswalkers = cardsToCheck.filter((card) => {
-    // Check if card is on battlefield by looking in zones
-    let isOnBattlefield = false;
-    for (const [zoneKey, zone] of updatedState.zones) {
-      if (zoneKey.includes("battlefield") && zone.cardIds.includes(card.id)) {
-        isOnBattlefield = true;
-        break;
-      }
-    }
-    return isOnBattlefield && isPlaneswalker(card);
+    // Check if card is on battlefield using the helper
+    const isOnBf = isOnBattlefield(updatedState, card.id);
+    return isOnBf && isPlaneswalker(card);
   });
   const pwTypeGroups = new Map<string, CardInstanceId[]>();
 

--- a/src/lib/game-state/types.ts
+++ b/src/lib/game-state/types.ts
@@ -107,16 +107,58 @@ export interface Counter {
  * Note: Zone type names use MTG terminology internally for backward compatibility.
  * Use translateZone() from terminology-translation.ts for user-facing display.
  */
-export type ZoneType =
-  | "library"
-  | "hand"
-  | "battlefield"
-  | "graveyard"
-  | "exile"
-  | "stack"
-  | "command"
-  | "sideboard"
-  | "anticipate";
+export enum ZoneType {
+  LIBRARY = "library",
+  HAND = "hand",
+  BATTLEFIELD = "battlefield",
+  GRAVEYARD = "graveyard",
+  STACK = "stack",
+  EXILE = "exile",
+  COMMAND = "command",
+  SIDEBOARD = "sideboard",
+  ANTICIPATE = "anticipate",
+}
+
+/**
+ * Get the zone key for a player's zone
+ */
+export function getZoneKey(playerId: PlayerId, zone: ZoneType): string {
+  if (zone === ZoneType.STACK) {
+    return ZoneType.STACK;
+  }
+  return `${playerId}-${zone}`;
+}
+
+/**
+ * Parse a zone key and return the playerId and zone
+ */
+export function parseZoneKey(zoneKey: string): {
+  playerId: PlayerId | null;
+  zone: ZoneType;
+} {
+  if (zoneKey === ZoneType.STACK) {
+    return { playerId: null, zone: ZoneType.STACK };
+  }
+  const parts = zoneKey.split("-");
+  const zone = parts.pop() as ZoneType;
+  const playerId = parts.join("-") as PlayerId;
+  return { playerId, zone };
+}
+
+/**
+ * Check if a card is on the battlefield
+ */
+export function isOnBattlefield(
+  state: GameState,
+  cardId: CardInstanceId,
+): boolean {
+  for (const zone of state.zones.values()) {
+    if (zone.type === ZoneType.BATTLEFIELD && zone.cardIds.includes(cardId)) {
+      return true;
+    }
+  }
+  return false;
+}
 
 /**
  * A specific location containing cards

--- a/src/lib/game-state/zones.ts
+++ b/src/lib/game-state/zones.ts
@@ -2,12 +2,8 @@
  * Zone management for Magic: The Gathering game state
  */
 
-import type {
-  CardInstanceId,
-  PlayerId,
-  Zone,
-  ZoneType,
-} from "./types";
+import type { CardInstanceId, PlayerId, Zone } from "./types";
+import { ZoneType, getZoneKey } from "./types";
 
 /**
  * Generate a unique zone ID
@@ -27,7 +23,7 @@ export function createZone(
     isRevealed?: boolean;
     visibleTo?: PlayerId[];
     initialCards?: CardInstanceId[];
-  } = {}
+  } = {},
 ): Zone {
   return {
     type: zoneType,
@@ -43,60 +39,60 @@ export function createZone(
  */
 export function createPlayerZones(
   playerId: PlayerId,
-  libraryCards: CardInstanceId[]
+  libraryCards: CardInstanceId[],
 ): Map<string, Zone> {
   const zones = new Map<string, Zone>();
 
   // Library - normally ordered, face down
   zones.set(
-    generateZoneId(playerId, "library"),
-    createZone("library", playerId, {
+    getZoneKey(playerId, ZoneType.LIBRARY),
+    createZone(ZoneType.LIBRARY, playerId, {
       initialCards: libraryCards,
-    })
+    }),
   );
 
   // Hand - normally only visible to owner
   zones.set(
-    generateZoneId(playerId, "hand"),
-    createZone("hand", playerId)
+    getZoneKey(playerId, ZoneType.HAND),
+    createZone(ZoneType.HAND, playerId),
   );
 
   // Battlefield - visible to all
   zones.set(
-    generateZoneId(playerId, "battlefield"),
-    createZone("battlefield", playerId, {
+    getZoneKey(playerId, ZoneType.BATTLEFIELD),
+    createZone(ZoneType.BATTLEFIELD, playerId, {
       isRevealed: true,
-    })
+    }),
   );
 
   // Graveyard - normally revealed to all
   zones.set(
-    generateZoneId(playerId, "graveyard"),
-    createZone("graveyard", playerId, {
+    getZoneKey(playerId, ZoneType.GRAVEYARD),
+    createZone(ZoneType.GRAVEYARD, playerId, {
       isRevealed: true,
-    })
+    }),
   );
 
   // Exile - normally revealed to all
   zones.set(
-    generateZoneId(playerId, "exile"),
-    createZone("exile", playerId, {
+    getZoneKey(playerId, ZoneType.EXILE),
+    createZone(ZoneType.EXILE, playerId, {
       isRevealed: true,
-    })
+    }),
   );
 
   // Command zone - revealed to all (commander, emblems, etc.)
   zones.set(
-    generateZoneId(playerId, "command"),
-    createZone("command", playerId, {
+    getZoneKey(playerId, ZoneType.COMMAND),
+    createZone(ZoneType.COMMAND, playerId, {
       isRevealed: true,
-    })
+    }),
   );
 
   // Sideboard - for constructed formats
   zones.set(
-    generateZoneId(playerId, "sideboard"),
-    createZone("sideboard", playerId)
+    getZoneKey(playerId, ZoneType.SIDEBOARD),
+    createZone(ZoneType.SIDEBOARD, playerId),
   );
 
   return zones;
@@ -110,10 +106,10 @@ export function createSharedZones(): Map<string, Zone> {
 
   // Stack - shared, visible to all
   zones.set(
-    "stack",
-    createZone("stack", null, {
+    ZoneType.STACK,
+    createZone(ZoneType.STACK, null, {
       isRevealed: true,
-    })
+    }),
   );
 
   return zones;
@@ -125,7 +121,7 @@ export function createSharedZones(): Map<string, Zone> {
 export function addCardToZone(
   zone: Zone,
   cardId: CardInstanceId,
-  position?: "top" | "bottom" | number
+  position?: "top" | "bottom" | number,
 ): Zone {
   let newCardIds: CardInstanceId[];
 
@@ -149,10 +145,7 @@ export function addCardToZone(
 /**
  * Remove a card from a zone
  */
-export function removeCardFromZone(
-  zone: Zone,
-  cardId: CardInstanceId
-): Zone {
+export function removeCardFromZone(zone: Zone, cardId: CardInstanceId): Zone {
   return {
     ...zone,
     cardIds: zone.cardIds.filter((id) => id !== cardId),
@@ -166,7 +159,7 @@ export function moveCardBetweenZones(
   fromZone: Zone,
   toZone: Zone,
   cardId: CardInstanceId,
-  position?: "top" | "bottom" | number
+  position?: "top" | "bottom" | number,
 ): { from: Zone; to: Zone } {
   const updatedFrom = removeCardFromZone(fromZone, cardId);
   const updatedTo = addCardToZone(toZone, cardId, position);
@@ -240,10 +233,7 @@ export function getCardPosition(zone: Zone, cardId: CardInstanceId): number {
 /**
  * Reorder cards within a zone
  */
-export function reorderCards(
-  zone: Zone,
-  cardIds: CardInstanceId[]
-): Zone {
+export function reorderCards(zone: Zone, cardIds: CardInstanceId[]): Zone {
   // Validate that all cards in the new order exist in the zone
   const zoneCardSet = new Set(zone.cardIds);
   const validOrder = cardIds.filter((id) => zoneCardSet.has(id));
@@ -268,10 +258,7 @@ export function hideZone(zone: Zone): Zone {
 /**
  * Make a zone visible to specific players
  */
-export function setZoneVisibility(
-  zone: Zone,
-  visibleTo: PlayerId[]
-): Zone {
+export function setZoneVisibility(zone: Zone, visibleTo: PlayerId[]): Zone {
   return { ...zone, isRevealed: false, visibleTo };
 }
 
@@ -296,7 +283,7 @@ export function canPlayerSeeZone(zone: Zone, playerId: PlayerId): boolean {
 export function drawCards(
   library: Zone,
   hand: Zone,
-  count: number
+  count: number,
 ): { library: Zone; hand: Zone; drawnCards: CardInstanceId[] } {
   const cardsToDraw = getTopCards(library, count);
 
@@ -322,7 +309,7 @@ export function drawCards(
 export function millCards(
   library: Zone,
   graveyard: Zone,
-  count: number
+  count: number,
 ): { library: Zone; graveyard: Zone; milledCards: CardInstanceId[] } {
   const cardsToMill = getTopCards(library, count);
 
@@ -330,7 +317,11 @@ export function millCards(
   let updatedGraveyard = graveyard;
 
   cardsToMill.forEach((cardId) => {
-    const moved = moveCardBetweenZones(updatedLibrary, updatedGraveyard, cardId);
+    const moved = moveCardBetweenZones(
+      updatedLibrary,
+      updatedGraveyard,
+      cardId,
+    );
     updatedLibrary = moved.from;
     updatedGraveyard = moved.to;
   });
@@ -348,7 +339,7 @@ export function millCards(
 export function exileCards(
   fromZone: Zone,
   exile: Zone,
-  cardIds: CardInstanceId[]
+  cardIds: CardInstanceId[],
 ): { from: Zone; exile: Zone; exiledCards: CardInstanceId[] } {
   let updatedFrom = fromZone;
   let updatedExile = exile;

--- a/src/lib/replay-sharing.ts
+++ b/src/lib/replay-sharing.ts
@@ -1,8 +1,8 @@
 /**
  * @fileOverview Replay sharing system for generating shareable links
- * 
+ *
  * Issue #92: Phase 5.3: Implement replay system with shareable links
- * 
+ *
  * Provides:
  * - Encode replay data into URL-safe format
  * - Generate short shareable links
@@ -10,11 +10,11 @@
  * - Import/export replay files
  */
 
-import type { Replay } from './game-state/replay';
-import type { ActionType, GameState, Zone } from './game-state/types';
-import { Phase } from './game-state/types';
+import type { Replay } from "./game-state/replay";
+import type { ActionType, GameState, Zone } from "./game-state/types";
+import { Phase, ZoneType } from "./game-state/types";
 
-const REPLAY_PARAM = 'replay';
+const REPLAY_PARAM = "replay";
 
 /**
  * Minified replay structure for URL encoding
@@ -84,8 +84,8 @@ export function encodeReplayToURL(replay: Replay): string {
     const base64 = btoa(encodeURIComponent(json));
     return base64;
   } catch (error) {
-    console.error('Failed to encode replay:', error);
-    throw new Error('Failed to encode replay for sharing');
+    console.error("Failed to encode replay:", error);
+    throw new Error("Failed to encode replay for sharing");
   }
 }
 
@@ -98,7 +98,7 @@ export function decodeReplayFromURL(encoded: string): Replay | null {
     const minified = JSON.parse(json);
     return expandReplay(minified);
   } catch (error) {
-    console.error('Failed to decode replay:', error);
+    console.error("Failed to decode replay:", error);
     return null;
   }
 }
@@ -109,17 +109,17 @@ export function decodeReplayFromURL(encoded: string): Replay | null {
 export function generateShareableURL(replay: Replay): string | null {
   try {
     const encoded = encodeReplayToURL(replay);
-    
+
     // Check if URL would be too long
     if (encoded.length > MAX_URL_LENGTH) {
-      console.warn('Replay data too large for URL sharing');
+      console.warn("Replay data too large for URL sharing");
       return null;
     }
-    
-    const baseURL = typeof window !== 'undefined' ? window.location.origin : '';
+
+    const baseURL = typeof window !== "undefined" ? window.location.origin : "";
     return `${baseURL}/replay?${REPLAY_PARAM}=${encoded}`;
   } catch (error) {
-    console.error('Failed to generate shareable URL:', error);
+    console.error("Failed to generate shareable URL:", error);
     return null;
   }
 }
@@ -128,24 +128,27 @@ export function generateShareableURL(replay: Replay): string | null {
  * Generate a shareable link using a unique ID (for server-based sharing)
  * This would be used when we have a backend to store the replay
  */
-export async function generateServerShareableLink(replay: Replay, serverURL: string): Promise<string | null> {
+export async function generateServerShareableLink(
+  replay: Replay,
+  serverURL: string,
+): Promise<string | null> {
   try {
     const response = await fetch(`${serverURL}/api/replays`, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
       body: JSON.stringify(replay),
     });
-    
+
     if (!response.ok) {
-      throw new Error('Failed to upload replay');
+      throw new Error("Failed to upload replay");
     }
-    
+
     const data = await response.json();
     return `${serverURL}/replay/${data.id}`;
   } catch (error) {
-    console.error('Failed to generate server shareable link:', error);
+    console.error("Failed to generate server shareable link:", error);
     return null;
   }
 }
@@ -154,11 +157,11 @@ export async function generateServerShareableLink(replay: Replay, serverURL: str
  * Extract replay parameter from current URL
  */
 export function getReplayFromCurrentURL(): Replay | null {
-  if (typeof window === 'undefined') return null;
-  
+  if (typeof window === "undefined") return null;
+
   const urlParams = new URLSearchParams(window.location.search);
   const encoded = urlParams.get(REPLAY_PARAM);
-  
+
   if (!encoded) return null;
   return decodeReplayFromURL(encoded);
 }
@@ -169,12 +172,12 @@ export function getReplayFromCurrentURL(): Replay | null {
 export async function copyShareableLink(replay: Replay): Promise<boolean> {
   const url = generateShareableURL(replay);
   if (!url) return false;
-  
+
   try {
     await navigator.clipboard.writeText(url);
     return true;
   } catch (error) {
-    console.error('Failed to copy to clipboard:', error);
+    console.error("Failed to copy to clipboard:", error);
     return false;
   }
 }
@@ -184,10 +187,10 @@ export async function copyShareableLink(replay: Replay): Promise<boolean> {
  */
 export function exportReplayToFile(replay: Replay, filename?: string): void {
   const json = JSON.stringify(replay, null, 2);
-  const blob = new Blob([json], { type: 'application/json' });
+  const blob = new Blob([json], { type: "application/json" });
   const url = URL.createObjectURL(blob);
-  
-  const a = document.createElement('a');
+
+  const a = document.createElement("a");
   a.href = url;
   a.download = filename || `replay-${replay.id}.json`;
   document.body.appendChild(a);
@@ -205,7 +208,7 @@ export async function importReplayFromFile(file: File): Promise<Replay | null> {
     const replay = JSON.parse(text) as Replay;
     return replay;
   } catch (error) {
-    console.error('Failed to import replay:', error);
+    console.error("Failed to import replay:", error);
     return null;
   }
 }
@@ -213,15 +216,18 @@ export async function importReplayFromFile(file: File): Promise<Replay | null> {
 /**
  * Import replay from a URL (server-based)
  */
-export async function importReplayFromURL(replayId: string, serverURL: string): Promise<Replay | null> {
+export async function importReplayFromURL(
+  replayId: string,
+  serverURL: string,
+): Promise<Replay | null> {
   try {
     const response = await fetch(`${serverURL}/api/replays/${replayId}`);
     if (!response.ok) {
-      throw new Error('Replay not found');
+      throw new Error("Replay not found");
     }
     return await response.json();
   } catch (error) {
-    console.error('Failed to import replay from URL:', error);
+    console.error("Failed to import replay from URL:", error);
     return null;
   }
 }
@@ -242,7 +248,7 @@ function minifyReplay(replay: Replay): MinifiedReplay {
       ed: replay.metadata.gameEndDate,
       er: replay.metadata.endReason ?? undefined,
     },
-    a: replay.actions.map(action => ({
+    a: replay.actions.map((action) => ({
       s: action.sequenceNumber,
       t: action.action.type,
       pid: action.action.playerId,
@@ -264,10 +270,10 @@ function minifyReplay(replay: Replay): MinifiedReplay {
 function minifyGameState(state: GameState): MinifiedGameState {
   // Extract player hand sizes from zones
   const playerHandSizes = new Map<string, number>();
-  
+
   // Count cards in each player's hand zone
   state.zones.forEach((zone) => {
-    if (zone.type === 'hand' && zone.playerId) {
+    if (zone.type === ZoneType.HAND && zone.playerId) {
       playerHandSizes.set(zone.playerId, zone.cardIds.length);
     }
   });
@@ -276,16 +282,16 @@ function minifyGameState(state: GameState): MinifiedGameState {
   let battlefieldCount = 0;
   let graveyardCount = 0;
   let libraryCount = 0;
-  
+
   state.zones.forEach((zone) => {
     switch (zone.type) {
-      case 'battlefield':
+      case ZoneType.BATTLEFIELD:
         battlefieldCount += zone.cardIds.length;
         break;
-      case 'graveyard':
+      case ZoneType.GRAVEYARD:
         graveyardCount += zone.cardIds.length;
         break;
-      case 'library':
+      case ZoneType.LIBRARY:
         libraryCount += zone.cardIds.length;
         break;
     }
@@ -331,7 +337,7 @@ function expandReplay(minified: MinifiedReplay): Replay {
     description: action.desc,
     recordedAt: action.ra,
   }));
-  
+
   return {
     id: minified.i,
     metadata: {
@@ -358,60 +364,69 @@ function expandReplay(minified: MinifiedReplay): Replay {
  */
 function expandGameState(minified: MinifiedGameState): GameState {
   const now = Date.now();
-  
+
   // Create players map
-  const players = new Map(minified.p?.map((p) => [p.id, {
-    id: p.id,
-    name: p.n,
-    life: p.l,
-    poisonCounters: 0,
-    commanderDamage: new Map(),
-    maxHandSize: 7,
-    currentHandSizeModifier: 0,
-    hasLost: false,
-    lossReason: null,
-    landsPlayedThisTurn: 0,
-    maxLandsPerTurn: 1,
-    manaPool: {
-      colorless: 0,
-      white: 0,
-      blue: 0,
-      black: 0,
-      red: 0,
-      green: 0,
-      generic: 0,
-    },
-    isInCommandZone: false,
-    experienceCounters: 0,
-    commanderCastCount: 0,
-    hasPassedPriority: false,
-    hasActivatedManaAbility: false,
-    additionalCombatPhase: false,
-    additionalMainPhase: false,
-    hasOfferedDraw: false,
-    hasAcceptedDraw: false,
-  }]));
+  const players = new Map(
+    minified.p?.map((p) => [
+      p.id,
+      {
+        id: p.id,
+        name: p.n,
+        life: p.l,
+        poisonCounters: 0,
+        commanderDamage: new Map(),
+        maxHandSize: 7,
+        currentHandSizeModifier: 0,
+        hasLost: false,
+        lossReason: null,
+        landsPlayedThisTurn: 0,
+        maxLandsPerTurn: 1,
+        manaPool: {
+          colorless: 0,
+          white: 0,
+          blue: 0,
+          black: 0,
+          red: 0,
+          green: 0,
+          generic: 0,
+        },
+        isInCommandZone: false,
+        experienceCounters: 0,
+        commanderCastCount: 0,
+        hasPassedPriority: false,
+        hasActivatedManaAbility: false,
+        additionalCombatPhase: false,
+        additionalMainPhase: false,
+        hasOfferedDraw: false,
+        hasAcceptedDraw: false,
+      },
+    ]),
+  );
 
   // Create zones map
   const zones = new Map<string, Zone>();
   let zoneId = 0;
-  
+
   minified.p?.forEach((p) => {
     // Hand zone for each player
     zones.set(`hand-${p.id}`, {
-      type: 'hand' as const,
+      type: ZoneType.HAND,
       playerId: p.id,
-      cardIds: Array(p.h).fill('').map(() => `placeholder-${++zoneId}`),
+      cardIds: Array(p.h)
+        .fill("")
+        .map(() => `placeholder-${++zoneId}`),
       isRevealed: false,
       visibleTo: [p.id],
     });
   });
 
   // Battlefield zone (shared)
-  zones.set('battlefield', {
-    type: 'battlefield' as const,
+  zones.set("battlefield", {
+    type: ZoneType.BATTLEFIELD,
     playerId: null,
-    cardIds: Array(minified.z?.bf || 0).fill('').map(() => `placeholder-${++zoneId}`),
+    cardIds: Array(minified.z?.bf || 0)
+      .fill("")
+      .map(() => `placeholder-${++zoneId}`),
     isRevealed: true,
     visibleTo: [],
   });
@@ -419,7 +434,7 @@ function expandGameState(minified: MinifiedGameState): GameState {
   // Graveyard zones
   minified.p?.forEach((p) => {
     zones.set(`graveyard-${p.id}`, {
-      type: 'graveyard' as const,
+      type: ZoneType.GRAVEYARD,
       playerId: p.id,
       cardIds: [],
       isRevealed: true,
@@ -430,16 +445,18 @@ function expandGameState(minified: MinifiedGameState): GameState {
   // Library zones
   minified.p?.forEach((p) => {
     zones.set(`library-${p.id}`, {
-      type: 'library' as const,
+      type: ZoneType.LIBRARY,
       playerId: p.id,
-      cardIds: Array(minified.z?.l || 0).fill('').map(() => `placeholder-${++zoneId}`),
+      cardIds: Array(minified.z?.l || 0)
+        .fill("")
+        .map(() => `placeholder-${++zoneId}`),
       isRevealed: false,
       visibleTo: [p.id],
     });
   });
 
   // Get first player as active player
-  const firstPlayerId = minified.p?.[0]?.id || '';
+  const firstPlayerId = minified.p?.[0]?.id || "";
 
   return {
     gameId: `replay-game-${now}`,
@@ -464,10 +481,14 @@ function expandGameState(minified: MinifiedGameState): GameState {
     waitingChoice: null,
     priorityPlayerId: minified.t?.pp || firstPlayerId,
     consecutivePasses: 0,
-    status: (minified.s || 'in_progress') as 'not_started' | 'in_progress' | 'paused' | 'completed',
+    status: (minified.s || "in_progress") as
+      | "not_started"
+      | "in_progress"
+      | "paused"
+      | "completed",
     winners: minified.w || [],
     endReason: minified.er || null,
-    format: 'unknown',
+    format: "unknown",
     createdAt: now,
     lastModifiedAt: now,
   };
@@ -491,7 +512,8 @@ export function canShareViaURL(replay: Replay): boolean {
 export function getEstimatedURLLength(replay: Replay): number {
   try {
     const encoded = encodeReplayToURL(replay);
-    const baseLength = typeof window !== 'undefined' ? window.location.origin.length : 30;
+    const baseLength =
+      typeof window !== "undefined" ? window.location.origin.length : 30;
     return baseLength + `/replay?${REPLAY_PARAM}=`.length + encoded.length;
   } catch {
     return -1;

--- a/src/test-utils/factories/game-state.ts
+++ b/src/test-utils/factories/game-state.ts
@@ -8,10 +8,10 @@ import type {
   CardInstance,
   Player,
   Zone,
-  ZoneType,
   Counter,
   ScryfallCard,
 } from "@/lib/game-state/types";
+import { ZoneType, getZoneKey } from "@/lib/game-state/types";
 import { createCard } from "./card";
 
 /**
@@ -307,32 +307,48 @@ export function createGameState(
       }),
     ],
     zones: {
-      [`${playerId}-library`]: createZone("library", playerId, playerLibrary),
-      [`${playerId}-hand`]: createZone("hand", playerId, playerHand),
-      [`${playerId}-graveyard`]: createZone(
-        "graveyard",
+      [getZoneKey(playerId, ZoneType.LIBRARY)]: createZone(
+        ZoneType.LIBRARY,
+        playerId,
+        playerLibrary,
+      ),
+      [getZoneKey(playerId, ZoneType.HAND)]: createZone(
+        ZoneType.HAND,
+        playerId,
+        playerHand,
+      ),
+      [getZoneKey(playerId, ZoneType.GRAVEYARD)]: createZone(
+        ZoneType.GRAVEYARD,
         playerId,
         options.playerGraveyard?.map((c) => c.id) ?? [],
       ),
-      [`${playerId}-battlefield`]: createZone(
-        "battlefield",
+      [getZoneKey(playerId, ZoneType.BATTLEFIELD)]: createZone(
+        ZoneType.BATTLEFIELD,
         playerId,
         options.battlefieldCards?.map((c) => c.id) ?? [],
       ),
-      [`${opponentId}-library`]: createZone(
-        "library",
+      [getZoneKey(opponentId, ZoneType.LIBRARY)]: createZone(
+        ZoneType.LIBRARY,
         opponentId,
         opponentLibrary,
       ),
-      [`${opponentId}-hand`]: createZone("hand", opponentId, opponentHand),
-      [`${opponentId}-graveyard`]: createZone(
-        "graveyard",
+      [getZoneKey(opponentId, ZoneType.HAND)]: createZone(
+        ZoneType.HAND,
+        opponentId,
+        opponentHand,
+      ),
+      [getZoneKey(opponentId, ZoneType.GRAVEYARD)]: createZone(
+        ZoneType.GRAVEYARD,
         opponentId,
         options.opponentGraveyard?.map((c) => c.id) ?? [],
       ),
-      [`${opponentId}-battlefield`]: createZone("battlefield", opponentId, []),
-      stack: createZone("stack", null),
-      command: createZone("command", null),
+      [getZoneKey(opponentId, ZoneType.BATTLEFIELD)]: createZone(
+        ZoneType.BATTLEFIELD,
+        opponentId,
+        [],
+      ),
+      [ZoneType.STACK]: createZone(ZoneType.STACK, null),
+      [ZoneType.COMMAND]: createZone(ZoneType.COMMAND, null),
     },
     turn: options.turn ?? 1,
     phase: options.phase ?? "precombat_main",


### PR DESCRIPTION
## Summary

This PR addresses three issues from Epic #754 (MTG Rules Engine Fixes - Phase 1):

### Issue #751: Code Quality - Zone detection uses fragile string matching
- Converted ZoneType from union type to enum
- Added helper functions: getZoneKey, parseZoneKey, isOnBattlefield
- Replaced all fragile string matching patterns throughout codebase
- Updated: types.ts, zones.ts, state-based-actions.ts, abilities.ts, spell-casting.ts, replay-sharing.ts, examples.ts, game-state.ts factory, validation-service.test.ts

### Issue #752: MTG Rule Violation - Triggered abilities lack timestamp ordering (CR 603.3)
- Added sourceCardTimestamp field to TriggeredAbilityInstance
- Implemented CR 603.3 ordering in checkTriggeredAbilities:
  1. Timestamp (older = lower = resolves first)
  2. APNAP order (active player triggers first)
  3. Source card timestamp (within same controller)
- Added tests for APNAP ordering

### Issue #753: Architecture - Integrate event sourcing for multiplayer sync
- Event sourcing infrastructure already existed
- Added export to index.ts
- Added multiplayer sync integration tests

### Also Fixed
- Pre-existing type errors in replacement-effects.test.ts (unused 3rd argument)

## Testing
- All 3314 tests pass
- TypeScript compilation passes

Closes #751
Closes #752
Closes #753