### PR TITLE
fix(a11y): resolve #934 — deck stats charts screen-reader alternatives

### DIFF
--- a/src/app/(app)/deck-builder/_components/__tests__/deck-stats-panel.test.tsx
+++ b/src/app/(app)/deck-builder/_components/__tests__/deck-stats-panel.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * @fileoverview Accessibility tests for DeckStatsPanel
+ *
+ * Verifies the collapse toggle exposes an accessible name and expanded state
+ * to assistive technology (issue #934).
+ */
+
+import { describe, it, expect, jest } from "@jest/globals";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+jest.mock("@/components/ui/card", () => ({
+  Card: ({ children, className, ...props }: any) => (
+    <div className={className} {...props}>
+      {children}
+    </div>
+  ),
+  CardHeader: ({ children, className }: any) => (
+    <div className={className}>{children}</div>
+  ),
+  CardTitle: ({ children, className }: any) => (
+    <h3 className={className}>{children}</h3>
+  ),
+  CardContent: ({ children, className, ...props }: any) => (
+    <div className={className} {...props}>
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, className, ...props }: any) => (
+    <button type="button" onClick={onClick} className={className} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock("@/components/ui/tabs", () => ({
+  Tabs: ({ children }: any) => <div>{children}</div>,
+  TabsList: ({ children }: any) => <div>{children}</div>,
+  TabsTrigger: ({ children, value }: any) => (
+    <button type="button" data-value={value}>
+      {children}
+    </button>
+  ),
+  TabsContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock("@/components/deck-statistics", () => ({
+  ManaCurveChart: () => <div data-testid="mana-curve-chart" />,
+  CardTypeChart: () => <div data-testid="card-type-chart" />,
+  DeckColorChart: () => <div data-testid="deck-color-chart" />,
+}));
+
+jest.mock("@/hooks/use-deck-statistics", () => ({
+  useDeckStatistics: () => ({
+    totalCards: 60,
+    uniqueCards: 40,
+    averageManaValue: 2.1,
+    manaCurve: { 0: 2, 1: 8, 2: 10 },
+    typeDistribution: { creature: 20, instant: 8, land: 24 },
+    colorDistribution: { R: 30, Colorless: 24 },
+  }),
+}));
+
+jest.mock("lucide-react", () => ({
+  BarChart3: () => <svg />,
+  PieChart: () => <svg />,
+  Palette: () => <svg />,
+  ChevronDown: () => <svg />,
+  ChevronUp: () => <svg />,
+  Calculator: () => <svg />,
+}));
+
+import { DeckStatsPanel } from "@/app/(app)/deck-builder/_components/deck-stats-panel";
+
+const deck = [{ id: "card-1", count: 1 }] as any;
+
+describe("DeckStatsPanel — collapse toggle accessibility", () => {
+  it("renders null when the deck is empty", () => {
+    const { container } = render(<DeckStatsPanel deck={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("labels the toggle button and reports the expanded state", () => {
+    render(<DeckStatsPanel deck={deck} />);
+
+    const toggle = screen.getByRole("button", {
+      name: "Collapse deck statistics",
+    });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(toggle).toHaveAttribute("aria-controls", "deck-statistics-content");
+  });
+
+  it("flips the accessible name and expanded state when toggled", () => {
+    render(<DeckStatsPanel deck={deck} />);
+
+    // Expanded initially
+    const collapseBtn = screen.getByRole("button", {
+      name: "Collapse deck statistics",
+    });
+    expect(collapseBtn).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(collapseBtn);
+
+    const expandBtn = screen.getByRole("button", {
+      name: "Expand deck statistics",
+    });
+    expect(expandBtn).toHaveAttribute("aria-expanded", "false");
+    expect(expandBtn).toHaveAttribute("aria-controls", "deck-statistics-content");
+  });
+
+  it("exposes the controlled region via the matching id when expanded", () => {
+    const { container } = render(<DeckStatsPanel deck={deck} />);
+    const region = container.querySelector("#deck-statistics-content");
+    expect(region).not.toBeNull();
+  });
+});

--- a/src/app/(app)/deck-builder/_components/deck-stats-panel.tsx
+++ b/src/app/(app)/deck-builder/_components/deck-stats-panel.tsx
@@ -48,12 +48,15 @@ export function DeckStatsPanel({ deck, className }: DeckStatsPanelProps) {
             variant="ghost"
             size="sm"
             onClick={() => setIsExpanded(!isExpanded)}
+            aria-label={isExpanded ? 'Collapse deck statistics' : 'Expand deck statistics'}
+            aria-expanded={isExpanded}
+            aria-controls="deck-statistics-content"
             className="h-8 w-8 p-0"
           >
             {isExpanded ? (
-              <ChevronUp className="w-4 h-4" />
+              <ChevronUp className="w-4 h-4" aria-hidden="true" />
             ) : (
-              <ChevronDown className="w-4 h-4" />
+              <ChevronDown className="w-4 h-4" aria-hidden="true" />
             )}
           </Button>
         </div>
@@ -68,7 +71,7 @@ export function DeckStatsPanel({ deck, className }: DeckStatsPanelProps) {
       </CardHeader>
       
       {isExpanded && (
-        <CardContent className="space-y-4">
+        <CardContent id="deck-statistics-content" className="space-y-4">
           {/* Chart type selector */}
           <Tabs 
             value={activeChart} 

--- a/src/components/__tests__/deck-statistics-charts.test.tsx
+++ b/src/components/__tests__/deck-statistics-charts.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * @fileoverview Accessibility tests for deck statistics chart components
+ *
+ * Each chart is purely visual (recharts SVG). These tests verify that a
+ * screen-reader text alternative (a visually-hidden data table mirroring the
+ * chart data) is rendered alongside every chart, and that the decorative
+ * SVG chart itself is hidden from assistive technology (issue #934).
+ */
+
+import { describe, it, expect, jest } from "@jest/globals";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// Stub recharts so charts render without jsdom layout dependencies.
+jest.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: any) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  BarChart: ({ children }: any) => (
+    <div data-testid="bar-chart">{children}</div>
+  ),
+  Bar: () => <div data-testid="bar" />,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  PieChart: ({ children }: any) => (
+    <div data-testid="pie-chart">{children}</div>
+  ),
+  Pie: () => <div data-testid="pie" />,
+  Cell: () => null,
+  Legend: () => null,
+}));
+
+jest.mock("@/components/ui/card", () => ({
+  Card: ({ children, className }: any) => (
+    <div className={className}>{children}</div>
+  ),
+  CardHeader: ({ children }: any) => <div>{children}</div>,
+  CardTitle: ({ children }: any) => <h3>{children}</h3>,
+  CardContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock("@/lib/utils", () => ({
+  cn: (...classes: any[]) => classes.filter(Boolean).join(" "),
+}));
+
+// Stub every lucide icon used anywhere in the module under test.
+jest.mock(
+  "lucide-react",
+  () =>
+    new Proxy(
+      {},
+      {
+        get: () => () => <svg data-testid="lucide-icon" />,
+      },
+    ),
+);
+
+import {
+  ManaCurveChart,
+  CardTypeChart,
+  DeckColorChart,
+} from "@/components/deck-statistics";
+
+function chartIsHiddenFromAT(container: HTMLElement): boolean {
+  // The decorative SVG chart must live inside an aria-hidden wrapper.
+  return (
+    container.querySelector('[aria-hidden="true"] [data-testid]') !== null
+  );
+}
+
+describe("ManaCurveChart — screen-reader alternative", () => {
+  it("renders a visually-hidden data table mirroring the mana curve", () => {
+    const { container } = render(
+      <ManaCurveChart manaCurve={{ 0: 2, 1: 8, 2: 6, 7: 3 }} />,
+    );
+
+    const table = container.querySelector("table.sr-only");
+    expect(table).not.toBeNull();
+    expect(table).toHaveTextContent(/Mana curve/i);
+    expect(table).toHaveTextContent("Converted Mana Cost");
+    expect(table).toHaveTextContent("Number of Cards");
+    // CMC bucket labels and counts are present.
+    expect(table).toHaveTextContent("8");
+    expect(table).toHaveTextContent("7+");
+  });
+
+  it("hides the decorative chart from assistive technology", () => {
+    const { container } = render(<ManaCurveChart manaCurve={{ 1: 4 }} />);
+    expect(chartIsHiddenFromAT(container)).toBe(true);
+  });
+});
+
+describe("CardTypeChart — screen-reader alternative", () => {
+  const typeDistribution = { creature: 20, instant: 8, sorcery: 4, land: 24 };
+
+  it("renders a visually-hidden data table for the bar chart", () => {
+    const { container } = render(
+      <CardTypeChart typeDistribution={typeDistribution} chartType="bar" />,
+    );
+
+    const table = container.querySelector("table.sr-only");
+    expect(table).not.toBeNull();
+    expect(table).toHaveTextContent(/Card type breakdown/i);
+    expect(table).toHaveTextContent("Percentage of Deck");
+    expect(table).toHaveTextContent("Creature");
+    expect(table).toHaveTextContent("Land");
+  });
+
+  it("renders a visually-hidden data table for the pie chart", () => {
+    const { container } = render(
+      <CardTypeChart typeDistribution={typeDistribution} chartType="pie" />,
+    );
+
+    const table = container.querySelector("table.sr-only");
+    expect(table).not.toBeNull();
+    expect(table).toHaveTextContent("Creature");
+    expect(table).toHaveTextContent("Instant");
+  });
+
+  it("hides the decorative chart from assistive technology", () => {
+    const { container } = render(
+      <CardTypeChart typeDistribution={typeDistribution} chartType="bar" />,
+    );
+    expect(chartIsHiddenFromAT(container)).toBe(true);
+  });
+
+  it("shows an accessible empty state message when there are no cards", () => {
+    const { container } = render(
+      <CardTypeChart typeDistribution={{}} chartType="bar" />,
+    );
+    expect(container).toHaveTextContent(/No cards in deck/i);
+    expect(container.querySelector("table.sr-only")).toBeNull();
+  });
+});
+
+describe("DeckColorChart — screen-reader alternative", () => {
+  const colorDistribution = { W: 5, U: 3, R: 12, Colorless: 8 };
+
+  it("renders a visually-hidden data table mirroring the color distribution", () => {
+    const { container } = render(
+      <DeckColorChart colorDistribution={colorDistribution} />,
+    );
+
+    const table = container.querySelector("table.sr-only");
+    expect(table).not.toBeNull();
+    expect(table).toHaveTextContent(/Color distribution/i);
+    expect(table).toHaveTextContent("Number of Cards");
+    expect(table).toHaveTextContent("Percentage of Deck");
+    // Resolved color names (not raw codes) are exposed to screen readers.
+    expect(table).toHaveTextContent("White");
+    expect(table).toHaveTextContent("Blue");
+    expect(table).toHaveTextContent("Red");
+    expect(table).toHaveTextContent("Colorless");
+  });
+
+  it("hides the decorative chart from assistive technology", () => {
+    const { container } = render(
+      <DeckColorChart colorDistribution={colorDistribution} />,
+    );
+    expect(chartIsHiddenFromAT(container)).toBe(true);
+  });
+
+  it("shows an accessible empty state message when there are no cards", () => {
+    const { container } = render(<DeckColorChart colorDistribution={{}} />);
+    expect(container).toHaveTextContent(/No cards in deck/i);
+    expect(container.querySelector("table.sr-only")).toBeNull();
+  });
+});

--- a/src/components/deck-statistics.tsx
+++ b/src/components/deck-statistics.tsx
@@ -271,35 +271,54 @@ export function ManaCurveChart({ manaCurve, className }: ManaCurveChartProps) {
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <ResponsiveContainer width="100%" height={200}>
-          <BarChart data={data} margin={{ top: 10, right: 10, left: -10, bottom: 0 }}>
-            <XAxis
-              dataKey="cmc"
-              tick={{ fontSize: 12 }}
-              tickLine={false}
-              axisLine={{ stroke: 'hsl(var(--border))' }}
-            />
-            <YAxis
-              tick={{ fontSize: 12 }}
-              tickLine={false}
-              axisLine={{ stroke: 'hsl(var(--border))' }}
-              width={30}
-            />
-            <Tooltip
-              contentStyle={{
-                backgroundColor: 'hsl(var(--card))',
-                border: '1px solid hsl(var(--border))',
-                borderRadius: '8px',
-              }}
-              formatter={(value: number) => [`${value} cards`, 'Count']}
-            />
-            <Bar
-              dataKey="count"
-              fill="hsl(var(--primary))"
-              radius={[4, 4, 0, 0]}
-            />
-          </BarChart>
-        </ResponsiveContainer>
+        <div aria-hidden="true">
+          <ResponsiveContainer width="100%" height={200}>
+            <BarChart data={data} margin={{ top: 10, right: 10, left: -10, bottom: 0 }}>
+              <XAxis
+                dataKey="cmc"
+                tick={{ fontSize: 12 }}
+                tickLine={false}
+                axisLine={{ stroke: 'hsl(var(--border))' }}
+              />
+              <YAxis
+                tick={{ fontSize: 12 }}
+                tickLine={false}
+                axisLine={{ stroke: 'hsl(var(--border))' }}
+                width={30}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: 'hsl(var(--card))',
+                  border: '1px solid hsl(var(--border))',
+                  borderRadius: '8px',
+                }}
+                formatter={(value: number) => [`${value} cards`, 'Count']}
+              />
+              <Bar
+                dataKey="count"
+                fill="hsl(var(--primary))"
+                radius={[4, 4, 0, 0]}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+        <table className="sr-only">
+          <caption>Mana curve: number of cards at each converted mana cost</caption>
+          <thead>
+            <tr>
+              <th scope="col">Converted Mana Cost</th>
+              <th scope="col">Number of Cards</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((d) => (
+              <tr key={String(d.cmc)}>
+                <th scope="row">{d.cmc}</th>
+                <td>{d.count}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </CardContent>
     </Card>
   );
@@ -346,6 +365,29 @@ export function CardTypeChart({ typeDistribution, chartType = 'pie', className }
     );
   }
 
+  // Screen-reader text alternative mirroring the chart data (WCAG 1.1.1)
+  const typeDataTable = (
+    <table className="sr-only">
+      <caption>Card type breakdown: number and percentage of cards by type</caption>
+      <thead>
+        <tr>
+          <th scope="col">Card Type</th>
+          <th scope="col">Number of Cards</th>
+          <th scope="col">Percentage of Deck</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((d) => (
+          <tr key={d.type}>
+            <th scope="row">{d.type}</th>
+            <td>{d.count}</td>
+            <td>{d.percentage}%</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+
   if (chartType === 'bar') {
     return (
       <Card className={className}>
@@ -355,8 +397,9 @@ export function CardTypeChart({ typeDistribution, chartType = 'pie', className }
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <ResponsiveContainer width="100%" height={200}>
-            <BarChart data={data} layout="vertical" margin={{ top: 10, right: 30, left: 60, bottom: 0 }}>
+          <div aria-hidden="true">
+            <ResponsiveContainer width="100%" height={200}>
+              <BarChart data={data} layout="vertical" margin={{ top: 10, right: 30, left: 60, bottom: 0 }}>
               <XAxis
                 type="number"
                 tick={{ fontSize: 12 }}
@@ -389,6 +432,8 @@ export function CardTypeChart({ typeDistribution, chartType = 'pie', className }
               </Bar>
             </BarChart>
           </ResponsiveContainer>
+          </div>
+          {typeDataTable}
         </CardContent>
       </Card>
     );
@@ -403,33 +448,36 @@ export function CardTypeChart({ typeDistribution, chartType = 'pie', className }
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <ResponsiveContainer width="100%" height={250}>
-          <PieChart>
-            <Pie
-              data={data}
-              cx="50%"
-              cy="50%"
-              outerRadius={80}
-              dataKey="count"
-              nameKey="type"
-              label={({ type, percentage }) => `${type}: ${percentage}%`}
-              labelLine={false}
-            >
-              {data.map((entry, index) => (
-                <Cell key={`cell-${index}`} fill={entry.fill} />
-              ))}
-            </Pie>
-            <Tooltip
-              contentStyle={{
-                backgroundColor: 'hsl(var(--card))',
-                border: '1px solid hsl(var(--border))',
-                borderRadius: '8px',
-              }}
-              formatter={(value: number) => [`${value} cards`, 'Count']}
-            />
-            <Legend />
-          </PieChart>
-        </ResponsiveContainer>
+        <div aria-hidden="true">
+          <ResponsiveContainer width="100%" height={250}>
+            <PieChart>
+              <Pie
+                data={data}
+                cx="50%"
+                cy="50%"
+                outerRadius={80}
+                dataKey="count"
+                nameKey="type"
+                label={({ type, percentage }) => `${type}: ${percentage}%`}
+                labelLine={false}
+              >
+                {data.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={entry.fill} />
+                ))}
+              </Pie>
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: 'hsl(var(--card))',
+                  border: '1px solid hsl(var(--border))',
+                  borderRadius: '8px',
+                }}
+                formatter={(value: number) => [`${value} cards`, 'Count']}
+              />
+              <Legend />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+        {typeDataTable}
       </CardContent>
     </Card>
   );
@@ -493,34 +541,55 @@ export function DeckColorChart({ colorDistribution, className }: DeckColorChartP
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <ResponsiveContainer width="100%" height={250}>
-          <PieChart>
-            <Pie
-              data={data}
-              cx="50%"
-              cy="50%"
-              innerRadius={50}
-              outerRadius={90}
-              dataKey="count"
-              nameKey="color"
-              label={({ color, percentage }) => `${colorNames[color] || color}: ${percentage}%`}
-              labelLine={false}
-            >
-              {data.map((entry, index) => (
-                <Cell key={`cell-${index}`} fill={entry.fill} stroke="hsl(var(--card))" strokeWidth={2} />
-              ))}
-            </Pie>
-            <Tooltip
-              contentStyle={{
-                backgroundColor: 'hsl(var(--card))',
-                border: '1px solid hsl(var(--border))',
-                borderRadius: '8px',
-              }}
-              formatter={(value: number) => [`${value} cards`, 'Count']}
-            />
-            <Legend />
-          </PieChart>
-        </ResponsiveContainer>
+        <div aria-hidden="true">
+          <ResponsiveContainer width="100%" height={250}>
+            <PieChart>
+              <Pie
+                data={data}
+                cx="50%"
+                cy="50%"
+                innerRadius={50}
+                outerRadius={90}
+                dataKey="count"
+                nameKey="color"
+                label={({ color, percentage }) => `${colorNames[color] || color}: ${percentage}%`}
+                labelLine={false}
+              >
+                {data.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={entry.fill} stroke="hsl(var(--card))" strokeWidth={2} />
+                ))}
+              </Pie>
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: 'hsl(var(--card))',
+                  border: '1px solid hsl(var(--border))',
+                  borderRadius: '8px',
+                }}
+                formatter={(value: number) => [`${value} cards`, 'Count']}
+              />
+              <Legend />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+        <table className="sr-only">
+          <caption>Color distribution: number and percentage of cards by color</caption>
+          <thead>
+            <tr>
+              <th scope="col">Color</th>
+              <th scope="col">Number of Cards</th>
+              <th scope="col">Percentage of Deck</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((d) => (
+              <tr key={d.color}>
+                <th scope="row">{colorNames[d.color] || d.color}</th>
+                <td>{d.count}</td>
+                <td>{d.percentage}%</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary

Resolves #934 — the deck statistics section rendered purely visual charts
(recharts SVGs) with **no** screen-reader text alternatives, and the panel's
collapse toggle was an **unlabeled** icon button.

### What changed

**Screen-reader text alternatives for every chart** (`src/components/deck-statistics.tsx`)
- Each chart now renders a visually-hidden data table (`<table class="sr-only">`,
  reusing the existing `.sr-only` utility from `globals.css`) that mirrors the
  chart data, so assistive-tech users get the actual values:
  - **Mana Curve** — caption + CMC bucket → card count
  - **Type Breakdown** (bar & pie) — type → count + percentage
  - **Color Distribution** — resolved color name → count + percentage
- The decorative SVG chart is wrapped in `aria-hidden="true"` so screen readers
  don't stumble through the raw recharts SVG; the data table (a sibling) remains
  in the accessibility tree (WCAG 1.1.1).
- Empty states already expose readable text ("No cards in deck") — left as-is.

**Collapse toggle labeled** (`.../deck-builder/_components/deck-stats-panel.tsx`)
- Added `aria-label` that reflects state ("Collapse deck statistics" /
  "Expand deck statistics").
- Added `aria-expanded` bound to the toggle state.
- Added `aria-controls="deck-statistics-content"` linking to the panel content
  region (which now carries that `id`).
- Marked the chevron icons `aria-hidden="true"`.

### Files changed
- `src/components/deck-statistics.tsx` — sr-only data tables + `aria-hidden` wrappers on `ManaCurveChart`, `CardTypeChart`, `DeckColorChart`.
- `src/app/(app)/deck-builder/_components/deck-stats-panel.tsx` — toggle a11y attributes + controlled-region id.

### Tests added
- `src/components/__tests__/deck-statistics-charts.test.tsx` — verifies each chart renders the sr-only data table (caption, headers, values) and that the decorative chart is `aria-hidden`.
- `src/app/(app)/deck-builder/_components/__tests__/deck-stats-panel.test.tsx` — verifies the toggle exposes an accessible name, correct `aria-expanded`, and `aria-controls`, and flips both on click.

### Test results
- New tests: **13/13 passing**.
- `tsc --noEmit`: clean.
- `eslint` (changed files): clean.

### Notes
- Scope limited to the deck statistics section; no other components touched.
- The shared chart components are currently only consumed by `DeckStatsPanel`,
  so adding the alternatives inside them keeps every usage accessible.