### PR TITLE
fix: resolve #910 — forced auto-pass priority destroys stack interaction

### DIFF
--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -85,6 +85,7 @@ import {
   getTotalMana,
   canCastSpell,
   canPlayLand,
+  shouldAutoPassPriority,
   type GameState,
   type Player,
   type CardInstance,
@@ -1427,19 +1428,16 @@ function GameBoardContent() {
     );
     if (!humanPlayer || !aiPlayer) return;
 
-    // Only auto-pass when it's the AI's turn and human has priority
-    const isAITurn = gameState.turn.activePlayerId === aiPlayer.id;
-    const humanHasPriority = gameState.priorityPlayerId === humanPlayer.id;
-
-    if (!isAITurn || !humanHasPriority) return;
-
-    // Don't auto-pass during combat phases where human might want to act
-    const combatPhases = [
-      "declare_attackers",
-      "declare_blockers",
-      "combat_damage",
-    ];
-    if (combatPhases.includes(gameState.turn.currentPhase)) return;
+    // Centralized guard: never auto-pass while the stack is non-empty or the
+    // human lacks a safe window to yield. This preserves the player's ability
+    // to respond to the AI's spells/abilities (#910).
+    if (
+      !shouldAutoPassPriority(gameState, {
+        activePlayerId: aiPlayer.id,
+        humanPlayerId: humanPlayer.id,
+      })
+    )
+      return;
 
     // Short delay so user can see the phase change
     const timer = setTimeout(() => {
@@ -1456,10 +1454,14 @@ function GameBoardContent() {
       );
       if (!currentHuman || !currentAI) return;
 
-      // Re-validate conditions with latest state
-      if (latestState.turn.activePlayerId !== currentAI.id) return;
-      if (latestState.priorityPlayerId !== currentHuman.id) return;
-      if (combatPhases.includes(latestState.turn.currentPhase)) return;
+      // Re-validate conditions (incl. empty stack) with the latest state.
+      if (
+        !shouldAutoPassPriority(latestState, {
+          activePlayerId: currentAI.id,
+          humanPlayerId: currentHuman.id,
+        })
+      )
+        return;
 
       const result = passPriority(latestState, currentHuman.id);
       if (result) {
@@ -1473,6 +1475,8 @@ function GameBoardContent() {
     gameState?.priorityPlayerId,
     gameState?.turn.activePlayerId,
     gameState?.turn.currentPhase,
+    gameState?.stack.length,
+    gameState?.status,
     mode,
     isAIThinking,
     playerName,

--- a/src/lib/game-state/__tests__/auto-pass-priority.test.ts
+++ b/src/lib/game-state/__tests__/auto-pass-priority.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @fileoverview Unit Tests for auto-pass priority guard (#910)
+ *
+ * The game UI auto-passes priority on the human's behalf during the AI's turn
+ * so they do not have to babysit every phase. That convenience must NEVER
+ * destroy the response window: when objects are on the stack the player must
+ * retain priority so they can cast instants/counterspells or activate
+ * abilities in response (CR 117).
+ */
+
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import {
+  createInitialGameState,
+  startGame,
+} from "../game-state";
+import { shouldAutoPassPriority } from "../auto-pass-priority";
+import { Phase } from "../types";
+import type { GameState, PlayerId, StackObject } from "../types";
+
+describe("shouldAutoPassPriority (#910 response window guard)", () => {
+  let state: GameState;
+  let humanId: PlayerId;
+  let aiId: PlayerId;
+
+  beforeEach(() => {
+    state = createInitialGameState(["Human", "AI"]);
+    state = startGame(state);
+
+    const ids = Array.from(state.players.keys());
+    // createInitialGameState makes the first player the active player. Put the
+    // AI on the hot seat by making player 2 the active player.
+    humanId = ids[0];
+    aiId = ids[1];
+
+    state.status = "in_progress";
+    state.turn.activePlayerId = aiId;
+    state.priorityPlayerId = humanId;
+    state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    state.stack = [];
+    state.players.forEach((p) =>
+      state.players.set(p.id, { ...p, hasPassedPriority: false }),
+    );
+    state.consecutivePasses = 0;
+  });
+
+  it("auto-passes on the AI's turn with an empty stack (convenience preserved)", () => {
+    expect(
+      shouldAutoPassPriority(state, {
+        activePlayerId: aiId,
+        humanPlayerId: humanId,
+      }),
+    ).toBe(true);
+  });
+
+  it("NEVER auto-passes while the stack is non-empty (response window preserved)", () => {
+    state.stack = [makeStackObject(aiId)];
+
+    expect(
+      shouldAutoPassPriority(state, {
+        activePlayerId: aiId,
+        humanPlayerId: humanId,
+      }),
+    ).toBe(false);
+  });
+
+  it("resumes auto-passing once the stack empties again", () => {
+    state.stack = [makeStackObject(aiId)];
+    expect(
+      shouldAutoPassPriority(state, {
+        activePlayerId: aiId,
+        humanPlayerId: humanId,
+      }),
+    ).toBe(false);
+
+    state.stack = [];
+    expect(
+      shouldAutoPassPriority(state, {
+        activePlayerId: aiId,
+        humanPlayerId: humanId,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not auto-pass through interactive combat phases even with an empty stack", () => {
+    for (const phase of [
+      Phase.DECLARE_ATTACKERS,
+      Phase.DECLARE_BLOCKERS,
+      Phase.COMBAT_DAMAGE,
+    ]) {
+      state.turn.currentPhase = phase;
+      state.stack = [];
+      expect(
+        shouldAutoPassPriority(state, {
+          activePlayerId: aiId,
+          humanPlayerId: humanId,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("does not auto-pass when it is the human's own turn", () => {
+    state.turn.activePlayerId = humanId;
+    expect(
+      shouldAutoPassPriority(state, {
+        activePlayerId: aiId,
+        humanPlayerId: humanId,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not auto-pass when the human does not have priority", () => {
+    state.priorityPlayerId = aiId;
+    expect(
+      shouldAutoPassPriority(state, {
+        activePlayerId: aiId,
+        humanPlayerId: humanId,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not auto-pass when the game is not in progress", () => {
+    state.status = "completed";
+    expect(
+      shouldAutoPassPriority(state, {
+        activePlayerId: aiId,
+        humanPlayerId: humanId,
+      }),
+    ).toBe(false);
+  });
+
+  it("a non-empty stack blocks auto-pass regardless of phase", () => {
+    // Even in a main phase where auto-pass would normally be fine, a live stack wins.
+    state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    state.stack = [makeStackObject(aiId), makeStackObject(humanId)];
+    expect(
+      shouldAutoPassPriority(state, {
+        activePlayerId: aiId,
+        humanPlayerId: humanId,
+      }),
+    ).toBe(false);
+  });
+});
+
+function makeStackObject(controllerId: PlayerId): StackObject {
+  return {
+    id: `stack-${Math.random().toString(36).slice(2)}`,
+    type: "spell",
+    sourceCardId: null,
+    controllerId,
+    name: "Test Spell",
+    text: "",
+    manaCost: "{U}",
+    targets: [],
+    chosenModes: [],
+    variableValues: new Map(),
+    isCountered: false,
+    timestamp: Date.now(),
+  };
+}

--- a/src/lib/game-state/auto-pass-priority.ts
+++ b/src/lib/game-state/auto-pass-priority.ts
@@ -1,0 +1,53 @@
+import type { GameState, PlayerId } from "./types";
+import { Phase } from "./types";
+
+/**
+ * Combat phases where the human player may need to take a specific action
+ * (declare attackers/blockers, order combat damage). Priority must not be
+ * auto-passed through these, otherwise the player loses their chance to act.
+ */
+const HUMAN_INTERACTIVE_COMBAT_PHASES: ReadonlySet<Phase> = new Set([
+  Phase.DECLARE_ATTACKERS,
+  Phase.DECLARE_BLOCKERS,
+  Phase.COMBAT_DAMAGE,
+  Phase.COMBAT_DAMAGE_FIRST_STRIKE,
+]);
+
+export interface AutoPassContext {
+  /** Player whose turn it is (the AI opponent in single-player mode). */
+  activePlayerId: PlayerId;
+  /** Human player on whose behalf priority would be auto-passed. */
+  humanPlayerId: PlayerId;
+}
+
+/**
+ * Decide whether it is safe to auto-pass priority on behalf of the human
+ * player during the opponent's turn, so they do not have to babysit every
+ * phase/step.
+ *
+ * CRITICAL (#910): the stack MUST be empty. Auto-passing while objects are on
+ * the stack destroys the response window — the player can never cast
+ * instants/counterspells or activate abilities in response. Per CR 117 the
+ * player must retain priority and have a genuine opportunity to respond before
+ * anything resolves. Auto-passing is only appropriate between phases/steps
+ * (empty stack), which keeps the game flowing without skipping responses.
+ */
+export function shouldAutoPassPriority(
+  state: GameState,
+  ctx: AutoPassContext,
+): boolean {
+  if (!state) return false;
+  if (state.status !== "in_progress") return false;
+
+  // Preserve the response window: never yield priority while the stack is live.
+  if (state.stack.length > 0) return false;
+
+  // Only auto-pass on the opponent's turn when the human actually has priority.
+  if (state.turn.activePlayerId !== ctx.activePlayerId) return false;
+  if (state.priorityPlayerId !== ctx.humanPlayerId) return false;
+
+  // Don't auto-pass through combat steps where the human may want to act.
+  if (HUMAN_INTERACTIVE_COMBAT_PHASES.has(state.turn.currentPhase)) return false;
+
+  return true;
+}

--- a/src/lib/game-state/index.ts
+++ b/src/lib/game-state/index.ts
@@ -54,6 +54,8 @@ export { getEffectivePower, getEffectiveToughness } from "./layer-system";
 export * from "./replacement-examples";
 export * from "./terminology-translation";
 export * from "./phasing";
+export { shouldAutoPassPriority } from "./auto-pass-priority";
+export type { AutoPassContext } from "./auto-pass-priority";
 
 // Local exports for common functions with consistent naming
 export { tapCard, untapCard, checkStateBasedActions };


### PR DESCRIPTION
## Problem

Resolves #910 — *CRITICAL: Forced auto-pass priority in game UI destroys stack interaction and response windows*.

The single-player game UI auto-passed priority on the human's behalf whenever they held priority during the AI's turn (`src/app/(app)/game/[id]/page.tsx`). Because `castSpell` hands priority to the next player (`spell-casting.ts`), the instant the AI cast a spell the human received priority with a **non-empty stack** — and the auto-pass effect immediately force-passed them. The result: the player could never cast instants/counterspells or activate abilities in response to the AI's spells/abilities, destroying the stack response window required by CR 117.

The core `passPriority` engine (`game-state.ts`) already resolves the stack correctly — the bug lived entirely in the UI auto-pass heuristic, which never inspected the stack.

## Solution

Extracted a pure, rules-documented guard `shouldAutoPassPriority(state, ctx)` whose central rule is: **never auto-pass while the stack is non-empty**. The auto-pass effect now:

1. Calls the guard up-front (refuses to auto-pass on a live stack, in interactive combat phases, on the human's own turn, or when the game isn't in progress).
2. Re-runs the same guard on the latest state inside the 400 ms timeout (race protection).
3. Adds `gameState.stack.length` and `gameState.status` to the effect's dependency array so auto-pass correctly resumes once the stack empties again.

Net behavior:
- AI casts → human keeps priority with a live stack → **can respond** (cast/activate) or click Pass. ✅ Response window preserved.
- Stack empty between phases → auto-pass still fires → no babysitting. ✅ Convenience preserved.

## Files changed
- `src/lib/game-state/auto-pass-priority.ts` — new pure `shouldAutoPassPriority` guard (empty-stack rule + turn/priority/combat/status checks).
- `src/lib/game-state/__tests__/auto-pass-priority.test.ts` — 8 unit tests covering the response-window invariant and surrounding conditions.
- `src/lib/game-state/index.ts` — re-export the new helper.
- `src/app/(app)/game/[id]/page.tsx` — wire the auto-pass effect to the guard; add stack length + status to deps.

## Test results
- New suite: `auto-pass-priority.test.ts` → **8/8 passing**.
- Regression: `priority-pass-apnap.test.ts` + `game-state.test.ts` → **88/88 passing**.
- `tsc --noEmit` → no errors in changed files.
- `eslint` (project v9, `--max-warnings 1000`) → 0 errors; only pre-existing warnings (no new ones introduced).

## Scope / assumptions
- Minimal, surgical fix targeting the forced auto-pass described in the issue. Existing `passPriority`/stack-resolution logic is untouched.
- A related, separate limitation exists: after the *human* casts, the AI's priority is still force-resolved (~lines 1561, 1774, 2013, …). That path is left as-is because the AI decision layer (`AIOpponent.makeDecision`) currently has no stack-response action, so changing it would add a manual Pass click with no functional gain. Preserving a genuine AI response window is deferred to follow-up work that wires `stack-interaction-ai` into the live loop.

## Summary by Sourcery

Guard the single-player UI auto-pass behavior so it never yields priority while the stack is live, preserving player response windows against AI actions.

Bug Fixes:
- Fix forced auto-pass during the AI's turn so the human retains priority and can respond when the stack is non-empty.

Enhancements:
- Introduce a reusable shouldAutoPassPriority helper with tests to centralize UI auto-pass rules and combat/turn/priority checks.

Tests:
- Add unit tests covering auto-pass behavior across stack states, phases, turn ownership, and game status.