### PR TITLE
Feature #770: Implement Prototype keyword (CR 702.152)

### DIFF
--- a/src/lib/__tests__/validation-service.test.ts
+++ b/src/lib/__tests__/validation-service.test.ts
@@ -78,6 +78,11 @@ describe("ValidationService", () => {
       chosenBasicLandType: null,
       isToken: false,
       tokenData: null,
+      // Prototype fields (CR 702.152)
+      isPrototype: false,
+      prototypePower: null,
+      prototypeToughness: null,
+      prototypeManaCost: null,
     };
 
     gameState = {

--- a/src/lib/game-state/card-instance.ts
+++ b/src/lib/game-state/card-instance.ts
@@ -47,6 +47,10 @@ export function createCardInstance(
     chosenBasicLandType: null,
     isToken: options.isToken || false,
     tokenData: options.tokenData || null,
+    isPrototype: options.isPrototype || false,
+    prototypePower: options.prototypePower || null,
+    prototypeToughness: options.prototypeToughness || null,
+    prototypeManaCost: options.prototypeManaCost || null,
   };
 }
 
@@ -287,10 +291,16 @@ export function isPermanent(card: CardInstance): boolean {
 
 /**
  * Get the power of a creature
+ * Per CR 613 - Interaction of Continuous Effects, applies prototype P/T
  */
 export function getPower(card: CardInstance): number {
   if (!isCreature(card)) {
     return 0;
+  }
+
+  // If prototype is active and has prototype power, use that
+  if (card.isPrototype && card.prototypePower !== null) {
+    return card.prototypePower + card.powerModifier;
   }
 
   // For double-faced cards, get the power from the current face
@@ -323,6 +333,7 @@ export function getPower(card: CardInstance): number {
 
 /**
  * Get the current face data for a card (handles double-faced cards)
+ * For prototype cards, we need to return the current face data but use prototype P/T
  */
 function getCurrentFaceData(card: CardInstance): ScryfallCard {
   if (card.cardData.card_faces && card.cardData.card_faces.length > 0) {
@@ -330,6 +341,8 @@ function getCurrentFaceData(card: CardInstance): ScryfallCard {
       card.currentFaceIndex,
       card.cardData.card_faces.length - 1,
     );
+    // For prototype cards, the prototype P/T is stored on the card instance
+    // The card_faces data is not modified
     return {
       ...card.cardData,
       power: card.cardData.card_faces[faceIndex].power,
@@ -343,10 +356,16 @@ function getCurrentFaceData(card: CardInstance): ScryfallCard {
 
 /**
  * Get the toughness of a creature
+ * Per CR 613 - Interaction of Continuous Effects, applies prototype P/T
  */
 export function getToughness(card: CardInstance): number {
   if (!isCreature(card)) {
     return 0;
+  }
+
+  // If prototype is active and has prototype toughness, use that
+  if (card.isPrototype && card.prototypeToughness !== null) {
+    return card.prototypeToughness + card.toughnessModifier;
   }
 
   // For double-faced cards, get the toughness from the current face

--- a/src/lib/game-state/mana.ts
+++ b/src/lib/game-state/mana.ts
@@ -64,6 +64,56 @@ export function addMana(
 }
 
 /**
+ * Check if a player can afford a mana cost (without spending it)
+ * This is a pure check that does not mutate state
+ */
+export function canAffordMana(
+  state: GameState,
+  playerId: PlayerId,
+  mana: Partial<ManaPool>,
+): boolean {
+  const player = state.players.get(playerId);
+  if (!player) {
+    return false;
+  }
+
+  const pool = player.manaPool;
+
+  // Check if player has enough colored mana (specific color requirements)
+  if (
+    pool.white < (mana.white ?? 0) ||
+    pool.blue < (mana.blue ?? 0) ||
+    pool.black < (mana.black ?? 0) ||
+    pool.red < (mana.red ?? 0) ||
+    pool.green < (mana.green ?? 0)
+  ) {
+    return false;
+  }
+
+  // Check if player has enough colorless mana (colorless is specific, like colored)
+  if (pool.colorless < (mana.colorless ?? 0)) {
+    return false;
+  }
+
+  // Calculate total mana available for generic costs
+  // Generic can be paid with: generic pool, colored mana, or colorless mana
+  const totalColored =
+    pool.white + pool.blue + pool.black + pool.red + pool.green;
+  const neededColored =
+    (mana.white ?? 0) +
+    (mana.blue ?? 0) +
+    (mana.black ?? 0) +
+    (mana.red ?? 0) +
+    (mana.green ?? 0);
+  const availableForGeneric =
+    pool.generic +
+    (totalColored - neededColored) +
+    (pool.colorless - (mana.colorless ?? 0));
+
+  return availableForGeneric >= (mana.generic ?? 0);
+}
+
+/**
  * Spend mana from a player's mana pool
  * Returns whether the payment was successful
  *

--- a/src/lib/game-state/oracle-text-parser.ts
+++ b/src/lib/game-state/oracle-text-parser.ts
@@ -573,7 +573,7 @@ export function extractKeywords(
 
   // Non-evergreen keywords (CR 702)
   const nonEvergreenKeywords = [
-    "Prototype", // CR 702.152
+    "prototype", // CR 702.152
   ];
 
   for (const keyword of nonEvergreenKeywords) {

--- a/src/lib/game-state/oracle-text-parser.ts
+++ b/src/lib/game-state/oracle-text-parser.ts
@@ -571,6 +571,20 @@ export function extractKeywords(
     }
   }
 
+  // Non-evergreen keywords (CR 702)
+  const nonEvergreenKeywords = [
+    "Prototype", // CR 702.152
+  ];
+
+  for (const keyword of nonEvergreenKeywords) {
+    if (combinedText.includes(keyword.toLowerCase())) {
+      keywords.push({
+        keyword,
+        type: "mechanic",
+      });
+    }
+  }
+
   // Remove duplicates
   const uniqueKeywords = keywords.filter(
     (item, index, self) =>
@@ -1338,5 +1352,76 @@ export function parseAttraction(oracleText: string): AttractionInfo {
     hasAttraction: true,
     spinResult: 0, // Will be determined by user action (spin/roll)
     description: "Spin the Attraction die to reveal cards",
+  };
+}
+
+/**
+ * Result of parsing Prototype ability
+ * CR 702.152: Prototype is a static ability that lets you cast a copy of the card
+ * with different power/toughness and mana cost.
+ */
+export interface PrototypeInfo {
+  /** Whether this card has prototype */
+  hasPrototype: boolean;
+  /** Alternative power when in prototype form */
+  prototypePower: number | null;
+  /** Alternative toughness when in prototype form */
+  prototypeToughness: number | null;
+  /** Alternative mana cost for prototype (as string like "{1}") */
+  prototypeManaCost: string | null;
+  /** Parsed prototype mana cost */
+  prototypeManaCostParsed: ParsedManaCost | null;
+  /** Description for UI */
+  description: string;
+}
+
+/**
+ * Parse prototype keyword from Oracle text
+ * CR 702.152: Prototype [cost] — [power]/[toughness]
+ * Format examples:
+ * - "Prototype {2}{U} — 3/3"
+ * - "Prototype {1}{R} — 2/2"
+ */
+export function parsePrototype(oracleText: string): PrototypeInfo {
+  if (!oracleText) {
+    return {
+      hasPrototype: false,
+      prototypePower: null,
+      prototypeToughness: null,
+      prototypeManaCost: null,
+      prototypeManaCostParsed: null,
+      description: "",
+    };
+  }
+
+  // Match prototype pattern: "Prototype {cost} — P/T"
+  // The cost is in curly braces, followed by em dash, followed by power/toughness
+  const prototypeMatch = oracleText.match(
+    /prototype\s*(\{[^}]+\}(?:\{[^}]+\})*)\s*[—–-]\s*(\d+)\/(\d+)/i,
+  );
+
+  if (!prototypeMatch) {
+    return {
+      hasPrototype: false,
+      prototypePower: null,
+      prototypeToughness: null,
+      prototypeManaCost: null,
+      prototypeManaCostParsed: null,
+      description: "",
+    };
+  }
+
+  const manaCostString = prototypeMatch[1];
+  const power = parseInt(prototypeMatch[2], 10);
+  const toughness = parseInt(prototypeMatch[3], 10);
+  const parsedCost = parseManaCost(manaCostString);
+
+  return {
+    hasPrototype: true,
+    prototypePower: power,
+    prototypeToughness: toughness,
+    prototypeManaCost: manaCostString,
+    prototypeManaCostParsed: parsedCost,
+    description: `Prototype ${manaCostString} — ${power}/${toughness}`,
   };
 }

--- a/src/lib/game-state/prototype.ts
+++ b/src/lib/game-state/prototype.ts
@@ -12,12 +12,21 @@
  * Reference: https://cards.highflip.dev/rule/702.152
  */
 
-import type { CardInstance, CardInstanceId, GameState, PlayerId } from "./types";
+import type {
+  CardInstance,
+  CardInstanceId,
+  GameState,
+  PlayerId,
+} from "./types";
 import type { ScryfallCard } from "@/app/actions";
-import { parsePrototype, type PrototypeInfo } from "./oracle-text-parser";
+import {
+  parsePrototype,
+  parseManaCost,
+  type PrototypeInfo,
+  type ParsedManaCost,
+} from "./oracle-text-parser";
 import { createCardInstance } from "./card-instance";
-import { spendMana } from "./mana";
-import type { ParsedManaCost } from "./oracle-text-parser";
+import { canAffordMana } from "./mana";
 
 /**
  * Check if a card has the Prototype keyword
@@ -66,14 +75,14 @@ export function canCastAsPrototype(
     return { canCast: false, reason: "Card is not in hand" };
   }
 
-  // Check mana cost (prototype version)
+  // Check mana cost (prototype version) - pure check, no state mutation
   if (prototypeInfo.prototypeManaCostParsed) {
-    const manaResult = spendMana(
+    const canAfford = canAffordMana(
       state,
       playerId,
       prototypeInfo.prototypeManaCostParsed,
     );
-    if (!manaResult.success) {
+    if (!canAfford) {
       return { canCast: false, reason: "Not enough mana for prototype cost" };
     }
   }
@@ -184,12 +193,11 @@ export function isPrototypePermanent(card: CardInstance): boolean {
 }
 
 /**
- * Parse prototype from a card's oracle text and initialize prototype state
- * Returns updated CardInstance with prototype fields set
+ * Derive prototype metadata for a card and store it on the card instance.
+ * Per CR 702.152, isPrototype should only be set when the card is actually
+ * cast as a prototype - not during initialization.
  */
-export function initializePrototype(
-  card: CardInstance,
-): CardInstance {
+export function initializePrototype(card: CardInstance): CardInstance {
   const prototypeInfo = getPrototypeInfo(card);
 
   if (!prototypeInfo.hasPrototype) {
@@ -198,7 +206,8 @@ export function initializePrototype(
 
   return {
     ...card,
-    isPrototype: true,
+    // Note: isPrototype is NOT set here - it is set at cast time
+    // when the card is actually played as a prototype
     prototypePower: prototypeInfo.prototypePower,
     prototypeToughness: prototypeInfo.prototypeToughness,
     prototypeManaCost: prototypeInfo.prototypeManaCost,
@@ -219,66 +228,4 @@ export function getPrototypeManaCostForSpell(
   }
   // Otherwise use normal mana cost parsing
   return parseManaCost(card.cardData.mana_cost || "");
-}
-
-/**
- * Parse a mana cost string into ParsedManaCost
- */
-function parseManaCost(costString: string): ParsedManaCost | null {
-  if (!costString || costString === "") {
-    return null;
-  }
-
-  const cost: ParsedManaCost = {
-    generic: 0,
-    colorless: 0,
-    white: 0,
-    blue: 0,
-    black: 0,
-    red: 0,
-    green: 0,
-    X: null,
-    snow: 0,
-  };
-
-  const matches = costString.match(/{[^}]+}/g) || [];
-
-  for (const match of matches) {
-    const symbol = match.slice(1, -1);
-
-    if (/^\d+$/.test(symbol)) {
-      cost.generic += parseInt(symbol, 10);
-      continue;
-    }
-
-    if (symbol === "X" || symbol === "x") {
-      cost.X = 0;
-      continue;
-    }
-
-    if (symbol === "C") {
-      cost.colorless += 1;
-      continue;
-    }
-
-    switch (symbol) {
-      case "W":
-        cost.white += 1;
-        break;
-      case "U":
-        cost.blue += 1;
-        break;
-      case "B":
-        cost.black += 1;
-        break;
-      case "R":
-        cost.red += 1;
-        break;
-      case "G":
-        cost.green += 1;
-        break;
-    }
-  }
-
-  return cost;
 }

--- a/src/lib/game-state/prototype.ts
+++ b/src/lib/game-state/prototype.ts
@@ -1,0 +1,284 @@
+/**
+ * Prototype Keyword System
+ *
+ * Implements the Prototype keyword ability per MTG Comprehensive Rules 702.152.
+ *
+ * CR 702.152 Prototype:
+ * - Prototype is a static ability
+ * - Format: "Prototype [cost] — [power]/[toughness]"
+ * - Allows casting a copy of the card with different P/T and mana cost
+ * - When the prototype permanent enters the battlefield, it enters with prototype values
+ *
+ * Reference: https://cards.highflip.dev/rule/702.152
+ */
+
+import type { CardInstance, CardInstanceId, GameState, PlayerId } from "./types";
+import type { ScryfallCard } from "@/app/actions";
+import { parsePrototype, type PrototypeInfo } from "./oracle-text-parser";
+import { createCardInstance } from "./card-instance";
+import { spendMana } from "./mana";
+import type { ParsedManaCost } from "./oracle-text-parser";
+
+/**
+ * Check if a card has the Prototype keyword
+ * CR 702.152
+ */
+export function hasPrototype(card: CardInstance): boolean {
+  const keywords = card.cardData.keywords || [];
+  return keywords.includes("Prototype");
+}
+
+/**
+ * Get prototype info for a card
+ */
+export function getPrototypeInfo(card: CardInstance): PrototypeInfo {
+  return parsePrototype(card.cardData.oracle_text || "");
+}
+
+/**
+ * Check if a card with prototype can be cast as a prototype
+ */
+export function canCastAsPrototype(
+  state: GameState,
+  playerId: PlayerId,
+  cardInstanceId: CardInstanceId,
+): { canCast: boolean; reason?: string } {
+  const card = state.cards.get(cardInstanceId);
+
+  if (!card) {
+    return { canCast: false, reason: "Card not found" };
+  }
+
+  const prototypeInfo = getPrototypeInfo(card);
+
+  if (!prototypeInfo.hasPrototype) {
+    return { canCast: false, reason: "Card does not have prototype" };
+  }
+
+  // Check if player has priority
+  if (state.priorityPlayerId !== playerId) {
+    return { canCast: false, reason: "You do not have priority" };
+  }
+
+  // Check if card is in hand
+  const handZone = state.zones.get(`${playerId}-hand`);
+  if (!handZone || !handZone.cardIds.includes(cardInstanceId)) {
+    return { canCast: false, reason: "Card is not in hand" };
+  }
+
+  // Check mana cost (prototype version)
+  if (prototypeInfo.prototypeManaCostParsed) {
+    const manaResult = spendMana(
+      state,
+      playerId,
+      prototypeInfo.prototypeManaCostParsed,
+    );
+    if (!manaResult.success) {
+      return { canCast: false, reason: "Not enough mana for prototype cost" };
+    }
+  }
+
+  return { canCast: true };
+}
+
+/**
+ * Create a prototype version of a card with alternative P/T and mana cost
+ * This is used when casting a card as a prototype
+ */
+export function createPrototypeCard(
+  cardData: ScryfallCard,
+  ownerId: PlayerId,
+  controllerId: PlayerId,
+  prototypeInfo: PrototypeInfo,
+): CardInstance {
+  // Create a modified card data with prototype values
+  // The prototype form has different P/T in the type line
+  const prototypeCardData: ScryfallCard = {
+    ...cardData,
+    // Prototype enters with alternative power/toughness
+    // We store the original on the card but use prototype values for the permanent
+  };
+
+  return createCardInstance(prototypeCardData, ownerId, controllerId, {
+    isPrototype: true,
+    prototypePower: prototypeInfo.prototypePower,
+    prototypeToughness: prototypeInfo.prototypeToughness,
+    prototypeManaCost: prototypeInfo.prototypeManaCost,
+  });
+}
+
+/**
+ * Get the effective power for a creature (considering prototype status)
+ * CR 613 - Interaction of Continuous Effects
+ */
+export function getPrototypePower(card: CardInstance): number | null {
+  // If prototype is active and has prototype power, use that
+  if (card.isPrototype && card.prototypePower !== null) {
+    return card.prototypePower;
+  }
+
+  // Otherwise use normal power from card data
+  const powerStr = card.cardData.power;
+  if (!powerStr) return null;
+
+  // Handle variable power like "*"
+  if (powerStr === "*") return 0;
+
+  return parseInt(powerStr, 10);
+}
+
+/**
+ * Get the effective toughness for a creature (considering prototype status)
+ * CR 613 - Interaction of Continuous Effects
+ */
+export function getPrototypeToughness(card: CardInstance): number | null {
+  // If prototype is active and has prototype toughness, use that
+  if (card.isPrototype && card.prototypeToughness !== null) {
+    return card.prototypeToughness;
+  }
+
+  // Otherwise use normal toughness from card data
+  const toughnessStr = card.cardData.toughness;
+  if (!toughnessStr) return null;
+
+  // Handle variable toughness like "*"
+  if (toughnessStr === "*") return 0;
+
+  return parseInt(toughnessStr, 10);
+}
+
+/**
+ * Get the effective mana cost for a card (considering prototype status)
+ */
+export function getPrototypeManaCost(card: CardInstance): string | null {
+  if (card.isPrototype && card.prototypeManaCost) {
+    return card.prototypeManaCost;
+  }
+  return card.cardData.mana_cost || null;
+}
+
+/**
+ * Transform a prototype card back to its normal form
+ * (For prototype permanents that should revert after some effect)
+ * Note: Per CR 702.152, prototype changes are not switching back
+ */
+export function transformFromPrototype(card: CardInstance): CardInstance {
+  if (!card.isPrototype) {
+    return card;
+  }
+
+  return {
+    ...card,
+    isPrototype: false,
+    prototypePower: null,
+    prototypeToughness: null,
+    prototypeManaCost: null,
+  };
+}
+
+/**
+ * Check if a card is currently a prototype permanent
+ */
+export function isPrototypePermanent(card: CardInstance): boolean {
+  return card.isPrototype;
+}
+
+/**
+ * Parse prototype from a card's oracle text and initialize prototype state
+ * Returns updated CardInstance with prototype fields set
+ */
+export function initializePrototype(
+  card: CardInstance,
+): CardInstance {
+  const prototypeInfo = getPrototypeInfo(card);
+
+  if (!prototypeInfo.hasPrototype) {
+    return card;
+  }
+
+  return {
+    ...card,
+    isPrototype: true,
+    prototypePower: prototypeInfo.prototypePower,
+    prototypeToughness: prototypeInfo.prototypeToughness,
+    prototypeManaCost: prototypeInfo.prototypeManaCost,
+  };
+}
+
+/**
+ * Get the mana cost object for a card, considering prototype status
+ * Returns the prototype mana cost if the card is a prototype permanent,
+ * otherwise returns the normal mana cost
+ */
+export function getPrototypeManaCostForSpell(
+  card: CardInstance,
+): ParsedManaCost | null {
+  // If prototype is active and has prototype mana cost, use that
+  if (card.isPrototype && card.prototypeManaCost) {
+    return parseManaCost(card.prototypeManaCost);
+  }
+  // Otherwise use normal mana cost parsing
+  return parseManaCost(card.cardData.mana_cost || "");
+}
+
+/**
+ * Parse a mana cost string into ParsedManaCost
+ */
+function parseManaCost(costString: string): ParsedManaCost | null {
+  if (!costString || costString === "") {
+    return null;
+  }
+
+  const cost: ParsedManaCost = {
+    generic: 0,
+    colorless: 0,
+    white: 0,
+    blue: 0,
+    black: 0,
+    red: 0,
+    green: 0,
+    X: null,
+    snow: 0,
+  };
+
+  const matches = costString.match(/{[^}]+}/g) || [];
+
+  for (const match of matches) {
+    const symbol = match.slice(1, -1);
+
+    if (/^\d+$/.test(symbol)) {
+      cost.generic += parseInt(symbol, 10);
+      continue;
+    }
+
+    if (symbol === "X" || symbol === "x") {
+      cost.X = 0;
+      continue;
+    }
+
+    if (symbol === "C") {
+      cost.colorless += 1;
+      continue;
+    }
+
+    switch (symbol) {
+      case "W":
+        cost.white += 1;
+        break;
+      case "U":
+        cost.blue += 1;
+        break;
+      case "B":
+        cost.black += 1;
+        break;
+      case "R":
+        cost.red += 1;
+        break;
+      case "G":
+        cost.green += 1;
+        break;
+    }
+  }
+
+  return cost;
+}

--- a/src/lib/game-state/spell-casting.ts
+++ b/src/lib/game-state/spell-casting.ts
@@ -25,6 +25,12 @@ import { parseKicker } from "./oracle-text-parser";
 import { checkTriggeredAbilities } from "./abilities";
 import { completeHandTargeting } from "./hand-targeting";
 import { destroyCard } from "./keyword-actions";
+import {
+  getPrototypeInfo,
+  initializePrototype,
+  getPrototypeManaCostForSpell,
+} from "./prototype";
+import type { CardInstance } from "./types";
 
 /**
  * Generate a unique stack object ID

--- a/src/lib/game-state/types.ts
+++ b/src/lib/game-state/types.ts
@@ -89,6 +89,16 @@ export interface CardInstance {
   isToken: boolean;
   /** For tokens, a copy of the token's defining characteristics */
   tokenData: ScryfallCard | null;
+
+  // Prototype-specific (CR 702.152)
+  /** Whether this permanent is currently in prototype form */
+  isPrototype: boolean;
+  /** Prototype alternative power (when in prototype form) */
+  prototypePower: number | null;
+  /** Prototype alternative toughness (when in prototype form) */
+  prototypeToughness: number | null;
+  /** Prototype alternative mana cost string (when in prototype form) */
+  prototypeManaCost: string | null;
 }
 
 /**

--- a/src/test-utils/factories/game-state.ts
+++ b/src/test-utils/factories/game-state.ts
@@ -143,6 +143,11 @@ export function createCardInstance(
     chosenBasicLandType: null,
     isToken: options.isToken || false,
     tokenData: options.isToken ? (cardData as unknown as ScryfallCard) : null,
+    // Prototype fields (CR 702.152)
+    isPrototype: false,
+    prototypePower: null,
+    prototypeToughness: null,
+    prototypeManaCost: null,
   };
 }
 


### PR DESCRIPTION
Closes #770

## Summary by Sourcery

Add support for the Magic: The Gathering Prototype keyword, including parsing, card state representation, and rules interactions.

New Features:
- Detect the Prototype keyword from oracle text and expose structured prototype metadata, including alternative mana cost and power/toughness.
- Introduce a prototype rules module to handle casting cards as prototypes, computing effective stats and mana costs, and managing prototype state on permanents.

Enhancements:
- Extend card instance and power/toughness calculation to respect prototype form stats when applicable.