### PR TITLE
feat: resolve #927 — wire incremental backup into the storage UI

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       next:
         specifier: ^16.2.4
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      pako:
+        specifier: ^2.2.0
+        version: 2.2.0
       patch-package:
         specifier: ^8.0.0
         version: 8.0.1
@@ -222,6 +225,9 @@ importers:
       '@types/node':
         specifier: ^20
         version: 20.19.41
+      '@types/pako':
+        specifier: ^2.0.4
+        version: 2.0.4
       '@types/qrcode':
         specifier: ^1.5.6
         version: 1.5.6
@@ -2917,6 +2923,9 @@ packages:
 
   '@types/node@20.19.41':
     resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
+
+  '@types/pako@2.0.4':
+    resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
 
   '@types/pg-pool@2.0.4':
     resolution: {integrity: sha512-qZAvkv1K3QbmHHFYSNRYPkRjOWRLBYrL4B9c+wG0GSVGBw0NtJwPcgx/DSddeDJvRGMHCEQ4VMEVfuJ/0gZ3XQ==}
@@ -5696,6 +5705,9 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  pako@2.2.0:
+    resolution: {integrity: sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -10131,6 +10143,8 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/pako@2.0.4': {}
+
   '@types/pg-pool@2.0.4':
     dependencies:
       '@types/pg': 8.6.1
@@ -13470,6 +13484,8 @@ snapshots:
 
   package-json-from-dist@1.0.1:
     optional: true
+
+  pako@2.2.0: {}
 
   parent-module@1.0.1:
     dependencies:

--- a/src/components/storage-backup-manager.tsx
+++ b/src/components/storage-backup-manager.tsx
@@ -12,20 +12,16 @@
 
 "use client";
 
-import { useState, useRef } from 'react';
-import { Button } from '@/components/ui/button';
+import { useState, useRef } from "react";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-} from '@/components/ui/card';
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from '@/components/ui/alert';
+} from "@/components/ui/card";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
   Dialog,
   DialogContent,
@@ -34,15 +30,10 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from '@/components/ui/dialog';
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from '@/components/ui/tabs';
-import { Progress } from '@/components/ui/progress';
-import { Badge } from '@/components/ui/badge';
+} from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Progress } from "@/components/ui/progress";
+import { Badge } from "@/components/ui/badge";
 import {
   Download,
   Upload,
@@ -51,12 +42,14 @@ import {
   AlertTriangle,
   CheckCircle,
   Loader2,
-} from 'lucide-react';
+  Layers,
+  FileStack,
+} from "lucide-react";
 import {
   useStorageBackup,
   validateBackupFile,
   getBackupMetadata,
-} from '@/hooks/use-storage-backup';
+} from "@/hooks/use-storage-backup";
 
 /**
  * Storage Backup Manager Component
@@ -68,6 +61,9 @@ export function StorageBackupManager() {
     error,
     quota,
     isInitialized,
+    backupMode,
+    setBackupMode,
+    lastIncrementalResult,
     exportData,
     importData,
     clearAllData,
@@ -79,6 +75,8 @@ export function StorageBackupManager() {
     storageUsage,
     storageQuota,
     storagePercentage,
+    hasIncrementalBaseline,
+    lastBackupAt,
   } = useStorageBackup();
 
   const [importFile, setImportFile] = useState<File | null>(null);
@@ -95,7 +93,7 @@ export function StorageBackupManager() {
 
     const isValid = await validateBackupFile(importFile);
     if (!isValid) {
-      alert('Invalid backup file. Please select a valid Planar Nexus backup.');
+      alert("Invalid backup file. Please select a valid Planar Nexus backup.");
       return;
     }
 
@@ -120,7 +118,7 @@ export function StorageBackupManager() {
     reset();
     setImportFile(null);
     if (fileInputRef.current) {
-      fileInputRef.current.value = '';
+      fileInputRef.current.value = "";
     }
   };
 
@@ -178,9 +176,10 @@ export function StorageBackupManager() {
               <HardDrive className="h-4 w-4" />
               <AlertTitle>Storage Information</AlertTitle>
               <AlertDescription>
-                Your data is stored locally using IndexedDB, which provides better
-                performance and larger storage capacity than localStorage. You can
-                export your data at any time to create a backup file.
+                Your data is stored locally using IndexedDB, which provides
+                better performance and larger storage capacity than
+                localStorage. You can export your data at any time to create a
+                backup file.
               </AlertDescription>
             </Alert>
           </TabsContent>
@@ -188,11 +187,74 @@ export function StorageBackupManager() {
           {/* Backup Tab */}
           <TabsContent value="backup" className="space-y-4">
             <div className="space-y-4">
+              {/* Backup mode selector */}
               <div>
-                <h3 className="text-sm font-medium mb-2">Export Data</h3>
+                <h3 className="text-sm font-medium mb-2">Backup Mode</h3>
+                <div className="grid grid-cols-2 gap-2">
+                  <Button
+                    type="button"
+                    variant={backupMode === "full" ? "default" : "outline"}
+                    onClick={() => setBackupMode("full")}
+                    disabled={isProcessing}
+                    className="w-full justify-start"
+                  >
+                    <HardDrive className="mr-2 h-4 w-4" />
+                    Full
+                  </Button>
+                  <Button
+                    type="button"
+                    variant={
+                      backupMode === "incremental" ? "default" : "outline"
+                    }
+                    onClick={() => setBackupMode("incremental")}
+                    disabled={isProcessing}
+                    className="w-full justify-start"
+                  >
+                    <Layers className="mr-2 h-4 w-4" />
+                    Incremental
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground mt-2">
+                  {backupMode === "incremental" ? (
+                    <>
+                      Exports only decks and games changed since the last
+                      backup.{" "}
+                      {hasIncrementalBaseline ? (
+                        <>
+                          Last backup:{" "}
+                          <span className="font-medium">
+                            {lastBackupAt
+                              ? new Date(lastBackupAt).toLocaleString()
+                              : "unknown"}
+                          </span>
+                          .
+                        </>
+                      ) : (
+                        <span className="font-medium">
+                          No previous backup — this first incremental will
+                          include all current data as a baseline.
+                        </span>
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      Exports all decks, saved games, and preferences as a
+                      complete snapshot.
+                    </>
+                  )}
+                </p>
+              </div>
+
+              <div>
+                <h3 className="text-sm font-medium mb-2">
+                  {backupMode === "incremental"
+                    ? "Export Incremental Backup"
+                    : "Export Data"}
+                </h3>
                 <p className="text-sm text-muted-foreground mb-4">
-                  Create a backup file containing all your decks, saved games, and
-                  preferences.
+                  {backupMode === "incremental"
+                    ? "Download only the records that changed since the last backup."
+                    : "Create a backup file containing all your decks, saved games, and preferences."}
                 </p>
                 <Button
                   onClick={handleExport}
@@ -204,6 +266,11 @@ export function StorageBackupManager() {
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                       Exporting...
                     </>
+                  ) : backupMode === "incremental" ? (
+                    <>
+                      <FileStack className="mr-2 h-4 w-4" />
+                      Export Incremental Backup
+                    </>
                   ) : (
                     <>
                       <Download className="mr-2 h-4 w-4" />
@@ -213,7 +280,28 @@ export function StorageBackupManager() {
                 </Button>
               </div>
 
-              {isComplete && (
+              {isComplete &&
+                lastIncrementalResult &&
+                backupMode === "incremental" && (
+                  <Alert>
+                    <CheckCircle className="h-4 w-4" />
+                    <AlertTitle>Incremental Export Complete</AlertTitle>
+                    <AlertDescription>
+                      Exported {lastIncrementalResult.deckCount} deck
+                      {lastIncrementalResult.deckCount === 1
+                        ? ""
+                        : "s"} and {lastIncrementalResult.savedGameCount} saved
+                      game
+                      {lastIncrementalResult.savedGameCount === 1
+                        ? ""
+                        : "s"}{" "}
+                      changed since{" "}
+                      {new Date(lastIncrementalResult.since).toLocaleString()}.
+                    </AlertDescription>
+                  </Alert>
+                )}
+
+              {isComplete && !lastIncrementalResult && (
                 <Alert>
                   <CheckCircle className="h-4 w-4" />
                   <AlertTitle>Export Complete</AlertTitle>
@@ -277,7 +365,9 @@ export function StorageBackupManager() {
                 {importFile && (
                   <div className="mt-4 p-4 border rounded-lg space-y-2">
                     <div className="flex items-center justify-between">
-                      <span className="text-sm font-medium">{importFile.name}</span>
+                      <span className="text-sm font-medium">
+                        {importFile.name}
+                      </span>
                       <Badge variant="secondary">
                         {getBackupMetadata(importFile).formattedSize}
                       </Badge>
@@ -339,7 +429,10 @@ export function StorageBackupManager() {
                   Clear all stored data. This action cannot be undone.
                 </p>
 
-                <Dialog open={showConfirmClear} onOpenChange={setShowConfirmClear}>
+                <Dialog
+                  open={showConfirmClear}
+                  onOpenChange={setShowConfirmClear}
+                >
                   <DialogTrigger asChild>
                     <Button variant="destructive" className="w-full">
                       <Trash2 className="mr-2 h-4 w-4" />
@@ -350,12 +443,15 @@ export function StorageBackupManager() {
                     <DialogHeader>
                       <DialogTitle>Clear All Data?</DialogTitle>
                       <DialogDescription>
-                        This will permanently delete all your decks, saved games,
-                        and preferences. This action cannot be undone.
+                        This will permanently delete all your decks, saved
+                        games, and preferences. This action cannot be undone.
                       </DialogDescription>
                     </DialogHeader>
                     <DialogFooter>
-                      <Button variant="outline" onClick={() => setShowConfirmClear(false)}>
+                      <Button
+                        variant="outline"
+                        onClick={() => setShowConfirmClear(false)}
+                      >
                         Cancel
                       </Button>
                       <Button variant="destructive" onClick={handleClearData}>
@@ -369,7 +465,7 @@ export function StorageBackupManager() {
           </TabsContent>
         </Tabs>
 
-        {status === 'error' && (
+        {status === "error" && (
           <div className="mt-4 flex justify-end">
             <Button onClick={handleReset} variant="outline" size="sm">
               Reset

--- a/src/hooks/__tests__/use-storage-backup.test.ts
+++ b/src/hooks/__tests__/use-storage-backup.test.ts
@@ -1,0 +1,519 @@
+/**
+ * @fileOverview Tests for useStorageBackup hook
+ *
+ * Issue #927: Incremental backup exists in the storage lib but is unreachable
+ * from the UI.
+ *
+ * Tests the hook's wiring of:
+ * - Backup mode toggle (full / incremental)
+ * - exportData routes to incremental path when mode is set
+ * - exportIncrementalData wraps indexedDBStorage.exportIncrementalBackup
+ * - importData handles incremental backup imports
+ * - lastIncrementalResult surfaced after incremental export
+ * - hasIncrementalBaseline / lastBackupAt computed from manifest
+ */
+
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useStorageBackup } from "../use-storage-backup";
+import { indexedDBStorage } from "@/lib/indexeddb-storage";
+import { compressData, decompressData } from "@/lib/backup-compression";
+
+// ---------------------------------------------------------------------------
+// Mocks — jest.mock is hoisted above the imports by babel-jest, so the named
+// imports above resolve to the mocked implementations. We access the mock
+// fns via typed cast accessors below (the repo convention, see
+// use-ai-worker.test.ts) instead of `require()`.
+// ---------------------------------------------------------------------------
+
+jest.mock("@/lib/indexeddb-storage", () => ({
+  indexedDBStorage: {
+    initialize: jest.fn(),
+    getStorageQuota: jest.fn(),
+    getBackupManifest: jest.fn(),
+    exportBackup: jest.fn(),
+    exportIncrementalBackup: jest.fn(),
+    importBackup: jest.fn(),
+    importIncrementalBackup: jest.fn(),
+    clearAll: jest.fn(),
+  },
+  formatBytes: (n: number) => `${n} B`,
+}));
+
+jest.mock("@/lib/backup-compression", () => ({
+  compressData: jest.fn().mockReturnValue(new Uint8Array([0x1f, 0x8b])),
+  decompressData: jest.fn(),
+  BACKUP_COMPRESSED_MIME: "application/gzip",
+  BACKUP_COMPRESSED_EXTENSION: ".json.gz",
+}));
+
+// Typed accessors for the mocked fns.
+const mocked = {
+  initialize: indexedDBStorage.initialize as unknown as jest.Mock,
+  getStorageQuota: indexedDBStorage.getStorageQuota as unknown as jest.Mock,
+  getBackupManifest: indexedDBStorage.getBackupManifest as unknown as jest.Mock,
+  exportBackup: indexedDBStorage.exportBackup as unknown as jest.Mock,
+  exportIncrementalBackup:
+    indexedDBStorage.exportIncrementalBackup as unknown as jest.Mock,
+  importBackup: indexedDBStorage.importBackup as unknown as jest.Mock,
+  importIncrementalBackup:
+    indexedDBStorage.importIncrementalBackup as unknown as jest.Mock,
+  clearAll: indexedDBStorage.clearAll as unknown as jest.Mock,
+  compressData: compressData as unknown as jest.Mock,
+  decompressData: decompressData as unknown as jest.Mock,
+};
+
+// ---------------------------------------------------------------------------
+// Browser API stubs (JSDOM does not implement URL.createObjectURL / FileReader)
+// ---------------------------------------------------------------------------
+
+const mockRevokeObjectURL = jest.fn();
+global.URL.createObjectURL = jest.fn(() => "blob:test-blob-id");
+global.URL.revokeObjectURL = mockRevokeObjectURL;
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  // Prevent initialize from running its effect (which calls getBackupManifest
+  // internally), so the test fully controls when getBackupManifest is called.
+  mocked.initialize.mockResolvedValue(undefined);
+  mocked.getStorageQuota.mockResolvedValue({
+    quota: 10 * 1024 * 1024,
+    usage: 2 * 1024 * 1024,
+    percentage: 20,
+    approachingLimit: false,
+  });
+  mocked.getBackupManifest.mockResolvedValue(null); // default; override per-test
+  mocked.exportBackup.mockResolvedValue({
+    type: "full",
+    version: "1.0.0",
+    exportedAt: "2026-01-01T00:00:00.000Z",
+    decks: [],
+    savedGames: [],
+    preferences: {},
+    usageTracking: [],
+    achievements: [],
+    checksum: "abc123",
+  });
+  mocked.exportIncrementalBackup.mockResolvedValue({
+    type: "incremental",
+    version: "1.0.0",
+    since: "2026-01-01T00:00:00.000Z",
+    exportedAt: "2026-06-01T00:00:00.000Z",
+    decks: [{ id: "deck-1", name: "Deck 1" }] as any,
+    savedGames: [{ id: "game-1", name: "Game 1" }] as any,
+    deletedRecords: [],
+    checksum: "delta-checksum",
+  });
+  mocked.importBackup.mockResolvedValue(undefined);
+  mocked.importIncrementalBackup.mockResolvedValue(undefined);
+  mocked.clearAll.mockResolvedValue(undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useStorageBackup hook", () => {
+  describe("initialization", () => {
+    it("initializes storage and loads quota on mount", async () => {
+      const { result } = renderHook(() => useStorageBackup());
+
+      await waitFor(() => {
+        expect(result.current.isInitialized).toBe(true);
+      });
+
+      expect(mocked.initialize).toHaveBeenCalledTimes(1);
+      expect(mocked.getStorageQuota).toHaveBeenCalled();
+      expect(mocked.getBackupManifest).toHaveBeenCalled();
+    });
+
+    it("exposes correct default values", async () => {
+      const { result } = renderHook(() => useStorageBackup());
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+      expect(result.current.backupMode).toBe("full");
+      expect(result.current.status).toBe("idle");
+      expect(result.current.progress).toBe(0);
+      expect(result.current.error).toBe(null);
+      expect(result.current.lastIncrementalResult).toBe(null);
+      expect(result.current.hasIncrementalBaseline).toBe(false);
+      expect(result.current.lastBackupAt).toBe(null);
+    });
+  });
+
+  describe("backup mode toggle", () => {
+    it("defaults to full mode", async () => {
+      const { result } = renderHook(() => useStorageBackup());
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+      expect(result.current.backupMode).toBe("full");
+    });
+
+    it("setBackupMode switches to incremental", async () => {
+      const { result } = renderHook(() => useStorageBackup());
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+      act(() => {
+        result.current.setBackupMode("incremental");
+      });
+
+      expect(result.current.backupMode).toBe("incremental");
+    });
+
+    it("setBackupMode switches back to full", async () => {
+      const { result } = renderHook(() => useStorageBackup());
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+      act(() => {
+        result.current.setBackupMode("incremental");
+      });
+      expect(result.current.backupMode).toBe("incremental");
+
+      act(() => {
+        result.current.setBackupMode("full");
+      });
+      expect(result.current.backupMode).toBe("full");
+    });
+  });
+
+  describe("exportData — full mode", () => {
+    it("calls indexedDBStorage.exportBackup in full mode", async () => {
+      mocked.exportBackup.mockResolvedValueOnce({
+        type: "full",
+        version: "1.0.0",
+        exportedAt: "2026-01-01T00:00:00.000Z",
+        decks: [],
+        savedGames: [],
+        preferences: {},
+        usageTracking: [],
+        achievements: [],
+        checksum: "full-checksum",
+      } as any);
+
+      const { result } = renderHook(() => useStorageBackup());
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+      act(() => result.current.setBackupMode("full"));
+
+      await act(async () => {
+        await result.current.exportData();
+      });
+
+      expect(mocked.exportBackup).toHaveBeenCalledTimes(1);
+      expect(mocked.exportIncrementalBackup).not.toHaveBeenCalled();
+      expect(result.current.status).toBe("complete");
+    });
+
+    it("compresses the exported data", async () => {
+      mocked.exportBackup.mockResolvedValueOnce({
+        type: "full",
+        version: "1.0.0",
+        exportedAt: "2026-01-01T00:00:00.000Z",
+        decks: [],
+        savedGames: [],
+        preferences: {},
+        usageTracking: [],
+        achievements: [],
+        checksum: "c",
+      } as any);
+
+      const { result } = renderHook(() => useStorageBackup());
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+      await act(async () => {
+        await result.current.exportData();
+      });
+
+      expect(mocked.compressData).toHaveBeenCalled();
+    });
+  });
+
+  describe("exportData — incremental mode", () => {
+    it("routes to exportIncrementalBackup when mode is incremental", async () => {
+      mocked.getBackupManifest.mockResolvedValue({
+        id: "backup-manifest",
+        lastFullBackupAt: "2026-01-01T00:00:00.000Z",
+      });
+      mocked.exportIncrementalBackup.mockResolvedValueOnce({
+        type: "incremental",
+        version: "1.0.0",
+        since: "2026-01-01T00:00:00.000Z",
+        exportedAt: "2026-06-01T00:00:00.000Z",
+        decks: [{ id: "deck-1" }] as any,
+        savedGames: [{ id: "game-1" }] as any,
+        deletedRecords: [],
+        checksum: "inc-checksum",
+      });
+
+      const { result } = renderHook(() => useStorageBackup());
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+      act(() => {
+        result.current.setBackupMode("incremental");
+      });
+
+      await act(async () => {
+        await result.current.exportData();
+      });
+
+      expect(mocked.exportIncrementalBackup).toHaveBeenCalledTimes(1);
+      expect(mocked.exportBackup).not.toHaveBeenCalled();
+      expect(result.current.status).toBe("complete");
+    });
+
+    it("sets lastIncrementalResult after successful incremental export", async () => {
+      mocked.getBackupManifest.mockResolvedValue({
+        id: "backup-manifest",
+        lastFullBackupAt: "2026-01-01T00:00:00.000Z",
+      });
+      mocked.exportIncrementalBackup.mockResolvedValueOnce({
+        type: "incremental",
+        version: "1.0.0",
+        since: "2026-01-01T00:00:00.000Z",
+        exportedAt: "2026-06-01T00:00:00.000Z",
+        decks: [{ id: "deck-1" }, { id: "deck-2" }] as any,
+        savedGames: [{ id: "game-1" }] as any,
+        deletedRecords: [],
+        checksum: "inc-cs",
+      });
+
+      const { result } = renderHook(() => useStorageBackup());
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+      act(() => result.current.setBackupMode("incremental"));
+
+      await act(async () => {
+        await result.current.exportData();
+      });
+
+      expect(result.current.lastIncrementalResult).not.toBeNull();
+      expect(result.current.lastIncrementalResult!.deckCount).toBe(2);
+      expect(result.current.lastIncrementalResult!.savedGameCount).toBe(1);
+      expect(result.current.lastIncrementalResult!.since).toBe(
+        "2026-01-01T00:00:00.000Z",
+      );
+    });
+
+    it("derives since timestamp from manifest lastIncrementalBackupAt when available", async () => {
+      // Persistent mock: getBackupManifest is called both on mount
+      // (refreshBackupManifest) and again inside exportIncrementalData,
+      // so both calls must observe the same manifest.
+      mocked.getBackupManifest.mockResolvedValue({
+        id: "backup-manifest",
+        lastIncrementalBackupAt: "2026-04-01T00:00:00.000Z",
+        lastFullBackupAt: "2026-01-01T00:00:00.000Z",
+      });
+      mocked.exportIncrementalBackup.mockResolvedValueOnce({
+        type: "incremental",
+        version: "1.0.0",
+        since: "2026-04-01T00:00:00.000Z",
+        exportedAt: "2026-06-01T00:00:00.000Z",
+        decks: [],
+        savedGames: [],
+        deletedRecords: [],
+        checksum: "cs",
+      });
+
+      const { result } = renderHook(() => useStorageBackup());
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+      act(() => result.current.setBackupMode("incremental"));
+
+      await act(async () => {
+        await result.current.exportData();
+      });
+
+      const sinceArg = mocked.exportIncrementalBackup.mock.calls[0][0] as Date;
+      expect(sinceArg.toISOString()).toBe("2026-04-01T00:00:00.000Z");
+    });
+
+    it("falls back to epoch when no manifest exists", async () => {
+      // Persistent null mock — see the note on the previous test.
+      mocked.getBackupManifest.mockResolvedValue(null);
+      mocked.exportIncrementalBackup.mockResolvedValueOnce({
+        type: "incremental",
+        version: "1.0.0",
+        since: new Date(0).toISOString(),
+        exportedAt: "2026-06-01T00:00:00.000Z",
+        decks: [],
+        savedGames: [],
+        deletedRecords: [],
+        checksum: "cs",
+      });
+
+      const { result } = renderHook(() => useStorageBackup());
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+      act(() => result.current.setBackupMode("incremental"));
+
+      await act(async () => {
+        await result.current.exportData();
+      });
+
+      const sinceArg = mocked.exportIncrementalBackup.mock.calls[0][0] as Date;
+      expect(sinceArg.getTime()).toBe(0);
+    });
+  });
+
+  describe("importData — full vs incremental", () => {
+    it("calls indexedDBStorage.importBackup for full backup", async () => {
+      const fullPayload = {
+        version: "1.0.0",
+        exportedAt: "2026-01-01T00:00:00.000Z",
+        checksum: "c",
+      };
+      mocked.decompressData.mockReturnValueOnce(fullPayload);
+
+      const raw = JSON.stringify(fullPayload);
+      const encoder = new TextEncoder();
+      const encoded = encoder.encode(raw);
+      const arrayBuffer = encoded.buffer.slice(
+        encoded.byteOffset,
+        encoded.byteOffset + encoded.byteLength,
+      );
+
+      // JSDOM File doesn't support arrayBuffer() — patch it.
+      const blob = new Blob([encoded], { type: "application/json" });
+      const file = new File([blob], "backup.json", {
+        type: "application/json",
+      });
+      Object.defineProperty(file, "arrayBuffer", {
+        value: () => Promise.resolve(arrayBuffer),
+        writable: true,
+      });
+
+      const { result } = renderHook(() => useStorageBackup());
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+      await act(async () => {
+        await result.current.importData(file);
+      });
+
+      expect(mocked.importBackup).toHaveBeenCalledTimes(1);
+      expect(mocked.importIncrementalBackup).not.toHaveBeenCalled();
+    });
+
+    it("calls indexedDBStorage.importIncrementalBackup for incremental backup", async () => {
+      const incrementalPayload = {
+        type: "incremental",
+        version: "1.0.0",
+        since: "2026-01-01T00:00:00.000Z",
+        exportedAt: "2026-06-01T00:00:00.000Z",
+        decks: [{ id: "deck-1" }],
+        savedGames: [],
+        deletedRecords: [],
+        checksum: "inc-cs",
+      };
+      mocked.decompressData.mockReturnValueOnce(incrementalPayload);
+
+      const raw = JSON.stringify(incrementalPayload);
+      const encoder = new TextEncoder();
+      const encoded = encoder.encode(raw);
+      const arrayBuffer = encoded.buffer.slice(
+        encoded.byteOffset,
+        encoded.byteOffset + encoded.byteLength,
+      );
+
+      const blob = new Blob([encoded], { type: "application/gzip" });
+      const file = new File([blob], "inc.json.gz", {
+        type: "application/gzip",
+      });
+      Object.defineProperty(file, "arrayBuffer", {
+        value: () => Promise.resolve(arrayBuffer),
+        writable: true,
+      });
+
+      const { result } = renderHook(() => useStorageBackup());
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+      await act(async () => {
+        await result.current.importData(file);
+      });
+
+      expect(mocked.importIncrementalBackup).toHaveBeenCalledTimes(1);
+      expect(mocked.importBackup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("hasIncrementalBaseline / lastBackupAt", () => {
+    it("is false when no manifest exists", async () => {
+      mocked.getBackupManifest.mockResolvedValueOnce(null);
+
+      const { result } = renderHook(() => useStorageBackup());
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+      expect(result.current.hasIncrementalBaseline).toBe(false);
+      expect(result.current.lastBackupAt).toBe(null);
+    });
+
+    it("is true when lastFullBackupAt is present", async () => {
+      mocked.getBackupManifest.mockResolvedValueOnce({
+        id: "backup-manifest",
+        lastFullBackupAt: "2026-01-01T00:00:00.000Z",
+      });
+
+      const { result } = renderHook(() => useStorageBackup());
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+      expect(result.current.hasIncrementalBaseline).toBe(true);
+      expect(result.current.lastBackupAt).toBe("2026-01-01T00:00:00.000Z");
+    });
+
+    it("prefers lastIncrementalBackupAt over lastFullBackupAt for lastBackupAt", async () => {
+      mocked.getBackupManifest.mockResolvedValueOnce({
+        id: "backup-manifest",
+        lastFullBackupAt: "2026-01-01T00:00:00.000Z",
+        lastIncrementalBackupAt: "2026-04-01T00:00:00.000Z",
+      });
+
+      const { result } = renderHook(() => useStorageBackup());
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+      expect(result.current.hasIncrementalBaseline).toBe(true);
+      expect(result.current.lastBackupAt).toBe("2026-04-01T00:00:00.000Z");
+    });
+  });
+
+  describe("reset", () => {
+    it("resets status, progress, and error", async () => {
+      mocked.exportBackup.mockRejectedValueOnce(new Error("export failed"));
+
+      const { result } = renderHook(() => useStorageBackup());
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+      await act(async () => {
+        await result.current.exportData().catch(() => {});
+      });
+
+      expect(result.current.status).toBe("error");
+      expect(result.current.error).not.toBeNull();
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.status).toBe("idle");
+      expect(result.current.progress).toBe(0);
+      expect(result.current.error).toBe(null);
+    });
+  });
+
+  describe("clearAllData", () => {
+    it("calls indexedDBStorage.clearAll", async () => {
+      mocked.clearAll.mockResolvedValueOnce(undefined);
+
+      const { result } = renderHook(() => useStorageBackup());
+      await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+      await act(async () => {
+        await result.current.clearAllData();
+      });
+
+      expect(mocked.clearAll).toHaveBeenCalledTimes(1);
+      expect(result.current.status).toBe("complete");
+    });
+  });
+});

--- a/src/hooks/use-storage-backup.ts
+++ b/src/hooks/use-storage-backup.ts
@@ -12,19 +12,21 @@
 
 "use client";
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect } from "react";
 import {
   indexedDBStorage,
   BackupData,
+  IncrementalBackupData,
+  BackupManifest,
   StorageQuotaInfo,
   formatBytes,
-} from '@/lib/indexeddb-storage';
+} from "@/lib/indexeddb-storage";
 import {
-  compressBackup,
-  decompressBackup,
+  compressData,
+  decompressData,
   BACKUP_COMPRESSED_MIME,
   BACKUP_COMPRESSED_EXTENSION,
-} from '@/lib/backup-compression';
+} from "@/lib/backup-compression";
 
 // ============================================================================
 // TYPES
@@ -34,13 +36,13 @@ import {
  * Backup operation status
  */
 export type BackupStatus =
-  | 'idle'
-  | 'preparing'
-  | 'exporting'
-  | 'importing'
-  | 'validating'
-  | 'complete'
-  | 'error';
+  | "idle"
+  | "preparing"
+  | "exporting"
+  | "importing"
+  | "validating"
+  | "complete"
+  | "error";
 
 /**
  * Backup operation error
@@ -57,7 +59,7 @@ export interface BackupError {
 /**
  * Import conflict resolution strategy
  */
-export type ConflictResolution = 'skip' | 'overwrite' | 'rename' | 'merge';
+export type ConflictResolution = "skip" | "overwrite" | "rename" | "merge";
 
 /**
  * Import options
@@ -77,6 +79,30 @@ export interface ImportOptions {
   importAchievements: boolean;
 }
 
+/**
+ * Which backup strategy the export control should use.
+ *
+ * - `full` — export every record (existing behavior, wraps `exportBackup`).
+ * - `incremental` — export only records changed since the last backup,
+ *   wrapping the existing `exportIncrementalBackup` lib capability.
+ */
+export type BackupMode = "full" | "incremental";
+
+/**
+ * Summary of the most recent incremental export, surfaced to the UI so the
+ * user can see what the delta actually contained.
+ */
+export interface IncrementalResult {
+  /** ISO timestamp the delta was computed from. */
+  since: string;
+  /** When the export ran. */
+  exportedAt: string;
+  /** Number of changed decks in the delta. */
+  deckCount: number;
+  /** Number of changed saved games in the delta. */
+  savedGameCount: number;
+}
+
 // ============================================================================
 // HOOK
 // ============================================================================
@@ -85,18 +111,38 @@ export interface ImportOptions {
  * Hook for storage backup and restore operations
  */
 export function useStorageBackup() {
-  const [status, setStatus] = useState<BackupStatus>('idle');
+  const [status, setStatus] = useState<BackupStatus>("idle");
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState<BackupError | null>(null);
   const [quota, setQuota] = useState<StorageQuotaInfo | null>(null);
   const [isInitialized, setIsInitialized] = useState(false);
+  const [backupMode, setBackupMode] = useState<BackupMode>("full");
+  const [backupManifest, setBackupManifest] = useState<BackupManifest | null>(
+    null,
+  );
+  const [lastIncrementalResult, setLastIncrementalResult] =
+    useState<IncrementalResult | null>(null);
 
   // Initialize storage on mount
   useEffect(() => {
     indexedDBStorage.initialize().then(() => {
       setIsInitialized(true);
       loadStorageQuota();
+      refreshBackupManifest();
     });
+  }, []);
+
+  /**
+   * Refresh the cached backup manifest (tracks last full/incremental times).
+   */
+  const refreshBackupManifest = useCallback(async () => {
+    try {
+      const manifest = await indexedDBStorage.getBackupManifest();
+      setBackupManifest(manifest);
+    } catch (err) {
+      // The manifest is informational only; don't surface a hard error.
+      console.error("Failed to load backup manifest:", err);
+    }
   }, []);
 
   /**
@@ -107,81 +153,176 @@ export function useStorageBackup() {
       const quotaInfo = await indexedDBStorage.getStorageQuota();
       setQuota(quotaInfo);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Unknown error';
-      console.error('Failed to load storage quota:', err);
+      const errorMessage = err instanceof Error ? err.message : "Unknown error";
+      console.error("Failed to load storage quota:", err);
       setError({
         message: `Failed to load storage quota: ${errorMessage}`,
-        code: 'QUOTA_LOAD_FAILED',
+        code: "QUOTA_LOAD_FAILED",
         details: err,
       });
     }
   }, []);
 
   /**
-   * Export all user data to a JSON file
+   * Export only the records changed since the last backup (incremental).
+   *
+   * Wraps the existing `indexedDBStorage.exportIncrementalBackup` capability.
+   * The `since` baseline is derived from the backup manifest — the last
+   * incremental time if present, otherwise the last full backup time, falling
+   * back to the epoch so a first-time incremental captures everything as a
+   * baseline delta.
    */
-  const exportData = useCallback(async (filename?: string): Promise<void> => {
-    setStatus('preparing');
-    setProgress(0);
-    setError(null);
+  const exportIncrementalData = useCallback(
+    async (filename?: string): Promise<void> => {
+      setStatus("preparing");
+      setProgress(0);
+      setError(null);
+      setLastIncrementalResult(null);
 
-    try {
-      setStatus('exporting');
-      setProgress(20);
+      try {
+        setStatus("exporting");
+        setProgress(20);
 
-      // Get backup data
-      const backupData = await indexedDBStorage.exportBackup();
-      setProgress(60);
+        // Read the manifest fresh so the baseline is never stale.
+        const manifest = await indexedDBStorage.getBackupManifest();
+        const sinceISO =
+          manifest?.lastIncrementalBackupAt ??
+          manifest?.lastFullBackupAt ??
+          null;
+        const since = sinceISO ? new Date(sinceISO) : new Date(0);
 
-      // Compress the backup (gzip) to keep export files small.
-      const compressed = compressBackup(backupData);
-      const blob = new Blob([compressed as BlobPart], {
-        type: BACKUP_COMPRESSED_MIME,
-      });
-      setProgress(80);
+        const incrementalData =
+          await indexedDBStorage.exportIncrementalBackup(since);
+        setProgress(60);
 
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
+        const compressed = compressData(incrementalData);
+        const blob = new Blob([compressed as BlobPart], {
+          type: BACKUP_COMPRESSED_MIME,
+        });
+        setProgress(80);
 
-      // Generate filename with timestamp
-      const timestamp = new Date().toISOString().split('T')[0];
-      a.download = filename || `planar-nexus-backup-${timestamp}${BACKUP_COMPRESSED_EXTENSION}`;
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        const timestamp = new Date().toISOString().split("T")[0];
+        a.download =
+          filename ||
+          `planar-nexus-incremental-${timestamp}${BACKUP_COMPRESSED_EXTENSION}`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
 
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+        setProgress(100);
+        setStatus("complete");
 
-      setProgress(100);
-      setStatus('complete');
+        setLastIncrementalResult({
+          since: incrementalData.since,
+          exportedAt: incrementalData.exportedAt,
+          deckCount: incrementalData.decks.length,
+          savedGameCount: incrementalData.savedGames.length,
+        });
 
-      // Reload quota after export
-      await loadStorageQuota();
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Unknown error';
-      setError({
-        message: 'Failed to export data',
-        code: 'EXPORT_FAILED',
-        details: err,
-      });
-      setStatus('error');
-      console.error('Export failed:', err);
-    }
-  }, [loadStorageQuota]);
+        await Promise.all([loadStorageQuota(), refreshBackupManifest()]);
+      } catch (err) {
+        const errorMessage =
+          err instanceof Error ? err.message : "Unknown error";
+        setError({
+          message: `Failed to export incremental backup: ${errorMessage}`,
+          code: "EXPORT_INCREMENTAL_FAILED",
+          details: err,
+        });
+        setStatus("error");
+        console.error("Incremental export failed:", err);
+      }
+    },
+    [loadStorageQuota, refreshBackupManifest],
+  );
+
+  /**
+   * Export all user data to a JSON/zip file.
+   *
+   * Routes to {@link exportIncrementalData} when `backupMode` is
+   * `'incremental'`; otherwise performs a full export.
+   */
+  const exportData = useCallback(
+    async (filename?: string): Promise<void> => {
+      if (backupMode === "incremental") {
+        return exportIncrementalData(filename);
+      }
+
+      setStatus("preparing");
+      setProgress(0);
+      setError(null);
+      setLastIncrementalResult(null);
+
+      try {
+        setStatus("exporting");
+        setProgress(20);
+
+        // Get backup data
+        const backupData = await indexedDBStorage.exportBackup();
+        setProgress(60);
+
+        // Compress the backup (gzip) to keep export files small.
+        const compressed = compressData(backupData);
+        const blob = new Blob([compressed as BlobPart], {
+          type: BACKUP_COMPRESSED_MIME,
+        });
+        setProgress(80);
+
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+
+        // Generate filename with timestamp
+        const timestamp = new Date().toISOString().split("T")[0];
+        a.download =
+          filename ||
+          `planar-nexus-backup-${timestamp}${BACKUP_COMPRESSED_EXTENSION}`;
+
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+
+        setProgress(100);
+        setStatus("complete");
+
+        // Reload quota after export
+        await Promise.all([loadStorageQuota(), refreshBackupManifest()]);
+      } catch (err) {
+        const errorMessage =
+          err instanceof Error ? err.message : "Unknown error";
+        setError({
+          message: "Failed to export data",
+          code: "EXPORT_FAILED",
+          details: err,
+        });
+        setStatus("error");
+        console.error("Export failed:", err);
+      }
+    },
+    [
+      backupMode,
+      exportIncrementalData,
+      loadStorageQuota,
+      refreshBackupManifest,
+    ],
+  );
 
   /**
    * Import data from a file
    */
   const importData = useCallback(
     async (file: File, options: Partial<ImportOptions> = {}): Promise<void> => {
-      setStatus('preparing');
+      setStatus("preparing");
       setProgress(0);
       setError(null);
 
       // Merge with default options
       const importOptions: ImportOptions = {
-        conflictResolution: 'overwrite',
+        conflictResolution: "overwrite",
         importDecks: true,
         importSavedGames: true,
         importPreferences: true,
@@ -192,7 +333,7 @@ export function useStorageBackup() {
 
       try {
         // Read file
-        setStatus('importing');
+        setStatus("importing");
         setProgress(20);
 
         // Read as raw bytes so we can detect and handle both the new
@@ -200,45 +341,72 @@ export function useStorageBackup() {
         const buffer = await file.arrayBuffer();
         setProgress(40);
 
-        // Parse and validate (auto-detects compressed vs legacy JSON)
-        setStatus('validating');
-        const backupData = decompressBackup(buffer);
+        // Parse and validate (auto-detects compressed vs legacy JSON).
+        // Generic decompress so we can then branch on full vs incremental.
+        setStatus("validating");
+        const parsed = decompressData<BackupData | IncrementalBackupData>(
+          buffer,
+        );
+        const isIncremental =
+          "type" in parsed &&
+          (parsed as IncrementalBackupData).type === "incremental";
 
-        // Validate backup structure
-        if (!backupData.version || !backupData.exportedAt) {
-          throw new Error('Invalid backup file format');
+        if (isIncremental) {
+          const incremental = parsed as IncrementalBackupData;
+          // Validate incremental structure.
+          if (
+            !incremental.version ||
+            !incremental.exportedAt ||
+            !incremental.checksum ||
+            !Array.isArray(incremental.decks) ||
+            !Array.isArray(incremental.savedGames)
+          ) {
+            throw new Error("Invalid incremental backup file format");
+          }
+          setProgress(60);
+          // Merge the delta without clearing existing data.
+          await indexedDBStorage.importIncrementalBackup(incremental);
+        } else {
+          const backupData = parsed as BackupData;
+          // Validate backup structure
+          if (!backupData.version || !backupData.exportedAt) {
+            throw new Error("Invalid backup file format");
+          }
+
+          setProgress(60);
+
+          // Check conflicts if needed
+          if (importOptions.conflictResolution === "merge") {
+            // For merge strategy, we'd need more complex logic
+            // For now, we'll use overwrite
+            console.warn(
+              "Merge strategy not fully implemented, using overwrite",
+            );
+          }
+
+          // Import data
+          await indexedDBStorage.importBackup(backupData);
         }
-
-        setProgress(60);
-
-        // Check conflicts if needed
-        if (importOptions.conflictResolution === 'merge') {
-          // For merge strategy, we'd need more complex logic
-          // For now, we'll use overwrite
-          console.warn('Merge strategy not fully implemented, using overwrite');
-        }
-
-        // Import data
-        await indexedDBStorage.importBackup(backupData);
         setProgress(90);
 
         setProgress(100);
-        setStatus('complete');
+        setStatus("complete");
 
-        // Reload quota after import
-        await loadStorageQuota();
+        // Reload quota and manifest after import
+        await Promise.all([loadStorageQuota(), refreshBackupManifest()]);
       } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : 'Unknown error';
+        const errorMessage =
+          err instanceof Error ? err.message : "Unknown error";
         setError({
           message: `Failed to import data: ${errorMessage}`,
-          code: 'IMPORT_FAILED',
+          code: "IMPORT_FAILED",
           details: err,
         });
-        setStatus('error');
-        console.error('Import failed:', err);
+        setStatus("error");
+        console.error("Import failed:", err);
       }
     },
-    [loadStorageQuota]
+    [loadStorageQuota, refreshBackupManifest],
   );
 
   /**
@@ -248,13 +416,13 @@ export function useStorageBackup() {
     try {
       const backupData = await indexedDBStorage.exportBackup();
       // Report the compressed size since that is what gets downloaded.
-      return compressBackup(backupData).length;
+      return compressData(backupData).length;
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Unknown error';
-      console.error('Failed to estimate backup size:', err);
+      const errorMessage = err instanceof Error ? err.message : "Unknown error";
+      console.error("Failed to estimate backup size:", err);
       setError({
         message: `Failed to estimate backup size: ${errorMessage}`,
-        code: 'SIZE_ESTIMATE_FAILED',
+        code: "SIZE_ESTIMATE_FAILED",
         details: err,
       });
       return 0;
@@ -265,25 +433,25 @@ export function useStorageBackup() {
    * Clear all data
    */
   const clearAllData = useCallback(async (): Promise<void> => {
-    setStatus('preparing');
+    setStatus("preparing");
     setProgress(0);
     setError(null);
 
     try {
       await indexedDBStorage.clearAll();
-      setStatus('complete');
+      setStatus("complete");
 
       // Reload quota after clear
       await loadStorageQuota();
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Unknown error';
+      const errorMessage = err instanceof Error ? err.message : "Unknown error";
       setError({
         message: `Failed to clear data: ${errorMessage}`,
-        code: 'CLEAR_FAILED',
+        code: "CLEAR_FAILED",
         details: err,
       });
-      setStatus('error');
-      console.error('Clear failed:', err);
+      setStatus("error");
+      console.error("Clear failed:", err);
     }
   }, [loadStorageQuota]);
 
@@ -291,7 +459,7 @@ export function useStorageBackup() {
    * Reset status to idle
    */
   const reset = useCallback(() => {
-    setStatus('idle');
+    setStatus("idle");
     setProgress(0);
     setError(null);
   }, []);
@@ -303,22 +471,37 @@ export function useStorageBackup() {
     error,
     quota,
     isInitialized,
+    backupMode,
+    backupManifest,
+    lastIncrementalResult,
 
     // Actions
     exportData,
+    exportIncrementalData,
     importData,
     getBackupSize,
     clearAllData,
     loadStorageQuota,
+    refreshBackupManifest,
+    setBackupMode,
     reset,
 
     // Computed
-    isProcessing: status !== 'idle' && status !== 'complete' && status !== 'error',
-    isComplete: status === 'complete',
+    isProcessing:
+      status !== "idle" && status !== "complete" && status !== "error",
+    isComplete: status === "complete",
     isApproachingLimit: quota?.approachingLimit || false,
-    storageUsage: quota ? formatBytes(quota.usage) : 'Unknown',
-    storageQuota: quota ? formatBytes(quota.quota) : 'Unknown',
-    storagePercentage: quota?.percentage.toFixed(1) || '0',
+    storageUsage: quota ? formatBytes(quota.usage) : "Unknown",
+    storageQuota: quota ? formatBytes(quota.quota) : "Unknown",
+    storagePercentage: quota?.percentage.toFixed(1) || "0",
+    hasIncrementalBaseline: Boolean(
+      backupManifest?.lastIncrementalBackupAt ||
+      backupManifest?.lastFullBackupAt,
+    ),
+    lastBackupAt:
+      backupManifest?.lastIncrementalBackupAt ??
+      backupManifest?.lastFullBackupAt ??
+      null,
   };
 }
 
@@ -340,7 +523,7 @@ export function validateBackupFile(file: File): Promise<boolean> {
         // Result is raw bytes; decompressBackup handles compressed and
         // legacy formats transparently.
         const bytes = new Uint8Array(e.target?.result as ArrayBuffer);
-        const data = decompressBackup(bytes) as BackupData;
+        const data = decompressData<BackupData>(bytes);
 
         // Check required fields
         const isValid =
@@ -350,13 +533,13 @@ export function validateBackupFile(file: File): Promise<boolean> {
 
         resolve(isValid);
       } catch (err) {
-        console.error('Failed to validate backup file:', err);
+        console.error("Failed to validate backup file:", err);
         resolve(false);
       }
     };
 
     reader.onerror = () => {
-      console.error('Failed to read backup file');
+      console.error("Failed to read backup file");
       resolve(false);
     };
 
@@ -389,7 +572,7 @@ export function getBackupMetadata(file: File): {
  */
 export function downloadBlob(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
+  const a = document.createElement("a");
   a.href = url;
   a.download = filename;
   document.body.appendChild(a);

--- a/src/lib/backup-compression.ts
+++ b/src/lib/backup-compression.ts
@@ -34,28 +34,31 @@ const GZIP_MAGIC_1 = 0x8b;
  * (0x7b), so the two formats are unambiguous.
  */
 export function isGzipBackup(bytes: Uint8Array): boolean {
-  return bytes.length >= 2 && bytes[0] === GZIP_MAGIC_0 && bytes[1] === GZIP_MAGIC_1;
+  return (
+    bytes.length >= 2 && bytes[0] === GZIP_MAGIC_0 && bytes[1] === GZIP_MAGIC_1
+  );
 }
 
 /**
- * Serialize a {@link BackupData} object into a compressed byte buffer.
+ * Serialize an arbitrary object into a compressed byte buffer.
  *
  * The JSON is emitted compactly (no indentation) because whitespace defeats
  * compression; readability of the on-disk artifact is not a goal for the
- * compressed format.
+ * compressed format. Generic so it can back both full ({@link BackupData})
+ * and incremental backup payloads.
  */
-export function compressBackup(data: BackupData): Uint8Array {
+export function compressData<T>(data: T): Uint8Array {
   const json = JSON.stringify(data);
   return gzip(json);
 }
 
 /**
- * Deserialize a backup byte buffer back into a {@link BackupData} object.
+ * Deserialize a compressed/raw byte buffer back into an object of type `T`.
  *
- * Accepts BOTH the new gzip-compressed format and legacy raw-JSON text for
+ * Accepts BOTH the gzip-compressed format and legacy raw-JSON text for
  * backward compatibility. Detection is performed via the gzip magic header.
  */
-export function decompressBackup(input: ArrayBuffer | Uint8Array): BackupData {
+export function decompressData<T>(input: ArrayBuffer | Uint8Array): T {
   const bytes = input instanceof Uint8Array ? input : new Uint8Array(input);
 
   let text: string;
@@ -65,5 +68,23 @@ export function decompressBackup(input: ArrayBuffer | Uint8Array): BackupData {
     text = new TextDecoder().decode(bytes);
   }
 
-  return JSON.parse(text) as BackupData;
+  return JSON.parse(text) as T;
+}
+
+/**
+ * Serialize a {@link BackupData} object into a compressed byte buffer.
+ *
+ * Thin typed wrapper around the generic {@link compressData}.
+ */
+export function compressBackup(data: BackupData): Uint8Array {
+  return compressData(data);
+}
+
+/**
+ * Deserialize a backup byte buffer back into a {@link BackupData} object.
+ *
+ * Thin typed wrapper around the generic {@link decompressData}.
+ */
+export function decompressBackup(input: ArrayBuffer | Uint8Array): BackupData {
+  return decompressData<BackupData>(input);
 }


### PR DESCRIPTION
## Summary

Resolves #927. The storage layer (`src/lib/indexeddb-storage.ts`) already implemented a full incremental-backup capability — `exportIncrementalBackup` / `importIncrementalBackup` plus a `BackupManifest` tracking `lastFullBackupAt` / `lastIncrementalBackupAt` — but it was **unreachable from the UI**. This PR wires it up behind a mode toggle while keeping full backup intact.

## The existing lib capability now wired

- `indexedDBStorage.exportIncrementalBackup(since: Date): Promise<IncrementalBackupData>` — exports only decks/saved games changed since the baseline.
- `indexedDBStorage.importIncrementalBackup(data): Promise<void>` — merges a delta without clearing existing data.
- `indexedDBStorage.getBackupManifest()` — tracks last backup timestamps; updated automatically by the lib after each full/incremental run.

## How the UI exposes it

- **Mode toggle** (`storage-backup-manager.tsx`): a Full / Incremental selector with contextual help text showing the last backup time (from `hasIncrementalBaseline` / `lastBackupAt`).
- **Hook routing** (`use-storage-backup.ts`): `exportData()` now branches on `backupMode` — `'incremental'` delegates to a new `exportIncrementalData()` (which derives `since` from the manifest: last incremental → else last full → else epoch for a first-time baseline delta); `'full'` keeps the original `exportBackup()` path. Both paths gzip-compress via `compressData`.
- **Result surfacing**: after an incremental export, an alert shows the delta summary (`lastIncrementalResult`: decks / saved games changed since `<timestamp>`).
- **Import**: `importData` auto-detects incremental payloads (via `type === 'incremental'`) and routes to `importIncrementalBackup`; full backups still go through `importBackup`.

## Full vs incremental

Both remain first-class: Full = every record; Incremental = only changed records since the last backup, with the manifest-derived `since` baseline. No existing full-backup behavior changed.

## Files changed

- `src/components/storage-backup-manager.tsx` — mode selector, conditional copy/result alert, wired to hook.
- `src/hooks/use-storage-backup.ts` — `BackupMode`, `IncrementalResult`, `exportIncrementalData`, manifest-backed baseline derivation, incremental import routing.
- `src/lib/backup-compression.ts` — generalized `compressData<T>`/`decompressData<T>` (the old `compressBackup`/`decompressBackup` are kept as thin typed wrappers, so **#918 gzip compression is fully preserved** — no regression; the existing `backup-compression.test.ts` still passes).
- `src/hooks/__tests__/use-storage-backup.test.ts` — **new**: 18 tests covering mode toggle, full vs incremental export routing, baseline derivation (manifest `lastIncrementalBackupAt` → `lastFullBackupAt` → epoch), incremental result surfacing, full vs incremental import, and manifest-derived computed values.
- `pnpm-lock.yaml` — adds `pako` + `@types/pako` (the gzip engine backing #918's compression).

## Test results

- `pnpm typecheck` (`tsc --noEmit`): **pass** (0 errors)
- `pnpm lint` on changed files: **pass** (0 errors; remaining 4 warnings are all pre-existing at HEAD)
- `jest` — relevant suites: **39/39 pass** (`use-storage-backup` 18, `backup-compression`, `indexeddb-incremental`)

Closes #927.