### PR TITLE
feat: resolve #916 — host migration keeps multiplayer alive when the host disconnects

### DIFF
--- a/src/hooks/use-p2p-connection.ts
+++ b/src/hooks/use-p2p-connection.ts
@@ -27,6 +27,13 @@ import {
   ConflictResolutionManager,
   type TimestampedAction,
 } from '@/lib/p2p-conflict-resolution';
+import {
+  HostMigrationManager,
+  createHostMigrationManager,
+  type HostMigrationMessage,
+  type HostMigrationResult,
+  type PeerRosterEntry,
+} from '@/lib/p2p-host-migration';
 import { useConnectionHealth, type ConnectionHealth } from '@/hooks/use-connection-health';
 import { logger } from '@/lib/logger';
 
@@ -40,6 +47,16 @@ export interface UseP2PConnectionOptions {
   enableHandshake?: boolean;
   enableConflictResolution?: boolean;
   conflictResolutionStrategy?: 'host-wins' | 'timestamp-based' | 'priority-based' | 'round-robin';
+  /** Enable host migration when the authoritative host disconnects (issue #916). */
+  enableHostMigration?: boolean;
+  /** Initial authoritative host id. Defaults to the host when role === 'host'. */
+  initialHostId?: string;
+  /** Initial peer roster used for deterministic successor selection. */
+  migrationPeers?: PeerRosterEntry[];
+  /** Called after a host migration completes (promotion or remote change). */
+  onHostMigrated?: (result: HostMigrationResult) => void;
+  /** Called when no peers remain and the multiplayer game must end cleanly. */
+  onGameTerminated?: (reason: string) => void;
 }
 
 export interface UseP2PConnectionReturn {
@@ -59,26 +76,44 @@ export interface UseP2PConnectionReturn {
   closeConnection: () => void;
   getConnection: () => P2PGameConnection | null;
   getConflictQueueSize: () => number;
+  /** Current authoritative host id (updates on host migration). */
+  currentHostId: string;
+  /** True when the local client currently holds host authority. */
+  isAuthoritativeHost: boolean;
 }
 
 export function useP2PConnection(options: UseP2PConnectionOptions): UseP2PConnectionReturn {
-  const { 
-    playerId, 
-    playerName, 
-    role, 
+  const {
+    playerId,
+    playerName,
+    role,
     gameCode,
     enableHandshake = true,
     enableConflictResolution = true,
     conflictResolutionStrategy = 'host-wins',
+    enableHostMigration = true,
+    initialHostId,
+    migrationPeers = [],
+    onHostMigrated,
+    onGameTerminated,
   } = options;
 
+  const fallbackHostId = initialHostId ?? (role === 'host' ? playerId : playerId);
   const [connectionState, setConnectionState] = useState<P2PConnectionState>('disconnected');
   const [signalingState, setSignalingState] = useState<LocalSignalingState | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [handshakeState, setHandshakeState] = useState<HandshakeState>('idle');
+  const [currentHostId, setCurrentHostIdState] = useState<string>(fallbackHostId);
   const connectionRef = useRef<P2PGameConnection | null>(null);
   const handshakeSessionRef = useRef<HandshakeSession | null>(null);
   const conflictManagerRef = useRef<ConflictResolutionManager | null>(null);
+  const hostMigrationRef = useRef<HostMigrationManager | null>(null);
+  // Keep latest callbacks in refs so the connection event handlers (created
+  // once per initialize) always see the current props without re-creating.
+  const onHostMigratedRef = useRef(onHostMigrated);
+  const onGameTerminatedRef = useRef(onGameTerminated);
+  onHostMigratedRef.current = onHostMigrated;
+  onGameTerminatedRef.current = onGameTerminated;
 
   // Initialize conflict resolution manager
   useEffect(() => {
@@ -89,6 +124,40 @@ export function useP2PConnection(options: UseP2PConnectionOptions): UseP2PConnec
       });
     }
   }, [enableConflictResolution, conflictResolutionStrategy, role, playerId]);
+
+  // Initialize host migration manager
+  useEffect(() => {
+    if (enableHostMigration && !hostMigrationRef.current) {
+      hostMigrationRef.current = createHostMigrationManager({
+        localPlayerId: playerId,
+        initialHostId: fallbackHostId,
+        initialPeers: migrationPeers,
+        events: {
+          onPromotedToHost: (result) => {
+            p2pLogger.info('Promoted to host after migration', result.newHostId);
+            conflictManagerRef.current?.updateConfig({ hostId: result.newHostId });
+            onHostMigratedRef.current?.(result);
+          },
+          onHostChanged: (result) => {
+            p2pLogger.info('Remote peer promoted to host', result.newHostId);
+            conflictManagerRef.current?.updateConfig({ hostId: result.newHostId });
+            onHostMigratedRef.current?.(result);
+          },
+          onTerminated: (reason) => {
+            p2pLogger.warn('Multiplayer game terminated', reason);
+            setError(reason);
+            onGameTerminatedRef.current?.(reason);
+          },
+        },
+      });
+      setCurrentHostIdState(hostMigrationRef.current.getHostId());
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enableHostMigration, playerId, fallbackHostId]);
+
+  const setCurrentHostId = useCallback((hostId: string) => {
+    setCurrentHostIdState(hostId);
+  }, []);
 
   // Initialize handshake session when connection is established
   useEffect(() => {
@@ -134,6 +203,80 @@ export function useP2PConnection(options: UseP2PConnectionOptions): UseP2PConnec
     enableMonitoring: true,
   });
 
+  // --- Host migration helpers (issue #916) ---
+
+  // Cache the latest authoritative game state so a promoted host can adopt it.
+  const cacheGameStateForMigration = useCallback((gameState: GameState) => {
+    hostMigrationRef.current?.setLastKnownGameState(gameState);
+  }, []);
+
+  // Track a newly-joined peer for successor-selection purposes.
+  const registerPeerForMigration = useCallback(
+    (peerPlayerId: string, peerPlayerName: string) => {
+      hostMigrationRef.current?.upsertPeer({
+        playerId: peerPlayerId,
+        playerName: peerPlayerName,
+        joinedAt: Date.now(),
+      });
+    },
+    [],
+  );
+
+  // Apply a received host-migration message (idempotent).
+  const applyHostMigrationMessage = useCallback(
+    (message: HostMigrationMessage) => {
+      const manager = hostMigrationRef.current;
+      if (!manager) return;
+      const result = manager.applyMigration(message);
+      if (result) {
+        setCurrentHostId(manager.getHostId());
+      }
+    },
+    [setCurrentHostId],
+  );
+
+  // Handle a peer leaving. If it was the host, run migration: the deterministic
+  // successor broadcasts a migration message and promotes itself; others apply
+  // it on receipt. If too few peers remain, the manager terminates cleanly.
+  const handlePeerLeftForMigration = useCallback(
+    (peerPlayerId: string, reason: 'host-disconnected' | 'host-left') => {
+      const manager = hostMigrationRef.current;
+      if (!manager) return;
+
+      const wasHost = manager.getHostId() === peerPlayerId;
+      manager.removePeer(peerPlayerId);
+
+      if (!wasHost) return;
+
+      const result = manager.initiateMigration(reason);
+      if (result.terminated) {
+        // onTerminated event already fired by the manager.
+        return;
+      }
+
+      if (result.promotedSelf) {
+        setCurrentHostId(manager.getHostId());
+        const message = manager.buildMigrationMessage(result);
+        connectionRef.current?.sendGameAction('host-migration', message);
+      }
+      // Non-successor peers do nothing here; they apply the successor's
+      // broadcast via applyHostMigrationMessage when it arrives.
+    },
+    [setCurrentHostId],
+  );
+
+  // Inspect a game-action message and route host-migration messages.
+  const handleMigrationGameAction = useCallback(
+    (action: string, data: unknown) => {
+      if (action !== 'host-migration') return;
+      if (!data || typeof data !== 'object') return;
+      const message = data as HostMigrationMessage;
+      if (message.type !== 'host-migration') return;
+      applyHostMigrationMessage(message);
+    },
+    [applyHostMigrationMessage],
+  );
+
   // Initialize connection as host
   const initializeAsHost = useCallback(async (): Promise<RTCSessionDescriptionInit> => {
     try {
@@ -161,9 +304,18 @@ export function useP2PConnection(options: UseP2PConnectionOptions): UseP2PConnec
               // Handshake message handling would go here
               // For now, we just log them
             }
+
+            // Route host-migration announcements (issue #916).
+            if (message.type === 'game-action') {
+              const payload = message.data as { action?: string; data?: unknown } | undefined;
+              if (payload?.action) {
+                handleMigrationGameAction(payload.action, payload.data);
+              }
+            }
           },
           onGameStateSync: (gameState) => {
             p2pLogger.debug('Received game state sync');
+            cacheGameStateForMigration(gameState);
             
             // Verify checksum if handshake completed
             if (handshakeState === 'completed' && handshakeSessionRef.current) {
@@ -184,6 +336,7 @@ export function useP2PConnection(options: UseP2PConnectionOptions): UseP2PConnec
           },
           onPlayerJoined: (playerId, playerName) => {
             p2pLogger.debug('Player joined:', playerName);
+            registerPeerForMigration(playerId, playerName);
             
             // Start handshake with new player
             if (enableHandshake && handshakeSessionRef.current) {
@@ -194,6 +347,7 @@ export function useP2PConnection(options: UseP2PConnectionOptions): UseP2PConnec
           },
           onPlayerLeft: (playerId) => {
             p2pLogger.debug('Player left:', playerId);
+            handlePeerLeftForMigration(playerId, 'host-disconnected');
             
             // Cleanup handshake
             if (handshakeSessionRef.current) {
@@ -219,7 +373,7 @@ export function useP2PConnection(options: UseP2PConnectionOptions): UseP2PConnec
       setError(errorMessage);
       throw err;
     }
-  }, [playerId, playerName, role, gameCode, enableHandshake, handshakeState]);
+  }, [playerId, playerName, role, gameCode, enableHandshake, handshakeState, cacheGameStateForMigration, registerPeerForMigration, handlePeerLeftForMigration, handleMigrationGameAction]);
 
   // Initialize connection as joiner
   const initializeAsJoiner = useCallback(
@@ -243,9 +397,18 @@ export function useP2PConnection(options: UseP2PConnectionOptions): UseP2PConnec
             onSignalingStateChange: setSignalingState,
             onMessage: (message) => {
               p2pLogger.debug('Received message:', message.type);
+
+              // Route host-migration announcements (issue #916).
+              if (message.type === 'game-action') {
+                const payload = message.data as { action?: string; data?: unknown } | undefined;
+                if (payload?.action) {
+                  handleMigrationGameAction(payload.action, payload.data);
+                }
+              }
             },
             onGameStateSync: (gameState) => {
               p2pLogger.debug('Received game state sync');
+              cacheGameStateForMigration(gameState);
             },
             onChat: (chatMessage) => {
               p2pLogger.debug('Received chat:', chatMessage.text);
@@ -255,9 +418,11 @@ export function useP2PConnection(options: UseP2PConnectionOptions): UseP2PConnec
             },
             onPlayerJoined: (playerId, playerName) => {
               p2pLogger.debug('Player joined:', playerName);
+              registerPeerForMigration(playerId, playerName);
             },
             onPlayerLeft: (playerId) => {
               p2pLogger.debug('Player left:', playerId);
+              handlePeerLeftForMigration(playerId, 'host-disconnected');
               
               // Cleanup handshake
               if (handshakeSessionRef.current) {
@@ -284,7 +449,7 @@ export function useP2PConnection(options: UseP2PConnectionOptions): UseP2PConnec
         throw err;
       }
     },
-    [playerId, playerName, role, gameCode]
+    [playerId, playerName, role, gameCode, cacheGameStateForMigration, registerPeerForMigration, handlePeerLeftForMigration, handleMigrationGameAction]
   );
 
   // Process answer (host only)
@@ -388,11 +553,13 @@ export function useP2PConnection(options: UseP2PConnectionOptions): UseP2PConnec
     if (handshakeSessionRef.current) {
       handshakeSessionRef.current.cleanup();
     }
+    hostMigrationRef.current?.reset();
+    setCurrentHostIdState(fallbackHostId);
     setConnectionState('disconnected');
     setSignalingState(null);
     setHandshakeState('idle');
     setError(null);
-  }, []);
+  }, [fallbackHostId]);
 
   // Get connection instance
   const getConnection = useCallback(() => {
@@ -424,6 +591,8 @@ export function useP2PConnection(options: UseP2PConnectionOptions): UseP2PConnec
     closeConnection,
     getConnection,
     getConflictQueueSize,
+    currentHostId,
+    isAuthoritativeHost: currentHostId === playerId,
   };
 }
 

--- a/src/lib/__tests__/p2p-host-migration.test.ts
+++ b/src/lib/__tests__/p2p-host-migration.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Host Migration Tests — Issue #916
+ *
+ * Covers: deterministic successor selection, host-disconnect promotion,
+ * state adoption, peer notification (idempotent apply), and clean
+ * termination when no peers remain.
+ */
+
+import {
+  HostMigrationManager,
+  createHostMigrationManager,
+  selectHostSuccessor,
+  buildMigrationId,
+  type HostMigrationMessage,
+  type PeerRosterEntry,
+  type HostMigrationResult,
+} from '../p2p-host-migration';
+
+const PEERS: PeerRosterEntry[] = [
+  { playerId: 'host', playerName: 'Host', joinedAt: 100 },
+  { playerId: 'alice', playerName: 'Alice', joinedAt: 200 },
+  { playerId: 'bob', playerName: 'Bob', joinedAt: 300 },
+  { playerId: 'carol', playerName: 'Carol', joinedAt: 400 },
+];
+
+describe('selectHostSuccessor', () => {
+  it('excludes the leaving host', () => {
+    expect(selectHostSuccessor(PEERS, 'host')).toBe('alice');
+  });
+
+  it('is deterministic regardless of input order', () => {
+    const shuffled = [PEERS[3], PEERS[0], PEERS[2], PEERS[1]];
+    expect(selectHostSuccessor(shuffled, 'host')).toBe('alice');
+  });
+
+  it('breaks ties on joinedAt by lexicographic playerId', () => {
+    const sameTime: PeerRosterEntry[] = [
+      { playerId: 'zoe', playerName: 'Z', joinedAt: 500 },
+      { playerId: 'amy', playerName: 'A', joinedAt: 500 },
+      { playerId: 'mike', playerName: 'M', joinedAt: 500 },
+    ];
+    expect(selectHostSuccessor(sameTime)).toBe('amy');
+  });
+
+  it('returns null when no candidates remain', () => {
+    expect(selectHostSuccessor([PEERS[0]], 'host')).toBeNull();
+    expect(selectHostSuccessor([], 'host')).toBeNull();
+  });
+});
+
+describe('buildMigrationId', () => {
+  it('produces a stable id for the same inputs', () => {
+    const a = buildMigrationId('host', 'alice', ['alice', 'bob', 'carol']);
+    const b = buildMigrationId('host', 'alice', ['alice', 'bob', 'carol']);
+    expect(a).toBe(b);
+    expect(a).toContain('host');
+    expect(a).toContain('alice');
+  });
+
+  it('differs when the new host differs', () => {
+    const a = buildMigrationId('host', 'alice', ['alice', 'bob']);
+    const b = buildMigrationId('host', 'bob', ['bob', 'carol']);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('HostMigrationManager — successor promotion', () => {
+  it('promotes the deterministic successor when the local client is it', () => {
+    const promoted: HostMigrationResult[] = [];
+    const changed: HostMigrationResult[] = [];
+
+    const manager = new HostMigrationManager({
+      localPlayerId: 'alice',
+      initialHostId: 'host',
+      initialPeers: PEERS,
+      events: {
+        onPromotedToHost: (r) => promoted.push(r),
+        onHostChanged: (r) => changed.push(r),
+      },
+    });
+
+    expect(manager.isLocalHost()).toBe(false);
+    const result = manager.initiateMigration('host-disconnected');
+
+    expect(result.terminated).toBe(false);
+    expect(result.promotedSelf).toBe(true);
+    expect(result.newHostId).toBe('alice');
+    expect(result.previousHostId).toBe('host');
+    expect(result.remainingPeers).toEqual(['alice', 'bob', 'carol']);
+    expect(promoted).toHaveLength(1);
+    expect(promoted[0].newHostId).toBe('alice');
+    expect(changed).toHaveLength(0);
+    expect(manager.isLocalHost()).toBe(true);
+    expect(manager.getHostId()).toBe('alice');
+  });
+
+  it('does not promote when the local client is not the successor', () => {
+    const promoted: HostMigrationResult[] = [];
+    const manager = new HostMigrationManager({
+      localPlayerId: 'bob',
+      initialHostId: 'host',
+      initialPeers: PEERS,
+      events: { onPromotedToHost: (r) => promoted.push(r) },
+    });
+
+    const result = manager.initiateMigration('host-disconnected');
+
+    // alice (earliest join) should be the computed successor, not bob.
+    expect(result.newHostId).toBe('alice');
+    expect(result.promotedSelf).toBe(false);
+    expect(promoted).toHaveLength(0);
+    // The local client must not have flipped its own authority.
+    expect(manager.isLocalHost()).toBe(false);
+  });
+
+  it('removes the leaving host from the roster on migration', () => {
+    const manager = new HostMigrationManager({
+      localPlayerId: 'alice',
+      initialHostId: 'host',
+      initialPeers: PEERS,
+    });
+    manager.initiateMigration('host-disconnected');
+    expect(manager.hasPeer('host')).toBe(false);
+    expect(manager.getRoster().map((p) => p.playerId)).toEqual([
+      'alice',
+      'bob',
+      'carol',
+    ]);
+  });
+});
+
+describe('HostMigrationManager — state adoption', () => {
+  it('the promoted host adopts and broadcasts the last known game state', () => {
+    const manager = new HostMigrationManager({
+      localPlayerId: 'alice',
+      initialHostId: 'host',
+      initialPeers: PEERS,
+    });
+    const authoritativeState = { turn: 5, players: ['alice', 'bob', 'carol'] };
+    manager.setLastKnownGameState(authoritativeState);
+
+    const result = manager.initiateMigration('host-disconnected');
+    const message = manager.buildMigrationMessage(result);
+
+    expect(message.gameState).toBe(authoritativeState);
+    expect(manager.getLastKnownGameState()).toBe(authoritativeState);
+  });
+
+  it('a follower adopts the authoritative state shipped by the new host', () => {
+    const follower = new HostMigrationManager({
+      localPlayerId: 'bob',
+      initialHostId: 'host',
+      initialPeers: PEERS,
+    });
+
+    const incomingState = { turn: 6 };
+    const message: HostMigrationMessage = {
+      type: 'host-migration',
+      migrationId: buildMigrationId('host', 'alice', ['alice', 'bob', 'carol']),
+      previousHostId: 'host',
+      newHostId: 'alice',
+      remainingPeers: ['alice', 'bob', 'carol'],
+      gameState: incomingState,
+      reason: 'host-disconnected',
+      timestamp: Date.now(),
+    };
+
+    const result = follower.applyMigration(message);
+    expect(result).not.toBeNull();
+    expect(result?.newHostId).toBe('alice');
+    expect(follower.getLastKnownGameState()).toBe(incomingState);
+    expect(follower.getHostId()).toBe('alice');
+    expect(follower.isLocalHost()).toBe(false);
+  });
+});
+
+describe('HostMigrationManager — peer notification & idempotency', () => {
+  it('applies a received migration message exactly once', () => {
+    const changed: HostMigrationResult[] = [];
+    const follower = new HostMigrationManager({
+      localPlayerId: 'bob',
+      initialHostId: 'host',
+      initialPeers: PEERS,
+      events: { onHostChanged: (r) => changed.push(r) },
+    });
+
+    const message: HostMigrationMessage = {
+      type: 'host-migration',
+      migrationId: 'mig-host-alice-alice,bob,carol',
+      previousHostId: 'host',
+      newHostId: 'alice',
+      remainingPeers: ['alice', 'bob', 'carol'],
+      gameState: null,
+      reason: 'host-disconnected',
+      timestamp: 1,
+    };
+
+    const first = follower.applyMigration(message);
+    const second = follower.applyMigration(message); // duplicate
+
+    expect(first).not.toBeNull();
+    expect(second).toBeNull(); // idempotent no-op
+    expect(changed).toHaveLength(1);
+    expect(follower.getHostId()).toBe('alice');
+  });
+
+  it('ignores malformed messages', () => {
+    const follower = new HostMigrationManager({
+      localPlayerId: 'bob',
+      initialHostId: 'host',
+      initialPeers: PEERS,
+    });
+    expect(follower.applyMigration({ ...({} as any) })).toBeNull();
+    expect(
+      follower.applyMigration({ ...({ type: 'host-migration' } as any), migrationId: 'x' }),
+    ).toBeNull();
+    expect(follower.getHostId()).toBe('host');
+  });
+
+  it('promotes self when receiving a message naming the local client', () => {
+    const promoted: HostMigrationResult[] = [];
+    const local = new HostMigrationManager({
+      localPlayerId: 'alice',
+      initialHostId: 'host',
+      initialPeers: PEERS,
+      events: { onPromotedToHost: (r) => promoted.push(r) },
+    });
+    const message: HostMigrationMessage = {
+      type: 'host-migration',
+      migrationId: 'mig-host-alice-alice,bob,carol',
+      previousHostId: 'host',
+      newHostId: 'alice',
+      remainingPeers: ['alice', 'bob', 'carol'],
+      gameState: null,
+      reason: 'host-left',
+      timestamp: 1,
+    };
+    const result = local.applyMigration(message);
+    expect(result?.promotedSelf).toBe(true);
+    expect(promoted).toHaveLength(1);
+    expect(local.isLocalHost()).toBe(true);
+  });
+});
+
+describe('HostMigrationManager — clean termination', () => {
+  it('terminates when not enough peers remain (1v1, opponent host leaves)', () => {
+    const terminated: string[] = [];
+    const manager = new HostMigrationManager({
+      localPlayerId: 'alice',
+      initialHostId: 'host',
+      // Only the host and the local client.
+      initialPeers: [
+        { playerId: 'host', playerName: 'Host', joinedAt: 100 },
+        { playerId: 'alice', playerName: 'Alice', joinedAt: 200 },
+      ],
+      events: { onTerminated: (reason) => terminated.push(reason) },
+    });
+
+    const result = manager.initiateMigration('host-left');
+    expect(result.terminated).toBe(true);
+    expect(result.newHostId).toBe('');
+    expect(result.promotedSelf).toBe(false);
+    expect(terminated).toHaveLength(1);
+    expect(terminated[0]).toMatch(/not enough players/i);
+    expect(manager.getStatus()).toBe('terminated');
+  });
+
+  it('continues when enough peers remain (3-player game, host leaves)', () => {
+    const terminated: string[] = [];
+    const manager = new HostMigrationManager({
+      localPlayerId: 'alice',
+      initialHostId: 'host',
+      initialPeers: [
+        { playerId: 'host', playerName: 'Host', joinedAt: 100 },
+        { playerId: 'alice', playerName: 'Alice', joinedAt: 200 },
+        { playerId: 'bob', playerName: 'Bob', joinedAt: 300 },
+      ],
+      events: { onTerminated: (r) => terminated.push(r) },
+    });
+
+    const result = manager.initiateMigration('host-disconnected');
+    expect(result.terminated).toBe(false);
+    expect(result.newHostId).toBe('alice');
+    expect(terminated).toHaveLength(0);
+  });
+
+  it('respects a custom minPlayersToContinue threshold', () => {
+    const manager = new HostMigrationManager({
+      localPlayerId: 'alice',
+      initialHostId: 'host',
+      initialPeers: [
+        { playerId: 'host', playerName: 'Host', joinedAt: 100 },
+        { playerId: 'alice', playerName: 'Alice', joinedAt: 200 },
+        { playerId: 'bob', playerName: 'Bob', joinedAt: 300 },
+      ],
+      minPlayersToContinue: 3,
+    });
+    const result = manager.initiateMigration('host-disconnected');
+    expect(result.terminated).toBe(true);
+  });
+});
+
+describe('HostMigrationManager — roster management', () => {
+  it('upsertPeer / removePeer keep the roster in sync', () => {
+    const manager = new HostMigrationManager({
+      localPlayerId: 'alice',
+      initialHostId: 'host',
+      initialPeers: [PEERS[0], PEERS[1]],
+    });
+    manager.upsertPeer({ playerId: 'bob', playerName: 'Bob', joinedAt: 300 });
+    expect(manager.hasPeer('bob')).toBe(true);
+    manager.removePeer('bob');
+    expect(manager.hasPeer('bob')).toBe(false);
+  });
+
+  it('computeSuccessor reflects live roster changes', () => {
+    const manager = new HostMigrationManager({
+      localPlayerId: 'carol',
+      initialHostId: 'host',
+      initialPeers: PEERS,
+    });
+    // alice drops before the host does.
+    manager.removePeer('alice');
+    expect(manager.computeSuccessor('host')).toBe('bob');
+  });
+
+  it('reset clears migration tracking', () => {
+    const manager = new HostMigrationManager({
+      localPlayerId: 'alice',
+      initialHostId: 'host',
+      initialPeers: PEERS,
+    });
+    manager.setLastKnownGameState({ x: 1 });
+    manager.reset();
+    expect(manager.getLastKnownGameState()).toBeNull();
+    expect(manager.getStatus()).toBe('stable');
+  });
+});
+
+describe('createHostMigrationManager factory', () => {
+  it('creates a working manager instance', () => {
+    const manager = createHostMigrationManager({
+      localPlayerId: 'alice',
+      initialHostId: 'host',
+      initialPeers: PEERS,
+    });
+    expect(manager).toBeInstanceOf(HostMigrationManager);
+    expect(manager.getHostId()).toBe('host');
+  });
+});
+
+describe('End-to-end migration scenario', () => {
+  it('successor broadcasts; followers apply; everyone agrees on the new host', () => {
+    // Three clients with identical rosters.
+    const successor = new HostMigrationManager({
+      localPlayerId: 'alice',
+      initialHostId: 'host',
+      initialPeers: PEERS,
+    });
+    const followerBob = new HostMigrationManager({
+      localPlayerId: 'bob',
+      initialHostId: 'host',
+      initialPeers: PEERS,
+    });
+    const followerCarol = new HostMigrationManager({
+      localPlayerId: 'carol',
+      initialHostId: 'host',
+      initialPeers: PEERS,
+    });
+
+    // The host disconnects. Alice (successor) initiates and builds the message.
+    successor.setLastKnownGameState({ turn: 9 });
+    const result = successor.initiateMigration('host-disconnected');
+    expect(result.promotedSelf).toBe(true);
+    const message = successor.buildMigrationMessage(result);
+
+    // Followers receive and apply the broadcast.
+    const bobResult = followerBob.applyMigration(message);
+    const carolResult = followerCarol.applyMigration(message);
+
+    expect(bobResult?.newHostId).toBe('alice');
+    expect(carolResult?.newHostId).toBe('alice');
+
+    // Every peer now agrees on the new host and the adopted state.
+    expect(successor.getHostId()).toBe('alice');
+    expect(followerBob.getHostId()).toBe('alice');
+    expect(followerCarol.getHostId()).toBe('alice');
+    expect(followerBob.getLastKnownGameState()).toEqual({ turn: 9 });
+    expect(followerCarol.getLastKnownGameState()).toEqual({ turn: 9 });
+
+    // A duplicate delivery is a no-op.
+    expect(followerBob.applyMigration(message)).toBeNull();
+  });
+});

--- a/src/lib/__tests__/use-p2p-connection.test.ts
+++ b/src/lib/__tests__/use-p2p-connection.test.ts
@@ -119,6 +119,8 @@ describe('use-p2p-connection Hook Types', () => {
         closeConnection: () => {},
         getConnection: () => null,
         getConflictQueueSize: () => 0,
+        currentHostId: 'player-1',
+        isAuthoritativeHost: true,
       };
 
       expect(returnValue.connectionState).toBeDefined();
@@ -137,6 +139,8 @@ describe('use-p2p-connection Hook Types', () => {
       expect(returnValue.closeConnection).toBeDefined();
       expect(returnValue.getConnection).toBeDefined();
       expect(returnValue.getConflictQueueSize).toBeDefined();
+      expect(returnValue.currentHostId).toBe('player-1');
+      expect(returnValue.isAuthoritativeHost).toBe(true);
     });
   });
 });

--- a/src/lib/multiplayer-types.ts
+++ b/src/lib/multiplayer-types.ts
@@ -72,10 +72,27 @@ export interface LobbySettings {
 }
 
 export interface LobbyMessage {
-  type: 'player-joined' | 'player-left' | 'player-ready' | 'player-not-ready' | 'game-starting' | 'chat' | 'error';
+  type: 'player-joined' | 'player-left' | 'player-ready' | 'player-not-ready' | 'game-starting' | 'chat' | 'host-migration' | 'error';
   data: unknown;
   senderId?: string;
   timestamp: number;
+}
+
+/**
+ * Host-migration announcement (issue #916). Broadcast when the authoritative
+ * host leaves so a remaining peer can be promoted and the game continues.
+ * Re-exported from the host-migration module for convenience.
+ */
+export interface HostMigrationLobbyMessage extends LobbyMessage {
+  type: 'host-migration';
+  data: {
+    migrationId: string;
+    previousHostId: string;
+    newHostId: string;
+    remainingPeers: string[];
+    gameState: unknown;
+    reason: 'host-disconnected' | 'host-left';
+  };
 }
 
 export interface HostGameConfig {

--- a/src/lib/p2p-host-migration.ts
+++ b/src/lib/p2p-host-migration.ts
@@ -1,0 +1,408 @@
+/**
+ * P2P Host Migration
+ *
+ * Issue #916: When the authoritative host disconnects from a multiplayer game,
+ * promote a remaining peer to host so the game continues instead of
+ * terminating for everyone.
+ *
+ * This module is intentionally transport-agnostic and kept distinct from the
+ * ICE-restart reconnection logic in `webrtc-p2p.ts` (issue #915): reconnection
+ * recovers a *transient* link to the same host, whereas host migration handles
+ * the *permanent* loss of the host by transferring authority to another peer.
+ *
+ * Design goals:
+ *  - Deterministic successor selection so every peer computes the same new
+ *    host without a central coordinator (prevents split-brain).
+ *  - Idempotent migration application (duplicate / reordered migration
+ *    messages are no-ops).
+ *  - Graceful termination when no peers remain to continue.
+ */
+
+/**
+ * A peer tracked for host-migration purposes.
+ */
+export interface PeerRosterEntry {
+  playerId: string;
+  playerName: string;
+  /** Join order / arrival time. Lower = earlier. Used for tie-breaking. */
+  joinedAt: number;
+}
+
+/**
+ * Why a host migration is happening.
+ */
+export type HostMigrationReason = 'host-disconnected' | 'host-left';
+
+/**
+ * The lifecycle state of migration for the local client.
+ */
+export type HostMigrationStatus = 'stable' | 'migrating' | 'migrated' | 'terminated';
+
+/**
+ * Wire message broadcast by the newly-promoted host (and relayed by peers) to
+ * announce authority transfer. Rides over the existing game-action channel.
+ */
+export interface HostMigrationMessage {
+  type: 'host-migration';
+  /** Idempotency key: identical messages are applied at most once. */
+  migrationId: string;
+  previousHostId: string;
+  newHostId: string;
+  /** Remaining peer ids in deterministic join order. */
+  remainingPeers: string[];
+  /**
+   * Authoritative game-state snapshot the new host adopted, so lagging peers
+   * can re-sync. Opaque to this module (typed `unknown`).
+   */
+  gameState: unknown;
+  reason: HostMigrationReason;
+  timestamp: number;
+}
+
+/**
+ * Outcome of a migration, returned to the caller and surfaced via events.
+ */
+export interface HostMigrationResult {
+  migrationId: string;
+  previousHostId: string;
+  newHostId: string;
+  remainingPeers: string[];
+  /** True when no peers are left to continue (clean terminal state). */
+  terminated: boolean;
+  /** True when the local client became the new host. */
+  promotedSelf: boolean;
+  reason: HostMigrationReason;
+  migratedAt: number;
+}
+
+/**
+ * Events emitted by {@link HostMigrationManager}.
+ */
+export interface HostMigrationEvents {
+  /** The local client was promoted to host. */
+  onPromotedToHost: (result: HostMigrationResult) => void;
+  /** A remote peer became host (the local client is a follower). */
+  onHostChanged: (result: HostMigrationResult) => void;
+  /** The game cannot continue; surface a clean terminal state to the UI. */
+  onTerminated: (reason: string) => void;
+}
+
+export interface HostMigrationManagerOptions {
+  localPlayerId: string;
+  initialPeers: PeerRosterEntry[];
+  initialHostId: string;
+  events?: Partial<HostMigrationEvents>;
+  /**
+   * Minimum number of remaining peers (including the new host) required to
+   * keep playing. When fewer remain after the host leaves, the game terminates
+   * cleanly. Defaults to 2 (a multiplayer game needs at least two players).
+   */
+  minPlayersToContinue?: number;
+}
+
+const DEFAULT_MIN_PLAYERS = 2;
+
+/**
+ * Deterministically pick the next host from a set of peers.
+ *
+ * Selection rule: the peer with the smallest `joinedAt`; ties broken by the
+ * lexicographically smallest `playerId`. The leaving host is excluded. The
+ * rule is total and order-independent, so every peer that runs it on the same
+ * roster obtains the same answer.
+ *
+ * @returns the chosen successor's id, or `null` if there is no candidate.
+ */
+export function selectHostSuccessor(
+  peers: PeerRosterEntry[],
+  excludeId?: string,
+): string | null {
+  const candidates = peers
+    .filter((p) => p.playerId !== excludeId)
+    .slice()
+    .sort((a, b) => {
+      if (a.joinedAt !== b.joinedAt) return a.joinedAt - b.joinedAt;
+      return a.playerId < b.playerId ? -1 : a.playerId > b.playerId ? 1 : 0;
+    });
+  return candidates.length > 0 ? candidates[0].playerId : null;
+}
+
+/**
+ * Build a stable, deterministic migration id so all peers that compute the
+ * same migration agree on the same key (extra dedup safety beyond the literal
+ * message id).
+ */
+export function buildMigrationId(
+  previousHostId: string,
+  newHostId: string,
+  remainingPeers: string[],
+): string {
+  return `mig-${previousHostId}-${newHostId}-${remainingPeers.join(',')}`;
+}
+
+/**
+ * Manages host migration for a P2P multiplayer session.
+ *
+ * The manager is pure coordination logic: it does not touch WebRTC directly.
+ * A host layer (e.g. the `useP2PConnection` hook) feeds it the peer roster and
+ * the latest authoritative game state, asks it to migrate on host loss, and
+ * applies received migration messages.
+ */
+export class HostMigrationManager {
+  private readonly localPlayerId: string;
+  private readonly minPlayersToContinue: number;
+  private hostId: string;
+  private peers: Map<string, PeerRosterEntry> = new Map();
+  private events: HostMigrationEvents;
+  private status: HostMigrationStatus = 'stable';
+  /** Migration ids already applied — dedupes duplicates / reordering. */
+  private appliedMigrationIds: Set<string> = new Set();
+  /** Latest authoritative game state known to this client. */
+  private lastKnownGameState: unknown = null;
+
+  constructor(options: HostMigrationManagerOptions) {
+    this.localPlayerId = options.localPlayerId;
+    this.hostId = options.initialHostId;
+    this.minPlayersToContinue = options.minPlayersToContinue ?? DEFAULT_MIN_PLAYERS;
+    this.events = {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      onPromotedToHost: () => {},
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      onHostChanged: () => {},
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      onTerminated: () => {},
+      ...options.events,
+    };
+    for (const peer of options.initialPeers) {
+      this.peers.set(peer.playerId, { ...peer });
+    }
+  }
+
+  /** Current authoritative host id. */
+  getHostId(): string {
+    return this.hostId;
+  }
+
+  /** True when the local client is the current host. */
+  isLocalHost(): boolean {
+    return this.hostId === this.localPlayerId;
+  }
+
+  getStatus(): HostMigrationStatus {
+    return this.status;
+  }
+
+  /** Snapshot of the tracked peers in deterministic join order. */
+  getRoster(): PeerRosterEntry[] {
+    return this.peersList();
+  }
+
+  /** Cache the latest authoritative game state (for adoption on promotion). */
+  setLastKnownGameState(state: unknown): void {
+    this.lastKnownGameState = state;
+  }
+
+  getLastKnownGameState(): unknown {
+    return this.lastKnownGameState;
+  }
+
+  /** Add or refresh a peer in the roster. */
+  upsertPeer(peer: PeerRosterEntry): void {
+    this.peers.set(peer.playerId, { ...peer });
+  }
+
+  /** Remove a peer from the roster (e.g. on disconnect). */
+  removePeer(playerId: string): void {
+    this.peers.delete(playerId);
+  }
+
+  hasPeer(playerId: string): boolean {
+    return this.peers.has(playerId);
+  }
+
+  /**
+   * Determine who should become host after the given host leaves, using the
+   * current roster. Exposed so callers can decide whether the local client is
+   * the initiator without mutating state.
+   */
+  computeSuccessor(leavingHostId: string): string | null {
+    return selectHostSuccessor(this.peersList(), leavingHostId);
+  }
+
+  /**
+   * Initiate a migration because the current host is gone. Only the computed
+   * successor should call this (it broadcasts the resulting message); other
+   * peers wait to receive the migration message and call {@link applyMigration}.
+   *
+   * - If too few peers remain, emits `onTerminated` and returns a terminal
+   *   result (no broadcast needed).
+   * - If the local client is the successor, promotes it, adopts the last known
+   *   game state, emits `onPromotedToHost`, and returns a result whose
+   *   message should be broadcast.
+   * - Otherwise returns a result describing the computed successor without
+   *   mutating local authority (the caller should not broadcast).
+   */
+  initiateMigration(reason: HostMigrationReason): HostMigrationResult {
+    const previousHostId = this.hostId;
+    // Drop the leaving host from the roster so successor selection is correct.
+    this.removePeer(previousHostId);
+
+    const remaining = this.peersList();
+    const remainingIds = remaining.map((p) => p.playerId);
+    const now = Date.now();
+
+    // Not enough players to keep the game alive → clean terminal state.
+    if (remaining.length < this.minPlayersToContinue) {
+      const result: HostMigrationResult = {
+        migrationId: buildMigrationId(previousHostId, '', remainingIds),
+        previousHostId,
+        newHostId: '',
+        remainingPeers: remainingIds,
+        terminated: true,
+        promotedSelf: false,
+        reason,
+        migratedAt: now,
+      };
+      this.status = 'terminated';
+      this.appliedMigrationIds.add(result.migrationId);
+      this.events.onTerminated(
+        reason === 'host-left'
+          ? 'Host left the game and not enough players remain to continue.'
+          : 'Host disconnected and not enough players remain to continue.',
+      );
+      return result;
+    }
+
+    const successor = selectHostSuccessor(remaining);
+    // successor is guaranteed non-null because remaining.length >= minPlayers >= 1
+    const newHostId = successor as string;
+    const migrationId = buildMigrationId(previousHostId, newHostId, remainingIds);
+    const promotedSelf = newHostId === this.localPlayerId;
+
+    const result: HostMigrationResult = {
+      migrationId,
+      previousHostId,
+      newHostId,
+      remainingPeers: remainingIds,
+      terminated: false,
+      promotedSelf,
+      reason,
+      migratedAt: now,
+    };
+
+    if (promotedSelf) {
+      this.applyResult(result, true);
+    }
+
+    return result;
+  }
+
+  /**
+   * Build the wire message for a migration result computed locally. The
+   * initiator broadcasts this so followers can apply it.
+   */
+  buildMigrationMessage(result: HostMigrationResult): HostMigrationMessage {
+    return {
+      type: 'host-migration',
+      migrationId: result.migrationId,
+      previousHostId: result.previousHostId,
+      newHostId: result.newHostId,
+      remainingPeers: result.remainingPeers,
+      gameState: result.promotedSelf ? this.lastKnownGameState : null,
+      timestamp: result.migratedAt,
+      reason: result.reason,
+    };
+  }
+
+  /**
+   * Apply a received migration message. Idempotent: a message whose
+   * `migrationId` was already applied is a no-op (returns null), which makes
+   * the protocol robust to duplicates and reordering.
+   *
+   * @returns the applied result, or `null` if it was a duplicate/no-op.
+   */
+  applyMigration(message: HostMigrationMessage): HostMigrationResult | null {
+    if (message.type !== 'host-migration') return null;
+    // Defensive validation: a P2P message handler must tolerate malformed input.
+    if (
+      typeof message.migrationId !== 'string' ||
+      typeof message.newHostId !== 'string' ||
+      !Array.isArray(message.remainingPeers)
+    ) {
+      return null;
+    }
+    if (this.appliedMigrationIds.has(message.migrationId)) {
+      return null;
+    }
+
+    // Record the id first so the apply is idempotent even if a downstream
+    // event handler re-enters applyMigration with the same message.
+    this.appliedMigrationIds.add(message.migrationId);
+
+    const previousHostId = this.hostId;
+    const promotedSelf = message.newHostId === this.localPlayerId;
+
+    // Ensure the leaving host is no longer tracked.
+    if (message.previousHostId && message.previousHostId !== message.newHostId) {
+      this.removePeer(message.previousHostId);
+    }
+
+    const result: HostMigrationResult = {
+      migrationId: message.migrationId,
+      previousHostId: message.previousHostId || previousHostId,
+      newHostId: message.newHostId,
+      remainingPeers: message.remainingPeers.slice(),
+      terminated: false,
+      promotedSelf,
+      reason: message.reason,
+      migratedAt: message.timestamp,
+    };
+
+    this.applyResult(result, promotedSelf);
+
+    // If the new host shipped an authoritative state, adopt it as the baseline.
+    if (message.gameState !== null && message.gameState !== undefined) {
+      this.lastKnownGameState = message.gameState;
+    }
+
+    return result;
+  }
+
+  /**
+   * Apply a locally-resolved result: update host authority, status and emit the
+   * appropriate event.
+   */
+  private applyResult(result: HostMigrationResult, promotedSelf: boolean): void {
+    this.hostId = result.newHostId;
+    this.status = 'migrated';
+    this.appliedMigrationIds.add(result.migrationId);
+
+    if (promotedSelf) {
+      this.events.onPromotedToHost(result);
+    } else {
+      this.events.onHostChanged(result);
+    }
+  }
+
+  private peersList(): PeerRosterEntry[] {
+    return Array.from(this.peers.values()).sort((a, b) => {
+      if (a.joinedAt !== b.joinedAt) return a.joinedAt - b.joinedAt;
+      return a.playerId < b.playerId ? -1 : a.playerId > b.playerId ? 1 : 0;
+    });
+  }
+
+  /** Reset all migration tracking (e.g. when starting a fresh session). */
+  reset(): void {
+    this.appliedMigrationIds.clear();
+    this.status = 'stable';
+    this.lastKnownGameState = null;
+  }
+}
+
+/**
+ * Convenience factory.
+ */
+export function createHostMigrationManager(
+  options: HostMigrationManagerOptions,
+): HostMigrationManager {
+  return new HostMigrationManager(options);
+}


### PR DESCRIPTION
## Summary

Resolves #916 — when the authoritative host disconnects from a P2P multiplayer game, a remaining peer is now promoted to host so the game continues instead of terminating for everyone.

## Problem

The host is authoritative for game-state ownership. Previously, losing the host (disconnect/leave) caused the game to terminate for **all** peers with no recovery path — the connection layer (#915) handles *transient* ICE link recovery, but had no answer for the *permanent* loss of the host.

## Solution

Host migration is implemented as a distinct, transport-agnostic coordination concern (kept separate from #915 reconnection):

- **Deterministic successor selection** (`selectHostSuccessor`): every remaining peer computes the same new host without a central coordinator — lowest `joinedAt`, ties broken by lexicographically smallest `playerId`. This prevents split-brain.
- **`HostMigrationManager`** (`src/lib/p2p-host-migration.ts`): tracks the peer roster + current host, initiates migration on host loss, and applies received migration messages.
  - On host disconnect, the computed successor promotes itself, **adopts the last known authoritative game state**, and broadcasts a `host-migration` message.
  - Followers apply the broadcast **idempotently** (duplicate / reordered messages are no-ops via `migrationId`).
  - When too few peers remain (e.g. 1v1 opponent leaves), the manager emits a **clean terminal state** instead of stranding the game.
- **Hook integration** (`src/hooks/use-p2p-connection.ts`): wires the manager into `onPlayerLeft` (host-leave detection), `onPlayerJoined` (roster tracking), `onGameStateSync` (state caching for adoption), and routes incoming `host-migration` actions. The conflict-resolution manager's `hostId` is updated on every migration so `host-wins` resolution follows authority. Exposes `currentHostId` / `isAuthoritativeHost` plus `onHostMigrated` / `onGameTerminated` callbacks.
- Migration messages ride the existing `game-action` channel, so no WebRTC message-enum churn was needed and the change is non-breaking.

## Files changed

- `src/lib/p2p-host-migration.ts` *(new)* — `HostMigrationManager`, `selectHostSuccessor`, `buildMigrationId`, message/result types.
- `src/lib/__tests__/p2p-host-migration.test.ts` *(new)* — 22 tests covering successor selection, promotion, state adoption, idempotent notification, clean termination, and an end-to-end multi-peer agreement scenario.
- `src/hooks/use-p2p-connection.ts` — wires host migration into the connection lifecycle; exposes `currentHostId` / `isAuthoritativeHost`.
- `src/lib/multiplayer-types.ts` — adds `host-migration` to `LobbyMessage` + a typed `HostMigrationLobbyMessage`.
- `src/lib/__tests__/use-p2p-connection.test.ts` — updates the return-type mock for the two new fields.

## Test results

- New suite: **22/22 passing**.
- Affected suites all green (no regressions): `p2p-host-migration`, `p2p-conflict-resolution`, `p2p-game-connection`, `use-p2p-connection`, `webrtc-p2p` (#915 reconnection), `lobby-manager`, `local-game-storage`, `local-signaling-client`, `p2p-signaling-client`, `use-p2p-signaling`, and `src/hooks` — **250+ tests passing**.
- `tsc --noEmit`: clean. `eslint` on changed files: 0 errors (only pre-existing warnings in untouched code).

## Notes / assumptions

- Host migration is layered above the transport and does **not** modify the #915 ICE-restart reconnection logic — the two concerns remain independent as requested.
- The successor-initiates protocol relies on deterministic selection so only one peer broadcasts; followers passively apply. If the chosen successor also crashes, the next `onPlayerLeft` event re-runs migration deterministically.
- The `opponent-deck-generator` flaky test was not touched and is unrelated.
