### PR TITLE
feat: resolve #912 — live opponent-archetype detection so ai adapts to the opponent

### DIFF
--- a/src/ai/__tests__/ai-turn-loop.test.ts
+++ b/src/ai/__tests__/ai-turn-loop.test.ts
@@ -9,7 +9,11 @@
  */
 
 import { describe, it, expect } from "@jest/globals";
-import { detectPlayerArchetype, type AITurnConfig } from "../ai-turn-loop";
+import {
+  detectPlayerArchetype,
+  detectOpponentArchetype,
+  type AITurnConfig,
+} from "../ai-turn-loop";
 import type { DeckCard } from "@/app/actions";
 import type {
   GameState as EngineGameState,
@@ -201,5 +205,126 @@ describe("AITurnConfig.archetype override (issue #911)", () => {
   it("leaves archetype optional for backward compatibility", () => {
     const config: AITurnConfig = { difficulty: "medium", delayMs: 0 };
     expect(config.archetype).toBeUndefined();
+  });
+});
+
+/**
+ * Build a minimal engine game state placing the given cards into specific
+ * OBSERVED zones for a player. Used to verify {@link detectOpponentArchetype}
+ * reads only revealed/played zones and never the opponent's hidden library
+ * or hand.
+ */
+function buildObservedState(
+  playerId: string,
+  zoneCards: Record<string, DeckCard[]>,
+): EngineGameState {
+  const cards = new Map<string, CardInstance>();
+  const zones = new Map<string, { cardIds: string[] }>();
+  let i = 0;
+  for (const [zoneSuffix, deck] of Object.entries(zoneCards)) {
+    const cardIds: string[] = [];
+    for (const card of deck) {
+      const id = `${playerId}-${zoneSuffix}-${i++}`;
+      cardIds.push(id);
+      cards.set(id, {
+        id,
+        oracleId: id,
+        cardData: { ...card },
+        currentFaceIndex: 0,
+        isFaceDown: false,
+        controllerId: playerId,
+        ownerId: playerId,
+        isTapped: false,
+        isFlipped: false,
+        isTurnedFaceUp: false,
+        isPhasedOut: false,
+      } as unknown as CardInstance);
+    }
+    zones.set(`${playerId}-${zoneSuffix}`, { cardIds });
+  }
+  return { zones, cards } as unknown as EngineGameState;
+}
+
+describe("detectOpponentArchetype (issue #912 — live opponent detection)", () => {
+  it("returns 'unknown' when the opponent has no observed cards", () => {
+    const empty = {
+      zones: new Map(),
+      cards: new Map(),
+    } as unknown as EngineGameState;
+    expect(detectOpponentArchetype(empty, "player2")).toBe("unknown");
+  });
+
+  it("detects 'aggro' from observed battlefield + graveyard cards", () => {
+    // Resolved burn spells in the graveyard (observed once cast) ...
+    const graveyard = [
+      createCard("Lightning Bolt", "Instant", 1, ["R"], "Deal 3 damage"),
+      createCard("Lava Spike", "Sorcery", 1, ["R"], "Deal 3 damage"),
+      createCard("Burst Lightning", "Instant", 2, ["R"], "Deal 4 damage"),
+    ];
+    // ... and aggressive creatures currently on the battlefield.
+    const battlefield = [
+      createCard("Goblin Guide", "Creature", 1, ["R"], "Haste"),
+      createCard("Monastery Swiftspear", "Creature", 1, ["R", "U"], "Prowess"),
+    ];
+    const state = buildObservedState("player2", {
+      graveyard,
+      battlefield,
+    });
+    expect(detectOpponentArchetype(state, "player2")).toBe("aggro");
+  });
+
+  it("does NOT read the opponent's hidden library or hand", () => {
+    // A full aggro deck placed ONLY in hidden zones (library + hand) must not
+    // influence detection — those cards are not yet observed information.
+    const aggroDeck: DeckCard[] = [
+      createCard("Lightning Bolt", "Instant", 1, ["R"], "Deal 3 damage"),
+      createCard("Lava Spike", "Sorcery", 1, ["R"], "Deal 3 damage"),
+      createCard("Goblin Guide", "Creature", 1, ["R"], "Haste"),
+      createCard("Monastery Swiftspear", "Creature", 1, ["R", "U"], "Prowess"),
+      createCard("Rift Bolt", "Sorcery", 3, ["R"], "Deal 3 damage"),
+    ];
+    const state = buildObservedState("player2", {
+      library: aggroDeck,
+      hand: aggroDeck,
+    });
+    // Observed zones are empty -> nothing detected, regardless of the hidden deck.
+    expect(detectOpponentArchetype(state, "player2")).toBe("unknown");
+  });
+
+  it("never throws and returns a valid archetype bucket", () => {
+    const state = buildObservedState("player2", {
+      battlefield: [createCard("Forest", "Land", 0, [], "")],
+    });
+    expect(() => detectOpponentArchetype(state, "player2")).not.toThrow();
+    expect([
+      "aggro",
+      "unknown",
+      "midrange",
+      "control",
+      "combo",
+      "ramp",
+    ]).toContain(detectOpponentArchetype(state, "player2"));
+  });
+
+  it("updates the detected archetype as the opponent plays more cards", () => {
+    const burnCards: DeckCard[] = [
+      createCard("Lightning Bolt", "Instant", 1, ["R"], "Deal 3 damage"),
+      createCard("Lava Spike", "Sorcery", 1, ["R"], "Deal 3 damage"),
+      createCard("Goblin Guide", "Creature", 1, ["R"], "Haste"),
+      createCard("Monastery Swiftspear", "Creature", 1, ["R", "U"], "Prowess"),
+    ];
+
+    // Early game: the opponent has revealed nothing yet.
+    const emptyState = buildObservedState("player2", {});
+    expect(detectOpponentArchetype(emptyState, "player2")).toBe("unknown");
+
+    // Later: the opponent has cast burn spells (now in the graveyard) and
+    // committed aggressive creatures to the battlefield. The detector should
+    // now classify the emerging archetype as aggro.
+    const midGameState = buildObservedState("player2", {
+      graveyard: burnCards.slice(0, 2),
+      battlefield: burnCards.slice(2),
+    });
+    expect(detectOpponentArchetype(midGameState, "player2")).toBe("aggro");
   });
 });

--- a/src/ai/__tests__/combat-decision-tree.test.ts
+++ b/src/ai/__tests__/combat-decision-tree.test.ts
@@ -8,10 +8,12 @@ import { describe, it, expect, beforeEach } from "@jest/globals";
 import {
   CombatDecisionTree,
   DefaultCombatConfigs,
+  deckArchetypeToOpponentArchetype,
   type CombatPlan,
   type AttackDecision,
   type BlockDecision,
 } from "../decision-making/combat-decision-tree";
+import { predictOpponentBlocks } from "../decision-making/block-prediction";
 import type {
   AIGameState,
   AIPlayerState,
@@ -829,6 +831,82 @@ describe("CombatDecisionTree", () => {
       expect(combo.generateAttackPlan().strategy).toBe("defensive");
       // midrange lifeThreshold stays at 10, so 14 life is still safe -> not defensive.
       expect(midrange.generateAttackPlan().strategy).not.toBe("defensive");
+    });
+  });
+
+  describe("live opponent-archetype detection (#912)", () => {
+    it('defaults opponentArchetype to "unknown" when none is supplied (backward compat)', () => {
+      const combatAI = new CombatDecisionTree(createTestGameState(), "player1");
+      expect(combatAI.getOpponentArchetype()).toBe("unknown");
+      expect(combatAI.getConfig().opponentArchetype).toBe("unknown");
+    });
+
+    it("stores the supplied opponent archetype and surfaces it in the config", () => {
+      const combatAI = new CombatDecisionTree(
+        createTestGameState(),
+        "player1",
+        "medium",
+        "unknown",
+        "control",
+      );
+      expect(combatAI.getOpponentArchetype()).toBe("control");
+      // Previously DefaultCombatConfigs forced this to "unknown" regardless.
+      expect(combatAI.getConfig().opponentArchetype).toBe("control");
+    });
+
+    it("keeps the AI's own archetype independent of the opponent archetype", () => {
+      const combatAI = new CombatDecisionTree(
+        createTestGameState(),
+        "player1",
+        "medium",
+        "aggro",
+        "control",
+      );
+      expect(combatAI.getArchetype()).toBe("aggro");
+      expect(combatAI.getOpponentArchetype()).toBe("control");
+    });
+
+    it("maps deck archetype buckets onto the opponent-archetype vocabulary", () => {
+      expect(deckArchetypeToOpponentArchetype("aggro")).toBe("aggro");
+      expect(deckArchetypeToOpponentArchetype("control")).toBe("control");
+      expect(deckArchetypeToOpponentArchetype("combo")).toBe("combo");
+      expect(deckArchetypeToOpponentArchetype("midrange")).toBe("midrange");
+      // ramp has no OpponentArchetype counterpart -> folds to midrange.
+      expect(deckArchetypeToOpponentArchetype("ramp")).toBe("midrange");
+      expect(deckArchetypeToOpponentArchetype("unknown")).toBe("unknown");
+    });
+
+    it("adapts block prediction to the detected opponent archetype", () => {
+      // Same attacker and potential blocker; only the opponent archetype
+      // changes. A control opponent blocks far more readily than an aggro one,
+      // so the predicted block probability and the weights consumed by the
+      // live combat tree must differ. This proves the detected opponent
+      // archetype reaches and shifts the strategy the AI plans against.
+      const attacker = createMockPermanent("a1", "Bear", "creature", 2, 2);
+      const blocker = createMockPermanent("b1", "Bear", "creature", 2, 2);
+
+      const aggroPred = predictOpponentBlocks(
+        [attacker],
+        [blocker],
+        20,
+        "aggro",
+      );
+      const controlPred = predictOpponentBlocks(
+        [attacker],
+        [blocker],
+        20,
+        "control",
+      );
+
+      // The archetype weights table is the bridge between detection and the
+      // block model — willingnessToBlock must reflect the opponent archetype.
+      expect(aggroPred.archetypeWeights.willingnessToBlock).toBeLessThan(
+        controlPred.archetypeWeights.willingnessToBlock,
+      );
+      // And the resulting block-probability feeding attack EV must differ.
+      expect(aggroPred.predictions[0].blockProbability).not.toBe(
+        controlPred.predictions[0].blockProbability,
+      );
     });
   });
 });

--- a/src/ai/ai-turn-loop.ts
+++ b/src/ai/ai-turn-loop.ts
@@ -99,6 +99,58 @@ export function detectPlayerArchetype(
 }
 
 /**
+ * Detect the OPPONENT's emerging deck archetype from the engine game state.
+ *
+ * Unlike {@link detectPlayerArchetype} (which reads the AI's own deck across
+ * every zone, including the hidden library/hand), this only inspects
+ * OBSERVED zones — cards the opponent has actually revealed or played during
+ * the game:
+ *   - battlefield (permanents they control)
+ *   - graveyard (resolved spells / dead creatures)
+ *   - exile (exiled cards)
+ *
+ * The opponent's library and hand are hidden information and are deliberately
+ * NOT consulted. As the opponent plays/reveals more cards across turns, the
+ * observed set grows and the detected archetype's confidence rises naturally.
+ *
+ * Returns the coarse {@link DeckArchetype} bucket; "unknown" until enough
+ * cards have been observed or when classification fails (issue #912).
+ */
+export function detectOpponentArchetype(
+  state: EngineGameState,
+  opponentId: PlayerId,
+): DeckArchetype {
+  // Observed zones only — never the opponent's hidden library or hand.
+  const zoneKeys = [
+    `${opponentId}-battlefield`,
+    `${opponentId}-graveyard`,
+    `${opponentId}-exile`,
+  ];
+
+  const cards: DeckCard[] = [];
+  for (const key of zoneKeys) {
+    const zone = state.zones.get(key);
+    if (!zone) continue;
+    for (const cardId of zone.cardIds) {
+      const card = state.cards.get(cardId);
+      if (card?.cardData) {
+        cards.push({ ...card.cardData, count: 1 } as DeckCard);
+      }
+    }
+  }
+
+  if (cards.length === 0) return "unknown";
+
+  try {
+    const result = detectArchetype(cards);
+    if (!result || result.primary === "Unknown") return "unknown";
+    return classifyArchetypeName(result.primary);
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
  * AI Turn result
  */
 export interface AITurnResult {
@@ -400,18 +452,27 @@ async function runCombatPhase(
 
   // Use CombatDecisionTree for intelligent attack decisions
   // Import dynamically to avoid circular dependencies
-  const { CombatDecisionTree } =
+  const { CombatDecisionTree, deckArchetypeToOpponentArchetype } =
     await import("./decision-making/combat-decision-tree");
   // Resolve the deck-specific playstyle so per-archetype weights reach the
   // live combat decisions. Prefer an explicit config override, otherwise
   // auto-detect from the AI player's deck (issue #911).
   const archetype =
     config.archetype ?? detectPlayerArchetype(currentState, aiPlayerId);
+  // Detect the opponent's emerging archetype from the cards they have
+  // revealed/played (observed zones only) so the AI can adapt its block
+  // prediction / strategy to what the opponent is actually doing. Previously
+  // the opponentArchetype config was always "unknown" (issue #912).
+  const opponentId = getOpponentId(currentState, aiPlayerId);
+  const opponentArchetype = deckArchetypeToOpponentArchetype(
+    detectOpponentArchetype(currentState, opponentId),
+  );
   const combatAI = new CombatDecisionTree(
     aiState,
     aiPlayerId,
     config.difficulty,
     archetype,
+    opponentArchetype,
   );
 
   // Generate attack plan using unified format

--- a/src/ai/decision-making/combat-decision-tree.ts
+++ b/src/ai/decision-making/combat-decision-tree.ts
@@ -82,6 +82,37 @@ function clamp01(value: number): number {
 }
 
 /**
+ * Map the coarse {@link DeckArchetype} bucket (the AI's own-deck vocabulary,
+ * also produced by the live opponent detector) onto the
+ * {@link OpponentArchetype} vocabulary that block prediction consumes.
+ *
+ * The two share aggro / control / combo / midrange. "ramp" has no direct
+ * counterpart in {@link OpponentArchetype} and is folded into "midrange"
+ * (a ramp deck blocks like a value/midrange deck); "unknown" passes through.
+ *
+ * Exported so the live turn loop can translate a *detected* opponent deck
+ * archetype into the form {@link CombatDecisionTree}'s block-prediction
+ * subsystem expects (issue #912).
+ */
+export function deckArchetypeToOpponentArchetype(
+  archetype: DeckArchetype,
+): OpponentArchetype {
+  switch (archetype) {
+    case "aggro":
+      return "aggro";
+    case "control":
+      return "control";
+    case "combo":
+      return "combo";
+    case "midrange":
+    case "ramp":
+      return "midrange";
+    default:
+      return "unknown";
+  }
+}
+
+/**
  * Card data interface for combat tricks
  * Extends the basic HandCard with combat-relevant information
  */
@@ -279,15 +310,18 @@ export class CombatDecisionTree {
   private heuristicTable: HeuristicTable;
   private lookaheadEngine: LookaheadEngine;
   private archetype: DeckArchetype;
+  private opponentArchetype: OpponentArchetype;
   constructor(
     gameState: GameState,
     aiPlayerId: string,
     difficulty: "easy" | "medium" | "hard" | "expert" = "medium",
     archetype: DeckArchetype = "unknown",
+    opponentArchetype: OpponentArchetype = "unknown",
   ) {
     this.gameState = gameState;
     this.aiPlayerId = aiPlayerId;
     this.archetype = archetype;
+    this.opponentArchetype = opponentArchetype;
 
     const baseConfig = DefaultCombatConfigs[difficulty];
     // Wire the deck-specific playstyle weights into the live combat config.
@@ -312,6 +346,11 @@ export class CombatDecisionTree {
     } else {
       this.config = { ...baseConfig };
     }
+    // Populate the opponent-archetype signal that block prediction consumes.
+    // DefaultCombatConfigs hardcodes this to "unknown", so without an explicit
+    // override the AI could never model how the opponent will block — the
+    // signal was effectively dead code (issue #912).
+    this.config.opponentArchetype = opponentArchetype;
     this.heuristicTable = new HeuristicTable();
     this.lookaheadEngine = new LookaheadEngine(
       this.heuristicTable,
@@ -325,6 +364,15 @@ export class CombatDecisionTree {
    */
   getArchetype(): DeckArchetype {
     return this.archetype;
+  }
+
+  /**
+   * The opponent's emerging archetype, as observed from the cards they have
+   * revealed/played ("unknown" until enough information is available). Drives
+   * block-prediction weights so the AI models how the opponent will block.
+   */
+  getOpponentArchetype(): OpponentArchetype {
+    return this.opponentArchetype;
   }
 
   /**
@@ -2078,12 +2126,14 @@ export function generateAttackDecisions(
   aiPlayerId: string,
   difficulty: "easy" | "medium" | "hard" | "expert" = "medium",
   archetype: DeckArchetype = "unknown",
+  opponentArchetype: OpponentArchetype = "unknown",
 ): CombatPlan {
   const ai = new CombatDecisionTree(
     gameState,
     aiPlayerId,
     difficulty,
     archetype,
+    opponentArchetype,
   );
   return ai.generateAttackPlan();
 }
@@ -2097,12 +2147,14 @@ export function generateBlockingDecisions(
   attackers: Permanent[],
   difficulty: "easy" | "medium" | "hard" | "expert" = "medium",
   archetype: DeckArchetype = "unknown",
+  opponentArchetype: OpponentArchetype = "unknown",
 ): CombatPlan {
   const ai = new CombatDecisionTree(
     gameState,
     aiPlayerId,
     difficulty,
     archetype,
+    opponentArchetype,
   );
   return ai.generateBlockingPlan(attackers);
 }

--- a/src/ai/decision-making/index.ts
+++ b/src/ai/decision-making/index.ts
@@ -10,6 +10,7 @@ export {
   generateBlockingDecisions,
   DefaultCombatConfigs,
   ARCHETYPE_COMBAT_MODIFIERS,
+  deckArchetypeToOpponentArchetype,
   type CombatAIConfig,
   type AttackDecision,
   type BlockDecision,


### PR DESCRIPTION
## Problem

Issue #912: the AI had **no live opponent-archetype detection**. Although `CombatDecisionTree` already defined a `config.opponentArchetype` field (consumed by `predictOpponentBlocks` to model how willingly the opponent blocks), `DefaultCombatConfigs` hardcoded it to `"unknown"` and **nothing ever populated it**. So block prediction always used the `unknown` weights — the AI could not adapt its strategy to what the opponent was actually playing.

This is the complement to #911 (which wired the AI's *own* archetype into the live turn loop).

## Solution

Detect the opponent's **emerging** archetype live, from cards they have actually **revealed/played**, and feed it into the combat decision tree so block prediction (and thus attack EV) adapts. Reuses the existing detection infrastructure — no duplication.

1. **`ai-turn-loop.ts`** — new `detectOpponentArchetype(state, opponentId)`. Mirrors the #911 `detectPlayerArchetype`, but inspects **observed zones only** (`battlefield`, `graveyard`, `exile`). The opponent's `library`/`hand` are hidden information and are deliberately **not** consulted — so confidence rises naturally as the opponent plays/reveals more cards across turns. `runCombatPhase` now detects the opponent archetype and passes it into `CombatDecisionTree`.
2. **`combat-decision-tree.ts`** — `CombatDecisionTree` accepts an optional `opponentArchetype` and populates `config.opponentArchetype` (previously always `"unknown"`). New `getOpponentArchetype()` getter. New `deckArchetypeToOpponentArchetype()` mapper bridges the two archetype vocabularies (`DeckArchetype` has `ramp`; `OpponentArchetype` has `tempo` — `ramp` folds to `midrange`). Threaded through `generateAttackDecisions`/`generateBlockingDecisions`.
3. **`decision-making/index.ts`** — re-export `deckArchetypeToOpponentArchetype`.

All constructor/wrapper changes are **additive** (new optional params/fields), so existing callers and tests remain backward compatible. The AI's own-archetype path from #911 is untouched.

## Files changed

- `src/ai/ai-turn-loop.ts` — `detectOpponentArchetype()` (observed-zones-only) + wiring into `runCombatPhase`.
- `src/ai/decision-making/combat-decision-tree.ts` — `opponentArchetype` ctor param + `getOpponentArchetype()` + `deckArchetypeToOpponentArchetype()` mapper + threading through convenience wrappers.
- `src/ai/decision-making/index.ts` — re-export mapper.
- `src/ai/__tests__/ai-turn-loop.test.ts` — `detectOpponentArchetype` suite (unknown when unobserved, detects aggro from observed cards, **does not read hidden library/hand**, updates as opponent plays more cards, never throws).
- `src/ai/__tests__/combat-decision-tree.test.ts` — `#912` suite (default backward compat, stores opponent archetype, independence from own archetype, mapper correctness, **block prediction adapts** to opponent archetype).

## Test results

- New/changed suites pass: `ai-turn-loop.test.ts`, `combat-decision-tree.test.ts`.
- Full AI suite: **525 / 525 passing** (`npx jest src/ai`) — up from 515 in #911 (10 new tests added).
- `npx tsc --noEmit`: clean.
- `npm run lint`: **0 errors** (only pre-existing warnings; none in changed files).

Key behavioral assertions:
- A full aggro deck placed **only** in the opponent's hidden `library`/`hand` yields `"unknown"` — hidden info is never peeked.
- The same aggro deck revealed via `graveyard` + `battlefield` yields `"aggro"`.
- An identical attacker/blocker board produces **different** predicted block probabilities against an `aggro` vs `control` opponent (control blocks more readily), proving the detected archetype reaches and shifts the strategy the AI plans against.

Closes #912.
