### PR TITLE
fix(#805): Triggered Ability Stack Ordering - APNAP Implementation (CR 603.3)

### DIFF
--- a/src/lib/game-state/__tests__/abilities.test.ts
+++ b/src/lib/game-state/__tests__/abilities.test.ts
@@ -743,4 +743,137 @@ describe("Abilities System - checkTriggeredAbilities", () => {
     expect(result.abilities[0].sourceCardTimestamp).toBeDefined();
     expect(typeof result.abilities[0].sourceCardTimestamp).toBe("number");
   });
+
+  it("should track triggeringPlayerId for each triggered ability", () => {
+    const playerIds = Array.from(state.players.keys());
+    const bobId = playerIds[1];
+
+    // Place card for Bob
+    const bobCardId = placeCardOnBattlefield(
+      createMockCard({
+        id: "bob-etb-trigger",
+        oracle_text: "When this creature enters the battlefield, draw a card.",
+      }),
+      bobId,
+    );
+
+    const result = checkTriggeredAbilities(state, "entersBattlefield");
+    expect(result.abilities.length).toBe(1);
+    expect(result.abilities[0].triggeringPlayerId).toBe(bobId);
+    expect(result.abilities[0].sourceCardId).toBe(bobCardId);
+  });
+
+  it("should order non-active players by turn order after active player (CR 603.3a)", () => {
+    // Create 3-player game
+    state = createInitialGameState(["Alice", "Bob", "Carol"], 20, false);
+    state = startGame(state);
+    const playerIds = Array.from(state.players.keys());
+    const bobId = playerIds[1];
+    const carolId = playerIds[2];
+
+    // Set Alice as active player
+    state.turn.activePlayerId = playerIds[0];
+
+    // Place cards for Bob and Carol (non-active players)
+    const bobCardId = placeCardOnBattlefield(
+      createMockCard({
+        id: "bob-trigger",
+        oracle_text: "When this creature enters the battlefield, draw a card.",
+      }),
+      bobId,
+    );
+
+    const carolCardId = placeCardOnBattlefield(
+      createMockCard({
+        id: "carol-trigger",
+        oracle_text: "When this creature enters the battlefield, gain 1 life.",
+      }),
+      carolId,
+    );
+
+    const result = checkTriggeredAbilities(state, "entersBattlefield");
+    expect(result.abilities.length).toBe(2);
+    // Bob (next in turn order after active) should be before Carol
+    expect(result.abilities[0].sourceCardId).toBe(bobCardId);
+    expect(result.abilities[1].sourceCardId).toBe(carolCardId);
+  });
+
+  it("should order multiple triggers from same player by sourceCardTimestamp (CR 603.3b)", () => {
+    const playerIds = Array.from(state.players.keys());
+    const bobId = playerIds[1];
+
+    // Set Bob as active player so we test non-active player ordering with same controller
+    state.turn.activePlayerId = bobId;
+
+    // Place first card for Alice (earlier timestamp, non-active player)
+    const card1 = placeCardOnBattlefield(
+      createMockCard({
+        id: "alice-trigger-1",
+        oracle_text: "When this creature enters the battlefield, draw a card.",
+      }),
+      playerIds[0], // Alice
+    );
+
+    // Place second card for Alice (later timestamp, same controller)
+    const card2 = placeCardOnBattlefield(
+      createMockCard({
+        id: "alice-trigger-2",
+        oracle_text: "When this creature enters the battlefield, gain 1 life.",
+      }),
+      playerIds[0], // Alice
+    );
+
+    const result = checkTriggeredAbilities(state, "entersBattlefield");
+    expect(result.abilities.length).toBe(2);
+    // Both are Alice's (non-active) triggers, should be ordered by timestamp
+    expect(result.abilities[0].sourceCardId).toBe(card1);
+    expect(result.abilities[1].sourceCardId).toBe(card2);
+  });
+
+  it("should handle 3+ player scenario with mixed APNAP ordering", () => {
+    // Create 3-player game
+    state = createInitialGameState(["Alice", "Bob", "Carol"], 20, false);
+    state = startGame(state);
+    const playerIds = Array.from(state.players.keys());
+    const bobId = playerIds[1];
+    const carolId = playerIds[2];
+
+    // Set Bob as active player
+    state.turn.activePlayerId = bobId;
+
+    // Place card for Alice (non-active, after Carol in turn order from Bob)
+    const aliceCardId = placeCardOnBattlefield(
+      createMockCard({
+        id: "alice-trigger",
+        oracle_text: "When this creature enters the battlefield, draw a card.",
+      }),
+      playerIds[0], // Alice
+    );
+
+    // Place card for Bob (active player)
+    const bobCardId = placeCardOnBattlefield(
+      createMockCard({
+        id: "bob-trigger",
+        oracle_text: "When this creature enters the battlefield, gain 1 life.",
+      }),
+      bobId,
+    );
+
+    // Place card for Carol (non-active, before Alice in turn order from Bob)
+    const carolCardId = placeCardOnBattlefield(
+      createMockCard({
+        id: "carol-trigger",
+        oracle_text: "When this creature enters the battlefield, scry 1.",
+      }),
+      carolId,
+    );
+
+    const result = checkTriggeredAbilities(state, "entersBattlefield");
+    expect(result.abilities.length).toBe(3);
+    // Turn order from Bob: Bob -> Carol -> Alice
+    // Order should be: Bob (active), then Carol (next), then Alice (last)
+    expect(result.abilities[0].sourceCardId).toBe(bobCardId);
+    expect(result.abilities[1].sourceCardId).toBe(carolCardId);
+    expect(result.abilities[2].sourceCardId).toBe(aliceCardId);
+  });
 });

--- a/src/lib/game-state/abilities.ts
+++ b/src/lib/game-state/abilities.ts
@@ -59,6 +59,10 @@ export interface TriggeredAbilityResult {
 export interface TriggeredAbilityInstance {
   id: string;
   sourceCardId: CardInstanceId;
+  /**
+   * The player who controls the card and whose trigger fired (CR 603.3)
+   */
+  triggeringPlayerId: PlayerId;
   triggerCondition: string;
   effect: string;
   timestamp: number;
@@ -649,6 +653,7 @@ export function detectTriggeredAbilities(
         triggeredAbilities.push({
           id: generateTriggeredAbilityId(),
           sourceCardId: cardId,
+          triggeringPlayerId: card.controllerId,
           triggerCondition: ability.trigger.event,
           effect: ability.effect,
           timestamp: Date.now(),
@@ -660,22 +665,48 @@ export function detectTriggeredAbilities(
 
   // Sort triggered abilities according to CR 603.3:
   // 603.3a: Abilities that trigger at the same time are put on the stack in APNAP order
+  //         Active player puts their abilities on stack first (in any order they choose)
+  //         Non-active players follow in turn order
   // 603.3b: Abilities with the same timestamp are ordered by the cards timestamp in the zone
   triggeredAbilities.sort((a, b) => {
-    // CR 603.3: Abilities that trigger at the same time are put on the stack in APNAP order
-    // First: APNAP order - active player's abilities resolve first
-    const aCard = state.cards.get(a.sourceCardId);
-    const bCard = state.cards.get(b.sourceCardId);
-    if (!aCard || !bCard) return 0;
-
     const activePlayerId = state.turn.activePlayerId;
-    const aIsActive = aCard.controllerId === activePlayerId;
-    const bIsActive = bCard.controllerId === activePlayerId;
+    const playerIds = Array.from(state.players.keys());
 
-    if (aIsActive && !bIsActive) return -1; // Active player first
-    if (!aIsActive && bIsActive) return 1; // Inactive player after active
+    // Check if a or b is the active player
+    const aIsActive = a.triggeringPlayerId === activePlayerId;
+    const bIsActive = b.triggeringPlayerId === activePlayerId;
 
-    // Second: same controller, order by source card's timestamp in zone (CR 603.3b)
+    // Active player abilities go first (CR 603.3a)
+    if (aIsActive && !bIsActive) return -1;
+    if (!aIsActive && bIsActive) return 1;
+
+    // Both are active player's abilities - use sourceCardTimestamp (CR 603.3b)
+    if (aIsActive && bIsActive) {
+      if (a.sourceCardTimestamp !== b.sourceCardTimestamp) {
+        return a.sourceCardTimestamp - b.sourceCardTimestamp;
+      }
+      return 0;
+    }
+
+    // Both are non-active players - use turn order (CR 603.3a)
+    // Get turn order position for non-active players
+    const activeIndex = playerIds.indexOf(activePlayerId);
+    const aPosition =
+      (playerIds.indexOf(a.triggeringPlayerId) -
+        activeIndex +
+        playerIds.length) %
+      playerIds.length;
+    const bPosition =
+      (playerIds.indexOf(b.triggeringPlayerId) -
+        activeIndex +
+        playerIds.length) %
+      playerIds.length;
+
+    if (aPosition !== bPosition) {
+      return aPosition - bPosition;
+    }
+
+    // Same non-active player - use sourceCardTimestamp (CR 603.3b)
     if (a.sourceCardTimestamp !== b.sourceCardTimestamp) {
       return a.sourceCardTimestamp - b.sourceCardTimestamp;
     }


### PR DESCRIPTION
Implements CR 603.3 APNAP ordering for triggered abilities that trigger simultaneously.

## Changes
- Added triggeringPlayerId to TriggeredAbilityInstance interface
- Updated detectTriggeredAbilities() to populate triggeringPlayerId
- Implemented full APNAP ordering: active player first, then non-active players in turn order

## Tests Added
- triggeringPlayerId tracking verification
- 2-player APNAP ordering (active player first)
- 3+ player turn order (non-active players follow active)
- Multiple triggers from same player ordered by timestamp
- 3+ player scenario with mixed APNAP ordering