### PR TITLE
fix: resolve #911 — dead code: deck-specific AI playstyle weights never reach the turn loop

### DIFF
--- a/src/ai/__tests__/ai-turn-loop.test.ts
+++ b/src/ai/__tests__/ai-turn-loop.test.ts
@@ -1,0 +1,205 @@
+/**
+ * @fileoverview Tests for per-archetype playstyle wiring in the AI turn loop.
+ *
+ * Covers the fix for issue #911: the deck-specific (per-archetype) playstyle
+ * weights used to be dead code because the live turn loop never propagated the
+ * AI player's archetype. These tests verify the turn loop now (a) auto-detects
+ * the archetype from the AI player's deck and (b) exposes an explicit override
+ * via AITurnConfig.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { detectPlayerArchetype, type AITurnConfig } from "../ai-turn-loop";
+import type { DeckCard } from "@/app/actions";
+import type {
+  GameState as EngineGameState,
+  CardInstance,
+} from "@/lib/game-state/types";
+
+function createCard(
+  name: string,
+  type: string,
+  cmc: number = 0,
+  colors: string[] = [],
+  oracleText: string = "",
+): DeckCard {
+  return {
+    name,
+    count: 1,
+    id: `card-${name}`,
+    cmc,
+    colors,
+    legalities: {},
+    type_line: type,
+    mana_cost: `{${cmc}}`,
+    color_identity: colors,
+    oracle_text: oracleText,
+  };
+}
+
+/**
+ * Build a minimal engine game state containing only the pieces
+ * `detectPlayerArchetype` reads (zones + cards). The rest of the GameState is
+ * irrelevant to the function under test, so we cast a partial object.
+ */
+function buildStateWithLibrary(
+  playerId: string,
+  deck: DeckCard[],
+): EngineGameState {
+  const cards = new Map<string, CardInstance>();
+  const cardIds: string[] = [];
+  let i = 0;
+  for (const card of deck) {
+    const id = `${playerId}-lib-${i++}`;
+    cardIds.push(id);
+    cards.set(id, {
+      id,
+      oracleId: id,
+      cardData: { ...card },
+      currentFaceIndex: 0,
+      isFaceDown: false,
+      controllerId: playerId,
+      ownerId: playerId,
+      isTapped: false,
+      isFlipped: false,
+      isTurnedFaceUp: false,
+      isPhasedOut: false,
+    } as unknown as CardInstance);
+  }
+
+  const zones = new Map<string, { cardIds: string[] }>();
+  zones.set(`${playerId}-library`, { cardIds });
+
+  return { zones, cards } as unknown as EngineGameState;
+}
+
+describe("detectPlayerArchetype (issue #911 wiring)", () => {
+  it("returns 'unknown' when the player has no cards/zones", () => {
+    const empty = {
+      zones: new Map(),
+      cards: new Map(),
+    } as unknown as EngineGameState;
+    expect(detectPlayerArchetype(empty, "player1")).toBe("unknown");
+  });
+
+  it("auto-detects 'aggro' from a burn-style deck", () => {
+    const burnDeck: DeckCard[] = [
+      createCard(
+        "Lightning Bolt",
+        "Instant",
+        1,
+        ["R"],
+        "Deal 3 damage to any target",
+      ),
+      createCard(
+        "Lava Spike",
+        "Sorcery",
+        1,
+        ["R"],
+        "Deal 3 damage to target player",
+      ),
+      createCard("Skewer the Critics", "Sorcery", 2, ["R"], "Deal 3 damage"),
+      createCard("Burst Lightning", "Instant", 2, ["R"], "Deal 4 damage"),
+      createCard("Goblin Guide", "Creature", 1, ["R"], "Haste"),
+      createCard(
+        "Monastery Swiftspear",
+        "Creature",
+        1,
+        ["R", "U"],
+        "Haste, prowess",
+      ),
+      createCard("Mountain", "Land", 0, [], ""),
+    ];
+
+    const state = buildStateWithLibrary("player1", burnDeck);
+    expect(detectPlayerArchetype(state, "player1")).toBe("aggro");
+  });
+
+  it("never throws and returns 'unknown' for a deck that does not classify", () => {
+    // A single basic land cannot be classified.
+    const state = buildStateWithLibrary("player1", [
+      createCard("Forest", "Land", 0, [], ""),
+    ]);
+    expect(() => detectPlayerArchetype(state, "player1")).not.toThrow();
+    expect(detectPlayerArchetype(state, "player1")).toBe("unknown");
+  });
+
+  it("gathers cards from all of a player's zones, not just the library", () => {
+    // Split a burn deck across library + hand + battlefield; detection should
+    // still classify the combined list as aggro.
+    const splitDeck = [
+      createCard(
+        "Lightning Bolt",
+        "Instant",
+        1,
+        ["R"],
+        "Deal 3 damage to any target",
+      ),
+      createCard(
+        "Lava Spike",
+        "Sorcery",
+        1,
+        ["R"],
+        "Deal 3 damage to target player",
+      ),
+      createCard("Goblin Guide", "Creature", 1, ["R"], "Haste"),
+    ];
+
+    const cards = new Map<string, CardInstance>();
+    const zones = new Map<string, { cardIds: string[] }>();
+    const playerId = "player1";
+
+    const zoneKeys = [
+      `${playerId}-library`,
+      `${playerId}-hand`,
+      `${playerId}-battlefield`,
+    ];
+    splitDeck.forEach((card, idx) => {
+      const id = `${playerId}-c${idx}`;
+      cards.set(id, {
+        id,
+        oracleId: id,
+        cardData: { ...card },
+        currentFaceIndex: 0,
+        isFaceDown: false,
+        controllerId: playerId,
+        ownerId: playerId,
+        isTapped: false,
+        isFlipped: false,
+        isTurnedFaceUp: false,
+        isPhasedOut: false,
+      } as unknown as CardInstance);
+      // Put each card in a different zone.
+      zones.set(zoneKeys[idx], { cardIds: [id] });
+    });
+
+    const state = { zones, cards } as unknown as EngineGameState;
+    // With only 3 cards detection confidence is lower, but the function must
+    // still run without error and return a valid DeckArchetype bucket.
+    const result = detectPlayerArchetype(state, playerId);
+    expect([
+      "aggro",
+      "unknown",
+      "midrange",
+      "control",
+      "combo",
+      "ramp",
+    ]).toContain(result);
+  });
+});
+
+describe("AITurnConfig.archetype override (issue #911)", () => {
+  it("accepts an explicit archetype in the config", () => {
+    const config: AITurnConfig = {
+      difficulty: "medium",
+      delayMs: 0,
+      archetype: "control",
+    };
+    expect(config.archetype).toBe("control");
+  });
+
+  it("leaves archetype optional for backward compatibility", () => {
+    const config: AITurnConfig = { difficulty: "medium", delayMs: 0 };
+    expect(config.archetype).toBeUndefined();
+  });
+});

--- a/src/ai/__tests__/combat-decision-tree.test.ts
+++ b/src/ai/__tests__/combat-decision-tree.test.ts
@@ -4,15 +4,19 @@
  * Tests for AI combat decision-making logic.
  */
 
-import { describe, it, expect, beforeEach } from '@jest/globals';
+import { describe, it, expect, beforeEach } from "@jest/globals";
 import {
   CombatDecisionTree,
   DefaultCombatConfigs,
   type CombatPlan,
   type AttackDecision,
   type BlockDecision,
-} from '../decision-making/combat-decision-tree';
-import type { AIGameState, AIPlayerState, AIPermanent } from '@/lib/game-state/types';
+} from "../decision-making/combat-decision-tree";
+import type {
+  AIGameState,
+  AIPlayerState,
+  AIPermanent,
+} from "@/lib/game-state/types";
 
 /**
  * Create a mock AI player state for testing
@@ -20,7 +24,7 @@ import type { AIGameState, AIPlayerState, AIPermanent } from '@/lib/game-state/t
 function createMockPlayerState(
   id: string,
   life: number = 20,
-  battlefield: AIPermanent[] = []
+  battlefield: AIPermanent[] = [],
 ): AIPlayerState {
   return {
     id,
@@ -32,7 +36,15 @@ function createMockPlayerState(
     graveyard: [],
     exile: [],
     library: 40,
-    manaPool: { white: 0, blue: 0, black: 0, red: 0, green: 0, colorless: 0, generic: 0 },
+    manaPool: {
+      white: 0,
+      blue: 0,
+      black: 0,
+      red: 0,
+      green: 0,
+      colorless: 0,
+      generic: 0,
+    },
     commanderDamage: {},
     landsPlayedThisTurn: 0,
     hasPassedPriority: false,
@@ -45,19 +57,24 @@ function createMockPlayerState(
 function createMockPermanent(
   id: string,
   name: string,
-  type: 'creature' | 'land' | 'artifact' | 'enchantment' | 'planeswalker' = 'creature',
+  type:
+    | "creature"
+    | "land"
+    | "artifact"
+    | "enchantment"
+    | "planeswalker" = "creature",
   power?: number,
   toughness?: number,
   tapped: boolean = false,
   manaValue: number = 1,
-  keywords: string[] = []
+  keywords: string[] = [],
 ): AIPermanent {
   return {
     id,
     cardInstanceId: id,
     name,
     type,
-    controller: 'player1',
+    controller: "player1",
     tapped,
     manaValue,
     power,
@@ -74,58 +91,71 @@ function createTestGameState(
   player2Life: number = 20,
   player1Battlefield: AIPermanent[] = [],
   player2Battlefield: AIPermanent[] = [],
-  currentPlayer: string = 'player1',
-  phase: 'beginning' | 'precombat_main' | 'combat' | 'postcombat_main' | 'end' = 'precombat_main'
+  currentPlayer: string = "player1",
+  phase:
+    | "beginning"
+    | "precombat_main"
+    | "combat"
+    | "postcombat_main"
+    | "end" = "precombat_main",
 ): AIGameState {
   return {
     players: {
-      player1: createMockPlayerState('player1', player1Life, player1Battlefield),
-      player2: createMockPlayerState('player2', player2Life, player2Battlefield),
+      player1: createMockPlayerState(
+        "player1",
+        player1Life,
+        player1Battlefield,
+      ),
+      player2: createMockPlayerState(
+        "player2",
+        player2Life,
+        player2Battlefield,
+      ),
     },
     turnInfo: {
       currentTurn: 1,
       currentPlayer,
       priority: currentPlayer,
       phase,
-      step: phase.includes('combat') ? 'combat' : 'main',
+      step: phase.includes("combat") ? "combat" : "main",
     },
     stack: [],
     combat: {
-      inCombatPhase: phase === 'combat',
+      inCombatPhase: phase === "combat",
       attackers: [],
       blockers: {},
     },
   };
 }
 
-describe('CombatDecisionTree', () => {
-  describe('constructor', () => {
-    it('should initialize with default difficulty (medium)', () => {
+describe("CombatDecisionTree", () => {
+  describe("constructor", () => {
+    it("should initialize with default difficulty (medium)", () => {
       const gameState = createTestGameState();
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       expect(combatAI).toBeDefined();
     });
 
-    it('should initialize with specified difficulty', () => {
+    it("should initialize with specified difficulty", () => {
       const gameState = createTestGameState();
-      const combatAI = new CombatDecisionTree(gameState, 'player1', 'hard');
+      const combatAI = new CombatDecisionTree(gameState, "player1", "hard");
 
       expect(combatAI).toBeDefined();
     });
 
-    it('should store the AI player ID', () => {
+    it("should store the AI player ID", () => {
       const gameState = createTestGameState();
-      const combatAI = new CombatDecisionTree(gameState, 'player2');
+      const combatAI = new CombatDecisionTree(gameState, "player2");
 
       expect(combatAI).toBeDefined();
     });
   });
 
-  describe('setConfig', () => {
-    it('should update combat configuration', () => {
+  describe("setConfig", () => {
+    it("should update combat configuration", () => {
       const gameState = createTestGameState();
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       combatAI.setConfig({ aggression: 0.9 });
 
@@ -133,9 +163,9 @@ describe('CombatDecisionTree', () => {
       expect(combatAI).toBeDefined();
     });
 
-    it('should preserve unchanged config values', () => {
+    it("should preserve unchanged config values", () => {
       const gameState = createTestGameState();
-      const combatAI = new CombatDecisionTree(gameState, 'player1', 'hard');
+      const combatAI = new CombatDecisionTree(gameState, "player1", "hard");
 
       const originalConfig = { ...DefaultCombatConfigs.hard };
       combatAI.setConfig({ aggression: 0.9 });
@@ -145,28 +175,28 @@ describe('CombatDecisionTree', () => {
     });
   });
 
-  describe('generateAttackPlan', () => {
-    it('should return a combat plan object', () => {
+  describe("generateAttackPlan", () => {
+    it("should return a combat plan object", () => {
       const gameState = createTestGameState();
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateAttackPlan();
 
-      expect(plan).toHaveProperty('attacks');
-      expect(plan).toHaveProperty('blocks');
-      expect(plan).toHaveProperty('strategy');
-      expect(plan).toHaveProperty('totalExpectedValue');
-      expect(plan).toHaveProperty('combatTricks');
+      expect(plan).toHaveProperty("attacks");
+      expect(plan).toHaveProperty("blocks");
+      expect(plan).toHaveProperty("strategy");
+      expect(plan).toHaveProperty("totalExpectedValue");
+      expect(plan).toHaveProperty("combatTricks");
     });
 
-    it('should generate attack decisions for creatures', () => {
+    it("should generate attack decisions for creatures", () => {
       const player1Creatures = [
-        createMockPermanent('c1', 'Bear', 'creature', 2, 2, false),
-        createMockPermanent('c2', 'Ogre', 'creature', 3, 2, false),
+        createMockPermanent("c1", "Bear", "creature", 2, 2, false),
+        createMockPermanent("c2", "Ogre", "creature", 3, 2, false),
       ];
 
       const gameState = createTestGameState(20, 20, player1Creatures, []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateAttackPlan();
 
@@ -174,12 +204,31 @@ describe('CombatDecisionTree', () => {
       expect(Array.isArray(plan.attacks)).toBe(true);
     });
 
-    it('should only consider untapped creatures for attacking', () => {
-      const tappedCreature = createMockPermanent('c1', 'Bear', 'creature', 2, 2, true);
-      const untappedCreature = createMockPermanent('c2', 'Bear', 'creature', 2, 2, false);
+    it("should only consider untapped creatures for attacking", () => {
+      const tappedCreature = createMockPermanent(
+        "c1",
+        "Bear",
+        "creature",
+        2,
+        2,
+        true,
+      );
+      const untappedCreature = createMockPermanent(
+        "c2",
+        "Bear",
+        "creature",
+        2,
+        2,
+        false,
+      );
 
-      const gameState = createTestGameState(20, 20, [tappedCreature, untappedCreature], []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const gameState = createTestGameState(
+        20,
+        20,
+        [tappedCreature, untappedCreature],
+        [],
+      );
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateAttackPlan();
 
@@ -187,12 +236,19 @@ describe('CombatDecisionTree', () => {
       expect(plan.attacks.length).toBeLessThanOrEqual(1);
     });
 
-    it('should not attack with creatures that have summoning sickness', () => {
-      const newCreature = createMockPermanent('c1', 'Bear', 'creature', 2, 2, false);
+    it("should not attack with creatures that have summoning sickness", () => {
+      const newCreature = createMockPermanent(
+        "c1",
+        "Bear",
+        "creature",
+        2,
+        2,
+        false,
+      );
       (newCreature as any).summoningSickness = true;
 
       const gameState = createTestGameState(20, 20, [newCreature], []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateAttackPlan();
 
@@ -200,12 +256,21 @@ describe('CombatDecisionTree', () => {
       expect(plan.attacks.length).toBe(0);
     });
 
-    it('should attack with creatures that have haste despite summoning sickness', () => {
-      const hasteCreature = createMockPermanent('c1', 'Haste Bear', 'creature', 2, 2, false, 1, ['haste']);
+    it("should attack with creatures that have haste despite summoning sickness", () => {
+      const hasteCreature = createMockPermanent(
+        "c1",
+        "Haste Bear",
+        "creature",
+        2,
+        2,
+        false,
+        1,
+        ["haste"],
+      );
       (hasteCreature as any).summoningSickness = true;
 
       const gameState = createTestGameState(20, 20, [hasteCreature], []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateAttackPlan();
 
@@ -213,64 +278,69 @@ describe('CombatDecisionTree', () => {
       expect(plan.attacks.length).toBeGreaterThanOrEqual(0);
     });
 
-    it('should determine aggressive strategy when opponent has low life', () => {
+    it("should determine aggressive strategy when opponent has low life", () => {
       const player1Creatures = [
-        createMockPermanent('c1', 'Bear', 'creature', 2, 2),
+        createMockPermanent("c1", "Bear", "creature", 2, 2),
       ];
 
       const gameState = createTestGameState(20, 8, player1Creatures, []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateAttackPlan();
 
-      expect(plan.strategy).toBe('aggressive');
+      expect(plan.strategy).toBe("aggressive");
     });
 
-    it('should determine defensive strategy when AI has low life', () => {
+    it("should determine defensive strategy when AI has low life", () => {
       const player1Creatures = [
-        createMockPermanent('c1', 'Bear', 'creature', 2, 2),
+        createMockPermanent("c1", "Bear", "creature", 2, 2),
       ];
 
       const gameState = createTestGameState(6, 20, player1Creatures, []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateAttackPlan();
 
-      expect(plan.strategy).toBe('defensive');
+      expect(plan.strategy).toBe("defensive");
     });
 
-    it('should determine moderate strategy in even game state', () => {
+    it("should determine moderate strategy in even game state", () => {
       const player1Creatures = [
-        createMockPermanent('c1', 'Bear', 'creature', 2, 2),
+        createMockPermanent("c1", "Bear", "creature", 2, 2),
       ];
       const player2Creatures = [
-        createMockPermanent('c2', 'Bear', 'creature', 2, 2),
+        createMockPermanent("c2", "Bear", "creature", 2, 2),
       ];
 
-      const gameState = createTestGameState(20, 20, player1Creatures, player2Creatures);
-      const combatAI = new CombatDecisionTree(gameState, 'player1', 'medium');
+      const gameState = createTestGameState(
+        20,
+        20,
+        player1Creatures,
+        player2Creatures,
+      );
+      const combatAI = new CombatDecisionTree(gameState, "player1", "medium");
 
       const plan = combatAI.generateAttackPlan();
 
-      expect(plan.strategy).toBe('moderate');
+      expect(plan.strategy).toBe("moderate");
     });
 
-    it('should calculate total expected value', () => {
+    it("should calculate total expected value", () => {
       const player1Creatures = [
-        createMockPermanent('c1', 'Bear', 'creature', 2, 2),
+        createMockPermanent("c1", "Bear", "creature", 2, 2),
       ];
 
       const gameState = createTestGameState(20, 20, player1Creatures, []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateAttackPlan();
 
-      expect(typeof plan.totalExpectedValue).toBe('number');
+      expect(typeof plan.totalExpectedValue).toBe("number");
     });
 
-    it('should handle empty battlefield', () => {
+    it("should handle empty battlefield", () => {
       const gameState = createTestGameState();
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateAttackPlan();
 
@@ -278,21 +348,21 @@ describe('CombatDecisionTree', () => {
       expect(plan.totalExpectedValue).toBe(0);
     });
 
-    it('should handle multiple opponents', () => {
+    it("should handle multiple opponents", () => {
       const gameState: AIGameState = {
         players: {
-          player1: createMockPlayerState('player1', 20, [
-            createMockPermanent('c1', 'Bear', 'creature', 2, 2),
+          player1: createMockPlayerState("player1", 20, [
+            createMockPermanent("c1", "Bear", "creature", 2, 2),
           ]),
-          player2: createMockPlayerState('player2', 20, []),
-          player3: createMockPlayerState('player3', 20, []),
+          player2: createMockPlayerState("player2", 20, []),
+          player3: createMockPlayerState("player3", 20, []),
         },
         turnInfo: {
           currentTurn: 1,
-          currentPlayer: 'player1',
-          priority: 'player1',
-          phase: 'precombat_main',
-          step: 'main',
+          currentPlayer: "player1",
+          priority: "player1",
+          phase: "precombat_main",
+          step: "main",
         },
         stack: [],
         combat: {
@@ -302,7 +372,7 @@ describe('CombatDecisionTree', () => {
         },
       };
 
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
       const plan = combatAI.generateAttackPlan();
 
       expect(plan).toBeDefined();
@@ -310,34 +380,34 @@ describe('CombatDecisionTree', () => {
     });
   });
 
-  describe('generateBlockingPlan', () => {
-    it('should return a combat plan for blocking', () => {
+  describe("generateBlockingPlan", () => {
+    it("should return a combat plan for blocking", () => {
       const gameState = createTestGameState();
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const attackers: AIPermanent[] = [
-        createMockPermanent('c1', 'Bear', 'creature', 2, 2),
+        createMockPermanent("c1", "Bear", "creature", 2, 2),
       ];
 
       const plan = combatAI.generateBlockingPlan(attackers);
 
-      expect(plan).toHaveProperty('attacks');
-      expect(plan).toHaveProperty('blocks');
-      expect(plan).toHaveProperty('strategy');
-      expect(plan.strategy).toBe('defensive');
+      expect(plan).toHaveProperty("attacks");
+      expect(plan).toHaveProperty("blocks");
+      expect(plan).toHaveProperty("strategy");
+      expect(plan.strategy).toBe("defensive");
     });
 
-    it('should generate block decisions for attackers', () => {
+    it("should generate block decisions for attackers", () => {
       const player1Creatures = [
-        createMockPermanent('c1', 'Bear', 'creature', 2, 2),
-        createMockPermanent('c2', 'Ogre', 'creature', 3, 2),
+        createMockPermanent("c1", "Bear", "creature", 2, 2),
+        createMockPermanent("c2", "Ogre", "creature", 3, 2),
       ];
       const attackers: AIPermanent[] = [
-        createMockPermanent('c3', 'Enemy Bear', 'creature', 2, 2),
+        createMockPermanent("c3", "Enemy Bear", "creature", 2, 2),
       ];
 
       const gameState = createTestGameState(20, 20, player1Creatures, []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateBlockingPlan(attackers);
 
@@ -345,45 +415,64 @@ describe('CombatDecisionTree', () => {
       expect(Array.isArray(plan.blocks)).toBe(true);
     });
 
-    it('should handle multiple attackers', () => {
+    it("should handle multiple attackers", () => {
       const player1Creatures = [
-        createMockPermanent('c1', 'Bear', 'creature', 2, 2),
+        createMockPermanent("c1", "Bear", "creature", 2, 2),
       ];
       const attackers: AIPermanent[] = [
-        createMockPermanent('c2', 'Enemy Bear 1', 'creature', 2, 2),
-        createMockPermanent('c3', 'Enemy Bear 2', 'creature', 2, 2),
+        createMockPermanent("c2", "Enemy Bear 1", "creature", 2, 2),
+        createMockPermanent("c3", "Enemy Bear 2", "creature", 2, 2),
       ];
 
       const gameState = createTestGameState(20, 20, player1Creatures, []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateBlockingPlan(attackers);
 
       expect(plan.blocks.length).toBeGreaterThanOrEqual(0);
     });
 
-    it('should handle no available blockers', () => {
+    it("should handle no available blockers", () => {
       const attackers: AIPermanent[] = [
-        createMockPermanent('c1', 'Enemy Bear', 'creature', 2, 2),
+        createMockPermanent("c1", "Enemy Bear", "creature", 2, 2),
       ];
 
       const gameState = createTestGameState(20, 20, [], []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateBlockingPlan(attackers);
 
       expect(plan.blocks.length).toBe(0);
     });
 
-    it('should only use untapped creatures for blocking', () => {
-      const tappedCreature = createMockPermanent('c1', 'Bear', 'creature', 2, 2, true);
-      const untappedCreature = createMockPermanent('c2', 'Bear', 'creature', 2, 2, false);
+    it("should only use untapped creatures for blocking", () => {
+      const tappedCreature = createMockPermanent(
+        "c1",
+        "Bear",
+        "creature",
+        2,
+        2,
+        true,
+      );
+      const untappedCreature = createMockPermanent(
+        "c2",
+        "Bear",
+        "creature",
+        2,
+        2,
+        false,
+      );
       const attackers: AIPermanent[] = [
-        createMockPermanent('c3', 'Enemy Bear', 'creature', 2, 2),
+        createMockPermanent("c3", "Enemy Bear", "creature", 2, 2),
       ];
 
-      const gameState = createTestGameState(20, 20, [tappedCreature, untappedCreature], []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const gameState = createTestGameState(
+        20,
+        20,
+        [tappedCreature, untappedCreature],
+        [],
+      );
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateBlockingPlan(attackers);
 
@@ -391,91 +480,91 @@ describe('CombatDecisionTree', () => {
       expect(plan).toBeDefined();
     });
 
-    it('should calculate total block value', () => {
+    it("should calculate total block value", () => {
       const player1Creatures = [
-        createMockPermanent('c1', 'Bear', 'creature', 2, 2),
+        createMockPermanent("c1", "Bear", "creature", 2, 2),
       ];
       const attackers: AIPermanent[] = [
-        createMockPermanent('c2', 'Enemy Bear', 'creature', 2, 2),
+        createMockPermanent("c2", "Enemy Bear", "creature", 2, 2),
       ];
 
       const gameState = createTestGameState(20, 20, player1Creatures, []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateBlockingPlan(attackers);
 
-      expect(typeof plan.totalExpectedValue).toBe('number');
+      expect(typeof plan.totalExpectedValue).toBe("number");
     });
   });
 
-  describe('evaluateAttacker (indirect)', () => {
-    it('should create attack decisions with required properties', () => {
+  describe("evaluateAttacker (indirect)", () => {
+    it("should create attack decisions with required properties", () => {
       const player1Creatures = [
-        createMockPermanent('c1', 'Bear', 'creature', 2, 2),
+        createMockPermanent("c1", "Bear", "creature", 2, 2),
       ];
 
       const gameState = createTestGameState(20, 20, player1Creatures, []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateAttackPlan();
 
       if (plan.attacks.length > 0) {
         const decision = plan.attacks[0];
-        expect(decision).toHaveProperty('creatureId');
-        expect(decision).toHaveProperty('shouldAttack');
-        expect(decision).toHaveProperty('target');
-        expect(decision).toHaveProperty('reasoning');
-        expect(decision).toHaveProperty('expectedValue');
-        expect(decision).toHaveProperty('riskLevel');
+        expect(decision).toHaveProperty("creatureId");
+        expect(decision).toHaveProperty("shouldAttack");
+        expect(decision).toHaveProperty("target");
+        expect(decision).toHaveProperty("reasoning");
+        expect(decision).toHaveProperty("expectedValue");
+        expect(decision).toHaveProperty("riskLevel");
       }
     });
   });
 
-  describe('evaluateBlocksForAttacker (indirect)', () => {
-    it('should create block decisions with required properties', () => {
+  describe("evaluateBlocksForAttacker (indirect)", () => {
+    it("should create block decisions with required properties", () => {
       const player1Creatures = [
-        createMockPermanent('c1', 'Bear', 'creature', 2, 2),
+        createMockPermanent("c1", "Bear", "creature", 2, 2),
       ];
       const attackers: AIPermanent[] = [
-        createMockPermanent('c2', 'Enemy Bear', 'creature', 2, 2),
+        createMockPermanent("c2", "Enemy Bear", "creature", 2, 2),
       ];
 
       const gameState = createTestGameState(20, 20, player1Creatures, []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateBlockingPlan(attackers);
 
       if (plan.blocks.length > 0) {
         const decision = plan.blocks[0];
-        expect(decision).toHaveProperty('blockerId');
-        expect(decision).toHaveProperty('attackerId');
-        expect(decision).toHaveProperty('reasoning');
-        expect(decision).toHaveProperty('expectedValue');
+        expect(decision).toHaveProperty("blockerId");
+        expect(decision).toHaveProperty("attackerId");
+        expect(decision).toHaveProperty("reasoning");
+        expect(decision).toHaveProperty("expectedValue");
       }
     });
   });
 
-  describe('difficulty-based combat behavior', () => {
-    it('should be more aggressive at hard difficulty', () => {
+  describe("difficulty-based combat behavior", () => {
+    it("should be more aggressive at hard difficulty", () => {
       const player1Creatures = [
-        createMockPermanent('c1', 'Bear', 'creature', 2, 2),
+        createMockPermanent("c1", "Bear", "creature", 2, 2),
       ];
 
       const gameState = createTestGameState(20, 20, player1Creatures, []);
-      const hardAI = new CombatDecisionTree(gameState, 'player1', 'hard');
+      const hardAI = new CombatDecisionTree(gameState, "player1", "hard");
 
       const hardPlan = hardAI.generateAttackPlan();
 
       expect(hardPlan).toBeDefined();
     });
 
-    it('should be more cautious at easy difficulty', () => {
+    it("should be more cautious at easy difficulty", () => {
       const player1Creatures = [
-        createMockPermanent('c1', 'Bear', 'creature', 2, 2),
+        createMockPermanent("c1", "Bear", "creature", 2, 2),
       ];
 
       const gameState = createTestGameState(20, 20, player1Creatures, []);
-      const easyAI = new CombatDecisionTree(gameState, 'player1', 'easy');
+      const easyAI = new CombatDecisionTree(gameState, "player1", "easy");
 
       const easyPlan = easyAI.generateAttackPlan();
 
@@ -483,12 +572,12 @@ describe('CombatDecisionTree', () => {
     });
   });
 
-  describe('edge cases', () => {
-    it('should handle creatures with 0 power', () => {
-      const weakCreature = createMockPermanent('c1', 'Wall', 'creature', 0, 5);
+  describe("edge cases", () => {
+    it("should handle creatures with 0 power", () => {
+      const weakCreature = createMockPermanent("c1", "Wall", "creature", 0, 5);
 
       const gameState = createTestGameState(20, 20, [weakCreature], []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateAttackPlan();
 
@@ -496,11 +585,17 @@ describe('CombatDecisionTree', () => {
       expect(plan.attacks.length).toBe(0);
     });
 
-    it('should handle very large creatures', () => {
-      const bigCreature = createMockPermanent('c1', 'Big Beast', 'creature', 10, 10);
+    it("should handle very large creatures", () => {
+      const bigCreature = createMockPermanent(
+        "c1",
+        "Big Beast",
+        "creature",
+        10,
+        10,
+      );
 
       const gameState = createTestGameState(20, 20, [bigCreature], []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateAttackPlan();
 
@@ -508,24 +603,40 @@ describe('CombatDecisionTree', () => {
       expect(plan.attacks.length).toBeGreaterThanOrEqual(0);
     });
 
-    it('should handle creatures with evasion keywords', () => {
-      const flyingCreature = createMockPermanent('c1', 'Flying Bear', 'creature', 2, 2, false, 1, ['flying']);
+    it("should handle creatures with evasion keywords", () => {
+      const flyingCreature = createMockPermanent(
+        "c1",
+        "Flying Bear",
+        "creature",
+        2,
+        2,
+        false,
+        1,
+        ["flying"],
+      );
 
       const gameState = createTestGameState(20, 20, [flyingCreature], []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateAttackPlan();
 
       expect(plan).toBeDefined();
     });
 
-    it('should handle combat phase state', () => {
+    it("should handle combat phase state", () => {
       const player1Creatures = [
-        createMockPermanent('c1', 'Bear', 'creature', 2, 2),
+        createMockPermanent("c1", "Bear", "creature", 2, 2),
       ];
 
-      const gameState = createTestGameState(20, 20, player1Creatures, [], 'player1', 'combat');
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const gameState = createTestGameState(
+        20,
+        20,
+        player1Creatures,
+        [],
+        "player1",
+        "combat",
+      );
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateAttackPlan();
 
@@ -533,19 +644,19 @@ describe('CombatDecisionTree', () => {
     });
   });
 
-  describe('optimizeBlockerOrdering (indirect)', () => {
-    it('should handle multi-block scenarios', () => {
+  describe("optimizeBlockerOrdering (indirect)", () => {
+    it("should handle multi-block scenarios", () => {
       const player1Creatures = [
-        createMockPermanent('c1', 'Bear 1', 'creature', 2, 2),
-        createMockPermanent('c2', 'Bear 2', 'creature', 2, 2),
-        createMockPermanent('c3', 'Bear 3', 'creature', 2, 2),
+        createMockPermanent("c1", "Bear 1", "creature", 2, 2),
+        createMockPermanent("c2", "Bear 2", "creature", 2, 2),
+        createMockPermanent("c3", "Bear 3", "creature", 2, 2),
       ];
       const attackers: AIPermanent[] = [
-        createMockPermanent('c4', 'Big Beast', 'creature', 5, 5),
+        createMockPermanent("c4", "Big Beast", "creature", 5, 5),
       ];
 
       const gameState = createTestGameState(20, 20, player1Creatures, []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1');
+      const combatAI = new CombatDecisionTree(gameState, "player1");
 
       const plan = combatAI.generateBlockingPlan(attackers);
 
@@ -553,19 +664,171 @@ describe('CombatDecisionTree', () => {
     });
   });
 
-  describe('evaluateCombatTricks (indirect)', () => {
-    it('should consider combat tricks when enabled', () => {
+  describe("evaluateCombatTricks (indirect)", () => {
+    it("should consider combat tricks when enabled", () => {
       const player1Creatures = [
-        createMockPermanent('c1', 'Bear', 'creature', 2, 2),
+        createMockPermanent("c1", "Bear", "creature", 2, 2),
       ];
 
       const gameState = createTestGameState(20, 20, player1Creatures, []);
-      const combatAI = new CombatDecisionTree(gameState, 'player1', 'expert');
+      const combatAI = new CombatDecisionTree(gameState, "player1", "expert");
 
       const plan = combatAI.generateAttackPlan();
 
       expect(plan.combatTricks).toBeDefined();
       expect(Array.isArray(plan.combatTricks)).toBe(true);
+    });
+  });
+
+  describe("per-archetype playstyle wiring (#911)", () => {
+    // Even board: 1 creature each, both at 20 life. On medium difficulty the
+    // strategy is decided purely by the effective aggression threshold, which
+    // the archetype modifier shifts.
+    function createEvenBoardState(): AIGameState {
+      const player1Creatures = [
+        createMockPermanent("c1", "Bear", "creature", 2, 2),
+      ];
+      const player2Creatures = [
+        createMockPermanent("c2", "Bear", "creature", 2, 2),
+      ];
+      return createTestGameState(20, 20, player1Creatures, player2Creatures);
+    }
+
+    it('defaults to "unknown" archetype when none is supplied (backward compat)', () => {
+      const combatAI = new CombatDecisionTree(
+        createEvenBoardState(),
+        "player1",
+      );
+      expect(combatAI.getArchetype()).toBe("unknown");
+    });
+
+    it("stores the supplied archetype", () => {
+      const combatAI = new CombatDecisionTree(
+        createEvenBoardState(),
+        "player1",
+        "medium",
+        "aggro",
+      );
+      expect(combatAI.getArchetype()).toBe("aggro");
+    });
+
+    it("keeps base config for the unknown archetype", () => {
+      const combatAI = new CombatDecisionTree(
+        createEvenBoardState(),
+        "player1",
+        "medium",
+      );
+      expect(combatAI.getConfig().aggression).toBe(
+        DefaultCombatConfigs.medium.aggression,
+      );
+    });
+
+    it("amplifies aggression for aggro and dampens it for control/combo/ramp", () => {
+      const state = createEvenBoardState();
+      const aggro = new CombatDecisionTree(state, "player1", "medium", "aggro");
+      const midrange = new CombatDecisionTree(
+        state,
+        "player1",
+        "medium",
+        "midrange",
+      );
+      const control = new CombatDecisionTree(
+        state,
+        "player1",
+        "medium",
+        "control",
+      );
+      const combo = new CombatDecisionTree(state, "player1", "medium", "combo");
+      const ramp = new CombatDecisionTree(state, "player1", "medium", "ramp");
+
+      // Strict ordering: aggro > midrange > control > combo, ramp below midrange.
+      expect(aggro.getConfig().aggression).toBeGreaterThan(
+        midrange.getConfig().aggression,
+      );
+      expect(midrange.getConfig().aggression).toBeGreaterThan(
+        control.getConfig().aggression,
+      );
+      expect(control.getConfig().aggression).toBeGreaterThan(
+        combo.getConfig().aggression,
+      );
+      expect(midrange.getConfig().aggression).toBeGreaterThan(
+        ramp.getConfig().aggression,
+      );
+      // midrange is a no-op modifier.
+      expect(midrange.getConfig().aggression).toBe(
+        DefaultCombatConfigs.medium.aggression,
+      );
+    });
+
+    it("clamps aggression to [0, 1] for an already-extreme difficulty", () => {
+      // expert aggression is 0.85; aggro +0.2 would exceed 1.
+      const expertAggro = new CombatDecisionTree(
+        createEvenBoardState(),
+        "player1",
+        "expert",
+        "aggro",
+      );
+      expect(expertAggro.getConfig().aggression).toBeLessThanOrEqual(1);
+      expect(expertAggro.getConfig().aggression).toBeGreaterThan(
+        DefaultCombatConfigs.expert.aggression,
+      );
+    });
+
+    it("shifts combat strategy by archetype on an even board (medium)", () => {
+      const state = createEvenBoardState();
+
+      const midrange = new CombatDecisionTree(
+        state,
+        "player1",
+        "medium",
+        "midrange",
+      );
+      const aggro = new CombatDecisionTree(state, "player1", "medium", "aggro");
+      const control = new CombatDecisionTree(
+        state,
+        "player1",
+        "medium",
+        "control",
+      );
+      const combo = new CombatDecisionTree(state, "player1", "medium", "combo");
+      const ramp = new CombatDecisionTree(state, "player1", "medium", "ramp");
+
+      // Same exact board, different decks -> different playstyles.
+      expect(midrange.generateAttackPlan().strategy).toBe("moderate");
+      expect(aggro.generateAttackPlan().strategy).toBe("aggressive");
+      expect(control.generateAttackPlan().strategy).toBe("defensive");
+      expect(combo.generateAttackPlan().strategy).toBe("defensive");
+      expect(ramp.generateAttackPlan().strategy).toBe("defensive");
+    });
+
+    it("raises defensive life threshold for fragile archetypes (combo)", () => {
+      // combo gets +4 to lifeThreshold at medium (10 -> 14). At 14 life the
+      // combo AI should already play defensively while a midrange AI at the
+      // same life does not.
+      const player1Creatures = [
+        createMockPermanent("c1", "Bear", "creature", 2, 2),
+      ];
+      const player2Creatures = [
+        createMockPermanent("c2", "Bear", "creature", 2, 2),
+      ];
+      const state = createTestGameState(
+        14,
+        20,
+        player1Creatures,
+        player2Creatures,
+      );
+
+      const combo = new CombatDecisionTree(state, "player1", "medium", "combo");
+      const midrange = new CombatDecisionTree(
+        state,
+        "player1",
+        "medium",
+        "midrange",
+      );
+
+      expect(combo.generateAttackPlan().strategy).toBe("defensive");
+      // midrange lifeThreshold stays at 10, so 14 life is still safe -> not defensive.
+      expect(midrange.generateAttackPlan().strategy).not.toBe("defensive");
     });
   });
 });

--- a/src/ai/ai-turn-loop.ts
+++ b/src/ai/ai-turn-loop.ts
@@ -27,6 +27,12 @@ import { drawCard } from "@/lib/game-state/game-state";
 import { engineToAIState } from "@/lib/game-state/serialization";
 import { getMaxHandSize } from "@/lib/game-rules";
 import { discardCards } from "@/lib/game-state/keyword-actions";
+import {
+  classifyArchetypeName,
+  type DeckArchetype,
+} from "./game-state-evaluator";
+import { detectArchetype } from "./archetype-detector";
+import type { DeckCard } from "@/app/actions";
 
 /**
  * AI Turn configuration
@@ -36,6 +42,60 @@ export interface AITurnConfig {
   delayMs: number; // Delay between actions for natural pacing
   skipPhases?: Phase[]; // Phases to skip (for testing)
   onCommentary?: (text: string) => void; // Callback for commentary generation
+  /**
+   * Deck-specific playstyle of the AI player. When provided, this drives the
+   * per-archetype combat/evaluation weights so the AI adapts its decisions to
+   * its deck (aggro vs control vs combo, ...).
+   *
+   * When omitted the turn loop auto-detects the archetype from the AI player's
+   * deck. Either path ensures the per-archetype weights reach the live turn
+   * loop (previously dead code — issue #911).
+   */
+  archetype?: DeckArchetype;
+}
+
+/**
+ * Detect the AI player's deck archetype from the engine game state.
+ *
+ * Gathers every card the player owns across all zones (library, hand,
+ * battlefield, graveyard, exile) and runs the deck archetype detector over it,
+ * mapping the detected archetype name onto the coarse {@link DeckArchetype}
+ * bucket the evaluator/combat tree consume. Returns "unknown" when the deck
+ * cannot be classified.
+ */
+export function detectPlayerArchetype(
+  state: EngineGameState,
+  playerId: PlayerId,
+): DeckArchetype {
+  const zoneKeys = [
+    `${playerId}-library`,
+    `${playerId}-hand`,
+    `${playerId}-battlefield`,
+    `${playerId}-graveyard`,
+    `${playerId}-exile`,
+  ];
+
+  const cards: DeckCard[] = [];
+  for (const key of zoneKeys) {
+    const zone = state.zones.get(key);
+    if (!zone) continue;
+    for (const cardId of zone.cardIds) {
+      const card = state.cards.get(cardId);
+      if (card?.cardData) {
+        cards.push({ ...card.cardData, count: 1 } as DeckCard);
+      }
+    }
+  }
+
+  if (cards.length === 0) return "unknown";
+
+  try {
+    const result = detectArchetype(cards);
+    if (!result || result.primary === "Unknown") return "unknown";
+    return classifyArchetypeName(result.primary);
+  } catch {
+    return "unknown";
+  }
 }
 
 /**
@@ -342,10 +402,16 @@ async function runCombatPhase(
   // Import dynamically to avoid circular dependencies
   const { CombatDecisionTree } =
     await import("./decision-making/combat-decision-tree");
+  // Resolve the deck-specific playstyle so per-archetype weights reach the
+  // live combat decisions. Prefer an explicit config override, otherwise
+  // auto-detect from the AI player's deck (issue #911).
+  const archetype =
+    config.archetype ?? detectPlayerArchetype(currentState, aiPlayerId);
   const combatAI = new CombatDecisionTree(
     aiState,
     aiPlayerId,
     config.difficulty,
+    archetype,
   );
 
   // Generate attack plan using unified format

--- a/src/ai/decision-making/combat-decision-tree.ts
+++ b/src/ai/decision-making/combat-decision-tree.ts
@@ -45,9 +45,41 @@ import {
   type LookaheadResult,
   type LookaheadConfig,
 } from "./lookahead";
+import type { DeckArchetype } from "../game-state-evaluator";
 
 // Re-export for backward compatibility
 export type { GameState, PlayerState, Permanent, HandCard };
+export type { DeckArchetype };
+
+/**
+ * Per-archetype combat playstyle modifiers.
+ *
+ * These adjust the difficulty-derived {@link CombatAIConfig} so the AI's combat
+ * decisions actually reflect how each archetype wants to fight:
+ *  - `aggression` shifts the strategy thresholds and attack willingness
+ *    (aggro attacks more freely, control/combo/ramp hold creatures back).
+ *  - `riskTolerance` mirrors that for trick/chump-risk decisions.
+ *  - `lifeThreshold` raises the life total at which fragile archetypes go
+ *    defensive (combo/ramp defend earlier because their board is expendable).
+ *
+ * This is the bridge that connects the per-archetype playstyle weights defined
+ * in game-state-evaluator.ts to the live combat decision tree. See issue #911.
+ */
+export const ARCHETYPE_COMBAT_MODIFIERS: Record<
+  Exclude<DeckArchetype, "unknown">,
+  { aggression: number; riskTolerance: number; lifeThreshold: number }
+> = {
+  aggro: { aggression: 0.2, riskTolerance: 0.15, lifeThreshold: -2 },
+  midrange: { aggression: 0.0, riskTolerance: 0.0, lifeThreshold: 0 },
+  control: { aggression: -0.15, riskTolerance: -0.1, lifeThreshold: 2 },
+  combo: { aggression: -0.25, riskTolerance: -0.15, lifeThreshold: 4 },
+  ramp: { aggression: -0.2, riskTolerance: -0.1, lifeThreshold: 3 },
+};
+
+function clamp01(value: number): number {
+  if (Number.isNaN(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
 
 /**
  * Card data interface for combat tricks
@@ -246,14 +278,40 @@ export class CombatDecisionTree {
   private config: CombatAIConfig;
   private heuristicTable: HeuristicTable;
   private lookaheadEngine: LookaheadEngine;
+  private archetype: DeckArchetype;
   constructor(
     gameState: GameState,
     aiPlayerId: string,
     difficulty: "easy" | "medium" | "hard" | "expert" = "medium",
+    archetype: DeckArchetype = "unknown",
   ) {
     this.gameState = gameState;
     this.aiPlayerId = aiPlayerId;
-    this.config = DefaultCombatConfigs[difficulty];
+    this.archetype = archetype;
+
+    const baseConfig = DefaultCombatConfigs[difficulty];
+    // Wire the deck-specific playstyle weights into the live combat config.
+    // Without this blend the AI plays every deck identically regardless of
+    // archetype — the per-archetype weights were effectively dead code (#911).
+    const modifier =
+      archetype !== "unknown"
+        ? ARCHETYPE_COMBAT_MODIFIERS[archetype]
+        : undefined;
+    if (modifier) {
+      this.config = {
+        ...baseConfig,
+        aggression: clamp01(baseConfig.aggression + modifier.aggression),
+        riskTolerance: clamp01(
+          baseConfig.riskTolerance + modifier.riskTolerance,
+        ),
+        lifeThreshold: Math.max(
+          1,
+          baseConfig.lifeThreshold + modifier.lifeThreshold,
+        ),
+      };
+    } else {
+      this.config = { ...baseConfig };
+    }
     this.heuristicTable = new HeuristicTable();
     this.lookaheadEngine = new LookaheadEngine(
       this.heuristicTable,
@@ -262,10 +320,25 @@ export class CombatDecisionTree {
   }
 
   /**
+   * The deck archetype currently driving combat decisions ("unknown" when no
+   * archetype was supplied or detected).
+   */
+  getArchetype(): DeckArchetype {
+    return this.archetype;
+  }
+
+  /**
    * Set custom combat AI configuration
    */
   setConfig(config: Partial<CombatAIConfig>): void {
     this.config = { ...this.config, ...config };
+  }
+
+  /**
+   * Get the effective combat configuration (post archetype adjustment).
+   */
+  getConfig(): CombatAIConfig {
+    return { ...this.config };
   }
 
   /**
@@ -2004,8 +2077,14 @@ export function generateAttackDecisions(
   gameState: GameState,
   aiPlayerId: string,
   difficulty: "easy" | "medium" | "hard" | "expert" = "medium",
+  archetype: DeckArchetype = "unknown",
 ): CombatPlan {
-  const ai = new CombatDecisionTree(gameState, aiPlayerId, difficulty);
+  const ai = new CombatDecisionTree(
+    gameState,
+    aiPlayerId,
+    difficulty,
+    archetype,
+  );
   return ai.generateAttackPlan();
 }
 
@@ -2017,7 +2096,13 @@ export function generateBlockingDecisions(
   aiPlayerId: string,
   attackers: Permanent[],
   difficulty: "easy" | "medium" | "hard" | "expert" = "medium",
+  archetype: DeckArchetype = "unknown",
 ): CombatPlan {
-  const ai = new CombatDecisionTree(gameState, aiPlayerId, difficulty);
+  const ai = new CombatDecisionTree(
+    gameState,
+    aiPlayerId,
+    difficulty,
+    archetype,
+  );
   return ai.generateBlockingPlan(attackers);
 }

--- a/src/ai/decision-making/index.ts
+++ b/src/ai/decision-making/index.ts
@@ -9,11 +9,13 @@ export {
   generateAttackDecisions,
   generateBlockingDecisions,
   DefaultCombatConfigs,
+  ARCHETYPE_COMBAT_MODIFIERS,
   type CombatAIConfig,
   type AttackDecision,
   type BlockDecision,
   type CombatPlan,
   type CombatTrick,
+  type DeckArchetype,
 } from "./combat-decision-tree";
 
 export {

--- a/src/ai/game-state-evaluator.ts
+++ b/src/ai/game-state-evaluator.ts
@@ -349,7 +349,15 @@ export const ArchetypeWeights: Record<
   },
 };
 
-function classifyArchetypeName(archetypeName: string): DeckArchetype {
+/**
+ * Map a free-form archetype name (e.g. from the deck archetype detector) onto
+ * the coarse-grained {@link DeckArchetype} bucket used by the evaluator's
+ * per-archetype playstyle weights.
+ *
+ * Exported so the live turn loop and combat decision tree can translate a
+ * detected deck archetype into the weights that drive evaluation scoring.
+ */
+export function classifyArchetypeName(archetypeName: string): DeckArchetype {
   const lower = archetypeName.toLowerCase();
   if (
     lower.includes("burn") ||


### PR DESCRIPTION
## Problem

Issue #911: the deck-specific (per-archetype) AI playstyle weights were **dead code**. `game-state-evaluator.ts` defines calibrated per-archetype evaluation weight vectors (`ArchetypeWeights` for aggro / control / combo / midrange / ramp) and `GameStateEvaluator` / `evaluateGameState` accept an `archetype` parameter to apply them. However, the **live turn loop** never propagated the AI player's archetype:

- `ai-turn-loop.ts` constructed `new CombatDecisionTree(aiState, aiPlayerId, config.difficulty)` — no archetype.
- `CombatDecisionTree` derived its `aggression` / strategy **only** from `difficulty`, ignoring the deck entirely.

Result: the AI played every deck identically regardless of whether it was aggro, control, combo, or ramp. The per-archetype weights never reached a live decision.

## Solution

Wire the deck archetype into the live combat/turn path:

1. **`game-state-evaluator.ts`** — export `classifyArchetypeName(...)` so a detected deck-archetype name can be mapped onto the coarse `DeckArchetype` weight buckets.
2. **`combat-decision-tree.ts`** — `CombatDecisionTree` now accepts an optional `archetype`. When set, it blends per-archetype combat modifiers (`ARCHETYPE_COMBAT_MODIFIERS`: aggression / riskTolerance / lifeThreshold) into the difficulty config, so `determineCombatStrategy` and attack thresholds adapt to the deck:
   - aggro → +aggression (attacks more freely)
   - control / combo / ramp → −aggression, +lifeThreshold (hold back, defend earlier)
   - midrange → neutral
3. **`ai-turn-loop.ts`** — `AITurnConfig` gains an optional `archetype` override, and `runCombatPhase` now passes the archetype into `CombatDecisionTree`. When no archetype is supplied it is **auto-detected** from the AI player's deck via the new `detectPlayerArchetype(state, playerId)` helper (gathers cards across all zones → `detectArchetype` → `classifyArchetypeName`). This makes the weights reach the live loop **by default**.

All constructor/argument changes are additive (new optional params / fields), so existing callers and tests remain backward compatible.

## Files changed

- `src/ai/game-state-evaluator.ts` — export `classifyArchetypeName`.
- `src/ai/decision-making/combat-decision-tree.ts` — archetype-aware `CombatDecisionTree` + `ARCHETYPE_COMBAT_MODIFIERS` + `getArchetype()`/`getConfig()`; thread archetype through `generateAttackDecisions`/`generateBlockingDecisions`.
- `src/ai/decision-making/index.ts` — re-export new symbols.
- `src/ai/ai-turn-loop.ts` — `AITurnConfig.archetype`, `detectPlayerArchetype()`, and threading into `runCombatPhase`.
- `src/ai/__tests__/combat-decision-tree.test.ts` — new `per-archetype playstyle wiring (#911)` suite.
- `src/ai/__tests__/ai-turn-loop.test.ts` — new tests for `detectPlayerArchetype` auto-detection and config override.

## Test results

- New/changed suites pass: `combat-decision-tree.test.ts`, `ai-turn-loop.test.ts`, `archetype-scoring.test.ts`.
- Full AI suite: **515 / 515 passing** (`npx jest src/ai`).
- `npx tsc --noEmit`: clean.
- `npm run lint`: 0 errors (only pre-existing warnings, none introduced by this change).

Key behavioral assertion: on an identical even board at medium difficulty, the combat strategy now differs by archetype — `midrange`→moderate, `aggro`→aggressive, `control`/`combo`/`ramp`→defensive.

Closes #911.
