### PR TITLE
perf: resolve #917 — virtualize collection view card grid

### DIFF
--- a/src/app/(app)/collection/page.tsx
+++ b/src/app/(app)/collection/page.tsx
@@ -16,6 +16,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { VirtualCardList } from "@/components/virtual-card-list";
 import { Search, Plus, Trash2, Download, Upload, FolderPlus, Package, GitCompare, ArrowRightLeft } from "lucide-react";
 
 /**
@@ -463,37 +464,34 @@ export default function CollectionPage() {
                 <p className="text-sm">Search for cards to add them.</p>
               </div>
             ) : (
-              <ScrollArea className="h-[400px]">
-                <div className="space-y-2">
-                  {filteredCards.map((collectionCard) => (
-                    <div
-                      key={collectionCard.card.id}
-                      className="flex items-center justify-between p-3 rounded-lg border bg-card hover:bg-accent/50 transition-colors"
-                    >
-                      <div className="flex items-center gap-3">
-                        <Badge variant="secondary" className="w-8 justify-center">
-                          {collectionCard.quantity}
-                        </Badge>
-                        <div>
-                          <div className="font-medium">{collectionCard.card.name}</div>
-                          {collectionCard.card.set && (
-                            <div className="text-xs text-muted-foreground">
-                              {collectionCard.card.set.toUpperCase()} #{collectionCard.card.collector_number}
-                            </div>
-                          )}
-                        </div>
+              <VirtualCardList
+                cards={filteredCards}
+                className="h-[400px]"
+                renderRow={(collectionCard) => (
+                  <div className="flex items-center justify-between p-3 rounded-lg border bg-card hover:bg-accent/50 transition-colors">
+                    <div className="flex items-center gap-3">
+                      <Badge variant="secondary" className="w-8 justify-center">
+                        {collectionCard.quantity}
+                      </Badge>
+                      <div>
+                        <div className="font-medium">{collectionCard.card.name}</div>
+                        {collectionCard.card.set && (
+                          <div className="text-xs text-muted-foreground">
+                            {collectionCard.card.set.toUpperCase()} #{collectionCard.card.collector_number}
+                          </div>
+                        )}
                       </div>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => handleRemoveCard(collectionCard.card.id, collectionCard.card.name)}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
                     </div>
-                  ))}
-                </div>
-              </ScrollArea>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleRemoveCard(collectionCard.card.id, collectionCard.card.name)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                )}
+              />
             )}
           </CardContent>
         </Card>

--- a/src/components/__tests__/virtual-card-list.test.tsx
+++ b/src/components/__tests__/virtual-card-list.test.tsx
@@ -1,0 +1,171 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { VirtualCardList } from "../virtual-card-list";
+import type { CollectionCard } from "@/hooks/use-collection";
+
+function makeCards(n: number): CollectionCard[] {
+  return Array.from({ length: n }, (_, i) => ({
+    card: {
+      id: `card-${i}`,
+      name: `Card ${i}`,
+      set: "tst",
+      collector_number: String(i),
+    } as CollectionCard["card"],
+    quantity: (i % 5) + 1,
+    addedAt: new Date().toISOString(),
+  }));
+}
+
+function rect(height: number): DOMRect {
+  return {
+    width: 600,
+    height,
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    bottom: height,
+    right: 600,
+    toJSON() {},
+  } as DOMRect;
+}
+
+describe("VirtualCardList", () => {
+  const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+  let originalClientHeight: PropertyDescriptor | undefined;
+  let originalOffsetHeight: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalClientHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientHeight",
+    );
+    originalOffsetHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "offsetHeight",
+    );
+
+    // Give the scroll viewport a non-zero size in jsdom.
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      get() {
+        return 400;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      configurable: true,
+      get() {
+        return 400;
+      },
+    });
+
+    // Give virtual rows a measurable height so dynamic measuring stabilizes.
+    Element.prototype.getBoundingClientRect = function getBoundingClientRect() {
+      if (this.hasAttribute && this.hasAttribute("data-index")) {
+        return rect(80);
+      }
+      if (this.getAttribute && this.getAttribute("role") === "list") {
+        return rect(400);
+      }
+      return originalGetBoundingClientRect.call(this);
+    };
+
+    // jsdom lacks ResizeObserver, which @tanstack/react-virtual relies on.
+    (global as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  });
+
+  afterEach(() => {
+    if (originalClientHeight) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        "clientHeight",
+        originalClientHeight,
+      );
+    }
+    if (originalOffsetHeight) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        "offsetHeight",
+        originalOffsetHeight,
+      );
+    }
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  });
+
+  it("renders only a bounded window of items, not the whole list", () => {
+    const cards = makeCards(1000);
+    render(
+      <VirtualCardList
+        cards={cards}
+        className="h-[400px]"
+        renderRow={(c) => <div>{c.card.name}</div>}
+      />,
+    );
+
+    const rendered = screen.getAllByText(/^Card \d+$/);
+    // A virtualized window must mount only a small fraction of 1000 items.
+    expect(rendered.length).toBeGreaterThan(0);
+    expect(rendered.length).toBeLessThan(100);
+  });
+
+  it("makes every item reachable as the user scrolls", () => {
+    const cards = makeCards(1000);
+    render(
+      <VirtualCardList
+        cards={cards}
+        className="h-[400px]"
+        renderRow={(c) => <div>{c.card.name}</div>}
+      />,
+    );
+
+    // Initially the first item is mounted and a far item is not.
+    expect(screen.getByText("Card 0")).toBeTruthy();
+    expect(screen.queryByText("Card 900")).toBeNull();
+
+    const scroller = document.querySelector('[role="list"]') as HTMLElement;
+    scroller.scrollTop = 79000;
+    fireEvent.scroll(scroller);
+
+    // After scrolling near the bottom, early items are unmounted and late
+    // items have entered the window — proving reachability via virtualization.
+    expect(screen.queryByText("Card 0")).toBeNull();
+    const renderedIndices = screen
+      .getAllByText(/^Card \d+$/)
+      .map((el) => Number(el.textContent?.replace("Card ", "")));
+    expect(Math.max(...renderedIndices)).toBeGreaterThan(400);
+  });
+
+  it("keeps existing row interactions working", () => {
+    const onAdd = jest.fn();
+    const cards = makeCards(3);
+    render(
+      <VirtualCardList
+        cards={cards}
+        className="h-[400px]"
+        renderRow={(c) => (
+          <button type="button" onClick={() => onAdd(c.card.id)}>
+            add {c.card.name}
+          </button>
+        )}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("add Card 0"));
+    expect(onAdd).toHaveBeenCalledWith("card-0");
+  });
+
+  it("renders no rows for an empty list without error", () => {
+    const { container } = render(
+      <VirtualCardList
+        cards={[]}
+        className="h-[400px]"
+        renderRow={(c) => <div>{c.card.name}</div>}
+      />,
+    );
+    expect(container.querySelectorAll('[role="listitem"]')).toHaveLength(0);
+  });
+});

--- a/src/components/collection-tracker.tsx
+++ b/src/components/collection-tracker.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { VirtualCardList } from '@/components/virtual-card-list';
 import {
   Dialog,
   DialogContent,
@@ -273,24 +274,26 @@ export function CollectionTracker({ className }: CollectionTrackerProps) {
       </div>
 
       {/* Card List */}
-      <ScrollArea className="flex-1">
-        <div className="p-4 space-y-2">
-          {filteredCards.length === 0 ? (
-            <div className="text-center py-8 text-muted-foreground">
-              {searchQuery ? 'No cards match your search' : 'Your collection is empty. Import cards to get started.'}
-            </div>
-          ) : (
-            filteredCards.map((card) => (
+      <div className="flex-1 min-h-0">
+        {filteredCards.length === 0 ? (
+          <div className="h-full flex items-center justify-center p-4 text-center text-muted-foreground">
+            {searchQuery ? 'No cards match your search' : 'Your collection is empty. Import cards to get started.'}
+          </div>
+        ) : (
+          <VirtualCardList
+            cards={filteredCards}
+            className="h-full"
+            contentClassName="p-4"
+            renderRow={(card) => (
               <CollectionCardItem
-                key={card.card.id}
                 card={card}
                 onAdd={() => addCard(card.card, 1)}
                 onRemove={() => removeCard(card.card.id, 1)}
               />
-            ))
-          )}
-        </div>
-      </ScrollArea>
+            )}
+          />
+        )}
+      </div>
 
       {/* New Collection Dialog */}
       <Dialog open={showNewCollectionDialog} onOpenChange={setShowNewCollectionDialog}>

--- a/src/components/virtual-card-list.tsx
+++ b/src/components/virtual-card-list.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import * as React from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import type { CollectionCard } from '@/hooks/use-collection';
+import { cn } from '@/lib/utils';
+
+export interface VirtualCardListProps {
+  cards: CollectionCard[];
+  renderRow: (card: CollectionCard, index: number) => React.ReactNode;
+  /** Class applied to the scroll container (e.g. height / flex sizing). */
+  className?: string;
+  /** Class applied to the inner content wrapper (e.g. padding). */
+  contentClassName?: string;
+  /** Estimated row height in px, used before a row is measured. */
+  estimateSize?: number;
+  /** Gap between rows in px (mirrors Tailwind `space-y-2` = 8px). */
+  gap?: number;
+  /** Number of rows rendered outside the visible window. */
+  overscan?: number;
+}
+
+/**
+ * Virtualized single-column list of collection cards.
+ *
+ * Only the visible window of rows (+ overscan) is mounted to the DOM, so large
+ * collections render in constant time. Built on `@tanstack/react-virtual` which
+ * is already a project dependency. Row heights are measured dynamically so the
+ * exact existing card markup (badges, wrapping text, etc.) is preserved.
+ */
+export function VirtualCardList({
+  cards,
+  renderRow,
+  className,
+  contentClassName,
+  estimateSize = 80,
+  gap = 8,
+  overscan = 6,
+}: VirtualCardListProps) {
+  const parentRef = React.useRef<HTMLDivElement>(null);
+
+  const rowVirtualizer = useVirtualizer({
+    count: cards.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => estimateSize,
+    overscan,
+    gap,
+  });
+
+  const virtualItems = rowVirtualizer.getVirtualItems();
+
+  return (
+    <div
+      ref={parentRef}
+      className={cn('overflow-y-auto overflow-x-hidden outline-none focus-visible:ring-2 focus-visible:ring-ring', className)}
+      role="list"
+      aria-label="Collection cards"
+      tabIndex={0}
+    >
+      <div className={contentClassName}>
+        <div
+          style={{
+            height: `${rowVirtualizer.getTotalSize()}px`,
+            width: '100%',
+            position: 'relative',
+          }}
+        >
+          {virtualItems.map((virtualRow) => {
+            const card = cards[virtualRow.index];
+            return (
+              <div
+                key={virtualRow.key}
+                data-index={virtualRow.index}
+                ref={rowVirtualizer.measureElement}
+                role="listitem"
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+              >
+                {renderRow(card, virtualRow.index)}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Resolve #917 — Virtualize collection view card grid

### Problem
The Collection view rendered its card lists with a flat `.map()` over the full
collection inside a `ScrollArea`. With large collections this mounted one DOM
node per card (every badge, button, and label), causing long initial render,
jank while scrolling, and high memory use.

Affected screens:
- `src/app/(app)/collection/page.tsx` — main collection card list
- `src/components/collection-tracker.tsx` — `CollectionTracker` card list

### Solution
Replaced both flat `.map()` lists with a **virtualized single-column list** that
mounts only the visible rows (plus an overscan window). Scrolling recycles DOM
nodes, so render cost stays roughly constant regardless of collection size.

The exact existing visual layout and interactions are preserved verbatim — the
same row markup, badges, add/remove/trash buttons, search filtering, and sorting
are passed through unchanged via a `renderRow` callback. A `min-h-0` wrapper was
added to the tracker's flex layout so the virtual viewport scrolls correctly
within the flex column.

### Library used
**`@tanstack/react-virtual`** — already a project dependency
(`package.json`, also used by `deck-builder` and `components/shared/virtualized-card-grid`).
No new dependency was added; `package.json`/`package-lock.json` are unchanged.

The existing `VirtualizedCardGrid` is a 2-D multi-column grid, which doesn't fit
these full-width single-column card rows, so a focused `VirtualCardList`
component was introduced (typed to `CollectionCard[]`, dynamic row measurement,
keyboard-focusable scroll container with `role="list"`).

### Files changed
- `src/components/virtual-card-list.tsx` (new) — reusable virtualized list built on `@tanstack/react-virtual` (dynamic row measurement, overscan, `role="list"` a11y).
- `src/components/__tests__/virtual-card-list.test.tsx` (new) — 4 tests: bounded window, reachability on scroll, row interactions, empty list.
- `src/app/(app)/collection/page.tsx` — swapped flat `.map()` + `ScrollArea` for `VirtualCardList` (row markup unchanged).
- `src/components/collection-tracker.tsx` — swapped flat `.map()` + `ScrollArea` for `VirtualCardList` (row markup unchanged).

### Test results
- New tests: **4 passed**
- Full suite: **191 suites / 3664 tests passed, 0 failed**
- `tsc --noEmit`: **clean**
- `eslint` (changed files): **0 errors / 0 warnings**

Closes #917.
