### PR TITLE
fix(e2e): raise navigatesidebar helper timeouts to 30s

### DIFF
--- a/e2e/basic-navigation.spec.ts
+++ b/e2e/basic-navigation.spec.ts
@@ -27,9 +27,12 @@ async function navigateViaSidebar(
     .getByRole("link", { name: linkName, exact: true })
     .click();
 
-  await expect(page).toHaveURL(urlRegex);
+  // First navigation to a heavy route triggers a one-time dev-compile that can
+  // exceed Playwright's 5s default. Allow up to 30s for the URL to settle.
+  await expect(page).toHaveURL(urlRegex, { timeout: 30000 });
   await expect(
     page.getByRole("heading", { name: headingName, level: 1, exact: true }),
+    { timeout: 30000 },
   ).toBeVisible();
 }
 
@@ -72,7 +75,12 @@ test.describe("Basic Navigation", () => {
   });
 
   test("should navigate to Multiplayer via sidebar", async ({ page }) => {
-    await navigateViaSidebar(page, "Multiplayer", /\/multiplayer/, "Multiplayer");
+    await navigateViaSidebar(
+      page,
+      "Multiplayer",
+      /\/multiplayer/,
+      "Multiplayer",
+    );
   });
 
   test("should navigate to AI Deck Coach via sidebar", async ({ page }) => {


### PR DESCRIPTION
Root-cause fix for the persistent basic-navigation E2E flake that has affected every PR since #921.

The shared navigateViaSidebar helper (used by ALL sidebar-nav tests) called expect(page).toHaveURL(urlRegex) with Playwright default 5000ms timeout. Heavy routes (Deck Builder, Single Player, Multiplayer) require a one-time dev-compile on first navigation that routinely exceeds 5s, so the URL stays /dashboard/ and the assertion fails intermittently.

#953 attempted to fix this but targeted the wrong call site. This fix updates the actual failing line (the shared helper) so ALL sidebar-nav tests benefit from the 30s timeout.

Pure E2E infrastructure fix — unrelated to any wave-issue PR.