### PR TITLE
feat: resolve #914 — sideboard validation: restricted & banned lists, combined copy limit

### DIFF
--- a/src/lib/__tests__/game-rules.test.ts
+++ b/src/lib/__tests__/game-rules.test.ts
@@ -7,6 +7,7 @@ import {
   formatRules,
   validateDeckFormat,
   validateSideboard,
+  validateDeckAndSideboard,
   isDeckLegal,
   getStartingLife,
   getCommanderDamageThreshold,
@@ -180,7 +181,7 @@ describe("Game Rules - validateDeckFormat", () => {
 
       expect(result.isValid).toBe(false);
       expect(result.errors).toContain(
-        "Legendary Commander decks must have exactly 100 cards (has 1)"
+        "Legendary Commander decks must have exactly 100 cards (has 1)",
       );
     });
 
@@ -193,24 +194,33 @@ describe("Game Rules - validateDeckFormat", () => {
 
       expect(result.isValid).toBe(false);
       expect(result.errors).toContain(
-        "Legendary Commander decks must have exactly 100 cards (has 101)"
+        "Legendary Commander decks must have exactly 100 cards (has 101)",
       );
     });
 
     it("should accept a valid legendary commander deck with 100 cards", () => {
       // Create a valid legendary commander deck with 100 singleton cards
-      const deck: { name: string; count: number; color_identity?: string[] }[] = [
-        { name: "Ghired, Shell of the Ghireds", count: 1, color_identity: ["R", "W", "G"] },
-        { name: "Forest", count: 35 },
-        { name: "Mountain", count: 35 },
-        { name: "Sol Ring", count: 1, color_identity: [] },
-        { name: "Lightning Bolt", count: 1, color_identity: ["R"] },
-        { name: "Swords to Plowshares", count: 1, color_identity: ["W"] },
-        { name: "Cultivate", count: 1, color_identity: ["G"] },
-      ];
+      const deck: { name: string; count: number; color_identity?: string[] }[] =
+        [
+          {
+            name: "Ghired, Shell of the Ghireds",
+            count: 1,
+            color_identity: ["R", "W", "G"],
+          },
+          { name: "Forest", count: 35 },
+          { name: "Mountain", count: 35 },
+          { name: "Sol Ring", count: 1, color_identity: [] },
+          { name: "Lightning Bolt", count: 1, color_identity: ["R"] },
+          { name: "Swords to Plowshares", count: 1, color_identity: ["W"] },
+          { name: "Cultivate", count: 1, color_identity: ["G"] },
+        ];
       // Add 25 more unique cards to reach 100
       for (let i = 1; i <= 25; i++) {
-        deck.push({ name: `Unique Card ${i}`, count: 1, color_identity: ["R", "W", "G"] });
+        deck.push({
+          name: `Unique Card ${i}`,
+          count: 1,
+          color_identity: ["R", "W", "G"],
+        });
       }
       const result = validateDeckFormat(deck, "legendary-commander", {
         name: "Ghired, Shell of the Ghireds",
@@ -231,9 +241,9 @@ describe("Game Rules - validateDeckFormat", () => {
       });
 
       expect(result.isValid).toBe(false);
-      expect(result.errors.some((e) => e.includes("Color identity violation"))).toBe(
-        true
-      );
+      expect(
+        result.errors.some((e) => e.includes("Color identity violation")),
+      ).toBe(true);
     });
 
     it("should allow basic lands regardless of color identity", () => {
@@ -247,9 +257,9 @@ describe("Game Rules - validateDeckFormat", () => {
       });
 
       // Basic lands should not trigger color identity errors
-      expect(result.errors.some((e) => e.includes("Color identity violation"))).toBe(
-        false
-      );
+      expect(
+        result.errors.some((e) => e.includes("Color identity violation")),
+      ).toBe(false);
     });
 
     it("should allow colorless cards", () => {
@@ -272,7 +282,7 @@ describe("Game Rules - validateDeckFormat", () => {
 
       expect(result.hasCommander).toBe(false);
       expect(result.warnings).toContain(
-        "No legendary specified - ensure deck follows color identity rules"
+        "No legendary specified - ensure deck follows color identity rules",
       );
     });
   });
@@ -284,7 +294,7 @@ describe("Game Rules - validateDeckFormat", () => {
 
       expect(result.isValid).toBe(false);
       expect(result.errors).toContain(
-        "Deck must have at least 60 cards (has 4)"
+        "Deck must have at least 60 cards (has 4)",
       );
     });
 
@@ -301,7 +311,7 @@ describe("Game Rules - validateDeckFormat", () => {
 
       expect(result.isValid).toBe(false);
       expect(result.errors).toContain(
-        "lightning bolt has 5 copies, maximum is 4 in Constructed Core"
+        "lightning bolt has 5 copies, maximum is 4 in Constructed Core",
       );
     });
 
@@ -325,7 +335,7 @@ describe("Game Rules - validateDeckFormat", () => {
 
       expect(result.isValid).toBe(false);
       expect(result.errors).toContain(
-        "black lotus is restricted in Constructed Vintage - maximum 1 copy allowed"
+        "black lotus is restricted in Constructed Vintage - maximum 1 copy allowed",
       );
     });
 
@@ -342,35 +352,33 @@ describe("Game Rules - validateDeckFormat", () => {
 
   describe("Ban list validation", () => {
     it("should reject banned cards in legendary-commander", () => {
-      const deck = [
-        { name: "Black Lotus", count: 1 },
-      ];
+      const deck = [{ name: "Black Lotus", count: 1 }];
       const result = validateDeckFormat(deck, "legendary-commander");
 
       expect(result.isValid).toBe(false);
-      expect(result.errors).toContain("black lotus is banned in Legendary Commander");
+      expect(result.errors).toContain(
+        "black lotus is banned in Legendary Commander",
+      );
     });
 
     it("should reject banned cards in constructed-extended", () => {
-      const deck = [
-        { name: "Jace, the Mind Sculptor", count: 1 },
-      ];
+      const deck = [{ name: "Jace, the Mind Sculptor", count: 1 }];
       const result = validateDeckFormat(deck, "constructed-extended");
 
       expect(result.isValid).toBe(false);
       expect(result.errors).toContain(
-        "jace, the mind sculptor is banned in Constructed Extended"
+        "jace, the mind sculptor is banned in Constructed Extended",
       );
     });
 
     it("should be case insensitive for ban list", () => {
-      const deck = [
-        { name: "BLACK LOTUS", count: 1 },
-      ];
+      const deck = [{ name: "BLACK LOTUS", count: 1 }];
       const result = validateDeckFormat(deck, "legendary-commander");
 
       expect(result.isValid).toBe(false);
-      expect(result.errors).toContain("black lotus is banned in Legendary Commander");
+      expect(result.errors).toContain(
+        "black lotus is banned in Legendary Commander",
+      );
     });
   });
 });
@@ -382,7 +390,7 @@ describe("Game Rules - validateSideboard", () => {
 
     expect(result.isValid).toBe(false);
     expect(result.errors).toContain(
-      "Legendary Commander format does not use sideboards"
+      "Legendary Commander format does not use sideboards",
     );
   });
 
@@ -404,7 +412,7 @@ describe("Game Rules - validateSideboard", () => {
 
     expect(result.isValid).toBe(false);
     expect(result.errors).toContain(
-      "Sideboard must have at most 15 cards (has 20)"
+      "Sideboard must have at most 15 cards (has 20)",
     );
   });
 
@@ -414,7 +422,179 @@ describe("Game Rules - validateSideboard", () => {
 
     expect(result.isValid).toBe(false);
     expect(result.errors).toContain(
-      "Sideboard: lightning bolt has 5 copies, maximum is 4"
+      "Sideboard: lightning bolt has 5 copies, maximum is 4",
+    );
+  });
+
+  it("should reject banned cards in the sideboard", () => {
+    // Jace, the Mind Sculptor is banned in constructed-extended
+    const sideboard = [{ name: "Jace, the Mind Sculptor", count: 1 }];
+    const result = validateSideboard(sideboard, "constructed-extended");
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain(
+      "jace, the mind sculptor is banned in Constructed Extended",
+    );
+  });
+
+  it("should reject more than 1 copy of a restricted card in the sideboard", () => {
+    // Black Lotus is restricted in constructed-vintage
+    const sideboard = [{ name: "Black Lotus", count: 2 }];
+    const result = validateSideboard(sideboard, "constructed-vintage");
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain(
+      "Sideboard: black lotus is restricted in Constructed Vintage - maximum 1 copy allowed",
+    );
+  });
+
+  it("should allow a single copy of a restricted card in the sideboard", () => {
+    const sideboard = [
+      { name: "Black Lotus", count: 1 },
+      { name: "Forest", count: 14 },
+    ];
+    const result = validateSideboard(sideboard, "constructed-vintage");
+
+    expect(result.isValid).toBe(true);
+  });
+
+  it("should exempt basic lands from the sideboard copy limit", () => {
+    // 15 basics fit within the sideboard size; even if grouped they must pass
+    const sideboard = [{ name: "Forest", count: 15 }];
+    const result = validateSideboard(sideboard, "constructed-core");
+
+    expect(result.isValid).toBe(true);
+  });
+});
+
+describe("Game Rules - validateDeckAndSideboard (combined limits)", () => {
+  // Helper: a legal 60-card main deck of basics + 4 Lightning Bolts
+  const legalMainDeck = () => [
+    { name: "Lightning Bolt", count: 4 },
+    { name: "Forest", count: 56 },
+  ];
+
+  it("should accept a valid deck and sideboard", () => {
+    const deck = legalMainDeck();
+    const sideboard = [
+      { name: "Counterspell", count: 4 },
+      { name: "Duress", count: 4 },
+    ];
+    const result = validateDeckAndSideboard(
+      deck,
+      sideboard,
+      "constructed-core",
+    );
+
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should reject a restricted card appearing more than once across main + sideboard", () => {
+    // Black Lotus is restricted (max 1) in constructed-vintage.
+    // 1 in main + 1 in sideboard = 2 combined -> must be rejected even though
+    // each list is individually legal.
+    const deck = [
+      { name: "Black Lotus", count: 1 },
+      { name: "Forest", count: 59 },
+    ];
+    const sideboard = [{ name: "Black Lotus", count: 1 }];
+    const result = validateDeckAndSideboard(
+      deck,
+      sideboard,
+      "constructed-vintage",
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(
+      result.errors.some((e) =>
+        e.includes("maximum 1 copy allowed across deck and sideboard"),
+      ),
+    ).toBe(true);
+  });
+
+  it("should reject a banned card present in the sideboard", () => {
+    // Jace, the Mind Sculptor is banned in constructed-extended
+    const deck = [{ name: "Forest", count: 60 }];
+    const sideboard = [{ name: "Jace, the Mind Sculptor", count: 1 }];
+    const result = validateDeckAndSideboard(
+      deck,
+      sideboard,
+      "constructed-extended",
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain(
+      "jace, the mind sculptor is banned in Constructed Extended",
+    );
+  });
+
+  it("should reject more than 4 combined copies of a non-basic-land card", () => {
+    // 4 Lightning Bolts in main + 1 in sideboard = 5 combined -> rejected
+    const deck = legalMainDeck();
+    const sideboard = [{ name: "Lightning Bolt", count: 1 }];
+    const result = validateDeckAndSideboard(
+      deck,
+      sideboard,
+      "constructed-core",
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(
+      result.errors.some((e) =>
+        e.includes(
+          "lightning bolt has 5 copies across deck and sideboard, maximum is 4",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("should exempt basic lands from the combined copy limit", () => {
+    // Many forests split across main + sideboard must remain legal
+    const deck = [{ name: "Forest", count: 60 }];
+    const sideboard = [{ name: "Forest", count: 15 }];
+    const result = validateDeckAndSideboard(
+      deck,
+      sideboard,
+      "constructed-core",
+    );
+
+    expect(result.isValid).toBe(true);
+  });
+
+  it("should aggregate errors from both the deck and sideboard validators", () => {
+    // Deck too small AND sideboard oversized
+    const deck = [{ name: "Lightning Bolt", count: 1 }];
+    const sideboard = Array(20).fill({ name: "Forest", count: 1 });
+    const result = validateDeckAndSideboard(
+      deck,
+      sideboard,
+      "constructed-core",
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.deckValidation).toBeDefined();
+    expect(result.sideboardValidation).toBeDefined();
+    expect(result.errors.some((e) => e.includes("at least 60 cards"))).toBe(
+      true,
+    );
+    expect(result.errors.some((e) => e.includes("at most 15 cards"))).toBe(
+      true,
+    );
+  });
+
+  it("should reject sideboards for formats that do not use them", () => {
+    const deck = Array(100).fill({ name: "Forest", count: 1 });
+    const sideboard = [{ name: "Lightning Bolt", count: 1 }];
+    const result = validateDeckAndSideboard(
+      deck,
+      sideboard,
+      "legendary-commander",
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain(
+      "Legendary Commander format does not use sideboards",
     );
   });
 });
@@ -423,7 +603,11 @@ describe("Game Rules - isDeckLegal", () => {
   it("should return true for a legal legendary commander deck", () => {
     // Create a valid legendary commander deck with 100 singleton cards
     const deck: { name: string; count: number; color_identity?: string[] }[] = [
-      { name: "Ghired, Shell of the Ghireds", count: 1, color_identity: ["R", "W", "G"] },
+      {
+        name: "Ghired, Shell of the Ghireds",
+        count: 1,
+        color_identity: ["R", "W", "G"],
+      },
       { name: "Forest", count: 35 },
       { name: "Mountain", count: 35 },
       { name: "Lightning Bolt", count: 1, color_identity: ["R"] },
@@ -432,32 +616,26 @@ describe("Game Rules - isDeckLegal", () => {
     ];
     // Add 26 more unique cards to reach 100
     for (let i = 1; i <= 26; i++) {
-      deck.push({ name: `Unique Card ${i}`, count: 1, color_identity: ["R", "W", "G"] });
-    }
-    const result = isDeckLegal(
-      deck,
-      "legendary-commander",
-      {
-        name: "Ghired, Shell of the Ghireds",
+      deck.push({
+        name: `Unique Card ${i}`,
+        count: 1,
         color_identity: ["R", "W", "G"],
-      }
-    );
+      });
+    }
+    const result = isDeckLegal(deck, "legendary-commander", {
+      name: "Ghired, Shell of the Ghireds",
+      color_identity: ["R", "W", "G"],
+    });
 
     expect(result).toBe(true);
   });
 
   it("should return false for an illegal legendary commander deck", () => {
-    const deck = [
-      { name: "Counterspell", count: 4, color_identity: ["U"] },
-    ];
-    const result = isDeckLegal(
-      deck,
-      "legendary-commander",
-      {
-        name: "Ghired, Shell of the Ghireds",
-        color_identity: ["R", "W"],
-      }
-    );
+    const deck = [{ name: "Counterspell", count: 4, color_identity: ["U"] }];
+    const result = isDeckLegal(deck, "legendary-commander", {
+      name: "Ghired, Shell of the Ghireds",
+      color_identity: ["R", "W"],
+    });
 
     expect(result).toBe(false);
   });
@@ -566,13 +744,25 @@ describe("Game Rules - Helper functions", () => {
 
   describe("getFormatDisplayName", () => {
     it("should return proper display names", () => {
-      expect(getFormatDisplayName("legendary-commander")).toBe("Legendary Commander");
+      expect(getFormatDisplayName("legendary-commander")).toBe(
+        "Legendary Commander",
+      );
       expect(getFormatDisplayName("constructed-core")).toBe("Constructed Core");
-      expect(getFormatDisplayName("constructed-legacy")).toBe("Constructed Legacy");
-      expect(getFormatDisplayName("constructed-vintage")).toBe("Constructed Vintage");
-      expect(getFormatDisplayName("constructed-extended")).toBe("Constructed Extended");
-      expect(getFormatDisplayName("constructed-restricted")).toBe("Constructed Restricted");
-      expect(getFormatDisplayName("constructed-pioneer")).toBe("Constructed Pioneer");
+      expect(getFormatDisplayName("constructed-legacy")).toBe(
+        "Constructed Legacy",
+      );
+      expect(getFormatDisplayName("constructed-vintage")).toBe(
+        "Constructed Vintage",
+      );
+      expect(getFormatDisplayName("constructed-extended")).toBe(
+        "Constructed Extended",
+      );
+      expect(getFormatDisplayName("constructed-restricted")).toBe(
+        "Constructed Restricted",
+      );
+      expect(getFormatDisplayName("constructed-pioneer")).toBe(
+        "Constructed Pioneer",
+      );
     });
   });
 });
@@ -610,7 +800,9 @@ describe("Game Rules - Game Mode System", () => {
     it("should return all game modes", () => {
       const modes = getAllGameModes();
       expect(modes.length).toBeGreaterThan(0);
-      expect(modes.every((mode) => mode.id && mode.name && mode.description)).toBe(true);
+      expect(
+        modes.every((mode) => mode.id && mode.name && mode.description),
+      ).toBe(true);
     });
   });
 
@@ -646,10 +838,7 @@ describe("Game Rules - Game Mode System", () => {
         name: "Custom Format",
         description: "A custom game mode",
         deckRules: DEFAULT_RULES.constructed,
-        rules: [
-          "Custom rule 1",
-          "Custom rule 2",
-        ],
+        rules: ["Custom rule 1", "Custom rule 2"],
         banList: ["banned card"],
       });
 
@@ -714,7 +903,9 @@ describe("Game Rules - Game Mode System", () => {
   describe("getGameModeDescription", () => {
     it("should return description for legendary-commander", () => {
       const desc = getGameModeDescription("legendary-commander");
-      expect(desc).toBe("Single-commander format with 100-card decks and 40 starting life");
+      expect(desc).toBe(
+        "Single-commander format with 100-card decks and 40 starting life",
+      );
     });
 
     it("should return description for constructed-core", () => {

--- a/src/lib/game-rules.ts
+++ b/src/lib/game-rules.ts
@@ -668,18 +668,51 @@ export function validateSideboard(
     );
   }
 
-  // Check that sideboard cards don't exceed 4 copies
-  const cardCounts = new Map<string, number>();
+  // Enforce banned list, restricted list, and copy limits in the sideboard.
+  // Combined main+sideboard limits are enforced by validateDeckAndSideboard.
+  const bannedCards = new Set(
+    (gameMode.banList || []).map((c) => c.toLowerCase()),
+  );
+  const restrictedCards = new Set(
+    (gameMode.restrictedList || []).map((c) => c.toLowerCase()),
+  );
+
+  const cardCounts = new Map<string, { count: number; isBasic: boolean }>();
 
   sideboardCards.forEach(({ name, count }) => {
     const normalizedName = name.toLowerCase().trim();
-    const currentCount = cardCounts.get(normalizedName) || 0;
-    cardCounts.set(normalizedName, currentCount + count);
+    const isBasic = isBasicLand(name);
+    const current = cardCounts.get(normalizedName) || { count: 0, isBasic };
+    cardCounts.set(normalizedName, {
+      count: current.count + count,
+      isBasic: current.isBasic && isBasic,
+    });
   });
 
-  cardCounts.forEach((count, cardName) => {
-    if (count > 4) {
-      errors.push(`Sideboard: ${cardName} has ${count} copies, maximum is 4`);
+  cardCounts.forEach(({ count, isBasic }, cardName) => {
+    // Banned cards are never allowed in the sideboard
+    if (bannedCards.has(cardName)) {
+      errors.push(`${cardName} is banned in ${gameMode.name}`);
+      return;
+    }
+
+    // Restricted cards are limited to a single copy
+    if (restrictedCards.has(cardName)) {
+      if (count > 1) {
+        errors.push(
+          `Sideboard: ${cardName} is restricted in ${gameMode.name} - maximum 1 copy allowed`,
+        );
+      }
+      return;
+    }
+
+    // Basic lands are exempt from copy limits
+    if (isBasic) return;
+
+    if (count > rules.maxCopies) {
+      errors.push(
+        `Sideboard: ${cardName} has ${count} copies, maximum is ${rules.maxCopies}`,
+      );
     }
   });
 
@@ -687,6 +720,117 @@ export function validateSideboard(
     isValid: errors.length === 0,
     errors,
     warnings,
+  };
+}
+
+/**
+ * Validation result for a deck and its sideboard checked together.
+ */
+export interface DeckAndSideboardValidationResult {
+  isValid: boolean;
+  errors: string[];
+  warnings: string[];
+  deckValidation: FormatValidationResult;
+  sideboardValidation: ValidationResult;
+}
+
+/**
+ * Validate a main deck together with its sideboard, enforcing the
+ * cross-list rules that per-list validators cannot catch:
+ *  - restricted cards are limited to 1 copy across main + sideboard combined
+ *  - banned cards are disallowed in both lists (delegated to per-list checks)
+ *  - non-basic-land cards are limited to maxCopies across main + sideboard combined
+ *
+ * Per-list checks (deck size, sideboard size, color identity, etc.) are
+ * delegated to validateDeckFormat and validateSideboard.
+ */
+export function validateDeckAndSideboard(
+  deckCards: {
+    name: string;
+    count: number;
+    color_identity?: string[];
+    type_line?: string;
+  }[],
+  sideboardCards: { name: string; count: number }[],
+  format: Format,
+  commander?: { name: string; color_identity: string[] },
+): DeckAndSideboardValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Validate each list independently first.
+  const deckValidation = validateDeckFormat(deckCards, format, commander);
+  const sideboardValidation = validateSideboard(sideboardCards, format);
+
+  errors.push(...deckValidation.errors, ...sideboardValidation.errors);
+  warnings.push(...deckValidation.warnings, ...sideboardValidation.warnings);
+
+  const gameModeId = getGameModeIdFromFormatName(format);
+  const gameMode = gameModes[gameModeId];
+
+  if (gameMode) {
+    const rules = gameMode.deckRules;
+    const bannedCards = new Set(
+      (gameMode.banList || []).map((c) => c.toLowerCase()),
+    );
+    const restrictedCards = new Set(
+      (gameMode.restrictedList || []).map((c) => c.toLowerCase()),
+    );
+
+    // Aggregate combined copy counts across main deck + sideboard.
+    const combined = new Map<string, { count: number; isBasic: boolean }>();
+
+    const addCards = (cards: { name: string; count: number }[]) => {
+      cards.forEach(({ name, count }) => {
+        const normalizedName = name.toLowerCase().trim();
+        const isBasic = isBasicLand(name);
+        const current = combined.get(normalizedName) || {
+          count: 0,
+          isBasic,
+        };
+        combined.set(normalizedName, {
+          count: current.count + count,
+          isBasic: current.isBasic && isBasic,
+        });
+      });
+    };
+
+    addCards(deckCards);
+    addCards(sideboardCards);
+
+    combined.forEach(({ count, isBasic }, cardName) => {
+      // Basic lands are exempt from copy limits
+      if (isBasic) return;
+
+      // Banned cards are already reported by the per-list validators;
+      // skip here to avoid duplicating the error message.
+      if (bannedCards.has(cardName)) return;
+
+      // Restricted cards: max 1 copy across main + sideboard combined
+      if (restrictedCards.has(cardName)) {
+        if (count > 1) {
+          errors.push(
+            `${cardName} is restricted in ${gameMode.name} - maximum 1 copy allowed across deck and sideboard (has ${count})`,
+          );
+        }
+        return;
+      }
+
+      // Standard copy limit across main + sideboard combined
+      if (count > rules.maxCopies) {
+        errors.push(
+          `${cardName} has ${count} copies across deck and sideboard, maximum is ${rules.maxCopies} in ${gameMode.name}`,
+        );
+      }
+    });
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+    warnings,
+    deckValidation,
+    sideboardValidation,
   };
 }
 


### PR DESCRIPTION
## Problem

Resolves #914 (follow-up to #894).

`validateSideboard` in `src/lib/game-rules.ts` only checked sideboard size and per-card copy counts (≤4). It **ignored** the format's banned and restricted lists, so a player could stash a banned card or multiple restricted cards in the sideboard. There was also **no combined main+sideboard enforcement**: a card could appear 4× in the main deck *and* again in the sideboard (exceeding the 4-copy limit), and a restricted card could appear once in each list (2 combined). The #894 fix only covered the main deck.

## Solution

- **`validateSideboard`**: now enforces the format's banned list (zero copies) and restricted list (≤1 copy) within the sideboard, and exempts basic lands from the copy limit (matching `validateDeckFormat`). Messages follow the existing style.
- **New `validateDeckAndSideboard(deckCards, sideboardCards, format, commander?)`**: delegates per-list checks to `validateDeckFormat` + `validateSideboard`, then enforces the cross-list rules that per-list validators cannot catch:
  - restricted card ≤ 1 copy across main + sideboard **combined**;
  - non-basic-land card ≤ `maxCopies` (4) across main + sideboard **combined**;
  - basic lands exempt; banned cards reported by per-list validators (no duplicate noise).
  Returns an aggregated result including the underlying deck/sideboard results for callers that want detail.

The new function is additive and backward-compatible; existing validators and their call sites are unchanged.

## Files changed

- `src/lib/game-rules.ts` — enhanced `validateSideboard` (banned/restricted/basic-land handling); added `validateDeckAndSideboard` + `DeckAndSideboardValidationResult` interface.
- `src/lib/__tests__/game-rules.test.ts` — added tests for sideboard banned/restricted enforcement and combined main+sideboard limits (restricted >1 combined, banned in sideboard, >4 combined non-basic, basic-land exemption, error aggregation, no-sideboard format).

## Test results

- `npx jest src/lib/__tests__/game-rules.test.ts` → **104 passed** (incl. new cases).
- `npx jest src/lib/__tests__/game-rules-custom-formats.test.ts sideboard-plans.test.ts` → **34 passed**.
- `npx tsc --noEmit` → clean.
- `npx eslint src/lib/game-rules.ts src/lib/__tests__/game-rules.test.ts` → clean.

## Notes / assumptions

- Issue #914 had no body/comments; scope was inferred from its title and the closed #894. Assumed standard Magic rules: banned = 0 copies; restricted = ≤1 copy across all zones; non-basic-land copy cap = `maxCopies` (4) across main+sideboard combined.
- Did not modify the unrelated, simpler `validateDeckFormat` in `deck-storage.ts` (different function operating on `Deck` objects); the format-aware legality layer lives in `game-rules.ts`.
- Builds on the #913 init-race fix already on the branch; no regression to it.
