### PR TITLE
fix: resolve #924 — remove leftover P2P console.log, validate peer JSON.parse

### DIFF
--- a/src/lib/__tests__/p2p-direct-connection.test.ts
+++ b/src/lib/__tests__/p2p-direct-connection.test.ts
@@ -10,57 +10,59 @@ import {
   generateICECandidateString,
   validateConnectionData,
   getConnectionState,
+  isConnectionData,
+  isICECandidateData,
   type ConnectionData,
   type ICECandidateData,
-} from '../p2p-direct-connection';
+} from "../p2p-direct-connection";
 
-describe('P2P Direct Connection Utilities', () => {
-  describe('parseConnectionData', () => {
-    it('should parse valid JSON connection data', () => {
+describe("P2P Direct Connection Utilities", () => {
+  describe("parseConnectionData", () => {
+    it("should parse valid JSON connection data", () => {
       const connectionData: ConnectionData = {
-        type: 'offer',
-        sessionId: 'session-123',
+        type: "offer",
+        sessionId: "session-123",
         timestamp: Date.now(),
-        sdp: { type: 'offer', sdp: 'mock-sdp' },
-        gameCode: 'ABC123',
-        hostName: 'Test Host',
-        format: 'commander',
+        sdp: { type: "offer", sdp: "mock-sdp" },
+        gameCode: "ABC123",
+        hostName: "Test Host",
+        format: "commander",
       };
 
       const result = parseConnectionData(JSON.stringify(connectionData));
 
       expect(result).not.toBeNull();
-      expect(result?.type).toBe('offer');
-      expect(result?.sessionId).toBe('session-123');
-      expect(result?.gameCode).toBe('ABC123');
-      expect(result?.hostName).toBe('Test Host');
+      expect(result?.type).toBe("offer");
+      expect(result?.sessionId).toBe("session-123");
+      expect(result?.gameCode).toBe("ABC123");
+      expect(result?.hostName).toBe("Test Host");
     });
 
-    it('should parse answer type connection data', () => {
+    it("should parse answer type connection data", () => {
       const connectionData: ConnectionData = {
-        type: 'answer',
-        sessionId: 'session-456',
+        type: "answer",
+        sessionId: "session-456",
         timestamp: Date.now(),
-        sdp: { type: 'answer', sdp: 'mock-answer-sdp' },
-        gameCode: 'XYZ789',
-        hostName: 'Host Player',
-        format: 'commander',
+        sdp: { type: "answer", sdp: "mock-answer-sdp" },
+        gameCode: "XYZ789",
+        hostName: "Host Player",
+        format: "commander",
       };
 
       const result = parseConnectionData(JSON.stringify(connectionData));
 
       expect(result).not.toBeNull();
-      expect(result?.type).toBe('answer');
+      expect(result?.type).toBe("answer");
     });
 
-    it('should return null for invalid JSON', () => {
-      const result = parseConnectionData('not valid json');
+    it("should return null for invalid JSON", () => {
+      const result = parseConnectionData("not valid json");
       expect(result).toBeNull();
     });
 
-    it('should return null for missing required fields', () => {
+    it("should return null for missing required fields", () => {
       const invalidData = {
-        type: 'offer',
+        type: "offer",
         // missing sessionId, sdp, gameCode
       };
 
@@ -68,25 +70,72 @@ describe('P2P Direct Connection Utilities', () => {
       expect(result).toBeNull();
     });
 
-    it('should return null for empty string', () => {
-      const result = parseConnectionData('');
+    it("should return null for empty string", () => {
+      const result = parseConnectionData("");
       expect(result).toBeNull();
     });
 
-    it('should reject malformed JSON', () => {
+    it("should reject malformed JSON", () => {
       const result = parseConnectionData('{ "type": "offer", invalid }');
       expect(result).toBeNull();
     });
+
+    it("should return null when required fields have the wrong type (#924)", () => {
+      // Valid JSON, wrong shape — must not be cast as ConnectionData.
+      const wrongTypes = {
+        type: 123,
+        sessionId: "session-123",
+        timestamp: Date.now(),
+        sdp: { type: "offer", sdp: "mock-sdp" },
+        gameCode: "ABC123",
+        hostName: "Host",
+        format: "commander",
+      };
+      expect(parseConnectionData(JSON.stringify(wrongTypes))).toBeNull();
+    });
+
+    it("should return null when sdp is missing (#924)", () => {
+      const noSdp = {
+        type: "offer",
+        sessionId: "session-123",
+        timestamp: Date.now(),
+        gameCode: "ABC123",
+        hostName: "Host",
+        format: "commander",
+      };
+      expect(parseConnectionData(JSON.stringify(noSdp))).toBeNull();
+    });
+
+    it("should return null for valid JSON scalars (#924)", () => {
+      expect(parseConnectionData("42")).toBeNull();
+      expect(parseConnectionData('"a string"')).toBeNull();
+      expect(parseConnectionData("null")).toBeNull();
+    });
+
+    it("should never throw on attacker-controlled input (#924)", () => {
+      const payloads = [
+        "",
+        "{",
+        "}}}",
+        "undefined",
+        '{"id":',
+        String.fromCharCode(0),
+      ];
+      for (const p of payloads) {
+        expect(() => parseConnectionData(p)).not.toThrow();
+        expect(parseConnectionData(p)).toBeNull();
+      }
+    });
   });
 
-  describe('parseICECandidateData', () => {
-    it('should parse valid ICE candidate data', () => {
+  describe("parseICECandidateData", () => {
+    it("should parse valid ICE candidate data", () => {
       const iceData: ICECandidateData = {
-        type: 'ice-candidate',
-        sessionId: 'session-123',
+        type: "ice-candidate",
+        sessionId: "session-123",
         candidate: {
-          candidate: 'candidate:123456789',
-          sdpMid: '0',
+          candidate: "candidate:123456789",
+          sdpMid: "0",
           sdpMLineIndex: 0,
         },
       };
@@ -94,209 +143,274 @@ describe('P2P Direct Connection Utilities', () => {
       const result = parseICECandidateData(JSON.stringify(iceData));
 
       expect(result).not.toBeNull();
-      expect(result?.type).toBe('ice-candidate');
-      expect(result?.sessionId).toBe('session-123');
+      expect(result?.type).toBe("ice-candidate");
+      expect(result?.sessionId).toBe("session-123");
       expect(result?.candidate).toBeDefined();
     });
 
-    it('should return null for invalid JSON', () => {
-      const result = parseICECandidateData('invalid');
+    it("should return null for invalid JSON", () => {
+      const result = parseICECandidateData("invalid");
       expect(result).toBeNull();
     });
 
-    it('should return null for missing required fields', () => {
+    it("should return null for missing required fields", () => {
       const invalidData = {
-        type: 'ice-candidate',
+        type: "ice-candidate",
         // missing sessionId, candidate
       };
 
       const result = parseICECandidateData(JSON.stringify(invalidData));
       expect(result).toBeNull();
     });
+
+    it("should return null when candidate has the wrong type (#924)", () => {
+      const wrongType = {
+        type: "ice-candidate",
+        sessionId: "session-123",
+        candidate: "not-an-object",
+      };
+      expect(parseICECandidateData(JSON.stringify(wrongType))).toBeNull();
+    });
   });
 
-  describe('generateConnectionString', () => {
-    it('should generate valid JSON string', () => {
-      const connectionData: ConnectionData = {
-        type: 'offer',
-        sessionId: 'session-123',
+  describe("isConnectionData (type guard)", () => {
+    it("accepts a valid ConnectionData", () => {
+      const valid: ConnectionData = {
+        type: "offer",
+        sessionId: "s",
         timestamp: Date.now(),
-        sdp: { type: 'offer', sdp: 'mock-sdp' },
-        gameCode: 'ABC123',
-        hostName: 'Test Host',
-        format: 'commander',
+        sdp: { type: "offer", sdp: "x" },
+        gameCode: "ABC123",
+        hostName: "Host",
+        format: "commander",
+      };
+      expect(isConnectionData(valid)).toBe(true);
+    });
+
+    it("rejects an invalid type value", () => {
+      expect(
+        isConnectionData({
+          type: "bogus",
+          sessionId: "s",
+          gameCode: "g",
+          hostName: "h",
+          timestamp: 1,
+          sdp: {},
+        }),
+      ).toBe(false);
+    });
+
+    it("rejects non-objects", () => {
+      expect(isConnectionData(null)).toBe(false);
+      expect(isConnectionData("offer")).toBe(false);
+      expect(isConnectionData(42)).toBe(false);
+    });
+  });
+
+  describe("isICECandidateData (type guard)", () => {
+    it("accepts valid ICE candidate data", () => {
+      expect(
+        isICECandidateData({
+          type: "ice-candidate",
+          sessionId: "s",
+          candidate: { candidate: "c" },
+        }),
+      ).toBe(true);
+    });
+
+    it("rejects a non-object candidate", () => {
+      expect(
+        isICECandidateData({
+          type: "ice-candidate",
+          sessionId: "s",
+          candidate: "c",
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("generateConnectionString", () => {
+    it("should generate valid JSON string", () => {
+      const connectionData: ConnectionData = {
+        type: "offer",
+        sessionId: "session-123",
+        timestamp: Date.now(),
+        sdp: { type: "offer", sdp: "mock-sdp" },
+        gameCode: "ABC123",
+        hostName: "Test Host",
+        format: "commander",
       };
 
       const result = generateConnectionString(connectionData);
 
-      expect(typeof result).toBe('string');
+      expect(typeof result).toBe("string");
       const parsed = JSON.parse(result);
-      expect(parsed.type).toBe('offer');
-      expect(parsed.sessionId).toBe('session-123');
+      expect(parsed.type).toBe("offer");
+      expect(parsed.sessionId).toBe("session-123");
     });
 
-    it('should generate string for answer type', () => {
+    it("should generate string for answer type", () => {
       const connectionData: ConnectionData = {
-        type: 'answer',
-        sessionId: 'session-456',
+        type: "answer",
+        sessionId: "session-456",
         timestamp: Date.now(),
-        sdp: { type: 'answer', sdp: 'mock-answer' },
-        gameCode: 'XYZ789',
-        hostName: 'Host',
-        format: 'commander',
+        sdp: { type: "answer", sdp: "mock-answer" },
+        gameCode: "XYZ789",
+        hostName: "Host",
+        format: "commander",
       };
 
       const result = generateConnectionString(connectionData);
       const parsed = JSON.parse(result);
 
-      expect(parsed.type).toBe('answer');
+      expect(parsed.type).toBe("answer");
     });
   });
 
-  describe('generateICECandidateString', () => {
-    it('should generate valid ICE candidate string', () => {
+  describe("generateICECandidateString", () => {
+    it("should generate valid ICE candidate string", () => {
       const candidate: RTCIceCandidateInit = {
-        candidate: 'candidate:123456789',
-        sdpMid: '0',
+        candidate: "candidate:123456789",
+        sdpMid: "0",
         sdpMLineIndex: 0,
       };
 
-      const result = generateICECandidateString('session-123', candidate);
+      const result = generateICECandidateString("session-123", candidate);
 
-      expect(typeof result).toBe('string');
+      expect(typeof result).toBe("string");
       const parsed = JSON.parse(result);
-      expect(parsed.type).toBe('ice-candidate');
-      expect(parsed.sessionId).toBe('session-123');
+      expect(parsed.type).toBe("ice-candidate");
+      expect(parsed.sessionId).toBe("session-123");
       expect(parsed.candidate).toBeDefined();
     });
   });
 
-  describe('validateConnectionData', () => {
-    it('should validate correct connection data', () => {
+  describe("validateConnectionData", () => {
+    it("should validate correct connection data", () => {
       const connectionData: ConnectionData = {
-        type: 'offer',
-        sessionId: 'session-123',
+        type: "offer",
+        sessionId: "session-123",
         timestamp: Date.now(),
-        sdp: { type: 'offer', sdp: 'mock-sdp' },
-        gameCode: 'ABC123',
-        hostName: 'Test Host',
-        format: 'commander',
+        sdp: { type: "offer", sdp: "mock-sdp" },
+        gameCode: "ABC123",
+        hostName: "Test Host",
+        format: "commander",
       };
 
       expect(validateConnectionData(connectionData)).toBe(true);
     });
 
-    it('should reject missing type', () => {
+    it("should reject missing type", () => {
       const connectionData = {
-        sessionId: 'session-123',
+        sessionId: "session-123",
         timestamp: Date.now(),
-        sdp: { type: 'offer', sdp: 'mock-sdp' },
-        gameCode: 'ABC123',
+        sdp: { type: "offer", sdp: "mock-sdp" },
+        gameCode: "ABC123",
       } as any;
 
       expect(validateConnectionData(connectionData)).toBe(false);
     });
 
-    it('should reject invalid type', () => {
+    it("should reject invalid type", () => {
       const connectionData: ConnectionData = {
-        type: 'invalid' as any,
-        sessionId: 'session-123',
+        type: "invalid" as any,
+        sessionId: "session-123",
         timestamp: Date.now(),
-        sdp: { type: 'offer', sdp: 'mock-sdp' },
-        gameCode: 'ABC123',
-        hostName: 'Test Host',
-        format: 'commander',
+        sdp: { type: "offer", sdp: "mock-sdp" },
+        gameCode: "ABC123",
+        hostName: "Test Host",
+        format: "commander",
       };
 
       expect(validateConnectionData(connectionData)).toBe(false);
     });
 
-    it('should reject old timestamp (more than 1 hour)', () => {
+    it("should reject old timestamp (more than 1 hour)", () => {
       const connectionData: ConnectionData = {
-        type: 'offer',
-        sessionId: 'session-123',
+        type: "offer",
+        sessionId: "session-123",
         timestamp: Date.now() - 2 * 60 * 60 * 1000, // 2 hours ago
-        sdp: { type: 'offer', sdp: 'mock-sdp' },
-        gameCode: 'ABC123',
-        hostName: 'Test Host',
-        format: 'commander',
+        sdp: { type: "offer", sdp: "mock-sdp" },
+        gameCode: "ABC123",
+        hostName: "Test Host",
+        format: "commander",
       };
 
       expect(validateConnectionData(connectionData)).toBe(false);
     });
 
-    it('should accept recent timestamp', () => {
+    it("should accept recent timestamp", () => {
       const connectionData: ConnectionData = {
-        type: 'offer',
-        sessionId: 'session-123',
+        type: "offer",
+        sessionId: "session-123",
         timestamp: Date.now() - 30 * 60 * 1000, // 30 minutes ago
-        sdp: { type: 'offer', sdp: 'mock-sdp' },
-        gameCode: 'ABC123',
-        hostName: 'Test Host',
-        format: 'commander',
+        sdp: { type: "offer", sdp: "mock-sdp" },
+        gameCode: "ABC123",
+        hostName: "Test Host",
+        format: "commander",
       };
 
       expect(validateConnectionData(connectionData)).toBe(true);
     });
 
-    it('should reject missing sessionId', () => {
+    it("should reject missing sessionId", () => {
       const connectionData = {
-        type: 'offer',
+        type: "offer",
         timestamp: Date.now(),
-        sdp: { type: 'offer', sdp: 'mock-sdp' },
-        gameCode: 'ABC123',
+        sdp: { type: "offer", sdp: "mock-sdp" },
+        gameCode: "ABC123",
       } as any;
 
       expect(validateConnectionData(connectionData)).toBe(false);
     });
 
-    it('should reject missing gameCode', () => {
+    it("should reject missing gameCode", () => {
       const connectionData: ConnectionData = {
-        type: 'offer',
-        sessionId: 'session-123',
+        type: "offer",
+        sessionId: "session-123",
         timestamp: Date.now(),
-        sdp: { type: 'offer', sdp: 'mock-sdp' },
+        sdp: { type: "offer", sdp: "mock-sdp" },
         // missing gameCode
-        hostName: 'Test Host',
-        format: 'commander',
+        hostName: "Test Host",
+        format: "commander",
       } as any;
 
       expect(validateConnectionData(connectionData)).toBe(false);
     });
   });
 
-  describe('getConnectionState', () => {
-    it('should return null for non-existent session', () => {
-      const result = getConnectionState('non-existent-session');
+  describe("getConnectionState", () => {
+    it("should return null for non-existent session", () => {
+      const result = getConnectionState("non-existent-session");
       expect(result).toBeNull();
     });
   });
 });
 
-describe('ConnectionData Type', () => {
-  it('should have correct type for offer', () => {
+describe("ConnectionData Type", () => {
+  it("should have correct type for offer", () => {
     const data: ConnectionData = {
-      type: 'offer',
-      sessionId: 'test',
+      type: "offer",
+      sessionId: "test",
       timestamp: Date.now(),
-      sdp: { type: 'offer', sdp: 'test' },
-      gameCode: 'TEST',
-      hostName: 'Host',
-      format: 'commander',
+      sdp: { type: "offer", sdp: "test" },
+      gameCode: "TEST",
+      hostName: "Host",
+      format: "commander",
     };
-    expect(data.type).toBe('offer');
+    expect(data.type).toBe("offer");
   });
 
-  it('should have correct type for answer', () => {
+  it("should have correct type for answer", () => {
     const data: ConnectionData = {
-      type: 'answer',
-      sessionId: 'test',
+      type: "answer",
+      sessionId: "test",
       timestamp: Date.now(),
-      sdp: { type: 'answer', sdp: 'test' },
-      gameCode: 'TEST',
-      hostName: 'Host',
-      format: 'commander',
+      sdp: { type: "answer", sdp: "test" },
+      gameCode: "TEST",
+      hostName: "Host",
+      format: "commander",
     };
-    expect(data.type).toBe('answer');
+    expect(data.type).toBe("answer");
   });
 });

--- a/src/lib/__tests__/p2p-game-connection.test.ts
+++ b/src/lib/__tests__/p2p-game-connection.test.ts
@@ -6,31 +6,32 @@
 import {
   P2PGameConnection,
   createP2PGameConnection,
+  isGameMessage,
   type P2PGameConnectionEvents,
   type P2PGameConnectionOptions,
   type P2PConnectionState,
   type GameMessage,
   type GameMessageType,
   type ChatMessage,
-} from '../p2p-game-connection';
+} from "../p2p-game-connection";
 
-describe('P2P Game Connection Types', () => {
-  describe('GameMessageType', () => {
-    it('should accept all valid message types', () => {
+describe("P2P Game Connection Types", () => {
+  describe("GameMessageType", () => {
+    it("should accept all valid message types", () => {
       const types: GameMessageType[] = [
-        'game-state-sync',
-        'game-action',
-        'chat',
-        'player-joined',
-        'player-left',
-        'ping',
-        'pong',
+        "game-state-sync",
+        "game-action",
+        "chat",
+        "player-joined",
+        "player-left",
+        "ping",
+        "pong",
       ];
 
       types.forEach((type) => {
         const message: GameMessage = {
           type,
-          senderId: 'player-1',
+          senderId: "player-1",
           timestamp: Date.now(),
           data: {},
         };
@@ -39,31 +40,31 @@ describe('P2P Game Connection Types', () => {
     });
   });
 
-  describe('ChatMessage', () => {
-    it('should create valid chat message', () => {
+  describe("ChatMessage", () => {
+    it("should create valid chat message", () => {
       const chatMessage: ChatMessage = {
-        senderId: 'player-1',
-        senderName: 'Player One',
-        text: 'Hello everyone!',
+        senderId: "player-1",
+        senderName: "Player One",
+        text: "Hello everyone!",
         timestamp: Date.now(),
       };
 
-      expect(chatMessage.senderId).toBe('player-1');
-      expect(chatMessage.senderName).toBe('Player One');
-      expect(chatMessage.text).toBe('Hello everyone!');
+      expect(chatMessage.senderId).toBe("player-1");
+      expect(chatMessage.senderName).toBe("Player One");
+      expect(chatMessage.text).toBe("Hello everyone!");
       expect(chatMessage.timestamp).toBeDefined();
     });
   });
 
-  describe('P2PConnectionState', () => {
-    it('should have all valid connection states', () => {
+  describe("P2PConnectionState", () => {
+    it("should have all valid connection states", () => {
       const states: P2PConnectionState[] = [
-        'disconnected',
-        'signaling',
-        'connecting',
-        'connected',
-        'reconnecting',
-        'failed',
+        "disconnected",
+        "signaling",
+        "connecting",
+        "connected",
+        "reconnecting",
+        "failed",
       ];
 
       states.forEach((state) => {
@@ -73,8 +74,8 @@ describe('P2P Game Connection Types', () => {
   });
 });
 
-describe('P2PGameConnection Events', () => {
-  it('should have all required event handlers', () => {
+describe("P2PGameConnection Events", () => {
+  it("should have all required event handlers", () => {
     const events: P2PGameConnectionEvents = {
       onConnectionStateChange: () => {},
       onSignalingStateChange: () => {},
@@ -96,7 +97,7 @@ describe('P2PGameConnection Events', () => {
     expect(events.onPlayerLeft).toBeDefined();
   });
 
-  it('should allow partial event handlers', () => {
+  it("should allow partial event handlers", () => {
     const events: Partial<P2PGameConnectionEvents> = {
       onError: () => {},
     };
@@ -105,35 +106,35 @@ describe('P2PGameConnection Events', () => {
   });
 });
 
-describe('P2PGameConnectionOptions', () => {
-  it('should require playerId and playerName', () => {
+describe("P2PGameConnectionOptions", () => {
+  it("should require playerId and playerName", () => {
     const options: P2PGameConnectionOptions = {
-      playerId: 'player-1',
-      playerName: 'Test Player',
-      role: 'host',
+      playerId: "player-1",
+      playerName: "Test Player",
+      role: "host",
     };
 
-    expect(options.playerId).toBe('player-1');
-    expect(options.playerName).toBe('Test Player');
-    expect(options.role).toBe('host');
+    expect(options.playerId).toBe("player-1");
+    expect(options.playerName).toBe("Test Player");
+    expect(options.role).toBe("host");
   });
 
-  it('should accept optional gameCode', () => {
+  it("should accept optional gameCode", () => {
     const options: P2PGameConnectionOptions = {
-      playerId: 'player-1',
-      playerName: 'Test Player',
-      role: 'joiner',
-      gameCode: 'ABC123',
+      playerId: "player-1",
+      playerName: "Test Player",
+      role: "joiner",
+      gameCode: "ABC123",
     };
 
-    expect(options.gameCode).toBe('ABC123');
+    expect(options.gameCode).toBe("ABC123");
   });
 
-  it('should accept optional events', () => {
+  it("should accept optional events", () => {
     const options: P2PGameConnectionOptions = {
-      playerId: 'player-1',
-      playerName: 'Test Player',
-      role: 'host',
+      playerId: "player-1",
+      playerName: "Test Player",
+      role: "host",
       events: {
         onConnectionStateChange: () => {},
         onError: () => {},
@@ -144,47 +145,45 @@ describe('P2PGameConnectionOptions', () => {
   });
 });
 
-describe('createP2PGameConnection factory', () => {
-  it('should create a P2PGameConnection instance', () => {
+describe("createP2PGameConnection factory", () => {
+  it("should create a P2PGameConnection instance", () => {
     const connection = createP2PGameConnection({
-      playerId: 'player-1',
-      playerName: 'Test Player',
-      role: 'host',
+      playerId: "player-1",
+      playerName: "Test Player",
+      role: "host",
     });
 
     expect(connection).toBeInstanceOf(P2PGameConnection);
   });
 
-  it('should create connection with joiner role', () => {
+  it("should create connection with joiner role", () => {
     const connection = createP2PGameConnection({
-      playerId: 'player-2',
-      playerName: 'Joiner Player',
-      role: 'joiner',
-      gameCode: 'ABC123',
+      playerId: "player-2",
+      playerName: "Joiner Player",
+      role: "joiner",
+      gameCode: "ABC123",
     });
 
     expect(connection).toBeInstanceOf(P2PGameConnection);
   });
 
-  it('should initialize with disconnected state', () => {
+  it("should initialize with disconnected state", () => {
     const connection = createP2PGameConnection({
-      playerId: 'player-1',
-      playerName: 'Test Player',
-      role: 'host',
+      playerId: "player-1",
+      playerName: "Test Player",
+      role: "host",
     });
 
-    expect(connection.getConnectionState()).toBe('disconnected');
+    expect(connection.getConnectionState()).toBe("disconnected");
   });
 
-  it('should create connection with custom ICE config', () => {
+  it("should create connection with custom ICE config", () => {
     const connection = createP2PGameConnection({
-      playerId: 'player-1',
-      playerName: 'Test Player',
-      role: 'host',
+      playerId: "player-1",
+      playerName: "Test Player",
+      role: "host",
       iceConfig: {
-        customStunServers: [
-          { urls: ['stun:custom.stun.server:19302'] },
-        ],
+        customStunServers: [{ urls: ["stun:custom.stun.server:19302"] }],
         candidatePoolSize: 10,
       },
     });
@@ -193,135 +192,255 @@ describe('createP2PGameConnection factory', () => {
   });
 });
 
-describe('P2PGameConnection instance methods', () => {
+describe("P2PGameConnection instance methods", () => {
   let connection: P2PGameConnection;
 
   beforeEach(() => {
     connection = createP2PGameConnection({
-      playerId: 'player-1',
-      playerName: 'Test Player',
-      role: 'host',
+      playerId: "player-1",
+      playerName: "Test Player",
+      role: "host",
     });
   });
 
-  describe('getConnectionState', () => {
-    it('should return disconnected initially', () => {
-      expect(connection.getConnectionState()).toBe('disconnected');
+  describe("getConnectionState", () => {
+    it("should return disconnected initially", () => {
+      expect(connection.getConnectionState()).toBe("disconnected");
     });
   });
 
-  describe('isConnected', () => {
-    it('should return false when disconnected', () => {
+  describe("isConnected", () => {
+    it("should return false when disconnected", () => {
       expect(connection.isConnected()).toBe(false);
     });
   });
 
-  describe('getSignalingState', () => {
-    it('should return signaling state', () => {
+  describe("getSignalingState", () => {
+    it("should return signaling state", () => {
       const state = connection.getSignalingState();
       expect(state).toBeDefined();
       expect(state.phase).toBeDefined();
     });
   });
 
-  describe('getSignalingClient', () => {
-    it('should return signaling client', () => {
+  describe("getSignalingClient", () => {
+    it("should return signaling client", () => {
       const client = connection.getSignalingClient();
       expect(client).toBeDefined();
     });
   });
 
-  describe('close', () => {
-    it('should close without error', () => {
+  describe("close", () => {
+    it("should close without error", () => {
       expect(() => connection.close()).not.toThrow();
-      expect(connection.getConnectionState()).toBe('disconnected');
+      expect(connection.getConnectionState()).toBe("disconnected");
     });
   });
 
-  describe('getStats', () => {
-    it('should return null when not connected', async () => {
+  describe("getStats", () => {
+    it("should return null when not connected", async () => {
       const stats = await connection.getStats();
       expect(stats).toBeNull();
     });
   });
 });
 
-describe('Message creation helpers', () => {
-  it('should create game state sync message', () => {
+describe("Message creation helpers", () => {
+  it("should create game state sync message", () => {
     const message: GameMessage = {
-      type: 'game-state-sync',
-      senderId: 'player-1',
+      type: "game-state-sync",
+      senderId: "player-1",
       timestamp: Date.now(),
       data: { gameState: {}, isFullSync: true },
     };
 
-    expect(message.type).toBe('game-state-sync');
-    expect(message.senderId).toBe('player-1');
+    expect(message.type).toBe("game-state-sync");
+    expect(message.senderId).toBe("player-1");
   });
 
-  it('should create game action message', () => {
+  it("should create game action message", () => {
     const message: GameMessage = {
-      type: 'game-action',
-      senderId: 'player-1',
+      type: "game-action",
+      senderId: "player-1",
       timestamp: Date.now(),
-      data: { action: 'play-card', cardId: 'card-1' },
+      data: { action: "play-card", cardId: "card-1" },
     };
 
-    expect(message.type).toBe('game-action');
+    expect(message.type).toBe("game-action");
   });
 
-  it('should create chat message', () => {
+  it("should create chat message", () => {
     const message: GameMessage = {
-      type: 'chat',
-      senderId: 'player-1',
+      type: "chat",
+      senderId: "player-1",
       timestamp: Date.now(),
-      data: { senderName: 'Player One', text: 'Hello!' },
+      data: { senderName: "Player One", text: "Hello!" },
     };
 
-    expect(message.type).toBe('chat');
+    expect(message.type).toBe("chat");
   });
 
-  it('should create player-joined message', () => {
+  it("should create player-joined message", () => {
     const message: GameMessage = {
-      type: 'player-joined',
-      senderId: 'player-1',
+      type: "player-joined",
+      senderId: "player-1",
       timestamp: Date.now(),
-      data: { playerId: 'player-2', playerName: 'Player Two' },
+      data: { playerId: "player-2", playerName: "Player Two" },
     };
 
-    expect(message.type).toBe('player-joined');
+    expect(message.type).toBe("player-joined");
   });
 
-  it('should create player-left message', () => {
+  it("should create player-left message", () => {
     const message: GameMessage = {
-      type: 'player-left',
-      senderId: 'player-1',
+      type: "player-left",
+      senderId: "player-1",
       timestamp: Date.now(),
-      data: { playerId: 'player-2' },
+      data: { playerId: "player-2" },
     };
 
-    expect(message.type).toBe('player-left');
+    expect(message.type).toBe("player-left");
   });
 
-  it('should create ping message', () => {
+  it("should create ping message", () => {
     const message: GameMessage = {
-      type: 'ping',
-      senderId: 'player-1',
-      timestamp: Date.now(),
-      data: {},
-    };
-
-    expect(message.type).toBe('ping');
-  });
-
-  it('should create pong message', () => {
-    const message: GameMessage = {
-      type: 'pong',
-      senderId: 'player-1',
+      type: "ping",
+      senderId: "player-1",
       timestamp: Date.now(),
       data: {},
     };
 
-    expect(message.type).toBe('pong');
+    expect(message.type).toBe("ping");
+  });
+
+  it("should create pong message", () => {
+    const message: GameMessage = {
+      type: "pong",
+      senderId: "player-1",
+      timestamp: Date.now(),
+      data: {},
+    };
+
+    expect(message.type).toBe("pong");
+  });
+});
+
+describe("isGameMessage (type guard)", () => {
+  it("accepts a well-formed GameMessage", () => {
+    const msg: GameMessage = {
+      type: "game-action",
+      senderId: "player-1",
+      timestamp: Date.now(),
+      data: {},
+    };
+    expect(isGameMessage(msg)).toBe(true);
+  });
+
+  it("accepts every valid message type", () => {
+    const types: GameMessageType[] = [
+      "game-state-sync",
+      "game-action",
+      "chat",
+      "player-joined",
+      "player-left",
+      "ping",
+      "pong",
+    ];
+    for (const type of types) {
+      expect(
+        isGameMessage({ type, senderId: "p", timestamp: 1, data: {} }),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects an unknown message type", () => {
+    expect(
+      isGameMessage({ type: "evil", senderId: "p", timestamp: 1, data: {} }),
+    ).toBe(false);
+  });
+
+  it("rejects a non-string senderId", () => {
+    expect(
+      isGameMessage({ type: "ping", senderId: 42, timestamp: 1, data: {} }),
+    ).toBe(false);
+  });
+
+  it("rejects non-objects and null", () => {
+    expect(isGameMessage(null)).toBe(false);
+    expect(isGameMessage("not-an-object")).toBe(false);
+    expect(isGameMessage(42)).toBe(false);
+  });
+});
+
+/**
+ * Integration coverage for the hardening of the data-channel message path.
+ * `handleMessage` receives raw bytes directly from a peer and must never throw
+ * or forward attacker-controlled shapes into business logic. (#924)
+ */
+describe("P2PGameConnection message validation (untrusted peer input)", () => {
+  let connection: P2PGameConnection;
+  let onMessage: jest.Mock;
+  let onError: jest.Mock;
+
+  beforeEach(() => {
+    onMessage = jest.fn();
+    onError = jest.fn();
+    connection = createP2PGameConnection({
+      playerId: "player-1",
+      playerName: "Host",
+      role: "host",
+      events: {
+        onConnectionStateChange: () => {},
+        onSignalingStateChange: () => {},
+        onMessage,
+        onGameStateSync: () => {},
+        onChat: () => {},
+        onError,
+        onPlayerJoined: () => {},
+        onPlayerLeft: () => {},
+      },
+    });
+  });
+
+  const handleMessage = (raw: string) =>
+    (
+      connection as unknown as { handleMessage: (d: string) => void }
+    ).handleMessage(raw);
+
+  it("does not throw and does not call onMessage for malformed JSON", () => {
+    expect(() => handleMessage("{ not json")).not.toThrow();
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it("rejects valid JSON with the wrong shape", () => {
+    expect(() => handleMessage(JSON.stringify({ foo: "bar" }))).not.toThrow();
+    expect(onMessage).not.toHaveBeenCalled();
+
+    expect(() =>
+      handleMessage(
+        JSON.stringify({ type: "evil", senderId: "x", timestamp: 1 }),
+      ),
+    ).not.toThrow();
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it("rejects JSON scalars and null without throwing", () => {
+    for (const raw of ["42", '"x"', "null", "true", "[1,2,3]"]) {
+      expect(() => handleMessage(raw)).not.toThrow();
+    }
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it("accepts a well-formed message and forwards it to onMessage", () => {
+    const msg: GameMessage = {
+      type: "game-action",
+      senderId: "player-2",
+      timestamp: Date.now(),
+      data: { action: "pass" },
+    };
+    expect(() => handleMessage(JSON.stringify(msg))).not.toThrow();
+    expect(onMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "game-action", senderId: "player-2" }),
+    );
   });
 });

--- a/src/lib/__tests__/p2p-json-validation.test.ts
+++ b/src/lib/__tests__/p2p-json-validation.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for safe JSON parsing of untrusted P2P / signaling data.
+ * Issue #924: unvalidated peer JSON.parse casts.
+ */
+
+import { safeParseJson } from "../p2p-json-validation";
+
+type Sample = { id: number; name: string };
+
+const isSample = (value: unknown): value is Sample =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof (value as Record<string, unknown>).id === "number" &&
+  typeof (value as Record<string, unknown>).name === "string";
+
+describe("safeParseJson", () => {
+  describe("acceptance", () => {
+    it("returns the validated value for well-formed JSON", () => {
+      const result = safeParseJson('{"id":1,"name":"alpha"}', isSample);
+      expect(result).toEqual({ id: 1, name: "alpha" });
+    });
+
+    it("parses nested valid objects", () => {
+      const result = safeParseJson('{"id":2,"name":"beta"}', isSample);
+      expect(result?.id).toBe(2);
+    });
+  });
+
+  describe("rejection (must never throw)", () => {
+    it("returns null for malformed JSON", () => {
+      expect(safeParseJson("{ not json", isSample)).toBeNull();
+    });
+
+    it("returns null for empty string", () => {
+      expect(safeParseJson("", isSample)).toBeNull();
+    });
+
+    it("returns null for a JSON scalar (number)", () => {
+      expect(safeParseJson("42", isSample)).toBeNull();
+    });
+
+    it("returns null for a JSON scalar (string)", () => {
+      expect(safeParseJson('"hello"', isSample)).toBeNull();
+    });
+
+    it("returns null for JSON null", () => {
+      expect(safeParseJson("null", isSample)).toBeNull();
+    });
+
+    it("returns null for a JSON array", () => {
+      expect(safeParseJson("[1,2,3]", isSample)).toBeNull();
+    });
+
+    it("returns null for valid JSON with the wrong shape", () => {
+      expect(safeParseJson('{"foo":"bar"}', isSample)).toBeNull();
+    });
+
+    it("returns null when a required field has the wrong type", () => {
+      expect(
+        safeParseJson('{"id":"not-a-number","name":"alpha"}', isSample),
+      ).toBeNull();
+    });
+  });
+
+  describe("robustness", () => {
+    it("never throws, regardless of input", () => {
+      const inputs = [
+        "",
+        "   ",
+        "{",
+        "}}}",
+        "undefined",
+        "[1,",
+        '{"id":1,"name":',
+        String.fromCharCode(0),
+      ];
+      for (const input of inputs) {
+        expect(() => safeParseJson(input, isSample)).not.toThrow();
+        expect(safeParseJson(input, isSample)).toBeNull();
+      }
+    });
+
+    it("returns null for non-string input (defensive)", () => {
+      // safeParseJson is typed for strings but external callers may bypass TS.
+      expect(
+        safeParseJson(undefined as unknown as string, isSample),
+      ).toBeNull();
+      expect(safeParseJson(null as unknown as string, isSample)).toBeNull();
+      expect(safeParseJson(123 as unknown as string, isSample)).toBeNull();
+    });
+  });
+});

--- a/src/lib/__tests__/p2p-signaling-client.test.ts
+++ b/src/lib/__tests__/p2p-signaling-client.test.ts
@@ -12,6 +12,8 @@ import {
   parseConnectionInfo,
   serializeSignalingData,
   deserializeSignalingData,
+  isConnectionInfo,
+  isSignalingData,
   type ConnectionInfo,
   type SignalingData,
   type SignalingEvents,
@@ -213,6 +215,37 @@ describe("parseConnectionInfo", () => {
     const result = parseConnectionInfo('{ "gameCode": invalid }');
     expect(result).toBeNull();
   });
+
+  it("should return null when gameCode has the wrong type (#924)", () => {
+    // Valid JSON, wrong shape — must not be cast as ConnectionInfo.
+    const wrongType = {
+      gameCode: 123,
+      hostName: "Host",
+      timestamp: Date.now(),
+    };
+    expect(parseConnectionInfo(JSON.stringify(wrongType))).toBeNull();
+  });
+
+  it("should return null for valid JSON scalars (#924)", () => {
+    expect(parseConnectionInfo("42")).toBeNull();
+    expect(parseConnectionInfo('"x"')).toBeNull();
+    expect(parseConnectionInfo("null")).toBeNull();
+  });
+
+  it("should never throw on attacker-controlled input (#924)", () => {
+    const payloads = [
+      "",
+      "{",
+      "}}}",
+      "undefined",
+      '{"x":',
+      String.fromCharCode(0),
+    ];
+    for (const p of payloads) {
+      expect(() => parseConnectionInfo(p)).not.toThrow();
+      expect(parseConnectionInfo(p)).toBeNull();
+    }
+  });
 });
 
 describe("serializeSignalingData", () => {
@@ -291,6 +324,72 @@ describe("deserializeSignalingData", () => {
   it("should return null for malformed JSON", () => {
     const result = deserializeSignalingData('{ "type": invalid }');
     expect(result).toBeNull();
+  });
+
+  it("should return null when shape does not match (#924)", () => {
+    // Previously this was a blind `as SignalingData` cast.
+    expect(deserializeSignalingData(JSON.stringify({ foo: "bar" }))).toBeNull();
+    expect(
+      deserializeSignalingData(
+        JSON.stringify({ type: "unknown", data: {}, senderCode: "ABC" }),
+      ),
+    ).toBeNull();
+    expect(
+      deserializeSignalingData(
+        JSON.stringify({
+          type: "offer",
+          data: "not-an-object",
+          senderCode: "ABC",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("should never throw on attacker-controlled input (#924)", () => {
+    const payloads = ["", "{", "}}}", "undefined", "null", "42", "[1,2]"];
+    for (const p of payloads) {
+      expect(() => deserializeSignalingData(p)).not.toThrow();
+      expect(deserializeSignalingData(p)).toBeNull();
+    }
+  });
+});
+
+describe("isConnectionInfo (type guard)", () => {
+  it("accepts valid connection info", () => {
+    expect(
+      isConnectionInfo({ gameCode: "ABC", hostName: "H", timestamp: 1 }),
+    ).toBe(true);
+  });
+
+  it("rejects wrong-typed fields", () => {
+    expect(isConnectionInfo({ gameCode: 1, hostName: "H", timestamp: 1 })).toBe(
+      false,
+    );
+  });
+
+  it("rejects non-objects", () => {
+    expect(isConnectionInfo(null)).toBe(false);
+    expect(isConnectionInfo("x")).toBe(false);
+  });
+});
+
+describe("isSignalingData (type guard)", () => {
+  it("accepts valid signaling data", () => {
+    expect(
+      isSignalingData({ type: "offer", data: { sdp: "x" }, senderCode: "ABC" }),
+    ).toBe(true);
+  });
+
+  it("rejects an invalid type value", () => {
+    expect(
+      isSignalingData({ type: "bogus", data: {}, senderCode: "ABC" }),
+    ).toBe(false);
+  });
+
+  it("rejects a non-object data field", () => {
+    expect(
+      isSignalingData({ type: "offer", data: "x", senderCode: "ABC" }),
+    ).toBe(false);
   });
 });
 

--- a/src/lib/p2p-direct-connection.ts
+++ b/src/lib/p2p-direct-connection.ts
@@ -7,15 +7,16 @@
  * and manual code entry, eliminating Firebase signaling dependency.
  */
 
-import QRCode from 'qrcode';
-import { generateGameCode } from './webrtc-p2p';
-import type { WebRTCConnection, P2PConnectionOptions } from './webrtc-p2p';
+import QRCode from "qrcode";
+import { generateGameCode } from "./webrtc-p2p";
+import type { WebRTCConnection, P2PConnectionOptions } from "./webrtc-p2p";
+import { safeParseJson } from "./p2p-json-validation";
 
 /**
  * Connection data for QR code encoding
  */
 export interface ConnectionData {
-  type: 'offer' | 'answer';
+  type: "offer" | "answer";
   sessionId: string;
   timestamp: number;
   sdp: RTCSessionDescriptionInit;
@@ -28,33 +29,73 @@ export interface ConnectionData {
  * ICE candidate data for exchange
  */
 export interface ICECandidateData {
-  type: 'ice-candidate';
+  type: "ice-candidate";
   sessionId: string;
   candidate: RTCIceCandidateInit;
+}
+
+/**
+ * Type guard validating the shape of untrusted {@link ConnectionData}.
+ * Rejects valid JSON that does not match the expected schema.
+ */
+export function isConnectionData(value: unknown): value is ConnectionData {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    (v.type === "offer" || v.type === "answer") &&
+    typeof v.sessionId === "string" &&
+    typeof v.gameCode === "string" &&
+    typeof v.hostName === "string" &&
+    typeof v.timestamp === "number" &&
+    typeof v.sdp === "object" &&
+    v.sdp !== null
+  );
+}
+
+/**
+ * Type guard validating the shape of untrusted {@link ICECandidateData}.
+ * Rejects valid JSON that does not match the expected schema.
+ */
+export function isICECandidateData(value: unknown): value is ICECandidateData {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    v.type === "ice-candidate" &&
+    typeof v.sessionId === "string" &&
+    typeof v.candidate === "object" &&
+    v.candidate !== null
+  );
 }
 
 /**
  * Connection state for direct P2P
  */
 export type DirectConnectionState =
-  | 'idle'
-  | 'generating-offer'
-  | 'waiting-for-answer'
-  | 'exchanging-ice'
-  | 'connected'
-  | 'failed';
+  | "idle"
+  | "generating-offer"
+  | "waiting-for-answer"
+  | "exchanging-ice"
+  | "connected"
+  | "failed";
 
 /**
  * Session manager for tracking P2P connections
  */
 class P2PSessionManager {
-  private sessions: Map<string, {
-    connection: WebRTCConnection;
-    state: DirectConnectionState;
-    connectionData: ConnectionData;
-    iceCandidates: RTCIceCandidateInit[];
-    timestamp: number;
-  }> = new Map();
+  private sessions: Map<
+    string,
+    {
+      connection: WebRTCConnection;
+      state: DirectConnectionState;
+      connectionData: ConnectionData;
+      iceCandidates: RTCIceCandidateInit[];
+      timestamp: number;
+    }
+  > = new Map();
 
   /**
    * Create a new P2P session
@@ -62,11 +103,11 @@ class P2PSessionManager {
   createSession(
     sessionId: string,
     connection: WebRTCConnection,
-    connectionData: ConnectionData
+    connectionData: ConnectionData,
   ): void {
     this.sessions.set(sessionId, {
       connection,
-      state: 'idle',
+      state: "idle",
       connectionData,
       iceCandidates: [],
       timestamp: Date.now(),
@@ -139,7 +180,10 @@ class P2PSessionManager {
   /**
    * Get all active sessions
    */
-  getActiveSessions(): Array<{ sessionId: string; state: DirectConnectionState }> {
+  getActiveSessions(): Array<{
+    sessionId: string;
+    state: DirectConnectionState;
+  }> {
     return Array.from(this.sessions.entries()).map(([sessionId, session]) => ({
       sessionId,
       state: session.state,
@@ -151,7 +195,7 @@ class P2PSessionManager {
 export const sessionManager = new P2PSessionManager();
 
 // Clean up old sessions every minute
-if (typeof window !== 'undefined') {
+if (typeof window !== "undefined") {
   setInterval(() => {
     sessionManager.cleanupOldSessions();
   }, 60 * 1000);
@@ -169,23 +213,26 @@ export async function generateConnectionQRCode(
       dark?: string;
       light?: string;
     };
-  }
+  },
 ): Promise<string> {
   const qrOptions = {
     width: options?.width || 300,
     margin: options?.margin || 2,
     color: options?.color || {
-      dark: '#000000',
-      light: '#FFFFFF',
+      dark: "#000000",
+      light: "#FFFFFF",
     },
   };
 
   try {
-    const dataUrl = await QRCode.toDataURL(JSON.stringify(connectionData), qrOptions);
+    const dataUrl = await QRCode.toDataURL(
+      JSON.stringify(connectionData),
+      qrOptions,
+    );
     return dataUrl;
   } catch (error) {
-    console.error('[P2P] Failed to generate QR code:', error);
-    throw new Error('Failed to generate connection QR code');
+    console.error("[P2P] Failed to generate QR code:", error);
+    throw new Error("Failed to generate connection QR code");
   }
 }
 
@@ -193,38 +240,28 @@ export async function generateConnectionQRCode(
  * Parse connection data from QR code or manual entry
  */
 export function parseConnectionData(input: string): ConnectionData | null {
-  try {
-    // Try parsing as JSON first (from QR code)
-    const parsed = JSON.parse(input);
-
-    // Validate structure
-    if (!parsed.type || !parsed.sessionId || !parsed.sdp || !parsed.gameCode) {
-      return null;
-    }
-
-    return parsed as ConnectionData;
-  } catch (error) {
-    console.error('[P2P] Failed to parse connection data:', error);
+  const parsed = safeParseJson<ConnectionData>(input, isConnectionData);
+  if (!parsed) {
+    console.error(
+      "[P2P] Failed to parse connection data: rejected malformed input",
+    );
     return null;
   }
+  return parsed;
 }
 
 /**
  * Parse ICE candidate data
  */
 export function parseICECandidateData(input: string): ICECandidateData | null {
-  try {
-    const parsed = JSON.parse(input);
-
-    if (!parsed.type || !parsed.sessionId || !parsed.candidate) {
-      return null;
-    }
-
-    return parsed as ICECandidateData;
-  } catch (error) {
-    console.error('[P2P] Failed to parse ICE candidate:', error);
+  const parsed = safeParseJson<ICECandidateData>(input, isICECandidateData);
+  if (!parsed) {
+    console.error(
+      "[P2P] Failed to parse ICE candidate: rejected malformed input",
+    );
     return null;
   }
+  return parsed;
 }
 
 /**
@@ -232,14 +269,23 @@ export function parseICECandidateData(input: string): ICECandidateData | null {
  */
 export async function createHostConnection(
   options: P2PConnectionOptions & {
-    onQRCodeGenerated?: (qrDataUrl: string, connectionData: ConnectionData) => void;
+    onQRCodeGenerated?: (
+      qrDataUrl: string,
+      connectionData: ConnectionData,
+    ) => void;
     onICECandidate?: (candidate: RTCIceCandidateInit) => void;
-  }
+  },
 ): Promise<WebRTCConnection> {
-  const { playerId, playerName, onQRCodeGenerated, onICECandidate, ...rtcOptions } = options;
+  const {
+    playerId,
+    playerName,
+    onQRCodeGenerated,
+    onICECandidate,
+    ...rtcOptions
+  } = options;
 
   // Create WebRTC connection
-  const connection = (await import('./webrtc-p2p')).createP2PConnection({
+  const connection = (await import("./webrtc-p2p")).createP2PConnection({
     playerId,
     playerName,
     ...rtcOptions,
@@ -258,26 +304,26 @@ export async function createHostConnection(
 
   // Create connection data for QR code
   const connectionData: ConnectionData = {
-    type: 'offer',
+    type: "offer",
     sessionId,
     timestamp: Date.now(),
     sdp: offer,
     gameCode,
     hostName: playerName,
-    format: rtcOptions.gameCode ? 'unknown' : 'commander',
+    format: rtcOptions.gameCode ? "unknown" : "commander",
   };
 
   // Create session
   sessionManager.createSession(sessionId, connection, connectionData);
-  sessionManager.updateSessionState(sessionId, 'waiting-for-answer');
+  sessionManager.updateSessionState(sessionId, "waiting-for-answer");
 
   // Generate QR code
   const qrDataUrl = await generateConnectionQRCode(connectionData);
   onQRCodeGenerated?.(qrDataUrl, connectionData);
 
   // Set up ICE candidate collection
-  const originalHandleICECandidate = connection['handleICECandidate'];
-  connection['handleICECandidate'] = (candidate: RTCIceCandidate) => {
+  const originalHandleICECandidate = connection["handleICECandidate"];
+  connection["handleICECandidate"] = (candidate: RTCIceCandidate) => {
     // Add to session
     sessionManager.addICECandidate(sessionId, candidate.toJSON());
 
@@ -287,8 +333,6 @@ export async function createHostConnection(
     // Call original handler if needed
     originalHandleICECandidate?.call(connection, candidate);
   };
-
-  
 
   return connection;
 }
@@ -301,12 +345,18 @@ export async function createClientConnection(
   options: P2PConnectionOptions & {
     onAnswerGenerated?: (answer: RTCSessionDescriptionInit) => void;
     onICECandidate?: (candidate: RTCIceCandidateInit) => void;
-  }
+  },
 ): Promise<WebRTCConnection> {
-  const { playerId, playerName, onAnswerGenerated, onICECandidate, ...rtcOptions } = options;
+  const {
+    playerId,
+    playerName,
+    onAnswerGenerated,
+    onICECandidate,
+    ...rtcOptions
+  } = options;
 
   // Create WebRTC connection
-  const connection = (await import('./webrtc-p2p')).createP2PConnection({
+  const connection = (await import("./webrtc-p2p")).createP2PConnection({
     playerId,
     playerName,
     ...rtcOptions,
@@ -318,16 +368,18 @@ export async function createClientConnection(
   await connection.initialize();
 
   // Create session
-  sessionManager.createSession(connectionData.sessionId, connection, connectionData);
-  sessionManager.updateSessionState(connectionData.sessionId, 'exchanging-ice');
+  sessionManager.createSession(
+    connectionData.sessionId,
+    connection,
+    connectionData,
+  );
+  sessionManager.updateSessionState(connectionData.sessionId, "exchanging-ice");
 
   // Handle offer
   const answer = await connection.handleOffer(connectionData.sdp);
 
   // Notify callback
   onAnswerGenerated?.(answer);
-
-  console.log('[P2P] Client connection created, answer generated...');
 
   return connection;
 }
@@ -338,7 +390,7 @@ export async function createClientConnection(
 export async function handleICEExchange(
   sessionId: string,
   candidate: RTCIceCandidateInit,
-  options: P2PConnectionOptions
+  options: P2PConnectionOptions,
 ): Promise<void> {
   const session = sessionManager.getSession(sessionId);
 
@@ -353,7 +405,9 @@ export async function handleICEExchange(
 /**
  * Generate connection string for manual entry
  */
-export function generateConnectionString(connectionData: ConnectionData): string {
+export function generateConnectionString(
+  connectionData: ConnectionData,
+): string {
   return JSON.stringify(connectionData);
 }
 
@@ -362,10 +416,10 @@ export function generateConnectionString(connectionData: ConnectionData): string
  */
 export function generateICECandidateString(
   sessionId: string,
-  candidate: RTCIceCandidateInit
+  candidate: RTCIceCandidateInit,
 ): string {
   const iceData: ICECandidateData = {
-    type: 'ice-candidate',
+    type: "ice-candidate",
     sessionId,
     candidate,
   };
@@ -382,7 +436,7 @@ export function validateConnectionData(data: ConnectionData): boolean {
   }
 
   // Check type
-  if (data.type !== 'offer' && data.type !== 'answer') {
+  if (data.type !== "offer" && data.type !== "answer") {
     return false;
   }
 
@@ -398,7 +452,9 @@ export function validateConnectionData(data: ConnectionData): boolean {
 /**
  * Get connection state for UI
  */
-export function getConnectionState(sessionId: string): DirectConnectionState | null {
+export function getConnectionState(
+  sessionId: string,
+): DirectConnectionState | null {
   const session = sessionManager.getSession(sessionId);
   return session?.state || null;
 }
@@ -407,7 +463,7 @@ export function getConnectionState(sessionId: string): DirectConnectionState | n
  * Close all P2P sessions
  */
 export function closeAllSessions(): void {
-  for (const [sessionId] of sessionManager['sessions'].entries()) {
+  for (const [sessionId] of sessionManager["sessions"].entries()) {
     sessionManager.closeSession(sessionId);
   }
 }
@@ -421,10 +477,12 @@ export function exportSessionData(): Array<{
   timestamp: number;
   iceCandidates: number;
 }> {
-  return Array.from(sessionManager['sessions'].entries()).map(([sessionId, session]) => ({
-    sessionId,
-    state: session.state,
-    timestamp: session.timestamp,
-    iceCandidates: session.iceCandidates.length,
-  }));
+  return Array.from(sessionManager["sessions"].entries()).map(
+    ([sessionId, session]) => ({
+      sessionId,
+      state: session.state,
+      timestamp: session.timestamp,
+      iceCandidates: session.iceCandidates.length,
+    }),
+  );
 }

--- a/src/lib/p2p-game-connection.ts
+++ b/src/lib/p2p-game-connection.ts
@@ -25,6 +25,7 @@ import {
   getGlobalICEManager,
   type ICEConfigOptions,
 } from "./ice-config";
+import { safeParseJson } from "./p2p-json-validation";
 
 /**
  * P2P connection events
@@ -76,6 +77,35 @@ export interface GameMessage {
   senderId: string;
   timestamp: number;
   data: unknown;
+}
+
+const GAME_MESSAGE_TYPES: ReadonlySet<GameMessageType> = new Set([
+  "game-state-sync",
+  "game-action",
+  "chat",
+  "player-joined",
+  "player-left",
+  "ping",
+  "pong",
+]);
+
+/**
+ * Type guard validating the shape of an untrusted {@link GameMessage}.
+ * Data-channel messages come directly from peers and must be validated before
+ * use. Rejects valid JSON that does not match the expected schema.
+ */
+export function isGameMessage(value: unknown): value is GameMessage {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.type === "string" &&
+    GAME_MESSAGE_TYPES.has(v.type as GameMessageType) &&
+    typeof v.senderId === "string" &&
+    typeof v.timestamp === "number"
+    // `data` is intentionally `unknown`; handlers validate it as needed.
+  );
 }
 
 /**
@@ -436,11 +466,18 @@ export class P2PGameConnection {
 
   /**
    * Handle incoming message
-   * Wraps message parsing in try/catch to prevent malformed messages from breaking the connection
+   * Validates the parsed payload's shape to prevent malformed or attacker-
+   * controlled data from flowing into business logic. Malformed messages are
+   * rejected gracefully without breaking the connection.
    */
   private handleMessage(data: string): void {
     try {
-      const message: GameMessage = JSON.parse(data);
+      const message = safeParseJson<GameMessage>(data, isGameMessage);
+      if (!message) {
+        // Malformed JSON or wrong shape — reject without breaking the channel.
+        console.error("[P2PGameConnection] Rejected malformed peer message");
+        return;
+      }
 
       // Update remote player info
       if (this.remotePlayerId === null) {
@@ -473,8 +510,8 @@ export class P2PGameConnection {
 
       this.events.onMessage(message);
     } catch (error) {
-      console.error("[P2PGameConnection] Failed to parse message:", error);
-      // Don't break connection for parse errors, just log them
+      console.error("[P2PGameConnection] Failed to handle message:", error);
+      // Don't break connection for handler errors, just log them
     }
   }
 

--- a/src/lib/p2p-json-validation.ts
+++ b/src/lib/p2p-json-validation.ts
@@ -1,0 +1,47 @@
+/**
+ * @fileOverview Safe JSON parsing helpers for untrusted P2P / signaling data.
+ *
+ * Data received from peers or signaling channels (QR codes, manual code entry,
+ * copy-paste, WebRTC data-channel messages) is UNTRUSTED. Parsing it safely
+ * requires two guarantees:
+ *   1. Never throw on malformed input — wrap JSON.parse so a bad payload
+ *      cannot crash or hang the connection.
+ *   2. Validate the SHAPE of the parsed value before treating it as a typed
+ *      object. A successful JSON.parse only proves syntactic validity, not
+ *      that the payload matches the expected schema. Blind `as T` casts let
+ *      attacker-controlled shapes flow into business logic.
+ *
+ * See issue #924.
+ */
+
+/**
+ * Safely parse a JSON string and validate its shape.
+ *
+ * @param raw      - Raw string received from an untrusted source (peer/signal).
+ * @param validate - Type guard returning true only when the parsed value has
+ *                   the expected shape. Receives `unknown`.
+ * @returns The validated value, or `null` if parsing or validation fails.
+ */
+export function safeParseJson<T>(
+  raw: string,
+  validate: (value: unknown) => value is T,
+): T | null {
+  if (typeof raw !== "string") {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Malformed JSON — reject gracefully without throwing to the caller.
+    return null;
+  }
+
+  // A valid JSON scalar (number, string, boolean, null) is never a message.
+  if (parsed === null || typeof parsed !== "object") {
+    return null;
+  }
+
+  return validate(parsed) ? parsed : null;
+}

--- a/src/lib/p2p-signaling-client.ts
+++ b/src/lib/p2p-signaling-client.ts
@@ -22,6 +22,7 @@ import type {
   P2PConnectionOptions,
 } from "./webrtc-p2p";
 import { WebRTCConnection, createP2PConnection } from "./webrtc-p2p";
+import { safeParseJson } from "./p2p-json-validation";
 
 /**
  * Connection information for P2P handshake
@@ -47,6 +48,39 @@ export interface SignalingData {
   data: RTCSessionDescriptionInit | RTCIceCandidateInit;
   /** Sender's game code */
   senderCode: string;
+}
+
+/**
+ * Type guard validating the shape of untrusted {@link ConnectionInfo}.
+ * Rejects valid JSON that does not match the expected schema.
+ */
+export function isConnectionInfo(value: unknown): value is ConnectionInfo {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.gameCode === "string" &&
+    typeof v.hostName === "string" &&
+    typeof v.timestamp === "number"
+  );
+}
+
+/**
+ * Type guard validating the shape of untrusted {@link SignalingData}.
+ * Rejects valid JSON that does not match the expected schema.
+ */
+export function isSignalingData(value: unknown): value is SignalingData {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    (v.type === "offer" || v.type === "answer" || v.type === "ice-candidate") &&
+    typeof v.senderCode === "string" &&
+    typeof v.data === "object" &&
+    v.data !== null
+  );
 }
 
 /**
@@ -420,19 +454,14 @@ export function createClientSignalingClient(
  * Parse connection info from QR code data
  */
 export function parseConnectionInfo(data: string): ConnectionInfo | null {
-  try {
-    const info = JSON.parse(data) as ConnectionInfo;
-
-    // Validate required fields
-    if (!info.gameCode || !info.hostName) {
-      return null;
-    }
-
-    return info;
-  } catch (error) {
-    console.error("[Signaling] Failed to parse connection info:", error);
+  const parsed = safeParseJson<ConnectionInfo>(data, isConnectionInfo);
+  if (!parsed) {
+    console.error(
+      "[Signaling] Failed to parse connection info: rejected malformed input",
+    );
     return null;
   }
+  return parsed;
 }
 
 /**
@@ -446,10 +475,12 @@ export function serializeSignalingData(data: SignalingData): string {
  * Deserialize signaling data from copy-paste
  */
 export function deserializeSignalingData(data: string): SignalingData | null {
-  try {
-    return JSON.parse(data) as SignalingData;
-  } catch (error) {
-    console.error("[Signaling] Failed to deserialize signaling data:", error);
+  const parsed = safeParseJson<SignalingData>(data, isSignalingData);
+  if (!parsed) {
+    console.error(
+      "[Signaling] Failed to deserialize signaling data: rejected malformed input",
+    );
     return null;
   }
+  return parsed;
 }


### PR DESCRIPTION
## Summary

Resolves #924 — P2P residuals after #841/#842/#888: leftover debug `console.log` statements and unvalidated `JSON.parse(...)` casts of **untrusted** peer/signaling data (security-labeled). A successful `JSON.parse` only proves syntactic validity; blind `as T` casts let attacker-controlled shapes flow into business logic, and malformed input could throw and break/hang the connection.

## Changes

### 1. Removed leftover debug `console.log` (1 site)
- `src/lib/p2p-direct-connection.ts` — removed `console.log('[P2P] Client connection created, answer generated...')` from `createClientConnection`.

> **Note:** `console.error` / `console.warn` statements (genuine error/diagnostic logging) were **kept**. The `console.log` references in `src/hooks/use-p2p-signaling.ts` are inside a JSDoc `@example` block (documentation), not runtime code — left untouched.

### 2. Hardened `JSON.parse` of untrusted input (5 sites)
Introduced a single shared helper and validated type guards; all untrusted parsing now (a) never throws and (b) validates shape before use.

**New shared helper** — `src/lib/p2p-json-validation.ts`:
- `safeParseJson<T>(raw, validate): T | null` — wraps `JSON.parse` in try/catch, rejects non-object scalars/arrays, and runs a caller-supplied type guard.

**Hardened sites:**
| File | Function | Before | After |
|------|----------|--------|-------|
| `p2p-direct-connection.ts` | `parseConnectionData` | `JSON.parse` + truthiness check + `as ConnectionData` | `safeParseJson` + `isConnectionData` type guard |
| `p2p-direct-connection.ts` | `parseICECandidateData` | `JSON.parse` + truthiness check + `as ICECandidateData` | `safeParseJson` + `isICECandidateData` type guard |
| `p2p-game-connection.ts` | `handleMessage` (private) | `JSON.parse(data) as GameMessage` **— no validation, direct peer data-channel input (most dangerous)** | `safeParseJson` + `isGameMessage` type guard; malformed rejected gracefully, channel stays alive |
| `p2p-signaling-client.ts` | `parseConnectionInfo` | `JSON.parse(...) as ConnectionInfo` + weak check | `safeParseJson` + `isConnectionInfo` type guard |
| `p2p-signaling-client.ts` | `deserializeSignalingData` | `JSON.parse(...) as SignalingData` **— no validation at all** | `safeParseJson` + `isSignalingData` type guard |

**Validation approach:** each type guard (`isConnectionData`, `isICECandidateData`, `isGameMessage`, `isConnectionInfo`, `isSignalingData`) checks the required fields' **types** and (for enum-like fields) valid values — rejecting valid JSON that does not match the expected schema. Legitimate `console.error` is preserved on rejection for diagnostics.

## Scope
- Only P2P lib/hooks touched. **No** changes to ICE-restart reconnection (#915) or host-migration (#916) logic.

## Files changed
- `src/lib/p2p-json-validation.ts` (new)
- `src/lib/p2p-direct-connection.ts`
- `src/lib/p2p-game-connection.ts`
- `src/lib/p2p-signaling-client.ts`
- `src/lib/__tests__/p2p-json-validation.test.ts` (new)
- `src/lib/__tests__/p2p-direct-connection.test.ts`
- `src/lib/__tests__/p2p-signaling-client.test.ts`
- `src/lib/__tests__/p2p-game-connection.test.ts`

## Tests
Added tests proving malformed/untrusted peer & signaling JSON is **rejected gracefully (no throw)** while valid JSON still parses:
- `safeParseJson`: malformed JSON, empty, JSON scalars/null/arrays, wrong shape, wrong field types, null-byte & truncated payloads, non-string defensive cases.
- Parse functions: wrong-typed fields, missing `sdp`, JSON scalars, attacker-controlled payloads never throw.
- `isGameMessage` + `P2PGameConnection.handleMessage` integration: malformed peer data-channel messages don't throw and don't reach `onMessage`; valid messages still forwarded.

**Results:**
- `npx jest p2p use-p2p webrtc-p2p` → **196 suites / 3793 tests pass** (0 failures)
- `npx tsc --noEmit` → **clean**
- `npx eslint <affected files>` → **clean (exit 0)**

Closes #924.