### PR TITLE
fix: resolve #919 — legendary rule SBA lets controller choose which to keep

### DIFF
--- a/src/lib/game-state/__tests__/state-based-actions.test.ts
+++ b/src/lib/game-state/__tests__/state-based-actions.test.ts
@@ -11,6 +11,13 @@ import {
   drawWithSBAChecking,
 } from "../state-based-actions";
 import {
+  resolveLegendaryChoice,
+  autoResolveLegendaryChoice,
+  findLegendaryViolations,
+  chooseLegendaryToKeep,
+  LEGENDARY_CHOICE_TYPE,
+} from "../legendary-rule";
+import {
   createInitialGameState,
   startGame,
   dealDamageToPlayer,
@@ -682,14 +689,28 @@ describe("State-Based Actions", () => {
     });
   });
 
-  describe("Legendary Rule (SBA 704.5j)", () => {
-    it("should destroy duplicate legendary permanents with the same name", () => {
+  describe("Legendary Rule (SBA 704.5u) - controller choice (#919)", () => {
+    // Helper to place a card instance on a player's battlefield.
+    function putOnBattlefield(
+      state: ReturnType<typeof createInitialGameState>,
+      card: ReturnType<typeof createCardInstance>,
+      playerId: string,
+    ) {
+      const key = `${playerId}-battlefield`;
+      const zone = state.zones.get(key)!;
+      state.cards.set(card.id, card);
+      state.zones.set(key, {
+        ...zone,
+        cardIds: [...zone.cardIds, card.id],
+      });
+      return state;
+    }
+
+    it("should surface a choice instead of auto-destroying duplicate legends", () => {
       let state = createInitialGameState(["Alice"], 20, false);
       state = startGame(state);
 
       const playerIds = Array.from(state.players.keys());
-
-      // Create two legendary creatures with the same name
       const legendData = createMockCreature(
         "Legendary Creature",
         3,
@@ -708,34 +729,27 @@ describe("State-Based Actions", () => {
         playerIds[0],
       );
 
-      const battlefield = state.zones.get(`${playerIds[0]}-battlefield`)!;
-      state.cards.set(legend1.id, legend1);
-      state.cards.set(legend2.id, legend2);
-      state.zones.set(`${playerIds[0]}-battlefield`, {
-        ...battlefield,
-        cardIds: [...battlefield.cardIds, legend1.id, legend2.id],
-      });
+      state = putOnBattlefield(state, legend1, playerIds[0]);
+      state = putOnBattlefield(state, legend2, playerIds[0]);
 
       const result = checkStateBasedActions(state);
 
       expect(result.actionsPerformed).toBe(true);
+      // Nothing destroyed yet: the controller must choose first.
+      expect(result.state.waitingChoice?.type).toBe(LEGENDARY_CHOICE_TYPE);
+      expect(result.state.waitingChoice?.playerId).toBe(playerIds[0]);
       const battlefieldAfter = result.state.zones.get(
         `${playerIds[0]}-battlefield`,
       )!;
-      const graveyard = result.state.zones.get(`${playerIds[0]}-graveyard`)!;
-
-      // One should remain, one should be destroyed
-      expect(battlefieldAfter.cardIds.length).toBe(1);
-      expect(graveyard.cardIds.length).toBe(1);
+      expect(battlefieldAfter.cardIds).toContain(legend1.id);
+      expect(battlefieldAfter.cardIds).toContain(legend2.id);
     });
 
-    it("should not destroy unique legendary permanents", () => {
-      let state = createInitialGameState(["Alice", "Bob"], 20, false);
+    it("should keep the controller's chosen legend and grave the rest", () => {
+      let state = createInitialGameState(["Alice"], 20, false);
       state = startGame(state);
 
       const playerIds = Array.from(state.players.keys());
-
-      // Create one legendary creature
       const legendData = createMockCreature(
         "Legendary Creature",
         3,
@@ -743,22 +757,187 @@ describe("State-Based Actions", () => {
         [],
         true,
       );
+      const legend1 = createCardInstance(
+        legendData,
+        playerIds[0],
+        playerIds[0],
+      );
+      const legend2 = createCardInstance(
+        legendData,
+        playerIds[0],
+        playerIds[0],
+      );
+
+      state = putOnBattlefield(state, legend1, playerIds[0]);
+      state = putOnBattlefield(state, legend2, playerIds[0]);
+
+      const sba = checkStateBasedActions(state);
+
+      // Controller chooses to keep legend2.
+      const resolved = resolveLegendaryChoice(
+        sba.state,
+        playerIds[0],
+        legend2.id,
+      );
+
+      expect(resolved.success).toBe(true);
+      expect(resolved.state.waitingChoice).toBeNull();
+      const battlefield = resolved.state.zones.get(
+        `${playerIds[0]}-battlefield`,
+      )!;
+      const graveyard = resolved.state.zones.get(`${playerIds[0]}-graveyard`)!;
+      expect(battlefield.cardIds).toContain(legend2.id);
+      expect(battlefield.cardIds).not.toContain(legend1.id);
+      expect(graveyard.cardIds).toContain(legend1.id);
+    });
+
+    it("should let the controller keep three duplicates down to one", () => {
+      let state = createInitialGameState(["Alice"], 20, false);
+      state = startGame(state);
+
+      const playerIds = Array.from(state.players.keys());
+      const data = createMockCreature("Triple Legend", 2, 2, [], true);
+      const a = createCardInstance(data, playerIds[0], playerIds[0]);
+      const b = createCardInstance(data, playerIds[0], playerIds[0]);
+      const c = createCardInstance(data, playerIds[0], playerIds[0]);
+
+      state = putOnBattlefield(state, a, playerIds[0]);
+      state = putOnBattlefield(state, b, playerIds[0]);
+      state = putOnBattlefield(state, c, playerIds[0]);
+
+      const sba = checkStateBasedActions(state);
+      const resolved = resolveLegendaryChoice(sba.state, playerIds[0], a.id);
+
+      const battlefield = resolved.state.zones.get(
+        `${playerIds[0]}-battlefield`,
+      )!;
+      const graveyard = resolved.state.zones.get(`${playerIds[0]}-graveyard`)!;
+      expect(battlefield.cardIds).toContain(a.id);
+      expect(graveyard.cardIds).toContain(b.id);
+      expect(graveyard.cardIds).toContain(c.id);
+    });
+
+    it("AI default should deterministically keep the toughest legend", () => {
+      let state = createInitialGameState(["Alice"], 20, false);
+      state = startGame(state);
+
+      const playerIds = Array.from(state.players.keys());
+      const weakData = createMockCreature("Same Legend", 2, 2, [], true);
+      const strongData = createMockCreature("Same Legend", 5, 5, [], true);
+      const weak = createCardInstance(weakData, playerIds[0], playerIds[0]);
+      const strong = createCardInstance(strongData, playerIds[0], playerIds[0]);
+
+      state = putOnBattlefield(state, weak, playerIds[0]);
+      state = putOnBattlefield(state, strong, playerIds[0]);
+
+      const sba = checkStateBasedActions(state);
+      const auto = autoResolveLegendaryChoice(sba.state);
+
+      expect(auto.success).toBe(true);
+      const battlefield = auto.state.zones.get(`${playerIds[0]}-battlefield`)!;
+      const graveyard = auto.state.zones.get(`${playerIds[0]}-graveyard`)!;
+      expect(battlefield.cardIds).toContain(strong.id);
+      expect(graveyard.cardIds).toContain(weak.id);
+    });
+
+    it("AI default should keep the legend with the most attachments", () => {
+      let state = createInitialGameState(["Alice"], 20, false);
+      state = startGame(state);
+
+      const playerIds = Array.from(state.players.keys());
+      const legendData = createMockCreature("Buffed Legend", 3, 3, [], true);
+      const plain = createCardInstance(legendData, playerIds[0], playerIds[0]);
+      const buffed = createCardInstance(legendData, playerIds[0], playerIds[0]);
+      // Attach two permanents to `buffed` so it is preferred over `plain`.
+      buffed.attachedCardIds = ["aura-1", "equip-1"];
+
+      state = putOnBattlefield(state, plain, playerIds[0]);
+      state = putOnBattlefield(state, buffed, playerIds[0]);
+
+      const keepId = chooseLegendaryToKeep(state, [plain.id, buffed.id]);
+      expect(keepId).toBe(buffed.id);
+
+      const sba = checkStateBasedActions(state);
+      const auto = autoResolveLegendaryChoice(sba.state);
+      const battlefield = auto.state.zones.get(`${playerIds[0]}-battlefield`)!;
+      expect(battlefield.cardIds).toContain(buffed.id);
+    });
+
+    it("should not trigger for a single legend", () => {
+      let state = createInitialGameState(["Alice", "Bob"], 20, false);
+      state = startGame(state);
+
+      const playerIds = Array.from(state.players.keys());
+      const legendData = createMockCreature("Lonely Legend", 3, 3, [], true);
       const legend = createCardInstance(legendData, playerIds[0], playerIds[0]);
 
-      const battlefield = state.zones.get(`${playerIds[0]}-battlefield`)!;
-      state.cards.set(legend.id, legend);
-      state.zones.set(`${playerIds[0]}-battlefield`, {
-        ...battlefield,
-        cardIds: [...battlefield.cardIds, legend.id],
-      });
+      state = putOnBattlefield(state, legend, playerIds[0]);
 
       const result = checkStateBasedActions(state);
 
-      expect(result.actionsPerformed).toBe(false);
-      const battlefieldAfter = result.state.zones.get(
+      expect(result.state.waitingChoice).toBeNull();
+      const battlefield = result.state.zones.get(
         `${playerIds[0]}-battlefield`,
       )!;
-      expect(battlefieldAfter.cardIds).toContain(legend.id);
+      expect(battlefield.cardIds).toContain(legend.id);
+    });
+
+    it("should not trigger for same-name legends controlled by different players", () => {
+      let state = createInitialGameState(["Alice", "Bob"], 20, false);
+      state = startGame(state);
+
+      const playerIds = Array.from(state.players.keys());
+      const legendData = createMockCreature("Shared Legend", 3, 3, [], true);
+      const alices = createCardInstance(legendData, playerIds[0], playerIds[0]);
+      const bobs = createCardInstance(legendData, playerIds[1], playerIds[1]);
+
+      state = putOnBattlefield(state, alices, playerIds[0]);
+      state = putOnBattlefield(state, bobs, playerIds[1]);
+
+      const violations = findLegendaryViolations(state);
+      expect(violations).toHaveLength(0);
+
+      const result = checkStateBasedActions(state);
+      expect(result.state.waitingChoice).toBeNull();
+    });
+
+    it("should not trigger for non-legendary duplicates", () => {
+      let state = createInitialGameState(["Alice"], 20, false);
+      state = startGame(state);
+
+      const playerIds = Array.from(state.players.keys());
+      const data = createMockCreature("Generic Creature", 3, 3, [], false);
+      const one = createCardInstance(data, playerIds[0], playerIds[0]);
+      const two = createCardInstance(data, playerIds[0], playerIds[0]);
+
+      state = putOnBattlefield(state, one, playerIds[0]);
+      state = putOnBattlefield(state, two, playerIds[0]);
+
+      const result = checkStateBasedActions(state);
+      expect(result.state.waitingChoice).toBeNull();
+      const battlefield = result.state.zones.get(
+        `${playerIds[0]}-battlefield`,
+      )!;
+      expect(battlefield.cardIds).toContain(one.id);
+      expect(battlefield.cardIds).toContain(two.id);
+    });
+
+    it("should reject a legend choice from the wrong player", () => {
+      let state = createInitialGameState(["Alice", "Bob"], 20, false);
+      state = startGame(state);
+
+      const playerIds = Array.from(state.players.keys());
+      const data = createMockCreature("Contested Legend", 3, 3, [], true);
+      const a = createCardInstance(data, playerIds[0], playerIds[0]);
+      const b = createCardInstance(data, playerIds[0], playerIds[0]);
+
+      state = putOnBattlefield(state, a, playerIds[0]);
+      state = putOnBattlefield(state, b, playerIds[0]);
+
+      const sba = checkStateBasedActions(state);
+      // Bob tries to resolve Alice's choice.
+      const wrong = resolveLegendaryChoice(sba.state, playerIds[1], a.id);
+      expect(wrong.success).toBe(false);
     });
   });
 
@@ -1480,17 +1659,25 @@ describe("State-Based Actions", () => {
       // Manually set priority to Alice
       state = { ...state, priorityPlayerId: aliceId };
 
-      // Pass priority - legendary rule SBA should trigger
+      // Pass priority - legendary rule SBA should trigger as a pending choice
       state = passPriority(state, aliceId);
 
-      // One legendary should be destroyed (legendary rule SBA 704.5j)
+      // The legendary rule surfaces a choice instead of auto-destroying (#919).
+      expect(state.waitingChoice?.type).toBe(LEGENDARY_CHOICE_TYPE);
+
+      // Alice (the controller) chooses to keep creature2.
+      const resolved = resolveLegendaryChoice(state, aliceId, creature2.id);
+      expect(resolved.success).toBe(true);
+      state = resolved.state;
+
       const battlefieldAfter = state.zones.get(`${aliceId}-battlefield`)!;
       const graveyardAfter = state.zones.get(`${aliceId}-graveyard`)!;
 
-      // Only one creature should remain on battlefield
-      expect(battlefieldAfter.cardIds.length).toBe(1);
-      // One should be in graveyard
-      expect(graveyardAfter.cardIds.length).toBe(1);
+      // Only the kept creature remains on the battlefield
+      expect(battlefieldAfter.cardIds).toContain(creature2.id);
+      expect(battlefieldAfter.cardIds).not.toContain(creature1.id);
+      // The other one is in the graveyard
+      expect(graveyardAfter.cardIds).toContain(creature1.id);
     });
 
     describe("State Isolation (Issue #891)", () => {

--- a/src/lib/game-state/legendary-rule.ts
+++ b/src/lib/game-state/legendary-rule.ts
@@ -1,0 +1,271 @@
+/**
+ * Legendary Rule (State-Based Action)
+ *
+ * Implements MTG Comprehensive Rules 704.5u (the "legend rule"): when a player
+ * controls two or more legendary permanents with the same name, that player
+ * chooses one to keep and the rest are put into their owner's graveyard.
+ *
+ * Unlike most SBAs, the legend rule requires a controller CHOICE. Because the
+ * engine resolves SBAs synchronously, the choice is surfaced as a pending
+ * `waitingChoice` of type `"choose_legend"` on the game state. The UI (or an
+ * automated/AI controller via `autoResolveLegendaryChoice`) resolves it.
+ *
+ * Issue #919: legendary rule SBA must let the controller choose which to keep.
+ */
+
+import type {
+  GameState,
+  CardInstanceId,
+  PlayerId,
+  WaitingChoice,
+  ChoiceOption,
+} from "./types";
+import { isOnBattlefield } from "./types";
+import { getToughness } from "./card-instance";
+import { destroyCard } from "./keyword-actions";
+
+/** Waiting-choice type value used for the legendary rule. */
+export const LEGENDARY_CHOICE_TYPE = "choose_legend" as const;
+
+/**
+ * A group of same-name legendary permanents controlled by a single player
+ * that violates the legend rule.
+ */
+export interface LegendaryViolation {
+  /** Player controlling the duplicates (the one who must choose). */
+  controllerId: PlayerId;
+  /** Lowercased legend name shared by every candidate. */
+  name: string;
+  /** IDs of the offending legendary permanents (length > 1). */
+  candidateIds: CardInstanceId[];
+}
+
+/**
+ * Find all legend-rule violations currently on the battlefield.
+ *
+ * Per CR 704.5u the rule is evaluated PER CONTROLLER: two players may each
+ * control a same-name legend without incident. Candidates are grouped by
+ * (controllerId, lowercased name) and sorted deterministically.
+ */
+export function findLegendaryViolations(
+  state: GameState,
+): LegendaryViolation[] {
+  // controllerId -> name -> candidate ids
+  const byController = new Map<PlayerId, Map<string, CardInstanceId[]>>();
+
+  for (const card of state.cards.values()) {
+    if (!isOnBattlefield(state, card.id)) continue;
+    const isLegendary =
+      card.cardData.type_line?.toLowerCase().includes("legendary") ?? false;
+    if (!isLegendary) continue;
+
+    const name = (card.cardData.name || "").toLowerCase();
+    let perName = byController.get(card.controllerId);
+    if (!perName) {
+      perName = new Map();
+      byController.set(card.controllerId, perName);
+    }
+    const existing = perName.get(name) ?? [];
+    existing.push(card.id);
+    perName.set(name, existing);
+  }
+
+  const violations: LegendaryViolation[] = [];
+  for (const [controllerId, perName] of byController) {
+    for (const [name, candidateIds] of perName) {
+      if (candidateIds.length > 1) {
+        violations.push({
+          controllerId,
+          name,
+          candidateIds: [...candidateIds].sort(), // deterministic ordering
+        });
+      }
+    }
+  }
+  return violations;
+}
+
+/**
+ * Choose which legendary permanent to keep using a deterministic heuristic.
+ *
+ * Used as the default for AI/automated controllers and as a stable fallback.
+ * Preference order (most valuable survives):
+ *   1. Most attached permanents (Auras / Equipment riding along)
+ *   2. Highest toughness (most likely to survive)
+ *   3. Most counters
+ *   4. Longest on the battlefield (earliest timestamp)
+ *   5. Lexicographically smallest id (final deterministic tiebreak)
+ */
+export function chooseLegendaryToKeep(
+  state: GameState,
+  candidateIds: CardInstanceId[],
+): CardInstanceId | null {
+  if (candidateIds.length === 0) return null;
+  if (candidateIds.length === 1) return candidateIds[0];
+
+  const scored = candidateIds.map((id) => {
+    const card = state.cards.get(id);
+    const attachments = card?.attachedCardIds.length ?? 0;
+    const toughness = card ? getToughness(card) : 0;
+    const counters = card
+      ? card.counters.reduce((sum, c) => sum + c.count, 0)
+      : 0;
+    const timestamp = card?.enteredBattlefieldTimestamp ?? Infinity;
+    return { id, attachments, toughness, counters, timestamp };
+  });
+
+  scored.sort((a, b) => {
+    if (b.attachments !== a.attachments) return b.attachments - a.attachments;
+    if (b.toughness !== a.toughness) return b.toughness - a.toughness;
+    if (b.counters !== a.counters) return b.counters - a.counters;
+    if (a.timestamp !== b.timestamp) return a.timestamp - b.timestamp;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+
+  return scored[0].id;
+}
+
+/**
+ * Build a `waitingChoice` describing the legend-rule decision for a violation.
+ * The controller must select exactly one candidate to keep.
+ */
+export function createLegendaryWaitingChoice(
+  violation: LegendaryViolation,
+  state: GameState,
+): WaitingChoice {
+  const options: ChoiceOption[] = violation.candidateIds.map((id) => {
+    const card = state.cards.get(id);
+    return {
+      label: card?.cardData.name ?? id,
+      value: id,
+      isValid: true,
+    };
+  });
+
+  return {
+    type: LEGENDARY_CHOICE_TYPE,
+    playerId: violation.controllerId,
+    stackObjectId: null,
+    prompt: `Legendary rule: choose a ${
+      state.cards.get(violation.candidateIds[0])?.cardData.name.toLowerCase() ??
+      "legend"
+    } to keep`,
+    choices: options,
+    minChoices: 1,
+    maxChoices: 1,
+    presentedAt: Date.now(),
+  };
+}
+
+/** Return true when a game state already has a pending legend-rule choice. */
+export function hasPendingLegendaryChoice(state: GameState): boolean {
+  return state.waitingChoice?.type === LEGENDARY_CHOICE_TYPE;
+}
+
+/**
+ * Resolve a pending legend-rule choice for a controller.
+ *
+ * `keepId` must be one of the recorded candidates. All other candidates are
+ * put into their owner's graveyard (via `destroyCard` so death triggers fire).
+ * The waiting choice is cleared.
+ */
+export function resolveLegendaryChoice(
+  state: GameState,
+  playerId: PlayerId,
+  keepId: CardInstanceId,
+): { success: boolean; state: GameState; description: string } {
+  const choice = state.waitingChoice;
+  if (!choice || choice.type !== LEGENDARY_CHOICE_TYPE) {
+    return {
+      success: false,
+      state,
+      description: "No pending legendary choice",
+    };
+  }
+  if (choice.playerId !== playerId) {
+    return {
+      success: false,
+      state,
+      description: "Not this player's choice to make",
+    };
+  }
+
+  const candidateIds = choice.choices.map((c) => String(c.value)).sort();
+  if (!candidateIds.includes(keepId)) {
+    return {
+      success: false,
+      state,
+      description: "Kept card is not a valid candidate",
+    };
+  }
+
+  let updatedState: GameState = { ...state, waitingChoice: null };
+  const descriptions: string[] = [];
+
+  for (const id of candidateIds) {
+    if (id === keepId) continue;
+    const result = destroyCard(updatedState, id);
+    if (result.success) {
+      updatedState = result.state;
+      const card = updatedState.cards.get(id);
+      descriptions.push(
+        `${card?.cardData.name ?? id} put into graveyard (legendary rule)`,
+      );
+    }
+  }
+
+  return {
+    success: true,
+    state: updatedState,
+    description: descriptions.join("; ") || "Legendary rule resolved",
+  };
+}
+
+/**
+ * Automatically resolve any pending legend-rule choice using the deterministic
+ * default heuristic. Intended for AI/automated controllers that do not prompt a
+ * human. Safe to call when no legend choice is pending (no-op).
+ */
+export function autoResolveLegendaryChoice(state: GameState): {
+  success: boolean;
+  state: GameState;
+  description: string;
+} {
+  const choice = state.waitingChoice;
+  if (!choice || choice.type !== LEGENDARY_CHOICE_TYPE) {
+    return { success: true, state, description: "No legendary choice pending" };
+  }
+  const candidateIds = choice.choices.map((c) => String(c.value));
+  const keepId = chooseLegendaryToKeep(state, candidateIds);
+  if (!keepId) {
+    return {
+      success: false,
+      state,
+      description: "Could not determine a legend to keep",
+    };
+  }
+  return resolveLegendaryChoice(state, choice.playerId, keepId);
+}
+
+/**
+ * Move the non-kept legends for a single violation straight to the graveyard
+ * without surfacing a choice. Provided for backwards-compatible / non-interactive
+ * callers and tests; the interactive path goes through `resolveLegendaryChoice`.
+ */
+export function applyLegendaryViolation(
+  state: GameState,
+  violation: LegendaryViolation,
+  keepId: CardInstanceId,
+): { state: GameState; destroyed: CardInstanceId[] } {
+  let updatedState = state;
+  const destroyed: CardInstanceId[] = [];
+  for (const id of violation.candidateIds) {
+    if (id === keepId) continue;
+    const result = destroyCard(updatedState, id);
+    if (result.success) {
+      updatedState = result.state;
+      destroyed.push(id);
+    }
+  }
+  return { state: updatedState, destroyed };
+}

--- a/src/lib/game-state/state-based-actions.ts
+++ b/src/lib/game-state/state-based-actions.ts
@@ -22,6 +22,11 @@ import {
 import { hasIndestructible, handlePersist } from "./keyword-actions";
 import { destroyCard, exileCard } from "./keyword-actions";
 import { DEFAULT_COMMANDER_DAMAGE_THRESHOLD } from "./commander-damage";
+import {
+  findLegendaryViolations,
+  hasPendingLegendaryChoice,
+  createLegendaryWaitingChoice,
+} from "./legendary-rule";
 
 // Helper functions to check card types
 function isAura(card: CardInstance): boolean {
@@ -331,38 +336,30 @@ export function checkStateBasedActions(
     }
   }
 
-  // Check for legendary rule (SBA 704.5j)
-  // Two legendary permanents with the same name - keep one, destroy the rest
-  const legendaryPermanents = cardsToCheck.filter((card) => {
-    // Check if card is on battlefield using the helper
-    const isOnBf = isOnBattlefield(updatedState, card.id);
-    const isLegendary =
-      card.cardData.type_line?.toLowerCase().includes("legendary") ?? false;
-    return isOnBf && isLegendary;
-  });
-
-  const nameGroups = new Map<string, CardInstanceId[]>();
-  for (const card of legendaryPermanents) {
-    const name = card.cardData.name.toLowerCase();
-    const existing = nameGroups.get(name) || [];
-    existing.push(card.id);
-    nameGroups.set(name, existing);
-  }
-
-  for (const cardIds of nameGroups.values()) {
-    if (cardIds.length > 1) {
-      // Keep the first one, destroy the rest
-      for (let i = 1; i < cardIds.length; i++) {
-        const destroyResult = destroyCard(updatedState, cardIds[i]);
-        if (destroyResult.success) {
-          updatedState = destroyResult.state;
-          const card = updatedState.cards.get(cardIds[i]);
-          descriptions.push(
-            `Destroyed ${card?.cardData.name} (legendary rule)`,
-          );
-          actionsPerformed = true;
-        }
-      }
+  // Legendary rule (SBA 704.5u): when a player controls two or more legendary
+  // permanents with the same name, that player CHOOSES one to keep and the rest
+  // are put into their owner's graveyard. Because the engine resolves SBAs
+  // synchronously, the choice is surfaced as a pending `waitingChoice` (type
+  // "choose_legend") that the UI or an automated controller resolves via
+  // `resolveLegendaryChoice` / `autoResolveLegendaryChoice`.
+  // Issue #919: do not auto-destroy; let the controller choose which to keep.
+  if (!hasPendingLegendaryChoice(updatedState)) {
+    const violations = findLegendaryViolations(updatedState);
+    if (violations.length > 0) {
+      // Surface one violation at a time. After it is resolved the duplicates
+      // leave the battlefield, so the next SBA pass surfaces any remaining one.
+      const violation = violations[0];
+      updatedState = {
+        ...updatedState,
+        waitingChoice: createLegendaryWaitingChoice(violation, updatedState),
+      };
+      const legendName =
+        updatedState.cards.get(violation.candidateIds[0])?.cardData.name ??
+        "Legendary permanent";
+      descriptions.push(
+        `${legendName}: legendary rule triggered, awaiting controller choice`,
+      );
+      actionsPerformed = true;
     }
   }
 

--- a/src/lib/game-state/types.ts
+++ b/src/lib/game-state/types.ts
@@ -628,7 +628,8 @@ export interface WaitingChoice {
     | "attackers"
     | "blockers"
     | "ordering"
-    | "priority";
+    | "priority"
+    | "choose_legend";
   /** ID of player who needs to make this choice */
   playerId: PlayerId;
   /** ID of the stack object this choice is for */


### PR DESCRIPTION
## Problem
The legendary rule (state-based action, MTG CR 704.5u) fired whenever a player controlled two or more legendary permanents sharing a name. The old implementation in `checkStateBasedActions` blindly **auto-destroyed all but the first** duplicate, never giving the controller the choice the rules require. It also grouped duplicates **across all players** rather than per-controller, which is incorrect (two opponents may each control the same-name legend).

Closes #919.

## Solution
The legend rule now **surfaces a pending choice to the controller** instead of auto-destroying, and resolves it through the engine's existing `waitingChoice` mechanism.

- `checkStateBasedActions` detects legend-rule **violations per controller** and, rather than destroying, records a `waitingChoice` of a new type `"choose_legend"` describing which legend to keep. Nothing is moved to the graveyard until the choice is made.
- The controller (UI) resolves it with `resolveLegendaryChoice(state, playerId, keepId)`, which moves the non-kept legends to their owner's graveyard via `destroyCard` (so death triggers still fire) and clears the choice.
- AI / automated controllers resolve it deterministically with `autoResolveLegendaryChoice`, whose heuristic (`chooseLegendaryToKeep`) keeps the most valuable legend: most attached Auras/Equipment → highest toughness → most counters → longest on battlefield → stable id tiebreak.
- The SBA pass is guarded with `hasPendingLegendaryChoice` so it surfaces one violation at a time and never overwrites a pending choice (avoids stalling the synchronous SBA loop). All other SBAs are untouched.

This matches the spec for a synchronous engine: the choice is a pending-decision state the UI resolves, with a sensible deterministic default for AI.

## Files changed
- `src/lib/game-state/legendary-rule.ts` (new) — violation detection, deterministic AI choice, choice builders, and `resolveLegendaryChoice` / `autoResolveLegendaryChoice` resolvers.
- `src/lib/game-state/state-based-actions.ts` — replaced the auto-destroy legend block with a pending-choice; added per-controller violation detection.
- `src/lib/game-state/types.ts` — added `"choose_legend"` to the `WaitingChoice.type` union.
- `src/lib/game-state/__tests__/state-based-actions.test.ts` — updated the two legacy legend tests to the choice semantics and added new tests (controller's chosen one is kept; 3→1; AI keeps toughest / most-attached; single legend unaffected; same-name legends under different players unaffected; non-legendary duplicates unaffected; wrong-player choice rejected).

## Test results
- `npx jest src/lib/game-state/` → **85 suites, 1657 passed, 4 skipped** (0 failed).
- `npx tsc --noEmit` → **0 errors**.
- `npm run lint` → **0 errors** (only pre-existing warnings in unrelated files).

## Notes / assumptions
- The engine resolves SBAs synchronously, so the choice is delivered as a `waitingChoice` pending-decision (the same channel used for target/mode selection) rather than pausing the engine. Wiring the human-facing dialog into the game board UI and calling `autoResolveLegendaryChoice` from the AI worker are the natural follow-ups; the engine rule, choice state, and deterministic default are delivered here and fully unit-tested.
- Unrelated open PR #899 (Map-mutation isolation for #891) is not in this branch's base, as instructed.
