### PR TITLE
feat: resolve #920 — implement ward keyword (counter targeted spells on non-payment)

### DIFF
--- a/src/ai/__tests__/ward-payment-ai.test.ts
+++ b/src/ai/__tests__/ward-payment-ai.test.ts
@@ -1,0 +1,194 @@
+/**
+ * AI Ward Payment Decision Tests — CR 702.21
+ *
+ * Issue #920: the AI must decide whether to pay a ward cost to keep its
+ * targeted spell/ability from being countered.
+ */
+
+import { decideWardPayments } from "../stack-interaction-ai";
+import { createInitialGameState, startGame } from "@/lib/game-state/game-state";
+import { createCardInstance } from "@/lib/game-state/card-instance";
+import { addMana } from "@/lib/game-state/mana";
+import type {
+  CardInstanceId,
+  PlayerId,
+  ScryfallCard,
+  StackEffect,
+  StackObject,
+  Target,
+} from "@/lib/game-state/types";
+
+function wardedCreature(
+  name: string,
+  wardText: string,
+  opts: { power?: number; toughness?: number; cmc?: number } = {},
+): ScryfallCard {
+  return {
+    id: `mock-${name.toLowerCase().replace(/\s+/g, "-")}`,
+    name,
+    type_line: "Creature — Test",
+    power: String(opts.power ?? 4),
+    toughness: String(opts.toughness ?? 4),
+    keywords: ["Ward"],
+    oracle_text: wardText,
+    mana_cost: "{2}{U}",
+    cmc: opts.cmc ?? 4,
+    colors: ["U"],
+    color_identity: ["U"],
+    card_faces: undefined,
+    layout: "normal",
+  } as ScryfallCard;
+}
+
+interface Scenario {
+  state: ReturnType<typeof startGame>;
+  aliceId: PlayerId;
+  bobId: PlayerId;
+  wardedId: CardInstanceId;
+  stackObjectId: string;
+}
+
+function setup(
+  wardText: string,
+  creatureOpts?: { power?: number; toughness?: number; cmc?: number },
+): Scenario {
+  let state = createInitialGameState(["Alice", "Bob"], 20, false);
+  state = startGame(state);
+  const [aliceId, bobId] = Array.from(state.players.keys()) as PlayerId[];
+
+  const creature = createCardInstance(
+    wardedCreature("Warded", wardText, creatureOpts),
+    bobId,
+    bobId,
+  );
+  state.cards.set(creature.id, creature);
+  const bf = state.zones.get(`${bobId}-battlefield`)!;
+  state.zones.set(`${bobId}-battlefield`, {
+    ...bf,
+    cardIds: [...bf.cardIds, creature.id],
+  });
+
+  state = addMana(state, aliceId, { blue: 4, generic: 4 });
+
+  const stackObject: StackObject = {
+    id: "ai-spell-1",
+    type: "ability",
+    sourceCardId: null,
+    controllerId: aliceId,
+    name: "AI Targeting Ability",
+    text: "",
+    manaCost: null,
+    targets: [{ type: "card", targetId: creature.id, isValid: true } as Target],
+    chosenModes: [],
+    variableValues: new Map(),
+    isCountered: false,
+    timestamp: Date.now(),
+    effects: [] as StackEffect[],
+  };
+  state.stack = [stackObject];
+
+  return {
+    state,
+    aliceId,
+    bobId,
+    wardedId: creature.id,
+    stackObjectId: stackObject.id,
+  };
+}
+
+describe("evaluateWardPayment (AI heuristic)", () => {
+  it("pays a mana ward when affordable and the target is valuable", () => {
+    const { state, stackObjectId } = setup("Ward {2}", { cmc: 4, power: 4 });
+    const { evaluations } = decideWardPayments(state, stackObjectId);
+    expect(evaluations).toHaveLength(1);
+    expect(evaluations[0].canAfford).toBe(true);
+    expect(evaluations[0].shouldPay).toBe(true);
+  });
+
+  it("declines a mana ward when the target is low-value", () => {
+    const { state, stackObjectId } = setup("Ward {2}", { cmc: 1, power: 1 });
+    const { evaluations } = decideWardPayments(state, stackObjectId);
+    expect(evaluations[0].shouldPay).toBe(false);
+    expect(evaluations[0].reasoning).toMatch(/not worth/i);
+  });
+
+  it("declines when it cannot afford the ward cost", () => {
+    const { state, stackObjectId, aliceId } = setup("Ward {50}", {
+      cmc: 5,
+      power: 5,
+    });
+    const player = state.players.get(aliceId)!;
+    state.players.set(aliceId, {
+      ...player,
+      manaPool: { ...player.manaPool, blue: 0, generic: 0, colorless: 0 },
+    });
+    const { evaluations } = decideWardPayments(state, stackObjectId);
+    expect(evaluations[0].canAfford).toBe(false);
+    expect(evaluations[0].shouldPay).toBe(false);
+  });
+
+  it("declines a life ward that would drop the AI to the safety floor", () => {
+    // Alice at 6 life, ward costs 3 life -> 6 - 3 = 3 <= floor(5) -> decline.
+    const { state, stackObjectId, aliceId } = setup("Ward—Pay 3 life.", {
+      cmc: 5,
+      power: 5,
+    });
+    const player = state.players.get(aliceId)!;
+    state.players.set(aliceId, { ...player, life: 6 });
+    const { evaluations } = decideWardPayments(state, stackObjectId);
+    expect(evaluations[0].shouldPay).toBe(false);
+    expect(evaluations[0].reasoning).toMatch(/life/i);
+  });
+
+  it("pays a life ward when safe and the target is valuable", () => {
+    const { state, stackObjectId, aliceId } = setup("Ward—Pay 3 life.", {
+      cmc: 5,
+      power: 5,
+    });
+    const player = state.players.get(aliceId)!;
+    state.players.set(aliceId, { ...player, life: 20 });
+    const { evaluations } = decideWardPayments(state, stackObjectId);
+    expect(evaluations[0].shouldPay).toBe(true);
+  });
+});
+
+describe("decideWardPayments (applies decisions)", () => {
+  it("records payment and spends resources when the AI decides to pay", () => {
+    const { state, stackObjectId, wardedId, aliceId } = setup("Ward {2}", {
+      cmc: 4,
+      power: 4,
+    });
+    const manaBefore = state.players.get(aliceId)!.manaPool;
+    const { state: after } = decideWardPayments(state, stackObjectId);
+
+    const paid = after.stack.find((s) => s.id === stackObjectId)!;
+    expect(paid.wardPaidTargetIds).toContain(wardedId);
+    const manaAfter = after.players.get(aliceId)!.manaPool;
+    expect(manaAfter.generic + manaAfter.blue).toBeLessThan(
+      manaBefore.generic + manaBefore.blue,
+    );
+  });
+
+  it("leaves the spell unpaid when the AI declines, so it will be countered", () => {
+    const { state, stackObjectId, wardedId } = setup("Ward {2}", {
+      cmc: 1,
+      power: 1,
+    });
+    const { state: after } = decideWardPayments(state, stackObjectId);
+    const paid = after.stack.find((s) => s.id === stackObjectId)!;
+    expect(paid.wardPaidTargetIds ?? []).not.toContain(wardedId);
+  });
+
+  it("is a no-op for a spell with no ward triggers", () => {
+    const { state, stackObjectId, bobId, wardedId } = setup("Ward {2}");
+    // Remove the warded creature from the battlefield so there's no trigger.
+    const bf = state.zones.get(`${bobId}-battlefield`)!;
+    state.zones.set(`${bobId}-battlefield`, {
+      ...bf,
+      cardIds: bf.cardIds.filter((id) => id !== wardedId),
+    });
+
+    const { evaluations } = decideWardPayments(state, stackObjectId);
+    expect(evaluations).toHaveLength(0);
+  });
+});

--- a/src/ai/stack-interaction-ai.ts
+++ b/src/ai/stack-interaction-ai.ts
@@ -21,6 +21,17 @@ import type {
   AIGameState as GameState,
   AIStackObject,
 } from "@/lib/game-state/types";
+import type {
+  GameState as EngineGameState,
+  StackObject as EngineStackObject,
+} from "@/lib/game-state/types";
+import {
+  canPayWardCost,
+  detectWardTriggers,
+  payWardCost,
+  declineWardPayment,
+  type WardTrigger,
+} from "@/lib/game-state/ward-system";
 import {
   evaluateGameState,
   ThreatAssessment,
@@ -2727,4 +2738,161 @@ export function shouldBluffHoldMana(
   const ai = new StackInteractionAI(gameState, playerId, difficulty);
   const currentEvaluation = evaluateGameState(gameState, playerId, "medium");
   return ai.shouldBluffHoldMana(context, currentEvaluation, opponentHistory);
+}
+
+// ===========================================================================
+// Ward payment decisions (CR 702.21)
+//
+// Ward is enforced at resolution time in the engine (ward-system.ts +
+// resolveTopOfStack). These helpers let the AI decide, for each warded target of
+// one of its own spells/abilities, whether paying the ward cost is worth it.
+// They operate on the canonical engine GameState so they can directly apply
+// `payWardCost` / `declineWardPayment`.
+// ===========================================================================
+
+/**
+ * Result of evaluating a single ward trigger.
+ */
+export interface WardPaymentEvaluation {
+  /** The ward trigger being evaluated. */
+  trigger: WardTrigger;
+  /** Whether the payer can currently afford the ward cost. */
+  canAfford: boolean;
+  /** Whether the AI decides to pay. */
+  shouldPay: boolean;
+  /** Human-readable rationale (useful for commentary / debugging). */
+  reasoning: string;
+}
+
+/** Below this life total the AI refuses life-based ward payments (safety). */
+const WARD_LIFE_SAFETY_FLOOR = 5;
+
+/**
+ * Decide whether the AI should pay a single ward cost.
+ *
+ * Heuristics:
+ *  - Never pay if it cannot afford the cost.
+ *  - Life ward: refuse if paying would drop the AI to or below the safety floor.
+ *  - Value test: pay when the targeted permanent is "worth it" — its mana value
+ *    is at least the ward's generic cost (so the AI isn't paying more than the
+ *    threat is worth), or it has meaningful power (a real threat/anchor).
+ *  - A valuable removal target (high CMC or power) is worth paying for; a cheap
+ *    blocker generally is not.
+ */
+export function evaluateWardPayment(
+  state: EngineGameState,
+  stackObject: EngineStackObject,
+  trigger: WardTrigger,
+): WardPaymentEvaluation {
+  const payer = state.players.get(stackObject.controllerId);
+  if (!payer) {
+    return {
+      trigger,
+      canAfford: false,
+      shouldPay: false,
+      reasoning: "Paying player not found",
+    };
+  }
+
+  const canAfford = canPayWardCost(payer, trigger.cost);
+
+  if (!canAfford) {
+    return {
+      trigger,
+      canAfford: false,
+      shouldPay: false,
+      reasoning: "Cannot afford ward cost",
+    };
+  }
+
+  const target = state.cards.get(trigger.targetCardId);
+  const targetManaValue = target?.cardData.cmc ?? 0;
+  const targetPower = Number(target?.cardData.power) || 0;
+
+  // Life safety: don't pay life down to a dangerous total.
+  if (
+    trigger.cost.kind === "life" &&
+    payer.life - trigger.cost.amount <= WARD_LIFE_SAFETY_FLOOR
+  ) {
+    return {
+      trigger,
+      canAfford: true,
+      shouldPay: false,
+      reasoning: `Refusing life payment to stay above ${WARD_LIFE_SAFETY_FLOOR} life`,
+    };
+  }
+
+  // Value test: is the targeted permanent worth the ward cost?
+  const wardGenericCost =
+    trigger.cost.kind === "mana" ? trigger.cost.generic : trigger.cost.amount;
+  const valuableByManaValue = targetManaValue >= Math.max(wardGenericCost, 3);
+  const valuableByPower = targetPower >= 3;
+
+  if (valuableByManaValue || valuableByPower) {
+    return {
+      trigger,
+      canAfford: true,
+      shouldPay: true,
+      reasoning: `Target is worth protecting against (cmc ${targetManaValue}, power ${targetPower})`,
+    };
+  }
+
+  return {
+    trigger,
+    canAfford: true,
+    shouldPay: false,
+    reasoning: `Target (cmc ${targetManaValue}, power ${targetPower}) not worth the ward cost`,
+  };
+}
+
+/**
+ * Evaluate and apply ward payment decisions for every warded target of a single
+ * AI-controlled spell/ability on the stack.
+ *
+ * @returns the updated state plus per-trigger evaluations.
+ */
+export function decideWardPayments(
+  state: EngineGameState,
+  stackObjectId: string,
+): {
+  state: EngineGameState;
+  evaluations: WardPaymentEvaluation[];
+} {
+  const stackObject = state.stack.find((s) => s.id === stackObjectId);
+  if (!stackObject) {
+    return { state, evaluations: [] };
+  }
+
+  const triggers = detectWardTriggers(state, stackObject);
+  if (triggers.length === 0) {
+    return { state, evaluations: [] };
+  }
+
+  let currentState = state;
+  const evaluations: WardPaymentEvaluation[] = [];
+
+  for (const trigger of triggers) {
+    const evaluation = evaluateWardPayment(currentState, stackObject, trigger);
+    evaluations.push(evaluation);
+
+    if (evaluation.shouldPay) {
+      const result = payWardCost(
+        currentState,
+        trigger.stackObjectId,
+        trigger.targetCardId,
+      );
+      if (result.success) {
+        currentState = result.state;
+      }
+    } else {
+      const result = declineWardPayment(
+        currentState,
+        trigger.stackObjectId,
+        trigger.targetCardId,
+      );
+      currentState = result.state;
+    }
+  }
+
+  return { state: currentState, evaluations };
 }

--- a/src/lib/game-state/__tests__/ward-keyword.test.ts
+++ b/src/lib/game-state/__tests__/ward-keyword.test.ts
@@ -1,0 +1,662 @@
+/**
+ * Ward Keyword System Tests — CR 702.21
+ *
+ * Issue #920: the ward keyword was an unimplemented stub; targeted spells and
+ * abilities were never countered for non-payment. These tests cover the full
+ * ward lifecycle: keyword/cost detection, trigger detection, payment, and the
+ * resolution-time countering wired into resolveTopOfStack.
+ *
+ * NOTE: `evergreen-keywords.test.ts` is in the repo's jest
+ * `testPathIgnorePatterns`, so this file is the one that actually runs in CI.
+ */
+
+import {
+  hasWard,
+  getWardCost,
+  isProtectedByWard,
+  getKeywordDescriptions,
+  getAllKeywords,
+} from "../evergreen-keywords";
+import {
+  parseWardCostString,
+  getWardCostDescriptor,
+  canPayWardCost,
+  detectWardTriggers,
+  applyWardResolution,
+  payWardCost,
+  declineWardPayment,
+} from "../ward-system";
+import { resolveTopOfStack } from "../spell-casting";
+import { createInitialGameState, startGame } from "../game-state";
+import { createCardInstance } from "../card-instance";
+import { addMana } from "../mana";
+import type {
+  CardInstance,
+  CardInstanceId,
+  PlayerId,
+  StackEffect,
+  StackObject,
+  Target,
+} from "../types";
+import type { ScryfallCard } from "@/app/actions";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createWardedCreature(
+  name: string,
+  oracleText: string,
+  keywords: string[] = [],
+): ScryfallCard {
+  return {
+    id: `mock-${name.toLowerCase().replace(/\s+/g, "-")}`,
+    name,
+    type_line: "Creature — Test",
+    power: "3",
+    toughness: "3",
+    keywords,
+    oracle_text: oracleText,
+    mana_cost: "{1}{U}",
+    cmc: 2,
+    colors: ["U"],
+    color_identity: ["U"],
+    legalities: { standard: "legal", commander: "legal" },
+    card_faces: undefined,
+    layout: "normal",
+  } as ScryfallCard;
+}
+
+function createPlainCreature(name: string): ScryfallCard {
+  return {
+    id: `mock-${name.toLowerCase().replace(/\s+/g, "-")}`,
+    name,
+    type_line: "Creature — Test",
+    power: "2",
+    toughness: "2",
+    keywords: [],
+    oracle_text: "",
+    mana_cost: "{1}{G}",
+    cmc: 2,
+    colors: ["G"],
+    color_identity: ["G"],
+    legalities: { standard: "legal", commander: "legal" },
+    card_faces: undefined,
+    layout: "normal",
+  } as ScryfallCard;
+}
+
+/**
+ * Build a 2-player game where Bob controls a warded creature and Alice (who will
+ * be the caster) has plenty of mana.
+ */
+function setupWardScenario(wardedCardData: ScryfallCard): {
+  state: ReturnType<typeof startGame>;
+  aliceId: PlayerId;
+  bobId: PlayerId;
+  wardedCreatureId: CardInstanceId;
+} {
+  let state = createInitialGameState(["Alice", "Bob"], 20, false);
+  state = startGame(state);
+
+  const playerIds = Array.from(state.players.keys());
+  const aliceId = playerIds[0];
+  const bobId = playerIds[1];
+
+  // Bob controls the warded creature.
+  const creature = createCardInstance(wardedCardData, bobId, bobId);
+  state.cards.set(creature.id, creature);
+
+  const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+  state.zones.set(`${bobId}-battlefield`, {
+    ...bobBattlefield,
+    cardIds: [...bobBattlefield.cardIds, creature.id],
+  });
+
+  // Alice has mana available to pay ward costs.
+  state = addMana(state, aliceId, { blue: 6, generic: 6 });
+
+  return { state, aliceId, bobId, wardedCreatureId: creature.id };
+}
+
+let stackCounter = 0;
+function makeTargetingStackObject(
+  controllerId: PlayerId,
+  targets: Target[],
+  effects: StackEffect[] = [],
+  extra: Partial<StackObject> = {},
+): StackObject {
+  stackCounter += 1;
+  return {
+    id: `ward-spell-${stackCounter}`,
+    type: "ability",
+    sourceCardId: null,
+    controllerId,
+    name: "Targeting Ability",
+    text: "",
+    manaCost: null,
+    targets,
+    chosenModes: [],
+    variableValues: new Map(),
+    isCountered: false,
+    timestamp: Date.now(),
+    effects,
+    ...extra,
+  };
+}
+
+function damageEffect(targetId: CardInstanceId, amount = 1): StackEffect {
+  return {
+    effectType: "damage",
+    amount,
+    targetId,
+    isCombatDamage: false,
+  };
+}
+
+function creatureDamage(
+  state: ReturnType<typeof startGame>,
+  cardId: CardInstanceId,
+): number {
+  return state.cards.get(cardId)?.damage ?? -1;
+}
+
+// ---------------------------------------------------------------------------
+// Keyword detection & cost parsing
+// ---------------------------------------------------------------------------
+
+describe("Ward keyword detection", () => {
+  const make = (oracle: string, keywords: string[] = []): CardInstance =>
+    createCardInstance(
+      createWardedCreature("Warded", oracle, keywords),
+      "p1" as PlayerId,
+      "p1" as PlayerId,
+    );
+
+  it("detects ward via keywords array", () => {
+    expect(hasWard(make("Ward {2}", ["Ward"]))).toBe(true);
+  });
+
+  it("detects ward via oracle text only", () => {
+    expect(hasWard(make("Ward {1}"))).toBe(true);
+  });
+
+  it("does not false-positive on words containing 'ward'", () => {
+    const card = createCardInstance(
+      createPlainCreature("Warden of the Depths"),
+      "p1" as PlayerId,
+      "p1" as PlayerId,
+    );
+    // Name/oracle without a standalone "ward" keyword should not count.
+    expect(hasWard(card)).toBe(false);
+  });
+
+  it("parses mana ward cost", () => {
+    expect(getWardCost(make("Ward {3}"))).toBe("{3}");
+  });
+
+  it("parses multi-symbol mana ward cost", () => {
+    expect(getWardCost(make("Ward {1}{U}"))).toBe("{1}{U}");
+  });
+
+  it("parses life ward cost", () => {
+    expect(getWardCost(make("Ward—Pay 3 life."))).toBe("3");
+  });
+
+  it("returns default ward cost for plain ward", () => {
+    expect(getWardCost(make("Ward"))).toBe("{2}");
+  });
+
+  it("returns null ward cost for non-ward card", () => {
+    expect(
+      getWardCost(
+        createCardInstance(
+          createPlainCreature("X"),
+          "p1" as PlayerId,
+          "p1" as PlayerId,
+        ),
+      ),
+    ).toBeNull();
+  });
+
+  it("includes ward in keyword descriptions", () => {
+    expect(getKeywordDescriptions(make("Ward {2}"))).toContain("Ward {2}");
+  });
+
+  it("includes ward in all keywords", () => {
+    expect(
+      getAllKeywords(make("Ward {1}")).map((k) => k.toLowerCase()),
+    ).toContain("ward");
+  });
+});
+
+describe("Ward cost descriptor & affordability", () => {
+  it("parses mana cost string", () => {
+    const desc = parseWardCostString("{1}{U}");
+    expect(desc?.kind).toBe("mana");
+    expect(desc).toMatchObject({ kind: "mana", generic: 1, blue: 1 });
+  });
+
+  it("parses life cost string", () => {
+    expect(parseWardCostString("3")).toMatchObject({ kind: "life", amount: 3 });
+  });
+
+  it("returns null for null input", () => {
+    expect(parseWardCostString(null)).toBeNull();
+  });
+
+  it("getWardCostDescriptor returns null for non-ward card", () => {
+    expect(
+      getWardCostDescriptor(
+        createCardInstance(
+          createPlainCreature("X"),
+          "p1" as PlayerId,
+          "p1" as PlayerId,
+        ),
+      ),
+    ).toBeNull();
+  });
+
+  it("canPayWardCost returns true when mana is available", () => {
+    let state = createInitialGameState(["Alice"], 20, false);
+    state = startGame(state);
+    const aliceId = Array.from(state.players.keys())[0];
+    state = addMana(state, aliceId, { blue: 2, generic: 3 });
+    const player = state.players.get(aliceId)!;
+    expect(
+      canPayWardCost(player, {
+        kind: "mana",
+        generic: 3,
+        white: 0,
+        blue: 1,
+        black: 0,
+        red: 0,
+        green: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("canPayWardCost returns false when colored mana is insufficient", () => {
+    let state = createInitialGameState(["Alice"], 20, false);
+    state = startGame(state);
+    const aliceId = Array.from(state.players.keys())[0];
+    state = addMana(state, aliceId, { generic: 5 });
+    const player = state.players.get(aliceId)!;
+    expect(
+      canPayWardCost(player, {
+        kind: "mana",
+        generic: 1,
+        white: 0,
+        blue: 2,
+        black: 0,
+        red: 0,
+        green: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("canPayWardCost respects life total", () => {
+    let state = createInitialGameState(["Alice"], 5, false);
+    state = startGame(state);
+    const aliceId = Array.from(state.players.keys())[0];
+    const player = state.players.get(aliceId)!;
+    expect(canPayWardCost(player, { kind: "life", amount: 3 })).toBe(true);
+    expect(canPayWardCost(player, { kind: "life", amount: 6 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isProtectedByWard
+// ---------------------------------------------------------------------------
+
+describe("isProtectedByWard", () => {
+  it("protects against opponents only", () => {
+    const card = createCardInstance(
+      createWardedCreature("W", "Ward {2}"),
+      "bob" as PlayerId,
+      "bob" as PlayerId,
+    );
+    expect(isProtectedByWard(card, "alice" as PlayerId)).toBe(true);
+    expect(isProtectedByWard(card, "bob" as PlayerId)).toBe(false);
+  });
+
+  it("does not protect non-ward cards", () => {
+    const card = createCardInstance(
+      createPlainCreature("Plain"),
+      "bob" as PlayerId,
+      "bob" as PlayerId,
+    );
+    expect(isProtectedByWard(card, "alice" as PlayerId)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trigger detection
+// ---------------------------------------------------------------------------
+
+describe("detectWardTriggers", () => {
+  it("triggers when targeting an opponent's warded permanent", () => {
+    const { state, aliceId, wardedCreatureId } = setupWardScenario(
+      createWardedCreature("Warded", "Ward {2}"),
+    );
+    const stackObject = makeTargetingStackObject(aliceId, [
+      { type: "card", targetId: wardedCreatureId, isValid: true },
+    ]);
+    const triggers = detectWardTriggers(state, stackObject);
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0].targetCardId).toBe(wardedCreatureId);
+    expect(triggers[0].cost).toMatchObject({ kind: "mana", generic: 2 });
+  });
+
+  it("does not trigger for the controller's own warded permanent", () => {
+    const { state, bobId, wardedCreatureId } = setupWardScenario(
+      createWardedCreature("Warded", "Ward {2}"),
+    );
+    // Bob targeting his own warded creature.
+    const stackObject = makeTargetingStackObject(bobId, [
+      { type: "card", targetId: wardedCreatureId, isValid: true },
+    ]);
+    expect(detectWardTriggers(state, stackObject)).toHaveLength(0);
+  });
+
+  it("does not trigger for a non-warded target", () => {
+    const { state, aliceId, bobId } = setupWardScenario(
+      createWardedCreature("Warded", "Ward {2}"),
+    );
+    // Add a plain creature Bob controls and target it instead.
+    const plain = createCardInstance(
+      createPlainCreature("Plain"),
+      bobId,
+      bobId,
+    );
+    state.cards.set(plain.id, plain);
+    const bf = state.zones.get(`${bobId}-battlefield`)!;
+    state.zones.set(`${bobId}-battlefield`, {
+      ...bf,
+      cardIds: [...bf.cardIds, plain.id],
+    });
+
+    const stackObject = makeTargetingStackObject(aliceId, [
+      { type: "card", targetId: plain.id, isValid: true },
+    ]);
+    expect(detectWardTriggers(state, stackObject)).toHaveLength(0);
+  });
+
+  it("ignores player targets", () => {
+    const { state, aliceId, bobId } = setupWardScenario(
+      createWardedCreature("Warded", "Ward {2}"),
+    );
+    const stackObject = makeTargetingStackObject(aliceId, [
+      { type: "player", targetId: bobId, isValid: true },
+    ]);
+    expect(detectWardTriggers(state, stackObject)).toHaveLength(0);
+  });
+
+  it("ignores non-targeted spells/abilities", () => {
+    const { state, aliceId } = setupWardScenario(
+      createWardedCreature("Warded", "Ward {2}"),
+    );
+    const stackObject = makeTargetingStackObject(aliceId, []);
+    expect(detectWardTriggers(state, stackObject)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resolution countering (the core fix for #920)
+// ---------------------------------------------------------------------------
+
+describe("applyWardResolution", () => {
+  it("counters when ward is unpaid", () => {
+    const { state, aliceId, wardedCreatureId } = setupWardScenario(
+      createWardedCreature("Warded", "Ward {2}"),
+    );
+    const stackObject = makeTargetingStackObject(aliceId, [
+      { type: "card", targetId: wardedCreatureId, isValid: true },
+    ]);
+    const result = applyWardResolution(state, stackObject);
+    expect(result.countered).toBe(true);
+    expect(result.unpaidTriggers).toHaveLength(1);
+  });
+
+  it("does not counter when ward is paid", () => {
+    const { state, aliceId, wardedCreatureId } = setupWardScenario(
+      createWardedCreature("Warded", "Ward {2}"),
+    );
+    const stackObject = makeTargetingStackObject(aliceId, [
+      { type: "card", targetId: wardedCreatureId, isValid: true },
+    ]);
+    stackObject.wardPaidTargetIds = [wardedCreatureId];
+    expect(applyWardResolution(state, stackObject).countered).toBe(false);
+  });
+
+  it("does not counter when there are no ward triggers", () => {
+    const { state, aliceId, bobId } = setupWardScenario(
+      createWardedCreature("Warded", "Ward {2}"),
+    );
+    const plain = createCardInstance(
+      createPlainCreature("Plain"),
+      bobId,
+      bobId,
+    );
+    state.cards.set(plain.id, plain);
+    const stackObject = makeTargetingStackObject(aliceId, [
+      { type: "card", targetId: plain.id, isValid: true },
+    ]);
+    expect(applyWardResolution(state, stackObject).countered).toBe(false);
+  });
+});
+
+describe("Ward resolution via resolveTopOfStack", () => {
+  it("counters an unpaid targeting spell — spell has no effect", () => {
+    const { state, aliceId, wardedCreatureId } = setupWardScenario(
+      createWardedCreature("Warded", "Ward {2}"),
+    );
+    state.stack = [
+      makeTargetingStackObject(
+        aliceId,
+        [{ type: "card", targetId: wardedCreatureId, isValid: true }],
+        [damageEffect(wardedCreatureId, 1)],
+      ),
+    ];
+
+    const result = resolveTopOfStack(state);
+
+    // Spell removed from the stack (countered).
+    expect(result.stack).toHaveLength(0);
+    // Ward countered the spell, so the damage effect never applied.
+    expect(creatureDamage(result, wardedCreatureId)).toBe(0);
+  });
+
+  it("resolves normally when the ward cost is paid", () => {
+    const { state, aliceId, wardedCreatureId } = setupWardScenario(
+      createWardedCreature("Warded", "Ward {2}"),
+    );
+    const stackObject = makeTargetingStackObject(
+      aliceId,
+      [{ type: "card", targetId: wardedCreatureId, isValid: true }],
+      [damageEffect(wardedCreatureId, 1)],
+    );
+    state.stack = [stackObject];
+
+    // Alice pays the ward cost.
+    const payResult = payWardCost(state, stackObject.id, wardedCreatureId);
+    expect(payResult.success).toBe(true);
+
+    const result = resolveTopOfStack(payResult.state);
+
+    expect(result.stack).toHaveLength(0);
+    // Spell resolved: the damage effect applied.
+    expect(creatureDamage(result, wardedCreatureId)).toBe(1);
+  });
+
+  it("does not trigger ward for the controller's own spell on their own permanent", () => {
+    const { state, bobId, wardedCreatureId } = setupWardScenario(
+      createWardedCreature("Warded", "Ward {2}"),
+    );
+    state.stack = [
+      makeTargetingStackObject(
+        bobId,
+        [{ type: "card", targetId: wardedCreatureId, isValid: true }],
+        [damageEffect(wardedCreatureId, 1)],
+      ),
+    ];
+
+    const result = resolveTopOfStack(state);
+    expect(result.stack).toHaveLength(0);
+    // No ward for own spell: effect resolves normally.
+    expect(creatureDamage(result, wardedCreatureId)).toBe(1);
+  });
+
+  it("ignores ward for non-targeted spells", () => {
+    const { state, aliceId, wardedCreatureId } = setupWardScenario(
+      createWardedCreature("Warded", "Ward {2}"),
+    );
+    // No targets, no ward trigger; resolution is unaffected.
+    state.stack = [makeTargetingStackObject(aliceId, [], [])];
+
+    const result = resolveTopOfStack(state);
+    expect(result.stack).toHaveLength(0);
+    expect(creatureDamage(result, wardedCreatureId)).toBe(0);
+  });
+
+  it("counters when the ward cost cannot be paid (insufficient mana)", () => {
+    const { state, aliceId, wardedCreatureId } = setupWardScenario(
+      createWardedCreature("Warded", "Ward {8}"),
+    );
+    // Drain Alice's mana so she cannot pay {8}.
+    const aliceIdLocal = aliceId;
+    const player = state.players.get(aliceIdLocal)!;
+    state.players.set(aliceIdLocal, {
+      ...player,
+      manaPool: { ...player.manaPool, blue: 0, generic: 0, colorless: 0 },
+    });
+
+    state.stack = [
+      makeTargetingStackObject(
+        aliceId,
+        [{ type: "card", targetId: wardedCreatureId, isValid: true }],
+        [damageEffect(wardedCreatureId, 1)],
+      ),
+    ];
+
+    // Attempting to pay fails because she cannot afford it.
+    const payResult = payWardCost(state, state.stack[0].id, wardedCreatureId);
+    expect(payResult.success).toBe(false);
+
+    const result = resolveTopOfStack(state);
+    expect(result.stack).toHaveLength(0);
+    expect(creatureDamage(result, wardedCreatureId)).toBe(0);
+  });
+
+  it("counters if ANY of multiple warded targets is unpaid", () => {
+    const {
+      state,
+      aliceId,
+      bobId,
+      wardedCreatureId: firstWarded,
+    } = setupWardScenario(createWardedCreature("Warded One", "Ward {2}"));
+    // Second warded creature for Bob.
+    const second = createCardInstance(
+      createWardedCreature("Warded Two", "Ward {1}"),
+      bobId,
+      bobId,
+    );
+    state.cards.set(second.id, second);
+    const bf = state.zones.get(`${bobId}-battlefield`)!;
+    state.zones.set(`${bobId}-battlefield`, {
+      ...bf,
+      cardIds: [...bf.cardIds, second.id],
+    });
+
+    const stackObject = makeTargetingStackObject(
+      aliceId,
+      [
+        { type: "card", targetId: firstWarded, isValid: true },
+        { type: "card", targetId: second.id, isValid: true },
+      ],
+      [damageEffect(firstWarded, 1)],
+    );
+    state.stack = [stackObject];
+
+    // Pay for the first target only.
+    const payResult = payWardCost(state, stackObject.id, firstWarded);
+    expect(payResult.success).toBe(true);
+
+    const result = resolveTopOfStack(payResult.state);
+    // Second ward unpaid -> whole spell countered.
+    expect(result.stack).toHaveLength(0);
+    expect(creatureDamage(result, firstWarded)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// payWardCost / declineWardPayment
+// ---------------------------------------------------------------------------
+
+describe("payWardCost", () => {
+  it("spends mana and records the payment", () => {
+    const { state, aliceId, wardedCreatureId } = setupWardScenario(
+      createWardedCreature("Warded", "Ward {2}"),
+    );
+    const stackObject = makeTargetingStackObject(aliceId, [
+      { type: "card", targetId: wardedCreatureId, isValid: true },
+    ]);
+    state.stack = [stackObject];
+
+    const before = state.players.get(aliceId)!.manaPool;
+    const result = payWardCost(state, stackObject.id, wardedCreatureId);
+
+    expect(result.success).toBe(true);
+    const paid = result.state.stack.find((s) => s.id === stackObject.id)!;
+    expect(paid.wardPaidTargetIds).toContain(wardedCreatureId);
+    // Mana was spent.
+    const after = result.state.players.get(aliceId)!.manaPool;
+    expect(after.generic + after.blue).toBeLessThan(
+      before.generic + before.blue,
+    );
+  });
+
+  it("fails when the player cannot afford the cost", () => {
+    const { state, aliceId, wardedCreatureId } = setupWardScenario(
+      createWardedCreature("Warded", "Ward {50}"),
+    );
+    const stackObject = makeTargetingStackObject(aliceId, [
+      { type: "card", targetId: wardedCreatureId, isValid: true },
+    ]);
+    state.stack = [stackObject];
+
+    const result = payWardCost(state, stackObject.id, wardedCreatureId);
+    expect(result.success).toBe(false);
+  });
+
+  it("spends life for a life-ward", () => {
+    const { state, aliceId, wardedCreatureId } = setupWardScenario(
+      createWardedCreature("Life Warded", "Ward—Pay 3 life."),
+    );
+    const stackObject = makeTargetingStackObject(aliceId, [
+      { type: "card", targetId: wardedCreatureId, isValid: true },
+    ]);
+    state.stack = [stackObject];
+
+    const lifeBefore = state.players.get(aliceId)!.life;
+    const result = payWardCost(state, stackObject.id, wardedCreatureId);
+    expect(result.success).toBe(true);
+    expect(result.state.players.get(aliceId)!.life).toBe(lifeBefore - 3);
+  });
+
+  it("declineWardPayment is a no-op that leaves the spell unpaid", () => {
+    const { state, aliceId, wardedCreatureId } = setupWardScenario(
+      createWardedCreature("Warded", "Ward {2}"),
+    );
+    const stackObject = makeTargetingStackObject(aliceId, [
+      { type: "card", targetId: wardedCreatureId, isValid: true },
+    ]);
+    state.stack = [stackObject];
+
+    const result = declineWardPayment(state, stackObject.id, wardedCreatureId);
+    expect(result.success).toBe(true);
+    expect(result.state.stack[0].wardPaidTargetIds ?? []).not.toContain(
+      wardedCreatureId,
+    );
+  });
+});

--- a/src/lib/game-state/evergreen-keywords.ts
+++ b/src/lib/game-state/evergreen-keywords.ts
@@ -695,6 +695,7 @@ export function getAllKeywords(card: CardInstance): string[] {
     "haste",
     "flash",
     "protection",
+    "ward",
   ];
 
   for (const kw of keywordTexts) {
@@ -752,29 +753,90 @@ export function getKeywordDescriptions(card: CardInstance): string[] {
   if (hasTrample(card)) descriptions.push("Trample");
   if (hasVigilance(card)) descriptions.push("Vigilance");
 
+  // Ward description uses the parsed cost (e.g., "Ward {2}")
+  const wardCost = getWardCost(card);
+  if (wardCost !== null) {
+    descriptions.push(`Ward ${wardCost}`);
+  }
+
   return descriptions;
 }
 
-/** @deprecated Stub - ward mechanic not yet implemented */
-export function hasWard(_card: CardInstance): boolean {
-  void _card;
-  return false;
+// ============== WARD ==============
+/**
+ * Default ward cost when a card has "Ward" with no explicit cost.
+ * Most printed Ward cards use a mana cost, so default to {2}.
+ */
+const DEFAULT_WARD_COST = "{2}";
+
+/**
+ * Check if a card has the ward keyword.
+ * CR 702.21: Ward is a triggered ability. "Whenever this permanent becomes the
+ * target of a spell or ability an opponent controls, counter that spell or ability
+ * unless its controller pays [cost]."
+ *
+ * Detection: the card's `keywords` array contains "Ward", OR the oracle text
+ * contains "ward" as a standalone keyword (word-bounded, so "warden"/"forward"
+ * do not match).
+ */
+export function hasWard(card: CardInstance): boolean {
+  const keywords = card.cardData.keywords || [];
+  if (keywords.some((k) => /^ward\b/i.test(k.trim()))) {
+    return true;
+  }
+  const oracleText = card.cardData.oracle_text || "";
+  return /\bward\b/i.test(oracleText);
 }
 
-/** @deprecated Stub - ward mechanic not yet implemented */
-export function getWardCost(_card: CardInstance): number | null {
-  void _card;
-  return null;
+/**
+ * Parse the ward cost of a card into its string representation.
+ *
+ * Supported formats (matching how Ward appears on cards):
+ *  - Mana cost:   "Ward {2}" / "Ward—{2}{U}"  -> "{2}" / "{2}{U}"
+ *  - Life cost:   "Ward—Pay 3 life."           -> "3"
+ *  - Plain ward:  "Ward"                        -> "{2}" (default)
+ *
+ * Returns null for cards without ward.
+ */
+export function getWardCost(card: CardInstance): string | null {
+  if (!hasWard(card)) {
+    return null;
+  }
+
+  const oracleText = card.cardData.oracle_text || "";
+
+  // Mana ward: one or more {...} mana symbols following "Ward"
+  const manaMatch = oracleText.match(/\bward\b(?:[—\-:]?\s*)((?:\{[^}]*\})+)/i);
+  if (manaMatch) {
+    return manaMatch[1];
+  }
+
+  // Life ward: "Ward—Pay N life"
+  const lifeMatch = oracleText.match(/\bward\b[—\-:]?\s*pay\s+(\d+)\s+life/i);
+  if (lifeMatch) {
+    return lifeMatch[1];
+  }
+
+  // Ward keyword present but no explicit cost -> default
+  return DEFAULT_WARD_COST;
 }
 
-/** @deprecated Stub - ward mechanic not yet implemented */
+/**
+ * Check if a card is protected by ward from a spell/ability controlled by the
+ * given player. Ward only protects against opposing sources (CR 702.21).
+ *
+ * @param card The potential target permanent
+ * @param sourceControllerId The controller of the targeting spell/ability
+ */
 export function isProtectedByWard(
-  _source: CardInstance,
-  _card: CardInstance,
+  card: CardInstance,
+  sourceControllerId: PlayerId,
 ): boolean {
-  void _source;
-  void _card;
-  return false;
+  if (!hasWard(card)) {
+    return false;
+  }
+  // Ward triggers only for opposing sources; a player's own spells ignore it.
+  return card.controllerId !== sourceControllerId;
 }
 
 // ============== PERSIST ==============

--- a/src/lib/game-state/spell-casting.ts
+++ b/src/lib/game-state/spell-casting.ts
@@ -48,6 +48,7 @@ import {
 } from "./effect-resolution";
 import type { CardInstance, StackEffect } from "./types";
 import { canTargetKeyword } from "./evergreen-keywords";
+import { applyWardResolution } from "./ward-system";
 
 /**
  * Generate a unique stack object ID
@@ -524,6 +525,14 @@ export function resolveTopOfStack(state: GameState): GameState {
 
   // If it's countered, just remove it
   if (stackObject.isCountered) {
+    return removeFromStack(state, stackObject.id);
+  }
+
+  // Ward (CR 702.21): if this spell/ability targets a warded permanent an
+  // opponent controls and the ward cost was not paid, it is countered (removed
+  // from the stack with no effect). This is enforced here, before resolution.
+  const wardResult = applyWardResolution(state, stackObject);
+  if (wardResult.countered) {
     return removeFromStack(state, stackObject.id);
   }
 

--- a/src/lib/game-state/types.ts
+++ b/src/lib/game-state/types.ts
@@ -388,6 +388,12 @@ export interface StackObject {
   buybackReturnZone?: string;
   /** Bestow attachment target (if cast as aura) */
   bestowTarget?: CardInstanceId;
+  /**
+   * Target card IDs for which the ward cost (CR 702.21) has been paid by this
+   * spell/ability's controller. On resolution, any warded opponent target NOT
+   * in this list causes this spell/ability to be countered.
+   */
+  wardPaidTargetIds?: string[];
   /** Structured effects to resolve (CR 608) */
   effects?: StackEffect[];
 }

--- a/src/lib/game-state/ward-system.ts
+++ b/src/lib/game-state/ward-system.ts
@@ -1,0 +1,399 @@
+/**
+ * Ward Keyword System — CR 702.21
+ *
+ * Ward is a triggered ability: "Whenever this permanent becomes the target of a
+ * spell or ability an opponent controls, counter that spell or ability unless its
+ * controller pays [cost]."
+ *
+ * This module implements the ward lifecycle:
+ *  1. Parse a card's ward cost (mana or life) into a payable descriptor.
+ *  2. Detect ward triggers for a targeted spell/ability on the stack.
+ *  3. Provide the payment API (pay / decline) used by players and the AI.
+ *  4. Decide, at resolution time, whether a spell/ability is countered for
+ *     non-payment of any ward cost.
+ *
+ * The countering itself is enforced in `resolveTopOfStack` (spell-casting.ts),
+ * which calls `applyWardResolution` before applying any effects.
+ */
+
+import { spendMana } from "./mana";
+import { getWardCost, hasWard, isProtectedByWard } from "./evergreen-keywords";
+import type {
+  CardInstance,
+  CardInstanceId,
+  GameState,
+  Player,
+  PlayerId,
+  StackObject,
+  WaitingChoice,
+} from "./types";
+import { isOnBattlefield } from "./types";
+
+/**
+ * A payable ward cost. Ward costs are either a mana cost (e.g. "{2}", "{1}{U}")
+ * or a life cost ("Ward—Pay 3 life").
+ */
+export type WardCostDescriptor =
+  | {
+      kind: "mana";
+      generic: number;
+      white: number;
+      blue: number;
+      black: number;
+      red: number;
+      green: number;
+    }
+  | { kind: "life"; amount: number };
+
+/**
+ * A single ward trigger raised against a spell/ability on the stack.
+ */
+export interface WardTrigger {
+  /** The stack object being countered (unless its ward is paid). */
+  stackObjectId: string;
+  /** The warded permanent that was targeted. */
+  targetCardId: CardInstanceId;
+  /** Controller of the warded permanent (an opponent of the caster). */
+  wardControllerId: PlayerId;
+  /** The cost the caster must pay to stop the counter. */
+  cost: WardCostDescriptor;
+}
+
+/** Result of checking ward at resolution time. */
+export interface WardResolutionResult {
+  /** True when at least one unpaid ward counter the stack object. */
+  countered: boolean;
+  /** The triggers that were detected (paid and unpaid). */
+  triggers: WardTrigger[];
+  /** The unpaid triggers that caused the counter. */
+  unpaidTriggers: WardTrigger[];
+}
+
+/**
+ * Parse a ward cost string (as produced by `getWardCost`) into a payable
+ * descriptor. Returns null when there is no cost to parse.
+ *
+ *  - Mana string e.g. "{2}" or "{2}{U}"  -> { kind: "mana", ... }
+ *  - Life string  e.g. "3"               -> { kind: "life", amount: 3 }
+ */
+export function parseWardCostString(
+  costStr: string | null,
+): WardCostDescriptor | null {
+  if (costStr === null) {
+    return null;
+  }
+
+  const trimmed = costStr.trim();
+
+  // Mana cost: contains one or more {...} symbols
+  if (/\{[^}]*\}/.test(trimmed)) {
+    const mana = {
+      generic: 0,
+      white: 0,
+      blue: 0,
+      black: 0,
+      red: 0,
+      green: 0,
+    };
+    const tokens = trimmed.match(/\{[^}]*\}/g) || [];
+    for (const token of tokens) {
+      const symbol = token.slice(1, -1).toUpperCase();
+      if (/^\d+$/.test(symbol)) {
+        mana.generic += parseInt(symbol, 10);
+      } else if (symbol === "W") {
+        mana.white += 1;
+      } else if (symbol === "U") {
+        mana.blue += 1;
+      } else if (symbol === "B") {
+        mana.black += 1;
+      } else if (symbol === "R") {
+        mana.red += 1;
+      } else if (symbol === "G") {
+        mana.green += 1;
+      }
+      // Unknown symbols (e.g. X, hybrid) are ignored for ward purposes.
+    }
+    return { kind: "mana", ...mana };
+  }
+
+  // Life cost: a bare number (e.g. "3")
+  if (/^\d+$/.test(trimmed)) {
+    return { kind: "life", amount: parseInt(trimmed, 10) };
+  }
+
+  return null;
+}
+
+/**
+ * Get the payable ward cost descriptor for a card, or null if it has no ward.
+ */
+export function getWardCostDescriptor(
+  card: CardInstance,
+): WardCostDescriptor | null {
+  if (!hasWard(card)) {
+    return null;
+  }
+  return parseWardCostString(getWardCost(card));
+}
+
+/**
+ * Check whether a player can currently pay a ward cost.
+ *
+ * Mana ward: colored pips must be present in the pool; the generic portion may be
+ * paid with any mana (generic, colorless, or leftover colored). Mirrors the
+ * canonical `spendMana` rules in mana.ts.
+ *
+ * Life ward: the player must have at least that much life (CR 118.4 — a player
+ * cannot pay more life than their current life total).
+ */
+export function canPayWardCost(
+  player: Player,
+  cost: WardCostDescriptor,
+): boolean {
+  if (cost.kind === "life") {
+    return player.life >= cost.amount;
+  }
+
+  const pool = player.manaPool;
+
+  // Colored requirements must be met by like-colored mana.
+  if (
+    pool.white < cost.white ||
+    pool.blue < cost.blue ||
+    pool.black < cost.black ||
+    pool.red < cost.red ||
+    pool.green < cost.green
+  ) {
+    return false;
+  }
+
+  // Generic portion can be paid with generic + colorless + any leftover colored mana.
+  const leftoverColored =
+    pool.white -
+    cost.white +
+    (pool.blue - cost.blue) +
+    (pool.black - cost.black) +
+    (pool.red - cost.red) +
+    (pool.green - cost.green);
+  const availableForGeneric = pool.generic + pool.colorless + leftoverColored;
+
+  return availableForGeneric >= cost.generic;
+}
+
+/**
+ * Detect all ward triggers raised by a spell/ability's targets.
+ *
+ * A trigger is raised for each target that is a permanent with ward controlled
+ * by an opponent of the stack object's controller (CR 702.21). Only `card`
+ * targets that are actual permanents raise ward — players, stack objects, and
+ * zones never do.
+ */
+export function detectWardTriggers(
+  state: GameState,
+  stackObject: StackObject,
+): WardTrigger[] {
+  const triggers: WardTrigger[] = [];
+
+  for (const target of stackObject.targets) {
+    if (target.type !== "card") {
+      continue;
+    }
+    const card = state.cards.get(target.targetId);
+    if (!card) {
+      continue;
+    }
+    // Ward only protects permanents on the battlefield (CR 702.21).
+    if (!isOnBattlefield(state, card.id)) {
+      continue;
+    }
+    // Ward only protects opposing permanents from being targeted.
+    if (!isProtectedByWard(card, stackObject.controllerId)) {
+      continue;
+    }
+    const cost = getWardCostDescriptor(card);
+    if (!cost) {
+      continue;
+    }
+    triggers.push({
+      stackObjectId: stackObject.id,
+      targetCardId: card.id,
+      wardControllerId: card.controllerId,
+      cost,
+    });
+  }
+
+  return triggers;
+}
+
+/**
+ * Resolve ward for a stack object that is about to resolve.
+ *
+ * Returns whether the object is countered: if ANY warded opponent target was
+ * not paid for, the spell/ability is countered in full (CR 702.21). This is a
+ * pure decision — it does not mutate the game state; the caller removes the
+ * countered object.
+ *
+ * @param state Current game state (used to look up targets)
+ * @param stackObject The spell/ability resolving
+ */
+export function applyWardResolution(
+  state: GameState,
+  stackObject: StackObject,
+): WardResolutionResult {
+  const triggers = detectWardTriggers(state, stackObject);
+  if (triggers.length === 0) {
+    return { countered: false, triggers: [], unpaidTriggers: [] };
+  }
+
+  const paidIds = stackObject.wardPaidTargetIds ?? [];
+  const unpaidTriggers = triggers.filter(
+    (t) => !paidIds.includes(t.targetCardId),
+  );
+
+  return {
+    countered: unpaidTriggers.length > 0,
+    triggers,
+    unpaidTriggers,
+  };
+}
+
+/**
+ * Pay the ward cost for a specific targeted permanent, recording the payment on
+ * the stack object so the spell/ability can resolve.
+ *
+ * Spends mana / life from the casting player's pool. Returns success=false if
+ * the stack object or target cannot be found, the target is not warded, the
+ * cost has already been paid, or the player cannot afford the cost.
+ *
+ * @param state Current game state
+ * @param stackObjectId The spell/ability whose ward cost is being paid
+ * @param targetCardId The warded permanent being paid for
+ */
+export function payWardCost(
+  state: GameState,
+  stackObjectId: string,
+  targetCardId: CardInstanceId,
+): { success: boolean; state: GameState; error?: string } {
+  const stackObject = state.stack.find((s) => s.id === stackObjectId);
+  if (!stackObject) {
+    return { success: false, state, error: "Stack object not found" };
+  }
+
+  const card = state.cards.get(targetCardId);
+  if (!card) {
+    return { success: false, state, error: "Target card not found" };
+  }
+
+  if (!isProtectedByWard(card, stackObject.controllerId)) {
+    return {
+      success: false,
+      state,
+      error: "Target is not protected by ward against this spell",
+    };
+  }
+
+  const cost = getWardCostDescriptor(card);
+  if (!cost) {
+    return { success: false, state, error: "Target has no ward cost" };
+  }
+
+  const payerId = stackObject.controllerId;
+  const payer = state.players.get(payerId);
+  if (!payer) {
+    return { success: false, state, error: "Paying player not found" };
+  }
+
+  if (!canPayWardCost(payer, cost)) {
+    return { success: false, state, error: "Cannot afford ward cost" };
+  }
+
+  // Spend the cost.
+  let currentState = state;
+  if (cost.kind === "mana") {
+    const spendResult = spendMana(currentState, payerId, {
+      white: cost.white,
+      blue: cost.blue,
+      black: cost.black,
+      red: cost.red,
+      green: cost.green,
+      generic: cost.generic,
+    });
+    if (!spendResult.success) {
+      return { success: false, state, error: "Failed to spend ward mana" };
+    }
+    currentState = spendResult.state;
+  } else {
+    // Life cost: reduce the payer's life total.
+    const updatedPlayers = new Map(currentState.players);
+    updatedPlayers.set(payerId, {
+      ...payer,
+      life: payer.life - cost.amount,
+    });
+    currentState = { ...currentState, players: updatedPlayers };
+  }
+
+  // Record the payment on the stack object.
+  const alreadyPaid = stackObject.wardPaidTargetIds ?? [];
+  if (alreadyPaid.includes(targetCardId)) {
+    // Defensive: shouldn't happen given checks above.
+    return { success: true, state: currentState };
+  }
+  const updatedStack = currentState.stack.map((obj) =>
+    obj.id === stackObjectId
+      ? {
+          ...obj,
+          wardPaidTargetIds: [...alreadyPaid, targetCardId],
+        }
+      : obj,
+  );
+
+  return {
+    success: true,
+    state: { ...currentState, stack: updatedStack },
+  };
+}
+
+/**
+ * Explicitly decline to pay the ward cost for a targeted permanent.
+ *
+ * Declining is the default (absence from `wardPaidTargetIds`), so this is a
+ * no-op kept for API symmetry and clarity of intent for callers/AI.
+ */
+export function declineWardPayment(
+  state: GameState,
+  _stackObjectId: string,
+  _targetCardId: CardInstanceId,
+): { success: boolean; state: GameState } {
+  return { success: true, state };
+}
+
+/**
+ * Build a player-facing payment choice for a ward trigger.
+ *
+ * Consumers (UI / AI) present this so the casting player can choose to pay the
+ * ward cost or let their spell/ability be countered.
+ */
+export function createWardPaymentChoice(
+  _state: GameState,
+  playerId: PlayerId,
+  stackObjectId: string,
+  prompt: string,
+): WaitingChoice {
+  return {
+    type: "payment",
+    playerId,
+    stackObjectId,
+    prompt,
+    choices: [
+      { label: "Pay ward cost", value: "pay", isValid: true },
+      {
+        label: "Do not pay (spell is countered)",
+        value: "decline",
+        isValid: true,
+      },
+    ],
+    minChoices: 1,
+    maxChoices: 1,
+    presentedAt: Date.now(),
+  };
+}


### PR DESCRIPTION
## Resolve #920 — Implement Ward keyword (counter targeted spells on non-payment)

### Problem
The **Ward** keyword (CR 702.21) was an unimplemented stub in `evergreen-keywords.ts`. `hasWard`/`getWardCost`/`isProtectedByWard` always returned `false`/`null`/`false`, and nothing in the resolution path checked for ward. As a result, targeted spells and abilities were **never** countered for non-payment — Ward did nothing. (The existing ward unit tests were also silently skipped because `evergreen-keywords.test.ts` is listed in `jest.config.js` `testPathIgnorePatterns`.)

### Solution
Implement the full Ward lifecycle and enforce it at resolution time:

1. **Keyword detection & cost parsing** (`evergreen-keywords.ts`) — replaced the stubs:
   - `hasWard` — detects `Ward` via the `keywords` array or oracle text (word-bounded, so "warden"/"forward" don't match).
   - `getWardCost` — parses mana (`"Ward {2}"` → `"{2}"`), life (`"Ward—Pay 3 life."` → `"3"`), and plain `Ward` (default `"{2}"`); `null` for non-ward cards.
   - `isProtectedByWard(card, sourceControllerId)` — true only when a warded permanent is targeted by an **opponent's** source (mirrors `isProtectedByHexproof`).
   - `getKeywordDescriptions` / `getAllKeywords` now include Ward.
2. **New `ward-system.ts`** — cost descriptors (`WardCostDescriptor`), `detectWardTriggers` (only opposing permanents on the battlefield that are actual `card` targets), `canPayWardCost`, `payWardCost`/`declineWardPayment` (spends mana/life, records payment), `applyWardResolution` (pure decision: countered if any warded opponent target is unpaid).
3. **Resolution enforcement** (`spell-casting.ts`) — `resolveTopOfStack` calls `applyWardResolution` before applying effects; an unpaid ward removes the spell/ability from the stack with no effect (reusing the existing `removeFromStack` counter path).
4. **AI decision** (`stack-interaction-ai.ts`) — `evaluateWardPayment` / `decideWardPayments`: pay only when affordable and the target is worth it (cmc ≥ 3 or power ≥ 3); refuse life payments that would drop the AI to/below a safety floor; decline when unaffordable.
5. **State** — added an optional `wardPaidTargetIds?: string[]` to `StackObject` to record per-target payment.

### Files changed
- `src/lib/game-state/evergreen-keywords.ts` — implemented the 3 ward helpers + Ward in descriptions/all-keywords.
- `src/lib/game-state/ward-system.ts` *(new)* — ward cost parsing, trigger detection, payment API, resolution counter.
- `src/lib/game-state/spell-casting.ts` — enforce ward in `resolveTopOfStack`.
- `src/lib/game-state/types.ts` — `wardPaidTargetIds` on `StackObject`.
- `src/ai/stack-interaction-ai.ts` — AI ward-payment heuristic (`evaluateWardPayment`, `decideWardPayments`).
- `src/lib/game-state/__tests__/ward-keyword.test.ts` *(new)* — 37 tests (detection, parsing, affordability, triggers, countering, pay/decline).
- `src/ai/__tests__/ward-payment-ai.test.ts` *(new)* — 8 AI decision tests.

### Test results
- New tests: **37 + 8 = 45 passing**.
- Also verified the previously-skipped Ward tests in `evergreen-keywords.test.ts` now pass (10/10).
- `src/lib/game-state/` + `src/ai/` suites: **110 suites, 2220 tests passing** (no regressions; `spell-casting` and `game-rules` deck-legality from #914 both green).
- `npx tsc --noEmit`: **no errors**. `npm run lint`: **0 errors** (only pre-existing warnings).

### Notes / assumptions
- Ward is enforced at resolution time (`resolveTopOfStack`), consistent with the engine's existing counter handling (`isCountered` → `removeFromStack`). The contract is: to let a targeting spell resolve against a warded opponent permanent, the caster must pay each ward via `payWardCost` before resolution; otherwise it is countered. This matches CR 702.21 ("counter unless its controller pays").
- Removed the incorrect `_source`/`_card` stub signature of `isProtectedByWard` to match `isProtectedByHexproof` and the (previously skipped) tests; no production callers referenced the stub.
- A known-flaky random test (`opponent-deck-generator.test.ts`, not in the suites above) may fail independently and is unrelated to this change.
