### PR TITLE
fix: resolve #915 — implement P2P reconnection (no-op stub stranded games in reconnecting forever)

### DIFF
--- a/src/lib/__tests__/webrtc-p2p.test.ts
+++ b/src/lib/__tests__/webrtc-p2p.test.ts
@@ -1,56 +1,363 @@
 /**
  * WebRTC P2P Connection Tests
- * 
+ *
  * Tests for the WebRTC P2P module which provides peer-to-peer connections
  * for multiplayer games.
  * Issue #604: Add tests for P2P networking
+ * Issue #915: attemptReconnection() ICE restart + bounded retries
  */
 
 import {
   DEFAULT_RTC_CONFIG,
   generateGameCode,
-} from '../webrtc-p2p';
+  WebRTCConnection,
+  type P2PEvents,
+} from "../webrtc-p2p";
 
-describe('WebRTC P2P', () => {
-  describe('generateGameCode', () => {
-    it('should generate a game code with default length of 6', () => {
+describe("WebRTC P2P", () => {
+  describe("generateGameCode", () => {
+    it("should generate a game code with default length of 6", () => {
       const code = generateGameCode();
-      
+
       expect(code).toHaveLength(6);
       expect(code).toMatch(/^[A-Z0-9]+$/);
     });
 
-    it('should generate a game code with custom length', () => {
+    it("should generate a game code with custom length", () => {
       const code = generateGameCode(4);
-      
+
       expect(code).toHaveLength(4);
     });
 
-    it('should generate unique codes', () => {
+    it("should generate unique codes", () => {
       const codes = new Set();
-      
+
       for (let i = 0; i < 100; i++) {
         codes.add(generateGameCode());
       }
-      
+
       // Should have mostly unique codes (allowing for tiny collision possibility)
       expect(codes.size).toBeGreaterThan(90);
     });
   });
 
-  describe('DEFAULT_RTC_CONFIG', () => {
-    it('should have STUN servers configured', () => {
+  describe("DEFAULT_RTC_CONFIG", () => {
+    it("should have STUN servers configured", () => {
       expect(DEFAULT_RTC_CONFIG).toBeDefined();
       expect(DEFAULT_RTC_CONFIG.iceServers).toBeDefined();
       expect(Array.isArray(DEFAULT_RTC_CONFIG.iceServers)).toBe(true);
       expect(DEFAULT_RTC_CONFIG.iceServers?.length ?? 0).toBeGreaterThan(0);
     });
 
-    it('should have valid STUN server URLs', () => {
+    it("should have valid STUN server URLs", () => {
       const servers = DEFAULT_RTC_CONFIG.iceServers ?? [];
       for (const server of servers) {
         expect(server.urls).toMatch(/^stun:/);
       }
     });
+  });
+});
+
+// =============================================================================
+// Issue #915: attemptReconnection() — ICE restart with bounded retries
+// =============================================================================
+
+/**
+ * Minimal data channel mock.
+ */
+class MockDataChannel {
+  readyState = "open";
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  send(): void {}
+  close(): void {
+    this.readyState = "closed";
+  }
+}
+
+/**
+ * Minimal RTCPeerConnection mock that records the operations needed to verify
+ * the ICE restart reconnection logic.
+ */
+let lastCreatedPC: MockRTCPeerConnection | null = null;
+
+class MockRTCPeerConnection {
+  connectionState: RTCPeerConnectionState = "new";
+  iceConnectionState: RTCIceConnectionState = "new";
+  signalingState: RTCSignalingState = "stable";
+
+  onconnectionstatechange: (() => void) | null = null;
+  oniceconnectionstatechange: (() => void) | null = null;
+  onicecandidate:
+    | ((event: { candidate: RTCIceCandidateInit | null }) => void)
+    | null = null;
+  ondatachannel: ((event: { channel: MockDataChannel }) => void) | null = null;
+
+  localDescription: RTCSessionDescriptionInit | null = null;
+  remoteDescription: RTCSessionDescriptionInit | null = null;
+
+  createOfferCalls: RTCOfferOptions[] = [];
+  setConfigurationCalls = 0;
+  closed = false;
+
+  constructor(_config?: RTCConfiguration) {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    lastCreatedPC = this;
+  }
+
+  setConfiguration(config: RTCConfiguration): void {
+    this.setConfigurationCalls++;
+    void config;
+  }
+
+  async createOffer(
+    options?: RTCOfferOptions,
+  ): Promise<RTCSessionDescriptionInit> {
+    this.createOfferCalls.push(options ?? {});
+    return {
+      type: "offer",
+      sdp: `mock-restart-sdp-${this.createOfferCalls.length}`,
+    };
+  }
+
+  async createAnswer(): Promise<RTCSessionDescriptionInit> {
+    return { type: "answer", sdp: "mock-answer" };
+  }
+
+  async setLocalDescription(desc: RTCSessionDescriptionInit): Promise<void> {
+    this.localDescription = desc;
+  }
+
+  async setRemoteDescription(desc: RTCSessionDescriptionInit): Promise<void> {
+    this.remoteDescription = desc;
+  }
+
+  async addIceCandidate(_candidate: RTCIceCandidateInit): Promise<void> {}
+
+  createDataChannel(label: string): MockDataChannel {
+    void label;
+    return new MockDataChannel();
+  }
+
+  async getStats(): Promise<Map<string, unknown>> {
+    return new Map();
+  }
+
+  close(): void {
+    this.closed = true;
+    this.connectionState = "closed";
+  }
+}
+
+describe("WebRTCConnection reconnection (issue #915)", () => {
+  const ORIGINAL_RTCP = global.RTCPeerConnection;
+
+  beforeEach(() => {
+    // jsdom has no RTCPeerConnection; provide a controllable mock.
+    (global as { RTCPeerConnection?: unknown }).RTCPeerConnection =
+      MockRTCPeerConnection as unknown as typeof RTCPeerConnection;
+  });
+
+  afterEach(() => {
+    (global as { RTCPeerConnection?: unknown }).RTCPeerConnection =
+      ORIGINAL_RTCP;
+  });
+
+  /** Poll-based wait that works with real timers and async reconnect loops. */
+  async function waitFor<T>(
+    fn: () => T | undefined | null,
+    { timeout = 3000, interval = 5 } = {},
+  ): Promise<T> {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+      const result = fn();
+      if (result) return result;
+      await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+    throw new Error(`waitFor timed out after ${timeout}ms`);
+  }
+
+  type ConnOptions = {
+    isHost?: boolean;
+    maxReconnectAttempts?: number;
+    reconnectBaseDelayMs?: number;
+    reconnectAttemptTimeoutMs?: number;
+    onReconnectOffer?: P2PEvents["onReconnectOffer"];
+    onError?: P2PEvents["onError"];
+    onConnectionStateChange?: P2PEvents["onConnectionStateChange"];
+  };
+
+  async function makeConnection(opts: ConnOptions = {}): Promise<{
+    conn: WebRTCConnection;
+    pc: MockRTCPeerConnection;
+    offerSpy: jest.Mock;
+    errorSpy: jest.Mock;
+    stateSpy: jest.Mock;
+  }> {
+    const offerSpy = jest.fn();
+    const errorSpy = jest.fn();
+    const stateSpy = jest.fn();
+
+    const conn = new WebRTCConnection({
+      playerId: "p1",
+      playerName: "Player 1",
+      isHost: opts.isHost ?? true,
+      enableICEMonitoring: false,
+      maxReconnectAttempts: opts.maxReconnectAttempts ?? 3,
+      reconnectBaseDelayMs: opts.reconnectBaseDelayMs ?? 2,
+      reconnectAttemptTimeoutMs: opts.reconnectAttemptTimeoutMs ?? 30,
+      events: {
+        onReconnectOffer: opts.onReconnectOffer ?? offerSpy,
+        onError: opts.onError ?? errorSpy,
+        onConnectionStateChange: opts.onConnectionStateChange ?? stateSpy,
+      },
+    });
+
+    await conn.initialize();
+
+    const pc = lastCreatedPC as MockRTCPeerConnection;
+    lastCreatedPC = null;
+    return { conn, pc, offerSpy, errorSpy, stateSpy };
+  }
+
+  function fireICEState(
+    pc: MockRTCPeerConnection,
+    state: RTCIceConnectionState,
+  ): void {
+    pc.iceConnectionState = state;
+    pc.oniceconnectionstatechange?.();
+  }
+
+  function fireConnectionState(
+    pc: MockRTCPeerConnection,
+    state: RTCPeerConnectionState,
+  ): void {
+    pc.connectionState = state;
+    pc.onconnectionstatechange?.();
+  }
+
+  it("performs an ICE restart on ICE disconnect and recovers to connected", async () => {
+    const { conn, pc, offerSpy } = await makeConnection();
+
+    // Establish the connection first.
+    fireConnectionState(pc, "connected");
+    expect(conn.getConnectionState()).toBe("connected");
+
+    // Simulate a transient ICE disconnect.
+    fireICEState(pc, "disconnected");
+
+    // The host should initiate an ICE restart (createOffer with iceRestart).
+    await waitFor(() => (pc.createOfferCalls.length > 0 ? true : false));
+    expect(pc.createOfferCalls[0]).toEqual({ iceRestart: true });
+    expect(pc.setConfigurationCalls).toBeGreaterThan(0);
+    // A restart offer must be emitted for the signaling layer to forward.
+    await waitFor(() => (offerSpy.mock.calls.length > 0 ? true : false));
+    expect(offerSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "offer" }),
+      "",
+    );
+    expect(conn.getConnectionState()).toBe("reconnecting");
+
+    // Simulate the peer completing renegotiation → connection recovers.
+    fireConnectionState(pc, "connected");
+
+    await waitFor(() =>
+      conn.getConnectionState() === "connected" ? true : false,
+    );
+    expect(conn.getConnectionState()).toBe("connected");
+    // Exactly one restart offer for a single successful recovery.
+    expect(offerSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries with backoff up to max attempts then transitions to terminal failed (not stuck reconnecting)", async () => {
+    const { conn, pc, errorSpy } = await makeConnection({
+      maxReconnectAttempts: 2,
+      reconnectBaseDelayMs: 2,
+      reconnectAttemptTimeoutMs: 15,
+    });
+
+    fireConnectionState(pc, "connected");
+    expect(conn.getConnectionState()).toBe("connected");
+
+    // ICE disconnect that never recovers.
+    fireICEState(pc, "disconnected");
+
+    // Must NOT strand in "reconnecting": it reaches the terminal "failed" state.
+    await waitFor(() =>
+      conn.getConnectionState() === "failed" ? true : false,
+    );
+    expect(conn.getConnectionState()).toBe("failed");
+    expect(conn.getConnectionState()).not.toBe("reconnecting");
+
+    // Two attempts ⇒ two ICE restart offers.
+    expect(pc.createOfferCalls).toHaveLength(2);
+    expect(pc.createOfferCalls.every((o) => o.iceRestart === true)).toBe(true);
+
+    // An actionable error must be surfaced when retries are exhausted.
+    await waitFor(() => (errorSpy.mock.calls.length > 0 ? true : false));
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const reported = errorSpy.mock.calls[0][0] as Error;
+    expect(reported.message).toMatch(/exhausted|unreachable/i);
+  });
+
+  it("does not retry beyond maxReconnectAttempts", async () => {
+    const { conn, pc } = await makeConnection({
+      maxReconnectAttempts: 3,
+      reconnectBaseDelayMs: 1,
+      reconnectAttemptTimeoutMs: 8,
+    });
+
+    fireConnectionState(pc, "connected");
+    fireICEState(pc, "disconnected");
+
+    await waitFor(() =>
+      conn.getConnectionState() === "failed" ? true : false,
+    );
+    // Exactly maxReconnectAttempts restart offers — no unbounded retrying.
+    expect(pc.createOfferCalls).toHaveLength(3);
+  });
+
+  it("answerer (non-host) does not generate a restart offer (avoids glare) and still terminates", async () => {
+    const { conn, pc, offerSpy } = await makeConnection({
+      isHost: false,
+      maxReconnectAttempts: 2,
+      reconnectAttemptTimeoutMs: 15,
+    });
+
+    fireConnectionState(pc, "connected");
+    fireICEState(pc, "disconnected");
+
+    await waitFor(() =>
+      conn.getConnectionState() === "failed" ? true : false,
+    );
+    expect(conn.getConnectionState()).toBe("failed");
+    // The answerer must not create offers (the host drives the restart).
+    expect(pc.createOfferCalls).toHaveLength(0);
+    expect(offerSpy).not.toHaveBeenCalled();
+  });
+
+  it("close() during reconnection settles the cycle without stranding", async () => {
+    const { conn, pc } = await makeConnection({
+      maxReconnectAttempts: 5,
+      reconnectAttemptTimeoutMs: 50,
+    });
+
+    fireConnectionState(pc, "connected");
+    fireICEState(pc, "disconnected");
+
+    // While a reconnection attempt is in flight, close the connection.
+    await waitFor(() =>
+      conn.getConnectionState() === "reconnecting" ? true : false,
+    );
+    conn.close();
+
+    // Give the in-flight async cycle a tick to settle.
+    await new Promise((resolve) => setTimeout(resolve, 80));
+
+    expect(conn.getConnectionState()).toBe("disconnected");
+    // It must not have transitioned into a perpetual reconnecting loop.
+    expect(conn.isConnected()).toBe(false);
   });
 });

--- a/src/lib/webrtc-p2p.ts
+++ b/src/lib/webrtc-p2p.ts
@@ -169,6 +169,12 @@ export interface P2PEvents {
   onError: (error: Error, peerId: string) => void;
   onPeerConnected: (peerInfo: PeerInfo) => void;
   onPeerDisconnected: (peerId: string) => void;
+  /**
+   * Emitted when a reconnection ICE restart produces a new offer that the
+   * signaling layer must forward to the remote peer so renegotiation can
+   * complete. Optional — only the offerer (host) emits this.
+   */
+  onReconnectOffer?: (offer: RTCSessionDescriptionInit, peerId: string) => void;
 }
 
 /**
@@ -187,6 +193,17 @@ export interface P2PConnectionOptions {
   enableICEMonitoring?: boolean;
   /** Fallback to relay on connection failure */
   fallbackToRelay?: boolean;
+  /**
+   * Maximum number of reconnection attempts before transitioning to the
+   * terminal "failed" state. Defaults to 3.
+   */
+  maxReconnectAttempts?: number;
+  /** Base delay (ms) for exponential backoff between reconnection attempts. */
+  reconnectBaseDelayMs?: number;
+  /** Upper bound (ms) for the exponential backoff delay. */
+  reconnectMaxDelayMs?: number;
+  /** Time (ms) to wait for recovery after each ICE restart attempt. */
+  reconnectAttemptTimeoutMs?: number;
 }
 
 /**
@@ -205,6 +222,15 @@ export class WebRTCConnection {
   private events: P2PEvents;
   private reconnectAttempts = 0;
   private maxReconnectAttempts = 3;
+  private reconnectBaseDelayMs = 1000;
+  private reconnectMaxDelayMs = 16000;
+  private reconnectAttemptTimeoutMs = 15000;
+  /** Guards against overlapping reconnection cycles. */
+  private isReconnecting = false;
+  /** Pending timer for the inter-attempt backoff sleep. */
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Resolvers waiting for a recovery verdict during a reconnect attempt. */
+  private recoveryWaiters: Array<(recovered: boolean) => void> = [];
   private pingInterval: ReturnType<typeof setInterval> | null = null;
   private iceManager: ICEConfigurationManager;
   private iceMonitor: ICEConnectionMonitor | null = null;
@@ -220,6 +246,10 @@ export class WebRTCConnection {
     this.gameCode = options.gameCode;
     this.enableICEMonitoring = options.enableICEMonitoring ?? true;
     this.fallbackToRelay = options.fallbackToRelay ?? true;
+    this.maxReconnectAttempts = options.maxReconnectAttempts ?? 3;
+    this.reconnectBaseDelayMs = options.reconnectBaseDelayMs ?? 1000;
+    this.reconnectMaxDelayMs = options.reconnectMaxDelayMs ?? 16000;
+    this.reconnectAttemptTimeoutMs = options.reconnectAttemptTimeoutMs ?? 15000;
 
     // Initialize ICE configuration
     if (options.iceConfig) {
@@ -745,16 +775,15 @@ export class WebRTCConnection {
    * Handle disconnection
    */
   private handleDisconnection(): void {
+    if (this.connectionState === "failed") return;
+
     this.updateConnectionState("disconnected");
     this.stopPingInterval();
 
-    // Attempt reconnection if not exceeded max attempts
-    if (
-      this.reconnectAttempts < this.maxReconnectAttempts &&
-      this.connectionState !== "failed"
-    ) {
-      this.attemptReconnection();
-    }
+    // Kick off (or re-enter) the bounded reconnection cycle. attemptReconnection
+    // is idempotent for concurrent invocations via the isReconnecting guard and
+    // self-limits to maxReconnectAttempts.
+    void this.attemptReconnection();
   }
 
   /**
@@ -763,18 +792,189 @@ export class WebRTCConnection {
   private handleConnectionFailure(): void {
     this.updateConnectionState("failed");
     this.stopPingInterval();
-    this.events.onError(new Error("Connection failed"), "");
+    this.events.onError(
+      new Error(
+        "P2P connection failed: reconnection attempts exhausted. The peer may be unreachable.",
+      ),
+      "",
+    );
   }
 
   /**
-   * Attempt to reconnect
+   * Attempt to recover the connection after a transient ICE disconnect.
+   *
+   * Strategy: perform an ICE restart (host/offerer generates a restart offer and
+   * emits it so the signaling layer can forward it to the remote peer) and wait
+   * for recovery, retrying with exponential backoff up to maxReconnectAttempts.
+   * On success the state transitions back to "connected"; once retries are
+   * exhausted the state transitions to the terminal "failed" state with an
+   * actionable error instead of stranding the game in "reconnecting" forever.
    */
   private async attemptReconnection(): Promise<void> {
-    this.reconnectAttempts++;
+    // Never strand: a closed connection (peerConnection === null) is terminal.
+    if (this.isReconnecting) return;
+    if (!this.peerConnection || this.getConnectionState() === "failed") return;
+
+    this.isReconnecting = true;
     this.updateConnectionState("reconnecting");
 
-    // In a full implementation, this would re-establish the connection
-    // using stored offer/answer or generating new ones
+    try {
+      while (this.reconnectAttempts < this.maxReconnectAttempts) {
+        // Bail out if the connection was closed or already recovered. State is
+        // read via getConnectionState() to avoid TS narrowing the field across
+        // the awaited backoff/recovery steps below.
+        if (!this.peerConnection || this.getConnectionState() === "failed")
+          return;
+        if (this.getConnectionState() === "connected") {
+          this.reconnectAttempts = 0;
+          return;
+        }
+
+        this.reconnectAttempts++;
+
+        // Exponential backoff before this attempt (no delay on the first
+        // attempt so transient blips recover immediately).
+        await this.sleepReconnect(
+          this.getReconnectDelay(this.reconnectAttempts),
+        );
+        if (!this.peerConnection || this.getConnectionState() === "failed")
+          return;
+        if (this.getConnectionState() === "connected") {
+          this.reconnectAttempts = 0;
+          return;
+        }
+
+        try {
+          const recovered = await this.runReconnectAttempt();
+          if (recovered) {
+            this.reconnectAttempts = 0;
+            return;
+          }
+        } catch (error) {
+          this.events.onError(
+            error instanceof Error
+              ? error
+              : new Error("Reconnection attempt failed"),
+            "",
+          );
+        }
+      }
+
+      // Retries exhausted → terminal failure with an actionable error.
+      if (this.getConnectionState() !== "connected") {
+        this.handleConnectionFailure();
+      }
+    } finally {
+      this.isReconnecting = false;
+    }
+  }
+
+  /**
+   * Run a single reconnection attempt: the host (offerer) initiates an ICE
+   * restart and emits the resulting offer; the answerer refreshes its ICE
+   * configuration and waits for the host's restart offer to arrive via
+   * signaling. Both sides then wait for recovery within the attempt timeout.
+   */
+  private async runReconnectAttempt(): Promise<boolean> {
+    const pc = this.peerConnection;
+    if (!pc) return false;
+
+    if (this.isHost) {
+      // The offerer drives the restart to avoid signaling glare.
+      await this.performIceRestart();
+    } else {
+      // The answerer refreshes ICE servers and waits for the remote restart.
+      try {
+        pc.setConfiguration(this.rtcConfig);
+      } catch {
+        // setConfiguration can throw if the connection is mid-negotiation;
+        // treat as best-effort and still wait for recovery.
+      }
+    }
+
+    return this.waitForRecovery(this.reconnectAttemptTimeoutMs);
+  }
+
+  /**
+   * Perform an ICE restart: refresh the ICE configuration, generate a new offer
+   * with the iceRestart flag, apply it locally, and emit the offer so the
+   * signaling layer can forward it to the remote peer for renegotiation.
+   */
+  private async performIceRestart(): Promise<void> {
+    const pc = this.peerConnection;
+    if (!pc) return;
+
+    pc.setConfiguration(this.rtcConfig);
+    const offer = await pc.createOffer({ iceRestart: true });
+    await pc.setLocalDescription(offer);
+
+    this.events.onReconnectOffer?.(offer, "");
+  }
+
+  /**
+   * Exponential backoff delay for the nth reconnection attempt. The first
+   * attempt has no delay; subsequent attempts back off exponentially up to the
+   * configured maximum.
+   */
+  private getReconnectDelay(attempt: number): number {
+    if (attempt <= 1) return 0;
+    const exp = this.reconnectBaseDelayMs * 2 ** (attempt - 2);
+    return Math.min(exp, this.reconnectMaxDelayMs);
+  }
+
+  /**
+   * Promise-based sleep used for inter-attempt backoff. Tracks the timer so it
+   * can be cancelled when the connection is closed.
+   */
+  private sleepReconnect(ms: number): Promise<void> {
+    if (ms <= 0) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      this.reconnectTimer = setTimeout(() => {
+        this.reconnectTimer = null;
+        resolve();
+      }, ms);
+    });
+  }
+
+  /**
+   * Wait for the connection to recover to "connected" within the given timeout.
+   * Resolves true on recovery, false on timeout or terminal failure.
+   */
+  private waitForRecovery(timeoutMs: number): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      if (this.connectionState === "connected") {
+        resolve(true);
+        return;
+      }
+
+      let settled = false;
+      const finish = (result: boolean): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this.recoveryWaiters = this.recoveryWaiters.filter(
+          (w) => w !== resolveWaiter,
+        );
+        resolve(result);
+      };
+      // resolveWaiter is invoked by updateConnectionState() when the state
+      // transitions to "connected" or "failed".
+      const resolveWaiter = finish;
+      this.recoveryWaiters.push(resolveWaiter);
+      const timer = setTimeout(
+        () => finish(this.connectionState === "connected"),
+        timeoutMs,
+      );
+    });
+  }
+
+  /**
+   * Resolve any pending recovery waiters with the given verdict.
+   */
+  private notifyRecoveryWaiters(recovered: boolean): void {
+    const waiters = this.recoveryWaiters;
+    this.recoveryWaiters = [];
+    waiters.forEach((w) => w(recovered));
   }
 
   /**
@@ -783,6 +983,12 @@ export class WebRTCConnection {
   private updateConnectionState(state: P2PConnectionState): void {
     this.connectionState = state;
     this.events.onConnectionStateChange(state, "");
+
+    if (state === "connected") {
+      this.notifyRecoveryWaiters(true);
+    } else if (state === "failed") {
+      this.notifyRecoveryWaiters(false);
+    }
   }
 
   /**
@@ -803,6 +1009,19 @@ export class WebRTCConnection {
       clearInterval(this.pingInterval);
       this.pingInterval = null;
     }
+  }
+
+  /**
+   * Cancel any in-flight reconnection cycle: clear the backoff timer and fail
+   * any pending recovery waiters so the reconnection promise settles.
+   */
+  private cancelReconnection(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.isReconnecting = false;
+    this.notifyRecoveryWaiters(false);
   }
 
   /**
@@ -958,6 +1177,7 @@ export class WebRTCConnection {
    */
   close(): void {
     this.stopPingInterval();
+    this.cancelReconnection();
 
     // Clean up ICE monitor
     if (this.iceMonitor) {


### PR DESCRIPTION
## Problem

`attemptReconnection()` in `src/lib/webrtc-p2p.ts` was a no-op stub. On a transient ICE disconnect (e.g. a brief network blip) the connection state transitioned to `"reconnecting"` but never recovered, **stranding P2P games in the `"reconnecting"` state forever**. The original code only incremented a counter and set the state, taking no recovery action.

## Solution

Replaced the stub with real, bounded reconnection logic:

- **ICE restart (host/offerer drives it):** on ICE disconnect the offerer calls `setConfiguration()` + `createOffer({ iceRestart: true })` + `setLocalDescription()`, then emits the restart offer via a new optional **`onReconnectOffer`** event so the signaling layer can forward it to the peer to complete renegotiation. The answerer refreshes its ICE config and waits for the remote restart offer (no signaling glare — only the offerer generates offers).
- **Bounded retries with exponential backoff:** up to `maxReconnectAttempts` (default 3, configurable), with a per-attempt recovery timeout (`reconnectAttemptTimeoutMs`, default 15s).
- **No more stranding:** on recovery the state returns to `"connected"` and counters reset; once retries are exhausted the state transitions to the terminal **`"failed"`** state with an actionable error message (`onError`), instead of being stuck in `"reconnecting"`.
- **Guards:** concurrent reconnection cycles are prevented (`isReconnecting`), and `close()` cancels any in-flight cycle and settles pending recovery waiters.
- **Existing connection-establishment path preserved:** `createOffer`/`handleOffer`/`handleAnswer`/`initialize` are untouched.

Tunable via new optional `P2PConnectionOptions`: `maxReconnectAttempts`, `reconnectBaseDelayMs`, `reconnectMaxDelayMs`, `reconnectAttemptTimeoutMs`.

## Files changed

- `src/lib/webrtc-p2p.ts` — implemented `attemptReconnection`, added `performIceRestart`, `runReconnectAttempt`, `waitForRecovery`, exponential backoff + cancellation helpers, `onReconnectOffer` event hook, and reconnect-tuning options.
- `src/lib/__tests__/webrtc-p2p.test.ts` — added a `MockRTCPeerConnection` and 5 new tests covering ICE-restart recovery, backoff-bounded retry, terminal failure (not stuck reconnecting), no-glare answerer path, and `close()` during reconnection.

## Test results

- `webrtc-p2p.test.ts`: **10/10 passing** (5 pre-existing + 5 new reconnection tests).
- Related suites (no regressions): `p2p-direct-connection`, `p2p-game-connection`, `use-p2p-connection`, `p2p-handshake`, `p2p-signaling-client`, `local-signaling-client` — **167/167 passing**.
- `tsc --noEmit`: **0 errors**.
- `npm run lint`: **0 errors** (only pre-existing warnings; none introduced by this change).

## Scope

Limited strictly to reconnection. Per the issue, intentionally **not** touching separate concerns (leftover `console.log`, `JSON.parse` validation, host migration, diagnostics, full signaling re-wiring) — those belong to other issues. The `onReconnectOffer` hook provides the integration point for the signaling layer to forward restart offers without expanding this fix's scope.

Closes #915.