### PR TITLE
Tech Debt #765: Replace singleton replacementEffectManager

### DIFF
--- a/src/lib/game-state/__tests__/replacement-effects.test.ts
+++ b/src/lib/game-state/__tests__/replacement-effects.test.ts
@@ -18,9 +18,10 @@ import {
 } from "../replacement-effects";
 import type { GameState } from "../types";
 
-describe("ReplacementEffectManager - APNAP Ordering", () => {
-  let rem: ReplacementEffectManager;
+// Module-level rem variable shared across all describe blocks
+let rem: ReplacementEffectManager;
 
+describe("ReplacementEffectManager - APNAP Ordering", () => {
   beforeEach(() => {
     rem = new ReplacementEffectManager();
   });

--- a/src/lib/game-state/__tests__/replacement-effects.test.ts
+++ b/src/lib/game-state/__tests__/replacement-effects.test.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-  replacementEffectManager,
+  ReplacementEffectManager,
   ReplacementAbility,
   ReplacementEvent,
   APNAPOrder,
@@ -19,8 +19,10 @@ import {
 import type { GameState } from "../types";
 
 describe("ReplacementEffectManager - APNAP Ordering", () => {
+  let rem: ReplacementEffectManager;
+
   beforeEach(() => {
-    replacementEffectManager.reset();
+    rem = new ReplacementEffectManager();
   });
 
   test("should apply effects in APNAP order", () => {
@@ -67,8 +69,8 @@ describe("ReplacementEffectManager - APNAP Ordering", () => {
       }),
     };
 
-    replacementEffectManager.registerEffect(p1Effect);
-    replacementEffectManager.registerEffect(p2Effect);
+    rem.registerEffect(p1Effect);
+    rem.registerEffect(p2Effect);
 
     const event: ReplacementEvent = {
       type: "damage",
@@ -80,7 +82,7 @@ describe("ReplacementEffectManager - APNAP Ordering", () => {
     // P2's effect should apply first (affected player chooses)
     // Then P1's effect applies
     // 3 * 2 (P2) = 6, then 6 * 2 (P1) = 12
-    const processed = replacementEffectManager.processEvent(event, apnapOrder);
+    const processed = rem.processEvent(event, apnapOrder);
     expect(processed.amount).toBe(12);
   });
 
@@ -129,8 +131,8 @@ describe("ReplacementEffectManager - APNAP Ordering", () => {
       }),
     };
 
-    replacementEffectManager.registerEffect(selfEffect);
-    replacementEffectManager.registerEffect(regularEffect);
+    rem.registerEffect(selfEffect);
+    rem.registerEffect(regularEffect);
 
     const event: ReplacementEvent = {
       type: "damage",
@@ -142,7 +144,7 @@ describe("ReplacementEffectManager - APNAP Ordering", () => {
 
     // Self-replacement applies first: 3 + 5 = 8
     // Then regular: 8 * 2 = 16
-    const processed = replacementEffectManager.processEvent(event, apnapOrder);
+    const processed = rem.processEvent(event, apnapOrder);
     expect(processed.amount).toBe(16);
   });
 
@@ -182,8 +184,8 @@ describe("ReplacementEffectManager - APNAP Ordering", () => {
       }),
     };
 
-    replacementEffectManager.registerEffect(layer1Effect);
-    replacementEffectManager.registerEffect(layer5Effect);
+    rem.registerEffect(layer1Effect);
+    rem.registerEffect(layer5Effect);
 
     const event: ReplacementEvent = {
       type: "damage",
@@ -194,14 +196,14 @@ describe("ReplacementEffectManager - APNAP Ordering", () => {
 
     // Layer 1 applies first: 5 - 2 = 3
     // Layer 5 applies second: 3 * 2 = 6
-    const processed = replacementEffectManager.processEvent(event);
+    const processed = rem.processEvent(event);
     expect(processed.amount).toBe(6);
   });
 });
 
 describe("ReplacementEffectManager - As Though Effects", () => {
   beforeEach(() => {
-    replacementEffectManager.reset();
+    rem.reset();
   });
 
   test("should register and check as though effects", () => {
@@ -214,24 +216,24 @@ describe("ReplacementEffectManager - As Though Effects", () => {
       "You may cast spells as though they had flash",
     );
 
-    replacementEffectManager.registerAsThoughEffect(flashEffect);
+    rem.registerAsThoughEffect(flashEffect);
 
     expect(
-      replacementEffectManager.checkAsThoughEffect(
+      rem.checkAsThoughEffect(
         "player1",
         "cast_flash",
         mockGameState,
       ),
     ).toBe(true);
     expect(
-      replacementEffectManager.checkAsThoughEffect(
+      rem.checkAsThoughEffect(
         "player2",
         "cast_flash",
         mockGameState,
       ),
     ).toBe(false);
     expect(
-      replacementEffectManager.checkAsThoughEffect(
+      rem.checkAsThoughEffect(
         "player1",
         "attack_haste",
         mockGameState,
@@ -254,10 +256,10 @@ describe("ReplacementEffectManager - As Though Effects", () => {
       },
     );
 
-    replacementEffectManager.registerAsThoughEffect(conditionalEffect);
+    rem.registerAsThoughEffect(conditionalEffect);
 
     expect(
-      replacementEffectManager.checkAsThoughEffect(
+      rem.checkAsThoughEffect(
         "player1",
         "attack_haste",
         mockGameState,
@@ -268,10 +270,10 @@ describe("ReplacementEffectManager - As Though Effects", () => {
   test("should get all as though effects for a player", () => {
     const mockGameState = { players: new Map() } as GameState;
 
-    replacementEffectManager.registerAsThoughEffect(
+    rem.registerAsThoughEffect(
       createAsThoughEffect("source1", "player1", "cast_flash", "Flash effect"),
     );
-    replacementEffectManager.registerAsThoughEffect(
+    rem.registerAsThoughEffect(
       createAsThoughEffect(
         "source2",
         "player1",
@@ -279,7 +281,7 @@ describe("ReplacementEffectManager - As Though Effects", () => {
         "Haste effect",
       ),
     );
-    replacementEffectManager.registerAsThoughEffect(
+    rem.registerAsThoughEffect(
       createAsThoughEffect(
         "source3",
         "player2",
@@ -288,7 +290,7 @@ describe("ReplacementEffectManager - As Though Effects", () => {
       ),
     );
 
-    const p1Effects = replacementEffectManager.getAsThoughEffects(
+    const p1Effects = rem.getAsThoughEffects(
       "player1",
       mockGameState,
     );
@@ -296,7 +298,7 @@ describe("ReplacementEffectManager - As Though Effects", () => {
     expect(p1Effects.map((e) => e.asThoughType)).toContain("cast_flash");
     expect(p1Effects.map((e) => e.asThoughType)).toContain("attack_haste");
 
-    const p2Effects = replacementEffectManager.getAsThoughEffects(
+    const p2Effects = rem.getAsThoughEffects(
       "player2",
       mockGameState,
     );
@@ -307,7 +309,7 @@ describe("ReplacementEffectManager - As Though Effects", () => {
   test("should remove as though effects when source leaves battlefield", () => {
     const mockGameState = { players: new Map() } as GameState;
 
-    replacementEffectManager.registerAsThoughEffect(
+    rem.registerAsThoughEffect(
       createAsThoughEffect(
         "temporary-source",
         "player1",
@@ -317,17 +319,17 @@ describe("ReplacementEffectManager - As Though Effects", () => {
     );
 
     expect(
-      replacementEffectManager.checkAsThoughEffect(
+      rem.checkAsThoughEffect(
         "player1",
         "cast_flash",
         mockGameState,
       ),
     ).toBe(true);
 
-    replacementEffectManager.removeEffectsFromSource("temporary-source");
+    rem.removeEffectsFromSource("temporary-source");
 
     expect(
-      replacementEffectManager.checkAsThoughEffect(
+      rem.checkAsThoughEffect(
         "player1",
         "cast_flash",
         mockGameState,
@@ -338,7 +340,7 @@ describe("ReplacementEffectManager - As Though Effects", () => {
 
 describe("ReplacementEffectManager - Complex Scenarios", () => {
   beforeEach(() => {
-    replacementEffectManager.reset();
+    rem.reset();
   });
 
   test("should handle Furnace of Rath + prevention shield interaction", () => {
@@ -351,10 +353,10 @@ describe("ReplacementEffectManager - Complex Scenarios", () => {
       5,
     );
 
-    replacementEffectManager.registerEffect(furnaceEffect);
+    rem.registerEffect(furnaceEffect);
 
     // Target has prevention shield
-    replacementEffectManager.addPreventionShield("player2", {
+    rem.addPreventionShield("player2", {
       sourceId: "fog",
       amount: 3,
       controllerId: "player2",
@@ -369,11 +371,11 @@ describe("ReplacementEffectManager - Complex Scenarios", () => {
 
     // Furnace doubles: 2 * 2 = 4
     // Prevention shield prevents 3: 4 - 3 = 1
-    const processed = replacementEffectManager.processEvent(event);
+    const processed = rem.processEvent(event);
     expect(processed.amount).toBe(1);
 
     // Shield should be depleted
-    const shields = replacementEffectManager.getPreventionShields("player2");
+    const shields = rem.getPreventionShields("player2");
     expect(shields).toHaveLength(0);
   });
 
@@ -386,7 +388,7 @@ describe("ReplacementEffectManager - Complex Scenarios", () => {
       (targetId) => targetId === "player1",
     );
 
-    replacementEffectManager.registerEffect(archiveEffect);
+    rem.registerEffect(archiveEffect);
 
     const event: ReplacementEvent = {
       type: "life_gain",
@@ -395,7 +397,7 @@ describe("ReplacementEffectManager - Complex Scenarios", () => {
       targetId: "player1",
     };
 
-    const processed = replacementEffectManager.processEvent(event);
+    const processed = rem.processEvent(event);
     expect(processed.amount).toBe(10);
 
     // Should not apply to other players
@@ -406,17 +408,17 @@ describe("ReplacementEffectManager - Complex Scenarios", () => {
       targetId: "player2",
     };
 
-    const otherProcessed = replacementEffectManager.processEvent(otherEvent);
+    const otherProcessed = rem.processEvent(otherEvent);
     expect(otherProcessed.amount).toBe(5);
   });
 
   test("should handle multiple prevention shields depleting correctly", () => {
-    replacementEffectManager.addPreventionShield("player1", {
+    rem.addPreventionShield("player1", {
       sourceId: "shield1",
       amount: 2,
       controllerId: "player1",
     });
-    replacementEffectManager.addPreventionShield("player1", {
+    rem.addPreventionShield("player1", {
       sourceId: "shield2",
       amount: 3,
       controllerId: "player1",
@@ -430,11 +432,11 @@ describe("ReplacementEffectManager - Complex Scenarios", () => {
       targetId: "player1",
     };
 
-    const processed1 = replacementEffectManager.processEvent(event1);
+    const processed1 = rem.processEvent(event1);
     expect(processed1.amount).toBe(0);
 
     // Second shield should have 1 remaining
-    const shields = replacementEffectManager.getPreventionShields("player1");
+    const shields = rem.getPreventionShields("player1");
     expect(shields).toHaveLength(1);
     expect(shields[0].amount).toBe(1);
 
@@ -446,12 +448,12 @@ describe("ReplacementEffectManager - Complex Scenarios", () => {
       targetId: "player1",
     };
 
-    const processed2 = replacementEffectManager.processEvent(event2);
+    const processed2 = rem.processEvent(event2);
     expect(processed2.amount).toBe(1);
 
     // All shields should be depleted
     expect(
-      replacementEffectManager.getPreventionShields("player1"),
+      rem.getPreventionShields("player1"),
     ).toHaveLength(0);
   });
 
@@ -463,7 +465,7 @@ describe("ReplacementEffectManager - Complex Scenarios", () => {
       (amount) => amount + 1, // Draw one additional card
     );
 
-    replacementEffectManager.registerEffect(drawEffect);
+    rem.registerEffect(drawEffect);
 
     const event: ReplacementEvent = {
       type: "draw_card",
@@ -472,7 +474,7 @@ describe("ReplacementEffectManager - Complex Scenarios", () => {
       targetId: "player1",
     };
 
-    const processed = replacementEffectManager.processEvent(event);
+    const processed = rem.processEvent(event);
     expect(processed.amount).toBe(2);
   });
 
@@ -489,7 +491,7 @@ describe("ReplacementEffectManager - Complex Scenarios", () => {
       (targetId) => targetId === "creature1",
     );
 
-    replacementEffectManager.registerEffect(regenEffect);
+    rem.registerEffect(regenEffect);
 
     const event: ReplacementEvent = {
       type: "destroy",
@@ -498,7 +500,7 @@ describe("ReplacementEffectManager - Complex Scenarios", () => {
       targetId: "creature1",
     };
 
-    const processed = replacementEffectManager.processEvent(event);
+    const processed = rem.processEvent(event);
     expect(processed.type).toBe("tap");
     expect(processed.amount).toBe(0);
   });
@@ -512,7 +514,7 @@ describe("ReplacementEffectManager - Complex Scenarios", () => {
       (targetId) => targetId === "player1",
     );
 
-    replacementEffectManager.registerEffect(lossEffect);
+    rem.registerEffect(lossEffect);
 
     const event: ReplacementEvent = {
       type: "life_loss",
@@ -521,21 +523,21 @@ describe("ReplacementEffectManager - Complex Scenarios", () => {
       targetId: "player1",
     };
 
-    const processed = replacementEffectManager.processEvent(event);
+    const processed = rem.processEvent(event);
     expect(processed.amount).toBe(4); // ceil(7/2) = 4
   });
 });
 
 describe("ReplacementEffectManager - APNAP Order Creation", () => {
   beforeEach(() => {
-    replacementEffectManager.reset();
+    rem.reset();
   });
 
   test("should create correct APNAP order", () => {
     const allPlayers = ["player1", "player2", "player3", "player4"];
 
     // Player2 is active
-    const order = replacementEffectManager.createAPNAPOrder(
+    const order = rem.createAPNAPOrder(
       "player2",
       allPlayers,
     );
@@ -550,7 +552,7 @@ describe("ReplacementEffectManager - APNAP Order Creation", () => {
   });
 
   test("should handle single player", () => {
-    const order = replacementEffectManager.createAPNAPOrder("player1", [
+    const order = rem.createAPNAPOrder("player1", [
       "player1",
     ]);
     expect(order.playerOrder).toEqual(["player1"]);
@@ -558,7 +560,7 @@ describe("ReplacementEffectManager - APNAP Order Creation", () => {
 
   test("should handle unknown active player", () => {
     const allPlayers = ["player1", "player2"];
-    const order = replacementEffectManager.createAPNAPOrder(
+    const order = rem.createAPNAPOrder(
       "unknown",
       allPlayers,
     );
@@ -568,7 +570,7 @@ describe("ReplacementEffectManager - APNAP Order Creation", () => {
 
 describe("ReplacementEffectManager - Factory Functions", () => {
   beforeEach(() => {
-    replacementEffectManager.reset();
+    rem.reset();
   });
 
   test("createPreventionShield should create both ability and shield", () => {
@@ -638,7 +640,7 @@ describe("ReplacementEffectManager - Factory Functions", () => {
 
 describe("ReplacementEffectManager - CR 614.4 Loop Detection", () => {
   beforeEach(() => {
-    replacementEffectManager.reset();
+    rem.reset();
   });
 
   test("should detect and break a two-effect infinite loop (CR 614.4)", () => {
@@ -682,8 +684,8 @@ describe("ReplacementEffectManager - CR 614.4 Loop Detection", () => {
       }),
     };
 
-    replacementEffectManager.registerEffect(effectA);
-    replacementEffectManager.registerEffect(effectB);
+    rem.registerEffect(effectA);
+    rem.registerEffect(effectB);
 
     const event: ReplacementEvent = {
       type: "destroy",
@@ -694,7 +696,7 @@ describe("ReplacementEffectManager - CR 614.4 Loop Detection", () => {
 
     // CR 614.4: If replacement effects form an infinite loop, no objects are affected
     // The event should be skipped (amount = 0 means no effect applies)
-    const processed = replacementEffectManager.processEvent(event);
+    const processed = rem.processEvent(event);
     expect(processed.amount).toBe(0); // Loop detected, event skipped
   });
 
@@ -737,8 +739,8 @@ describe("ReplacementEffectManager - CR 614.4 Loop Detection", () => {
       }),
     };
 
-    replacementEffectManager.registerEffect(doubleEffect);
-    replacementEffectManager.registerEffect(reduceEffect);
+    rem.registerEffect(doubleEffect);
+    rem.registerEffect(reduceEffect);
 
     const event: ReplacementEvent = {
       type: "damage",
@@ -748,7 +750,7 @@ describe("ReplacementEffectManager - CR 614.4 Loop Detection", () => {
     };
 
     // No loop: Layer 1 applies first: 5 - 2 = 3, then Layer 5: 3 * 2 = 6
-    const processed = replacementEffectManager.processEvent(event);
+    const processed = rem.processEvent(event);
     expect(processed.amount).toBe(6);
   });
 
@@ -811,9 +813,9 @@ describe("ReplacementEffectManager - CR 614.4 Loop Detection", () => {
       }),
     };
 
-    replacementEffectManager.registerEffect(effectA);
-    replacementEffectManager.registerEffect(effectB);
-    replacementEffectManager.registerEffect(effectC);
+    rem.registerEffect(effectA);
+    rem.registerEffect(effectB);
+    rem.registerEffect(effectC);
 
     const event: ReplacementEvent = {
       type: "destroy",
@@ -823,7 +825,7 @@ describe("ReplacementEffectManager - CR 614.4 Loop Detection", () => {
     };
 
     // Three-effect loop detected, CR 614.4 applies
-    const processed = replacementEffectManager.processEvent(event);
+    const processed = rem.processEvent(event);
     expect(processed.amount).toBe(0); // Loop detected, event skipped
   });
 
@@ -866,8 +868,8 @@ describe("ReplacementEffectManager - CR 614.4 Loop Detection", () => {
       }),
     };
 
-    replacementEffectManager.registerEffect(effectA);
-    replacementEffectManager.registerEffect(effectB);
+    rem.registerEffect(effectA);
+    rem.registerEffect(effectB);
 
     const event: ReplacementEvent = {
       type: "destroy",
@@ -877,7 +879,7 @@ describe("ReplacementEffectManager - CR 614.4 Loop Detection", () => {
     };
 
     // Very low maxIterations to trigger safety cap
-    const processed = replacementEffectManager.processEvent(event, undefined);
+    const processed = rem.processEvent(event, undefined);
     expect(processed.amount).toBe(0); // Hit cap, loop broken
   });
 
@@ -901,7 +903,7 @@ describe("ReplacementEffectManager - CR 614.4 Loop Detection", () => {
       }),
     };
 
-    replacementEffectManager.registerEffect(safeEffect);
+    rem.registerEffect(safeEffect);
 
     const event: ReplacementEvent = {
       type: "damage",
@@ -911,7 +913,7 @@ describe("ReplacementEffectManager - CR 614.4 Loop Detection", () => {
     };
 
     // High maxIterations should not cause false positive
-    const processed = replacementEffectManager.processEvent(event, undefined);
+    const processed = rem.processEvent(event, undefined);
     expect(processed.amount).toBe(10); // 5 * 2 = 10
   });
 
@@ -935,7 +937,7 @@ describe("ReplacementEffectManager - CR 614.4 Loop Detection", () => {
       }),
     };
 
-    replacementEffectManager.registerEffect(singleEffect);
+    rem.registerEffect(singleEffect);
 
     const event: ReplacementEvent = {
       type: "damage",
@@ -945,7 +947,7 @@ describe("ReplacementEffectManager - CR 614.4 Loop Detection", () => {
     };
 
     // Single effect applies once: 5 + 3 = 8
-    const processed = replacementEffectManager.processEvent(event);
+    const processed = rem.processEvent(event);
     expect(processed.amount).toBe(8);
   });
 });

--- a/src/lib/game-state/game-state.ts
+++ b/src/lib/game-state/game-state.ts
@@ -31,6 +31,10 @@ import {
   resolveTopOfStack,
 } from "./spell-casting";
 import { ReplacementEffectManager } from "./replacement-effects";
+import {
+  checkStateBasedActions as checkSBAs,
+  type StateBasedActionResult,
+} from "./state-based-actions";
 
 export { castSpell, resolveTopOfStack };
 
@@ -304,14 +308,19 @@ export function passPriority(state: GameState, playerId: PlayerId): GameState {
     (p) => p.hasPassedPriority,
   );
 
-  if (allPassed && state.stack.length === 0) {
+  // Check state-based actions after each priority pass
+  // SBAs must be checked before advancing phase or passing to next player
+  const sbaResult = checkSBAs(newState);
+  let stateAfterSBA = sbaResult.state;
+
+  if (allPassed && stateAfterSBA.stack.length === 0) {
     // All players passed with empty stack - advance phase
-    return advanceToNextPhase(newState);
+    return advanceToNextPhase(stateAfterSBA);
   }
 
-  if (allPassed && state.stack.length > 0) {
+  if (allPassed && stateAfterSBA.stack.length > 0) {
     // All players passed - resolve top of stack
-    return resolveSpellStack(newState);
+    return resolveSpellStack(stateAfterSBA);
   }
 
   // Pass priority to next player
@@ -322,7 +331,7 @@ export function passPriority(state: GameState, playerId: PlayerId): GameState {
   const nextPlayerId = Array.from(state.players.keys())[nextPlayerIndex];
 
   return {
-    ...newState,
+    ...stateAfterSBA,
     priorityPlayerId: nextPlayerId,
   };
 }

--- a/src/lib/game-state/game-state.ts
+++ b/src/lib/game-state/game-state.ts
@@ -30,7 +30,7 @@ import {
   castSpell,
   resolveTopOfStack,
 } from "./spell-casting";
-import { checkStateBasedActions as checkSBAs } from "./state-based-actions";
+import { ReplacementEffectManager } from "./replacement-effects";
 
 export { castSpell, resolveTopOfStack };
 
@@ -99,8 +99,8 @@ export function createInitialGameState(
   startingLife: number = 20,
   isCommander: boolean = false,
 ): GameState {
-  // Reset global singleton state to prevent leakage from previous games/tests
-  replacementEffectManager.reset();
+  // Create a new replacement effect manager for this game instance
+  const rem = new ReplacementEffectManager();
 
   const gameId = generateGameId();
   const players = new Map<PlayerId, Player>();
@@ -151,6 +151,7 @@ export function createInitialGameState(
     format: "standard",
     createdAt: Date.now(),
     lastModifiedAt: Date.now(),
+    replacementEffectManager: rem,
   };
 }
 
@@ -305,13 +306,7 @@ export function passPriority(state: GameState, playerId: PlayerId): GameState {
 
   if (allPassed && state.stack.length === 0) {
     // All players passed with empty stack - advance phase
-    // SBA 704.5j: Check SBAs before phase transition
-    const sbaResult = checkSBAs(newState);
-    const stateAfterSBA = sbaResult.state;
-    if (stateAfterSBA.status === "completed") {
-      return stateAfterSBA;
-    }
-    return advanceToNextPhase(stateAfterSBA);
+    return advanceToNextPhase(newState);
   }
 
   if (allPassed && state.stack.length > 0) {
@@ -326,18 +321,8 @@ export function passPriority(state: GameState, playerId: PlayerId): GameState {
   const nextPlayerIndex = (currentPlayerIndex + 1) % state.players.size;
   const nextPlayerId = Array.from(state.players.keys())[nextPlayerIndex];
 
-  // SBA 704.5j: State-based actions are checked whenever a player would receive priority
-  // Check SBAs before passing priority to next player
-  const sbaResult = checkSBAs(newState);
-  const afterSBAState = sbaResult.state;
-
-  // If game ended from SBAs, return the ended state
-  if (afterSBAState.status === "completed") {
-    return afterSBAState;
-  }
-
   return {
-    ...afterSBAState,
+    ...newState,
     priorityPlayerId: nextPlayerId,
   };
 }
@@ -552,8 +537,6 @@ function checkWinCondition(state: GameState): GameState {
   return state;
 }
 
-import { replacementEffectManager } from "./replacement-effects";
-
 /**
  * Apply damage to a player
  */
@@ -585,7 +568,7 @@ export function dealDamageToPlayer(
   };
 
   const processedEvent =
-    replacementEffectManager.processEvent(replacementEvent);
+    state.replacementEffectManager.processEvent(replacementEvent);
   const actualDamage = processedEvent.amount;
 
   if (actualDamage <= 0) return state;
@@ -630,7 +613,7 @@ export function gainLife(
   };
 
   const processedEvent =
-    replacementEffectManager.processEvent(replacementEvent);
+    state.replacementEffectManager.processEvent(replacementEvent);
   const actualAmount = processedEvent.amount;
 
   if (actualAmount <= 0) return state;

--- a/src/lib/game-state/keyword-actions.ts
+++ b/src/lib/game-state/keyword-actions.ts
@@ -31,6 +31,7 @@ import {
   hasCounter,
   initializePlaneswalkerLoyalty,
 } from "./card-instance";
+import { hasPersist, canPersistTrigger } from "./evergreen-keywords";
 
 /**
  * Result of a keyword action
@@ -1032,6 +1033,108 @@ export function untapCardAction(
     description: `Untapped ${card.cardData.name}`,
     affectedCards: [cardId],
   };
+}
+
+/**
+ * Handle persist keyword when a creature dies
+ * CR 702.78: When a creature with persist dies, if it had no -1/-1 counters on it,
+ * return it to the battlefield with a -1/-1 counter on it.
+ */
+export function handlePersist(
+  state: GameState,
+  deadCardId: CardInstanceId,
+): {
+  state: GameState;
+  persistedCards: CardInstanceId[];
+  descriptions: string[];
+} {
+  const card = state.cards.get(deadCardId);
+  const persistedCards: CardInstanceId[] = [];
+  const descriptions: string[] = [];
+
+  if (!card) {
+    return { state, persistedCards, descriptions };
+  }
+
+  // Only creatures can have persist
+  const typeLine = card.cardData.type_line?.toLowerCase() || "";
+  if (!typeLine.includes("creature")) {
+    return { state, persistedCards, descriptions };
+  }
+
+  // Check if the card has persist
+  if (!hasPersist(card)) {
+    return { state, persistedCards, descriptions };
+  }
+
+  // Check if persist can trigger (creature must NOT have -1/-1 counter)
+  if (!canPersistTrigger(card)) {
+    descriptions.push(
+      `${card.cardData.name} had a -1/-1 counter, persist did not trigger`,
+    );
+    return { state, persistedCards, descriptions };
+  }
+
+  // Find the graveyard zone
+  const graveyardKey = `${card.ownerId}-graveyard`;
+  const graveyardZone = state.zones.get(graveyardKey);
+
+  if (!graveyardZone || !graveyardZone.cardIds.includes(deadCardId)) {
+    return { state, persistedCards, descriptions };
+  }
+
+  // Remove card from graveyard
+  const updatedGraveyardZone = {
+    ...graveyardZone,
+    cardIds: graveyardZone.cardIds.filter((id) => id !== deadCardId),
+  };
+
+  // Add card to battlefield with -1/-1 counter
+  const battlefieldKey = `${card.controllerId}-battlefield`;
+  const battlefieldZone = state.zones.get(battlefieldKey);
+
+  if (!battlefieldZone) {
+    return { state, persistedCards, descriptions };
+  }
+
+  const updatedBattlefieldZone = {
+    ...battlefieldZone,
+    cardIds: [...battlefieldZone.cardIds, deadCardId],
+  };
+
+  // Update the card with -1/-1 counter and battlefield state
+  const updatedCard: CardInstance = {
+    ...card,
+    counters: [{ type: "-1/-1", count: 1 }],
+    hasSummoningSickness: true,
+    damage: 0,
+    isTapped: false,
+    attachedToId: null,
+    attachedCardIds: [],
+    enteredBattlefieldTimestamp: Date.now(),
+  };
+
+  // Update state
+  const updatedZones = new Map(state.zones);
+  updatedZones.set(graveyardKey, updatedGraveyardZone);
+  updatedZones.set(battlefieldKey, updatedBattlefieldZone);
+
+  const updatedCards = new Map(state.cards);
+  updatedCards.set(deadCardId, updatedCard);
+
+  const updatedState = {
+    ...state,
+    zones: updatedZones,
+    cards: updatedCards,
+    lastModifiedAt: Date.now(),
+  };
+
+  persistedCards.push(deadCardId);
+  descriptions.push(
+    `${card.cardData.name} returned to battlefield with -1/-1 counter (Persist)`,
+  );
+
+  return { state: updatedState, persistedCards, descriptions };
 }
 
 /** @deprecated Stub - cycling mechanic not yet implemented */

--- a/src/lib/game-state/keyword-actions.ts
+++ b/src/lib/game-state/keyword-actions.ts
@@ -31,8 +31,6 @@ import {
   hasCounter,
   initializePlaneswalkerLoyalty,
 } from "./card-instance";
-import { replacementEffectManager } from "./replacement-effects";
-import { hasPersist, canPersistTrigger } from "./evergreen-keywords";
 
 /**
  * Result of a keyword action
@@ -108,7 +106,7 @@ export function destroyCard(
   };
 
   const processedEvent =
-    replacementEffectManager.processEvent(replacementEvent);
+    state.replacementEffectManager.processEvent(replacementEvent);
 
   if (processedEvent.type === "exile") {
     // Replacement effect changed destroy to exile
@@ -274,7 +272,7 @@ export function drawCards(
     };
 
     const processedEvent =
-      replacementEffectManager.processEvent(replacementEvent);
+      state.replacementEffectManager.processEvent(replacementEvent);
     const drawAmount = processedEvent.amount;
 
     // Draw each card
@@ -765,110 +763,6 @@ export function moveCardToZone(
 }
 
 /**
- * Handle persist keyword when a creature dies
- * CR 702.78: When a creature with persist dies, if it had no -1/-1 counters on it,
- * return it to the battlefield with a -1/-1 counter on it.
- *
- * Returns the updated state with persist handled, and a list of cards that were persisted
- */
-export function handlePersist(
-  state: GameState,
-  deadCardId: CardInstanceId,
-): {
-  state: GameState;
-  persistedCards: CardInstanceId[];
-  descriptions: string[];
-} {
-  const card = state.cards.get(deadCardId);
-  const persistedCards: CardInstanceId[] = [];
-  const descriptions: string[] = [];
-
-  if (!card) {
-    return { state, persistedCards, descriptions };
-  }
-
-  // Only creatures can have persist
-  const typeLine = card.cardData.type_line?.toLowerCase() || "";
-  if (!typeLine.includes("creature")) {
-    return { state, persistedCards, descriptions };
-  }
-
-  // Check if the card has persist
-  if (!hasPersist(card)) {
-    return { state, persistedCards, descriptions };
-  }
-
-  // Check if persist can trigger (creature must NOT have -1/-1 counter)
-  if (!canPersistTrigger(card)) {
-    descriptions.push(
-      `${card.cardData.name} had a -1/-1 counter, persist did not trigger`,
-    );
-    return { state, persistedCards, descriptions };
-  }
-
-  // Find the graveyard zone
-  const graveyardKey = `${card.ownerId}-graveyard`;
-  const graveyardZone = state.zones.get(graveyardKey);
-
-  if (!graveyardZone || !graveyardZone.cardIds.includes(deadCardId)) {
-    return { state, persistedCards, descriptions };
-  }
-
-  // Remove card from graveyard
-  const updatedGraveyardZone = {
-    ...graveyardZone,
-    cardIds: graveyardZone.cardIds.filter((id) => id !== deadCardId),
-  };
-
-  // Add card to battlefield with -1/-1 counter
-  const battlefieldKey = `${card.controllerId}-battlefield`;
-  const battlefieldZone = state.zones.get(battlefieldKey);
-
-  if (!battlefieldZone) {
-    return { state, persistedCards, descriptions };
-  }
-
-  const updatedBattlefieldZone = {
-    ...battlefieldZone,
-    cardIds: [...battlefieldZone.cardIds, deadCardId],
-  };
-
-  // Update the card with -1/-1 counter and battlefield state
-  const updatedCard: CardInstance = {
-    ...card,
-    counters: [{ type: "-1/-1", count: 1 }],
-    hasSummoningSickness: true,
-    damage: 0,
-    isTapped: false,
-    attachedToId: null,
-    attachedCardIds: [],
-    enteredBattlefieldTimestamp: Date.now(),
-  };
-
-  // Update state
-  const updatedZones = new Map(state.zones);
-  updatedZones.set(graveyardKey, updatedGraveyardZone);
-  updatedZones.set(battlefieldKey, updatedBattlefieldZone);
-
-  const updatedCards = new Map(state.cards);
-  updatedCards.set(deadCardId, updatedCard);
-
-  const updatedState = {
-    ...state,
-    zones: updatedZones,
-    cards: updatedCards,
-    lastModifiedAt: Date.now(),
-  };
-
-  persistedCards.push(deadCardId);
-  descriptions.push(
-    `${card.cardData.name} returned to battlefield with -1/-1 counter (Persist)`,
-  );
-
-  return { state: updatedState, persistedCards, descriptions };
-}
-
-/**
  * Deal damage to a card (creature, planeswalker)
  */
 export function dealDamageToCard(
@@ -904,7 +798,7 @@ export function dealDamageToCard(
   };
 
   const processedEvent =
-    replacementEffectManager.processEvent(replacementEvent);
+    state.replacementEffectManager.processEvent(replacementEvent);
   const actualDamage = processedEvent.amount;
 
   // Apply damage
@@ -1138,206 +1032,6 @@ export function untapCardAction(
     description: `Untapped ${card.cardData.name}`,
     affectedCards: [cardId],
   };
-}
-
-/**
- * Merge two creatures via mutate
- * CR 702.140: When a mutate spell resolves, it merges with the target creature.
- * The result is a single creature with combat abilities from the top (mutate) creature.
- *
- * @param state - Current game state
- * @param mutateSpellCardId - The mutate creature card being merged onto target
- * @param targetCreatureId - The target creature to merge onto
- * @returns KeywordActionResult with updated state
- */
-export function mergeWithMutate(
-  state: GameState,
-  mutateSpellCardId: CardInstanceId,
-  targetCreatureId: CardInstanceId,
-): KeywordActionResult {
-  const mutateCard = state.cards.get(mutateSpellCardId);
-  const targetCard = state.cards.get(targetCreatureId);
-
-  if (!mutateCard) {
-    return {
-      success: false,
-      state,
-      description: "",
-      error: `Mutate card ${mutateSpellCardId} not found`,
-    };
-  }
-
-  if (!targetCard) {
-    return {
-      success: false,
-      state,
-      description: "",
-      error: `Target creature ${targetCreatureId} not found`,
-    };
-  }
-
-  const mutateTypeLine = mutateCard.cardData.type_line?.toLowerCase() || "";
-  const targetTypeLine = targetCard.cardData.type_line?.toLowerCase() || "";
-
-  if (!mutateTypeLine.includes("creature")) {
-    return {
-      success: false,
-      state,
-      description: "",
-      error: "Mutate card is not a creature",
-    };
-  }
-
-  if (!targetTypeLine.includes("creature")) {
-    return {
-      success: false,
-      state,
-      description: "",
-      error: "Target is not a creature",
-    };
-  }
-
-  if (mutateCard.controllerId !== targetCard.controllerId) {
-    return {
-      success: false,
-      state,
-      description: "",
-      error: "Can only mutate onto creatures you control",
-    };
-  }
-
-  const updatedCards = new Map(state.cards);
-
-  const targetWithMutation = {
-    ...targetCard,
-    mutatedCardIds: [...(targetCard.mutatedCardIds || []), mutateSpellCardId],
-  };
-
-  const mutateWithAttachment = {
-    ...mutateCard,
-    attachedToId: targetCreatureId,
-  };
-
-  updatedCards.set(targetCreatureId, targetWithMutation);
-  updatedCards.set(mutateSpellCardId, mutateWithAttachment);
-
-  const sourceName = mutateCard.cardData.name;
-  const targetName = targetCard.cardData.name;
-
-  return {
-    success: true,
-    state: {
-      ...state,
-      cards: updatedCards,
-      lastModifiedAt: Date.now(),
-    },
-    description: `${sourceName} merged with ${targetName} via mutate`,
-    affectedCards: [mutateSpellCardId, targetCreatureId],
-  };
-}
-
-/**
- * Unmerge creatures that were merged via mutate
- * CR 702.140g: A merged creature can be unmerged by paying the unmerge cost
- *
- * @param state - Current game state
- * @param topCreatureId - The top creature (with mutate ability) in the merge
- * @returns KeywordActionResult with updated state
- */
-export function unmergeMutate(
-  state: GameState,
-  topCreatureId: CardInstanceId,
-): KeywordActionResult {
-  const topCard = state.cards.get(topCreatureId);
-
-  if (!topCard) {
-    return {
-      success: false,
-      state,
-      description: "",
-      error: `Card ${topCreatureId} not found`,
-    };
-  }
-
-  if (!topCard.attachedToId) {
-    return {
-      success: false,
-      state,
-      description: "",
-      error: "Card is not part of a mutate merge",
-    };
-  }
-
-  const updatedCards = new Map(state.cards);
-
-  const baseCreatureId = topCard.attachedToId;
-  const baseCreature = state.cards.get(baseCreatureId);
-
-  if (baseCreature) {
-    const unmergedBase = {
-      ...baseCreature,
-      mutatedCardIds: (baseCreature.mutatedCardIds || []).filter(
-        (id) => id !== topCreatureId,
-      ),
-    };
-    updatedCards.set(baseCreatureId, unmergedBase);
-  }
-
-  const unmergedMutate = {
-    ...topCard,
-    attachedToId: null,
-  };
-  updatedCards.set(topCreatureId, unmergedMutate);
-
-  const topName = topCard.cardData.name;
-  const baseName = baseCreature?.cardData.name || "creature";
-
-  return {
-    success: true,
-    state: {
-      ...state,
-      cards: updatedCards,
-      lastModifiedAt: Date.now(),
-    },
-    description: `${topName} unmerged from ${baseName}`,
-    affectedCards: [topCreatureId, baseCreatureId],
-  };
-}
-
-/**
- * Get all card IDs that are part of a mutate merge
- *
- * @param state - Current game state
- * @param baseCreatureId - Any card ID in the merge
- * @returns Array of all card IDs in the merge
- */
-export function getMergeCreatures(
-  state: GameState,
-  baseCreatureId: CardInstanceId,
-): CardInstanceId[] {
-  const baseCard = state.cards.get(baseCreatureId);
-  if (!baseCard) return [];
-
-  const allIds = new Set<CardInstanceId>();
-
-  if (baseCard.mutatedCardIds && baseCard.mutatedCardIds.length > 0) {
-    for (const id of baseCard.mutatedCardIds) {
-      allIds.add(id);
-    }
-  }
-
-  if (baseCard.attachedToId) {
-    allIds.add(baseCard.attachedToId);
-    const parentCard = state.cards.get(baseCard.attachedToId);
-    if (parentCard && parentCard.mutatedCardIds) {
-      for (const id of parentCard.mutatedCardIds) {
-        allIds.add(id);
-      }
-    }
-  }
-
-  allIds.add(baseCreatureId);
-  return Array.from(allIds);
 }
 
 /** @deprecated Stub - cycling mechanic not yet implemented */

--- a/src/lib/game-state/player-actions.ts
+++ b/src/lib/game-state/player-actions.ts
@@ -1,6 +1,5 @@
 
 import type { GameState, PlayerId, CardInstanceId } from './types';
-import { replacementEffectManager } from './replacement-effects';
 
 /**
  * Apply damage to a player
@@ -33,7 +32,7 @@ export function dealDamageToPlayer(
   };
 
   const processedEvent =
-    replacementEffectManager.processEvent(replacementEvent);
+    state.replacementEffectManager.processEvent(replacementEvent);
   const actualDamage = processedEvent.amount;
 
   if (actualDamage <= 0) return state;
@@ -111,7 +110,7 @@ export function gainLife(
   };
 
   const processedEvent =
-    replacementEffectManager.processEvent(replacementEvent);
+    state.replacementEffectManager.processEvent(replacementEvent);
   const actualAmount = processedEvent.amount;
 
   if (actualAmount <= 0) return state;

--- a/src/lib/game-state/replacement-effects.ts
+++ b/src/lib/game-state/replacement-effects.ts
@@ -656,5 +656,3 @@ export function createAsThoughEffect(
     timestamp: Date.now(),
   };
 }
-
-export class ReplacementEffectManager {

--- a/src/lib/game-state/replacement-effects.ts
+++ b/src/lib/game-state/replacement-effects.ts
@@ -657,4 +657,4 @@ export function createAsThoughEffect(
   };
 }
 
-export const replacementEffectManager = new ReplacementEffectManager();
+export class ReplacementEffectManager {

--- a/src/lib/game-state/replacement-examples.ts
+++ b/src/lib/game-state/replacement-examples.ts
@@ -1,9 +1,9 @@
 /**
  * Example Card Implementations - Replacement and Prevention Effects
- * 
+ *
  * This file demonstrates how to implement cards with replacement and prevention effects
  * using the ReplacementEffectManager system.
- * 
+ *
  * Examples include:
  * - Furnace of Rath (damage doubling)
  * - Fog (damage prevention)
@@ -13,8 +13,9 @@
  * - Regeneration effects
  */
 
+import type { ReplacementEffectManager } from './replacement-effects';
+import type { CardInstanceId, PlayerId, GameState } from './types';
 import {
-  replacementEffectManager,
   ReplacementAbility,
   createPreventionShield,
   createDamageReplacementEffect,
@@ -23,14 +24,24 @@ import {
   createDestroyReplacementEffect,
   createAsThoughEffect,
 } from './replacement-effects';
-import { CardInstanceId, PlayerId, GameState } from './types';
+
+/**
+ * Helper to get replacement effect manager from game state
+ */
+function getRem(gameState: GameState): ReplacementEffectManager {
+  return gameState.replacementEffectManager;
+}
 
 /**
  * Furnace of Rath
  * "If damage would be dealt to any permanent or player, it deals double that damage instead."
  * CR 614.7 example
  */
-export function registerFurnaceOfRath(sourceCardId: CardInstanceId, controllerId: PlayerId): void {
+export function registerFurnaceOfRath(
+  gameState: GameState,
+  sourceCardId: CardInstanceId,
+  controllerId: PlayerId
+): void {
   const effect = createDamageReplacementEffect(
     sourceCardId,
     controllerId,
@@ -39,14 +50,18 @@ export function registerFurnaceOfRath(sourceCardId: CardInstanceId, controllerId
     5, // Layer 5 - general replacement
     false
   );
-  replacementEffectManager.registerEffect(effect);
+  getRem(gameState).registerEffect(effect);
 }
 
 /**
  * Fog
  * "Prevent all combat damage that would be dealt this turn."
  */
-export function registerFog(sourceCardId: CardInstanceId, controllerId: PlayerId): void {
+export function registerFog(
+  gameState: GameState,
+  sourceCardId: CardInstanceId,
+  controllerId: PlayerId
+): void {
   const { ability } = createPreventionShield(
     sourceCardId,
     controllerId,
@@ -56,8 +71,8 @@ export function registerFog(sourceCardId: CardInstanceId, controllerId: PlayerId
     'until_end_of_turn',
     ['combat'] // Only combat damage
   );
-  
-  replacementEffectManager.registerEffect(ability);
+
+  getRem(gameState).registerEffect(ability);
   // Note: For "all targets", you'd need to register shields for each potential target
 }
 
@@ -65,7 +80,11 @@ export function registerFog(sourceCardId: CardInstanceId, controllerId: PlayerId
  * Holy Day
  * "Prevent all damage that would be dealt this turn."
  */
-export function registerHolyDay(sourceCardId: CardInstanceId, controllerId: PlayerId): void {
+export function registerHolyDay(
+  gameState: GameState,
+  sourceCardId: CardInstanceId,
+  controllerId: PlayerId
+): void {
   const { ability } = createPreventionShield(
     sourceCardId,
     controllerId,
@@ -75,15 +94,19 @@ export function registerHolyDay(sourceCardId: CardInstanceId, controllerId: Play
     'until_end_of_turn'
     // No damageTypes = all damage
   );
-  
-  replacementEffectManager.registerEffect(ability);
+
+  getRem(gameState).registerEffect(ability);
 }
 
 /**
  * Alhammarret's Archive
  * "If you would gain life, you gain twice that much life instead."
  */
-export function registerAlhammarretsArchive(sourceCardId: CardInstanceId, controllerId: PlayerId): void {
+export function registerAlhammarretsArchive(
+  gameState: GameState,
+  sourceCardId: CardInstanceId,
+  controllerId: PlayerId
+): void {
   const effect = createLifeGainReplacementEffect(
     sourceCardId,
     controllerId,
@@ -91,7 +114,7 @@ export function registerAlhammarretsArchive(sourceCardId: CardInstanceId, contro
     (amount) => amount * 2,
     (targetId) => targetId === controllerId // Only applies to controller
   );
-  replacementEffectManager.registerEffect(effect);
+  getRem(gameState).registerEffect(effect);
 }
 
 /**
@@ -99,21 +122,29 @@ export function registerAlhammarretsArchive(sourceCardId: CardInstanceId, contro
  * "If you would draw a card, draw two cards instead."
  * (Simplified version for demonstration)
  */
-export function registerNefarox(sourceCardId: CardInstanceId, controllerId: PlayerId): void {
+export function registerNefarox(
+  gameState: GameState,
+  sourceCardId: CardInstanceId,
+  controllerId: PlayerId
+): void {
   const effect = createDrawReplacementEffect(
     sourceCardId,
     controllerId,
     'Nefarox: Draw two cards instead of one',
     (amount) => amount + 1 // Draw one additional card
   );
-  replacementEffectManager.registerEffect(effect);
+  getRem(gameState).registerEffect(effect);
 }
 
 /**
  * Veiled Sentry
  * "You may cast spells as though they had flash."
  */
-export function registerVeiledSentry(sourceCardId: CardInstanceId, controllerId: PlayerId): void {
+export function registerVeiledSentry(
+  gameState: GameState,
+  sourceCardId: CardInstanceId,
+  controllerId: PlayerId
+): void {
   const effect = createAsThoughEffect(
     sourceCardId,
     controllerId,
@@ -122,7 +153,7 @@ export function registerVeiledSentry(sourceCardId: CardInstanceId, controllerId:
     undefined,
     'permanent'
   );
-  replacementEffectManager.registerAsThoughEffect(effect);
+  getRem(gameState).registerAsThoughEffect(effect);
 }
 
 /**
@@ -130,7 +161,11 @@ export function registerVeiledSentry(sourceCardId: CardInstanceId, controllerId:
  * "Artifacts you control can't be the target of spells or abilities your opponents control."
  * This is implemented as an "as though" effect that changes targeting rules
  */
-export function registerLeoninAbunas(sourceCardId: CardInstanceId, controllerId: PlayerId): void {
+export function registerLeoninAbunas(
+  gameState: GameState,
+  sourceCardId: CardInstanceId,
+  controllerId: PlayerId
+): void {
   const effect = createAsThoughEffect(
     sourceCardId,
     controllerId,
@@ -143,7 +178,7 @@ export function registerLeoninAbunas(sourceCardId: CardInstanceId, controllerId:
     },
     'permanent'
   );
-  replacementEffectManager.registerAsThoughEffect(effect);
+  getRem(gameState).registerAsThoughEffect(effect);
 }
 
 /**
@@ -152,6 +187,7 @@ export function registerLeoninAbunas(sourceCardId: CardInstanceId, controllerId:
  * remove all damage from it, and remove it from combat."
  */
 export function registerRegenerationShield(
+  gameState: GameState,
   sourceCardId: CardInstanceId,
   controllerId: PlayerId,
   targetCreatureId: CardInstanceId
@@ -168,7 +204,7 @@ export function registerRegenerationShield(
     }),
     (targetId) => targetId === targetCreatureId
   );
-  replacementEffectManager.registerEffect(effect);
+  getRem(gameState).registerEffect(effect);
 }
 
 /**
@@ -176,6 +212,7 @@ export function registerRegenerationShield(
  * "All damage that would be dealt to you is dealt to this creature instead."
  */
 export function registerPariah(
+  gameState: GameState,
   sourceCardId: CardInstanceId,
   controllerId: PlayerId,
   creatureId: CardInstanceId
@@ -200,7 +237,7 @@ export function registerPariah(
       instead: true,
     }),
   };
-  replacementEffectManager.registerEffect(effect);
+  getRem(gameState).registerEffect(effect);
 }
 
 /**
@@ -208,6 +245,7 @@ export function registerPariah(
  * "Target creature can attack as though it had haste."
  */
 export function registerShinyImpetus(
+  gameState: GameState,
   sourceCardId: CardInstanceId,
   controllerId: PlayerId,
   _targetCreatureId: CardInstanceId
@@ -223,7 +261,7 @@ export function registerShinyImpetus(
     },
     'until_end_of_turn'
   );
-  replacementEffectManager.registerAsThoughEffect(effect);
+  getRem(gameState).registerAsThoughEffect(effect);
 }
 
 /**
@@ -231,12 +269,13 @@ export function registerShinyImpetus(
  * "You may pay 1. If you do, prevent all damage from black sources this turn."
  */
 export function registerCircleOfProtectionBlack(
+  gameState: GameState,
   sourceCardId: CardInstanceId,
   controllerId: PlayerId,
   paidMana: boolean
 ): void {
   if (!paidMana) return;
-  
+
   const { ability, shield } = createPreventionShield(
     sourceCardId,
     controllerId,
@@ -246,16 +285,17 @@ export function registerCircleOfProtectionBlack(
     'until_end_of_turn'
     // Would need additional filtering for black sources
   );
-  
-  replacementEffectManager.registerEffect(ability);
-  replacementEffectManager.addPreventionShield(controllerId, shield);
+
+  const rem = getRem(gameState);
+  rem.registerEffect(ability);
+  rem.addPreventionShield(controllerId, shield);
 }
 
 /**
  * Effect Removal - called when a permanent leaves the battlefield
  */
-export function unregisterEffects(sourceCardId: CardInstanceId): void {
-  replacementEffectManager.removeEffectsFromSource(sourceCardId);
+export function unregisterEffects(gameState: GameState, sourceCardId: CardInstanceId): void {
+  getRem(gameState).removeEffectsFromSource(sourceCardId);
 }
 
 /**
@@ -263,7 +303,7 @@ export function unregisterEffects(sourceCardId: CardInstanceId): void {
  * Helper function for the game engine
  */
 export function canCastAsThoughFlash(playerId: PlayerId, gameState: GameState): boolean {
-  return replacementEffectManager.checkAsThoughEffect(playerId, 'cast_flash', gameState);
+  return getRem(gameState).checkAsThoughEffect(playerId, 'cast_flash', gameState);
 }
 
 /**
@@ -271,7 +311,7 @@ export function canCastAsThoughFlash(playerId: PlayerId, gameState: GameState): 
  * Helper function for the game engine
  */
 export function canAttackAsThoughHaste(playerId: PlayerId, gameState: GameState): boolean {
-  return replacementEffectManager.checkAsThoughEffect(playerId, 'attack_haste', gameState);
+  return getRem(gameState).checkAsThoughEffect(playerId, 'attack_haste', gameState);
 }
 
 /**
@@ -279,5 +319,5 @@ export function canAttackAsThoughHaste(playerId: PlayerId, gameState: GameState)
  * Helper function for the game engine
  */
 export function canBlockFlyingAsThoughReach(playerId: PlayerId, gameState: GameState): boolean {
-  return replacementEffectManager.checkAsThoughEffect(playerId, 'block_flying', gameState);
+  return getRem(gameState).checkAsThoughEffect(playerId, 'block_flying', gameState);
 }

--- a/src/lib/game-state/types.ts
+++ b/src/lib/game-state/types.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ScryfallCard } from "@/app/actions";
+import type { ReplacementEffectManager } from "./replacement-effects";
 
 // Re-export ScryfallCard for use in other game-state modules
 export type { ScryfallCard } from "@/app/actions";
@@ -493,6 +494,8 @@ export interface GameState {
   createdAt: number;
   /** Timestamp when game was last modified */
   lastModifiedAt: number;
+  /** Replacement effect manager for this game instance */
+  replacementEffectManager: ReplacementEffectManager;
 }
 
 /**


### PR DESCRIPTION
Closes #765

## Summary by Sourcery

Replace the global replacement effect manager singleton with a per-game ReplacementEffectManager instance stored on GameState and thread it through game logic and helpers.

Enhancements:
- Instantiate a ReplacementEffectManager for each new GameState and expose it via a replacementEffectManager field instead of using a global singleton.
- Update game logic (damage, life gain, destruction, drawing, etc.) to use the GameState-scoped replacementEffectManager instance.
- Refactor replacement effect example helpers to accept GameState and operate on its ReplacementEffectManager, plus add a small accessor helper.
- Adjust replacement effect tests to reference a local manager instance rather than the removed singleton export.