### PR TITLE
fix: resolve #922 — enforce honest jest coverage thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,14 +290,17 @@ npm run test:watch
 
 #### Coverage Goals
 
-The project enforces the following coverage thresholds:
+The project **target** is 70% coverage across all metrics. The CI-enforced floor
+(see `jest.config.js` `coverageThreshold`) is set just below currently-measured
+coverage so the gate catches regressions without being flaky; it will be raised
+toward the 70% target as coverage improves.
 
-| Metric     | Target |
-| ---------- | ------ |
-| Lines      | 70%    |
-| Functions  | 70%    |
-| Statements | 70%    |
-| Branches   | 60%    |
+| Metric     | Target | CI-enforced floor |
+| ---------- | ------ | ----------------- |
+| Lines      | 70%    | 29%               |
+| Functions  | 70%    | 23%               |
+| Statements | 70%    | 29%               |
+| Branches   | 60%    | 22%               |
 
 Coverage reports are generated in:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -314,14 +314,17 @@ afterAll(() => server.close());
 
 ## Coverage Goals
 
-The project enforces the following coverage thresholds:
+The project **target** is 70% coverage across all metrics. The CI-enforced floor
+(see `jest.config.js` `coverageThreshold`) is set just below currently-measured
+coverage so the gate catches regressions without being flaky; it will be raised
+toward the 70% target as coverage improves.
 
-| Metric | Target |
-|--------|--------|
-| Lines | 70% |
-| Functions | 70% |
-| Statements | 70% |
-| Branches | 60% |
+| Metric | Target | CI-enforced floor |
+|--------|--------|-------------------|
+| Lines | 70% | 29% |
+| Functions | 70% | 23% |
+| Statements | 70% | 29% |
+| Branches | 60% | 22% |
 
 Run coverage report:
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -35,12 +35,21 @@ module.exports = {
     "!src/**/*.d.ts",
     "!src/**/__tests__/**",
   ],
+  // Coverage thresholds — ENFORCED by CI (ci.yml "Run unit tests with coverage").
+  // Values are set just below MEASURED coverage so the gate catches real
+  // regressions without being flaky. Measured 2026-06-24 (jest --coverage):
+  //   statements 32.86% | branches 25.58% | functions 26.99% | lines 33.19%
+  // These ~double the previous 15/17/22 floor. The documented project target
+  // is 70% (README/TESTING/CONTRIBUTING); raising toward 70% is tracked as
+  // follow-up work — DO NOT raise a threshold above measured coverage or CI
+  // will fail. Re-measure with `npm run test:coverage` before adjusting.
+  // See: https://github.com/anchapin/planar-nexus/issues/922
   coverageThreshold: {
     global: {
-      branches: 15,
-      functions: 17,
-      lines: 22,
-      statements: 22,
+      branches: 22,
+      functions: 23,
+      lines: 29,
+      statements: 29,
     },
   },
   coverageReporters: ["text-summary", "lcov", "html"],


### PR DESCRIPTION
## Summary

Resolves #922.

The repo **documents** a 70% coverage target (README, TESTING.md, CONTRIBUTING.md, BRANCH_PROTECTION.md), but `jest.config.js` enforced only **15–22%** — so CI's coverage gate never caught real regressions. It was effectively **off**.

This PR makes the coverage threshold **honest and enforced** at a level that reflects *measured* reality, and documents the remaining gap to 70% as tracked follow-up work.

## Old vs. new thresholds (`jest.config.js` → `coverageThreshold.global`)

| Metric     | Old (effectively off) | New (enforced) | Measured |
| ---------- | --------------------- | -------------- | -------- |
| Lines      | 22%                   | **29%**        | 33.19%   |
| Functions  | 17%                   | **23%**        | 26.99%   |
| Statements | 22%                   | **29%**        | 32.86%   |
| Branches   | 15%                   | **22%**        | 25.58%   |

## Why this level

- **Measured first.** Ran `npm test -- --coverage --ci --maxWorkers=2 --forceExit` (the exact CI command from `ci.yml`) and read the authoritative `coverage-summary.json` produced by Istanbul/Jest.
- **Set ~3–4 pts below measured** so the gate (a) is honest about current state, (b) actually **fails CI on real regressions** (>3–4 pt drop), and (c) is **not flaky** against normal run-to-run variance (including the known-flaky `opponent-deck-generator` random test).
- **Roughly doubles** the previous floor across all metrics.
- **Does NOT set 70%** — actual coverage is ~33%, so a 70% threshold would immediately break CI. Raising toward 70% is tracked follow-up; the new `jest.config.js` comment instructs maintainers to re-measure before adjusting.

## Documentation made honest

README.md and TESTING.md previously said *"The project enforces the following coverage thresholds: … 70%"* — directly contradicting the 15–22% reality. Both now distinguish the **70% target** from the **CI-enforced floor**, eliminating the contradiction at the heart of #922.

## Verification (local)

- ✅ **Coverage threshold PASSES**: re-ran `jest --coverage` with the new config — no `coverage threshold` failure; measured (33.19/26.99/32.86/25.58) clears the new floor (29/23/29/22) by clear margins.
- ✅ `npm run lint` → 0 errors (warnings only, within `--max-warnings 1000`).
- ⚠️ `npm run typecheck` and the full test run report **1** failure in this worktree: `src/lib/__tests__/backup-compression.test.ts` / `src/lib/backup-compression.ts` → `Cannot find module 'pako'`. This is a **local-only environment artifact** (worktree uses a symlinked `node_modules` lacking `pako`). `pako` is a declared dependency present in `package-lock.json`, so CI's `npm ci` installs it and both typecheck and this test pass there. Not a regression.

## Path to 70%

This is a stepping stone. To raise the floor further, add/expand unit tests (priority: the large uncovered areas in `src/`) and bump the `coverageThreshold.global` values *only after* re-measuring with `npm run test:coverage`.

## Files changed

- `jest.config.js` — honest enforced thresholds + explanatory comment (measured figures, rationale, link to #922).
- `README.md`, `TESTING.md` — corrected the "enforces 70%" claim to distinguish target vs. CI-enforced floor.
