### PR TITLE
fix: enforce Layer 7 sublayer dependencies per CR 613.8

### DIFF
--- a/src/lib/game-state/layer-system.ts
+++ b/src/lib/game-state/layer-system.ts
@@ -76,11 +76,27 @@ export const LAYER_7_SUBLAYER_DEPENDENCIES: ReadonlyMap<
   PowerToughnessSublayer,
   PowerToughnessSublayer[]
 > = new Map([
-  [PowerToughnessSublayer.CHARACTERISTIC_DEFINING, []], // 7a depends on nothing in our model
-  [PowerToughnessSublayer.SET, []], // 7b depends on nothing
-  [PowerToughnessSublayer.COUNTERS, []], // 7c depends on nothing
-  [PowerToughnessSublayer.SWITCH, []], // 7d depends on nothing
-  [PowerToughnessSublayer.MODIFY, []], // 7e depends on nothing
+  // CR 613.8: Earlier sublayers must apply BEFORE later ones (dependence flows down)
+  // 7a (CDA) depends on nothing - applies first, later effects can modify it
+  [PowerToughnessSublayer.CHARACTERISTIC_DEFINING, []],
+  // 7b (Set P/T) depends on 7c, 7d, 7e - must apply before counters/switch/modify
+  [
+    PowerToughnessSublayer.SET,
+    [
+      PowerToughnessSublayer.COUNTERS,
+      PowerToughnessSublayer.SWITCH,
+      PowerToughnessSublayer.MODIFY,
+    ],
+  ],
+  // 7c (Counters) depends on 7d, 7e - must apply before switch/modify
+  [
+    PowerToughnessSublayer.COUNTERS,
+    [PowerToughnessSublayer.SWITCH, PowerToughnessSublayer.MODIFY],
+  ],
+  // 7d (Switch P/T) depends on 7e - must apply before modify
+  [PowerToughnessSublayer.SWITCH, [PowerToughnessSublayer.MODIFY]],
+  // 7e (Modify P/T) depends on nothing - applies last
+  [PowerToughnessSublayer.MODIFY, []],
 ]);
 
 /**


### PR DESCRIPTION
## Summary
Fixed LAYER_7_SUBLAYER_DEPENDENCIES to correctly model the dependency order per CR 613.8.

## Changes
Updated LAYER_7_SUBLAYER_DEPENDENCIES map with correct dependency graph:
- 7b (Set P/T) depends on 7c, 7d, 7e (must apply before them)
- 7c (Counters) depends on 7d, 7e
- 7d (Switch P/T) depends on 7e
- 7e (Modify P/T) depends on nothing

Previously all sublayers had empty dependency arrays.

## Issue
Fixes #814

## Testing
npm test -- --grep="layer"

## Summary by Sourcery

Bug Fixes:
- Correct Layer 7 sublayer dependency graph so set, counter, switch, and modify effects resolve in the proper order.