### PR TITLE
fix(indexeddb): abort transaction on setAll error (#887)

### DIFF
--- a/src/lib/__tests__/indexeddb-storage.test.ts
+++ b/src/lib/__tests__/indexeddb-storage.test.ts
@@ -185,6 +185,39 @@ describe("IndexedDB Storage", () => {
       expect(allDecks).toHaveLength(2);
     });
 
+    it("should properly handle setAll with empty array", async () => {
+      // Empty array should return early without error
+      await expect(storage.setAll("test-decks", [])).resolves.toBeUndefined();
+    });
+
+    it("should handle setAll followed by successful operations", async () => {
+      // First add some valid data
+      const validData = [
+        {
+          id: "valid-1",
+          name: "Valid Deck 1",
+          format: "standard",
+          cards: [],
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          metadata: {},
+        },
+        {
+          id: "valid-2",
+          name: "Valid Deck 2",
+          format: "modern",
+          cards: [],
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          metadata: {},
+        },
+      ];
+
+      await storage.setAll("test-decks", validData);
+      const decks = await storage.getAll("test-decks");
+      expect(decks).toHaveLength(2);
+    });
+
     it("should delete a value", async () => {
       const testData = {
         id: "test-1",

--- a/src/lib/indexeddb-storage.ts
+++ b/src/lib/indexeddb-storage.ts
@@ -353,26 +353,32 @@ export class IndexedDBStorage {
       const transaction = this.db!.transaction(storeName, "readwrite");
       const store = transaction.objectStore(storeName);
 
+      // Catch fatal transaction errors
+      transaction.onerror = () => {
+        reject(new Error(`Transaction failed: ${transaction.error}`));
+      };
+
       let completed = 0;
-      let error: Error | null = null;
+      let hasError = false;
 
       for (const value of values) {
+        // Skip if we've already encountered an error
+        if (hasError) break;
+
         const request = store.put(value);
 
         request.onsuccess = () => {
           completed++;
           if (completed === values.length) {
-            if (error) {
-              reject(error);
-            } else {
-              resolve();
-            }
+            resolve();
           }
         };
 
         request.onerror = () => {
-          if (!error) {
-            error = new Error(`Failed to set item: ${request.error}`);
+          if (!hasError) {
+            hasError = true;
+            transaction.abort();
+            reject(new Error(`Failed to set item: ${request.error}`));
           }
         };
       }


### PR DESCRIPTION
## Summary

**Issue**: CRITICAL: IndexedDB setAll does not abort transaction on error

**Root Cause**: In the setAll method of IndexedDBStorage, when a put operation failed:
1. The error was captured but the transaction was never aborted
2. Processing continued for all remaining items even after an error
3. The transaction could end up in an inconsistent state

**Fix**:
1. Added transaction.onerror handler to catch fatal transaction errors
2. Call transaction.abort() immediately when a put operation fails
3. Stop processing remaining items after an error by breaking from the loop
4. Changed error handling flow to properly reject with the error message

**Files Changed**:
- src/lib/indexeddb-storage.ts - Fixed error handling in setAll method
- src/lib/__tests__/indexeddb-storage.test.ts - Added tests for empty array and sequential operations

**Testing**: All 46 IndexedDB storage tests pass

## Summary by Sourcery

Improve IndexedDBStorage.setAll transaction error handling to ensure failures abort the transaction and correctly reject the operation.

Bug Fixes:
- Abort the IndexedDB transaction and stop further writes when a setAll put operation fails, preventing inconsistent transaction state.
- Surface transaction-level failures via a transaction.onerror handler so callers receive proper error messages from setAll.

Tests:
- Add tests covering setAll with an empty array and sequential successful setAll operations to validate behavior and regression prevention.