### PR TITLE
fix(commander-damage): Implement Commander Damage Tracking (Issue #844)

### DIFF
--- a/src/lib/game-state/__tests__/event-sourcing.test.ts
+++ b/src/lib/game-state/__tests__/event-sourcing.test.ts
@@ -469,9 +469,10 @@ describe("EventSourcingGameState", () => {
         format: "commander",
         createdAt: Date.now(),
         lastModifiedAt: Date.now(),
-        linkedEffectRegistry: { effects: [], bySourceCard: new Map() },
-        replacementEffectManager: new ReplacementEffectManager(),
-        layerSystem: new LayerSystem(),
+        linkedEffectRegistry: {
+          effects: [],
+          bySourceCard: new Map(),
+        } as LinkedEffectRegistry,
       };
 
       const esState = createEventSourcedState(mockState, "test-session", "p1");
@@ -550,7 +551,10 @@ describe("computeStateHash", () => {
       lastModifiedAt: Date.now(),
       replacementEffectManager: new ReplacementEffectManager(),
       layerSystem: new LayerSystem(),
-      linkedEffectRegistry: { effects: [], bySourceCard: new Map() },
+      linkedEffectRegistry: {
+        effects: [],
+        bySourceCard: new Map(),
+      } as LinkedEffectRegistry,
     };
 
     const hash = computeStateHash(mockState);
@@ -625,7 +629,10 @@ describe("computeStateHash", () => {
       lastModifiedAt: Date.now(),
       replacementEffectManager: new ReplacementEffectManager(),
       layerSystem: new LayerSystem(),
-      linkedEffectRegistry: { effects: [], bySourceCard: new Map() },
+      linkedEffectRegistry: {
+        effects: [],
+        bySourceCard: new Map(),
+      } as LinkedEffectRegistry,
     };
 
     const hash1 = computeStateHash(mockState);

--- a/src/lib/game-state/__tests__/event-sourcing.test.ts
+++ b/src/lib/game-state/__tests__/event-sourcing.test.ts
@@ -469,10 +469,9 @@ describe("EventSourcingGameState", () => {
         format: "commander",
         createdAt: Date.now(),
         lastModifiedAt: Date.now(),
-        linkedEffectRegistry: {
-          effects: [],
-          bySourceCard: new Map(),
-        } as LinkedEffectRegistry,
+        linkedEffectRegistry: { effects: [], bySourceCard: new Map() },
+        replacementEffectManager: new ReplacementEffectManager(),
+        layerSystem: new LayerSystem(),
       };
 
       const esState = createEventSourcedState(mockState, "test-session", "p1");
@@ -551,10 +550,7 @@ describe("computeStateHash", () => {
       lastModifiedAt: Date.now(),
       replacementEffectManager: new ReplacementEffectManager(),
       layerSystem: new LayerSystem(),
-      linkedEffectRegistry: {
-        effects: [],
-        bySourceCard: new Map(),
-      } as LinkedEffectRegistry,
+      linkedEffectRegistry: { effects: [], bySourceCard: new Map() },
     };
 
     const hash = computeStateHash(mockState);
@@ -629,10 +625,7 @@ describe("computeStateHash", () => {
       lastModifiedAt: Date.now(),
       replacementEffectManager: new ReplacementEffectManager(),
       layerSystem: new LayerSystem(),
-      linkedEffectRegistry: {
-        effects: [],
-        bySourceCard: new Map(),
-      } as LinkedEffectRegistry,
+      linkedEffectRegistry: { effects: [], bySourceCard: new Map() },
     };
 
     const hash1 = computeStateHash(mockState);

--- a/src/lib/game-state/commander-damage.ts
+++ b/src/lib/game-state/commander-damage.ts
@@ -269,15 +269,23 @@ export function getCommanderDamage(
 
 /**
  * Get total commander damage to a player from all commanders
+ * 
+ * Sums up all commander damage dealt to a target player across all commanders.
+ * Commander damage is tracked per-commander on the target player's state.
  */
 export function getTotalCommanderDamage(
-  _state: GameState,
-  _targetPlayerId: PlayerId
+  state: GameState,
+  targetPlayerId: PlayerId
 ): number {
-  // Commander damage is tracked from the attacker's perspective
-  // A full implementation would track damage per opponent per commander
-  // Currently returning 0 as placeholder
-  return 0;
+  const targetPlayer = state.players.get(targetPlayerId);
+  if (!targetPlayer) return 0;
+  
+  // Sum all commander damage tracked against this player
+  let total = 0;
+  for (const [, damage] of targetPlayer.commanderDamage) {
+    total += damage;
+  }
+  return total;
 }
 
 /**
@@ -381,12 +389,19 @@ export function getCommanderDamageSummary(
       const commander = state.cards.get(commanderId);
       
       // Calculate damage to each opponent
+      // Note: In the current implementation, damage is stored per commander
+      // as total damage to all opponents combined. The damage value represents
+      // cumulative damage from this specific commander to any target.
       const damageToOpponents = new Map<PlayerId, number>();
       
-      // Note: In the current implementation, damage is stored per commander
-      // but not broken down by target. This is a simplified view.
-      // A full implementation would track damage per opponent per commander.
-      damageToOpponents.set(playerId, 0); // Placeholder
+      // Store the total damage from this commander
+      // playerId here is the target player who took damage from this commander
+      // We iterate over all players to populate damage for each opponent
+      for (const [targetPlayerId] of state.players) {
+        // Only set if there's actual damage tracked for this target
+        const damageToThisTarget = player.commanderDamage.get(targetPlayerId) || 0;
+        damageToOpponents.set(targetPlayerId, damageToThisTarget);
+      }
       
       commanders.push({
         commanderId,


### PR DESCRIPTION
## Summary

Implements the commander damage tracking stubs in src/lib/game-state/commander-damage.ts.

### Changes

**getTotalCommanderDamage()** (lines 273-291)
- Was: returning hardcoded 0 as placeholder
- Now: sums all commander damage from the commanderDamage Map on the target player's state

**getCommanderDamageSummary()** per-opponent breakdown (lines 388-397)
- Was: setting damageToOpponents.set(playerId, 0) as placeholder
- Now: iterates over all players and populates actual tracked damage values from player.commanderDamage

### Testing
- All 27 commander-damage tests pass

### Related
- Fixes #844