### PR TITLE
fix: Layer 2 control-changing effects update controllerId (#827)

### DIFF
--- a/src/lib/game-state/__tests__/layer-system.test.ts
+++ b/src/lib/game-state/__tests__/layer-system.test.ts
@@ -110,6 +110,7 @@ describe("Layer System", () => {
         "player1",
         "player2",
         "Change control",
+        layerSystem,
       );
 
       layerSystem.registerEffect(ptEffect);
@@ -246,12 +247,33 @@ describe("Layer System", () => {
         "player1",
         "player2",
         "Gain control",
+        layerSystem,
       );
 
       layerSystem.registerEffect(controlEffect);
       const result = layerSystem.applyEffects(creature);
 
       expect(result.controllerId).toBe("player2");
+    });
+
+    it("should persist controllerId change in overrides", () => {
+      const creatureData = createMockCreature("Test Creature", 3, 3);
+      const creature = createCardInstance(creatureData, "player1", "player1");
+
+      const controlEffect = createControlChangeEffect(
+        "source",
+        "player1",
+        "player2",
+        "Gain control",
+        layerSystem,
+      );
+
+      layerSystem.registerEffect(controlEffect);
+      layerSystem.applyEffects(creature);
+
+      // Check that controllerId is stored in overrides for persistence
+      const characteristics = layerSystem.getEffectiveCharacteristics(creature);
+      expect(characteristics.controllerId).toBe("player2");
     });
 
     it("should only apply to cards controlled by the specified player", () => {
@@ -263,6 +285,7 @@ describe("Layer System", () => {
         "player1",
         "player2",
         "Gain control",
+        layerSystem,
       );
 
       expect(controlEffect.canApply(creature)).toBe(false);

--- a/src/lib/game-state/layer-system.ts
+++ b/src/lib/game-state/layer-system.ts
@@ -240,6 +240,8 @@ export interface CardOverrides {
   toughnessSet?: number;
   /** Whether power/toughness are switched */
   switched?: boolean;
+  /** Controller ID (Layer 2 - CR 613.3) */
+  controllerId?: PlayerId;
 }
 
 /**
@@ -584,6 +586,7 @@ export class LayerSystem {
     oracleText: string;
     grantedAbilities: string[];
     removedAbilities: string[];
+    controllerId?: PlayerId;
   } {
     const modified = this.applyEffects(card);
     const cardData = modified.cardData;
@@ -614,6 +617,7 @@ export class LayerSystem {
       oracleText: overrides.text || cardData.oracle_text || "",
       grantedAbilities: overrides.grantedAbilities || [],
       removedAbilities: overrides.removedAbilities || [],
+      controllerId: overrides.controllerId || modified.controllerId,
     };
   }
 
@@ -787,6 +791,7 @@ export function createControlChangeEffect(
   controllerId: PlayerId,
   newControllerId: PlayerId,
   description: string,
+  layerSystemInstance?: LayerSystem,
 ): ContinuousEffect {
   return {
     id: `control-${sourceCardId}-${Date.now()}`,
@@ -798,10 +803,12 @@ export function createControlChangeEffect(
     timestamp: Date.now(),
     priority: 0,
     canApply: (card) => card.controllerId === controllerId,
-    apply: (card) => ({
-      ...card,
-      controllerId: newControllerId,
-    }),
+    apply: (card) => {
+      const ls = layerSystemInstance || getLayerSystemInstance();
+      const overrides = ls.getOverrides(card.id);
+      overrides.controllerId = newControllerId;
+      return { ...card, controllerId: newControllerId };
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

Layer 2 control-changing effects like Corrupted Conscience were updating  on the returned card instance during , but the change was not being persisted to the  map.

### Changes

1. ** interface**: Added  field for Layer 2 control-changing effects (CR 613.3)

2. ****: Now stores  in  via  for persistence, not just returning modified card

3. ****: Returns  from overrides if present, providing effective controller after layer effects

4. **Tests**: Updated existing test to pass  instance, added new test 

### Technical Details

The issue was that control changes were ephemeral - returning modified card from  but not storing the override. Other layer effects (type, color, P/T) use  which is accessed via , but control change was the exception. Now control change also stores in overrides for consistent persistence.

Closes #827