### PR TITLE
test: resolve #931 — integration test suite and jest config fix

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,8 +3,14 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
-  roots: ["<rootDir>/src"],
-  testMatch: ["**/__tests__/**/*.test.ts", "**/__tests__/**/*.test.tsx"],
+  roots: ["<rootDir>/src", "<rootDir>/tests"],
+  testMatch: [
+    "**/__tests__/**/*.test.ts",
+    "**/__tests__/**/*.test.tsx",
+    // Integration tests live in the repo-root <rootDir>/tests directory and
+    // exercise real cross-module workflows. See issue #931.
+    "<rootDir>/tests/**/*.test.ts",
+  ],
   testPathIgnorePatterns: [
     "/src/lib/__tests__/keyword-actions.test.ts",
     "/src/lib/game-state/__tests__/keyword-actions.test.ts",

--- a/tests/backup-roundtrip.integration.test.ts
+++ b/tests/backup-roundtrip.integration.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Integration test: storage backup compress / decompress roundtrip.
+ *
+ * Exercises the real cross-module data flow used by the storage backup feature:
+ *   in-memory BackupData
+ *     -> backup-compression.compressBackup  (pako gzip, RFC-1952 magic header)
+ *     -> isGzipBackup                        (format detection)
+ *     -> backup-compression.decompressBackup (restore, auto-detects gzip vs legacy JSON)
+ *
+ * It also covers the legacy uncompressed-JSON backward-compatibility path and
+ * the generic compressData/decompressData helpers. Resolves issue #931.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import {
+  compressBackup,
+  decompressBackup,
+  compressData,
+  decompressData,
+  isGzipBackup,
+} from "@/lib/backup-compression";
+import type { BackupData } from "@/lib/indexeddb-storage";
+
+function buildBackup(): BackupData {
+  return {
+    version: "2.0.0",
+    exportedAt: "2026-06-24T00:00:00.000Z",
+    decks: [
+      {
+        id: "deck-burn-001",
+        name: "Mono-Red Burn",
+        format: "constructed-core",
+        cards: [],
+        createdAt: "2026-06-01T00:00:00.000Z",
+        updatedAt: "2026-06-24T00:00:00.000Z",
+      },
+    ] as unknown as BackupData["decks"],
+    savedGames: [] as BackupData["savedGames"],
+    preferences: { theme: "dark", soundEnabled: true, lastFormat: "constructed-core" },
+    checksum: "sha256:deadbeefcafef00d",
+  };
+}
+
+describe("backup compress / decompress roundtrip", () => {
+  const data = buildBackup();
+
+  it("compresses a backup into a gzip stream marked by the RFC-1952 magic bytes", () => {
+    const compressed = compressBackup(data);
+    expect(compressed).toBeInstanceOf(Uint8Array);
+    expect(compressed.length).toBeGreaterThan(2);
+    expect(isGzipBackup(compressed)).toBe(true);
+    // gzip magic header doubles as the format marker.
+    expect(compressed[0]).toBe(0x1f);
+    expect(compressed[1]).toBe(0x8b);
+  });
+
+  it("restores a compressed backup byte-for-byte (deep equality)", () => {
+    const compressed = compressBackup(data);
+    const restored = decompressBackup(compressed);
+    expect(restored).toEqual(data);
+    expect(restored.decks[0].name).toBe("Mono-Red Burn");
+    expect(restored.preferences).toEqual(data.preferences);
+  });
+
+  it("restores legacy uncompressed-JSON backups for backward compatibility", () => {
+    // Legacy backups were raw UTF-8 JSON (no gzip magic) -> must not be detected as gzip.
+    const legacyBytes = new TextEncoder().encode(JSON.stringify(data));
+    expect(isGzipBackup(legacyBytes)).toBe(false);
+
+    const restored = decompressData<BackupData>(legacyBytes);
+    expect(restored).toEqual(data);
+  });
+
+  it("accepts ArrayBuffer input (the shape produced by File.arrayBuffer())", () => {
+    const compressed = compressBackup(data);
+    // Reconstruct a standalone ArrayBuffer the same way File.arrayBuffer() would.
+    const buf = new ArrayBuffer(compressed.byteLength);
+    new Uint8Array(buf).set(compressed);
+    const restored = decompressBackup(buf);
+    expect(restored).toEqual(data);
+  });
+
+  it("meaningfully compresses large repetitive payloads", () => {
+    const large = { repeat: "ABCD".repeat(5000), nested: { values: Array.from({ length: 1000 }, (_, i) => i) } };
+    const jsonBytes = new TextEncoder().encode(JSON.stringify(large)).length;
+    const compressed = compressData(large);
+    expect(isGzipBackup(compressed)).toBe(true);
+    // gzip should crush 20KB of repetition to a small fraction of its size.
+    expect(compressed.length).toBeLessThan(jsonBytes * 0.1);
+  });
+
+  it("round-trips arbitrary typed payloads through the generic helpers", () => {
+    const payload = { count: 42, items: ["a", "b", "c"], flag: false };
+    const restored = decompressData<typeof payload>(compressData(payload));
+    expect(restored).toEqual(payload);
+  });
+});

--- a/tests/deck-construction.integration.test.ts
+++ b/tests/deck-construction.integration.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Integration test: deck construction pipeline.
+ *
+ * Exercises the real cross-module flow a user triggers when building a deck:
+ *   decklist text
+ *     -> decklist-utils.parseDecklist (parsing + format detection)
+ *     -> game-rules.validateDeckFormat (constructed format legality)
+ *     -> deck-analyzer.analyzeDeck (heuristic mana-curve / color / type analysis)
+ *
+ * Nothing is mocked — the three modules are wired together the same way the
+ * deck-builder UI wires them. Resolves issue #931.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import { parseDecklist, detectDecklistFormat } from "@/lib/decklist-utils";
+import { validateDeckFormat, type Format } from "@/lib/game-rules";
+import { analyzeDeck } from "@/lib/deck-analyzer";
+import type { DeckCard } from "@/app/actions";
+import { makeCard, buildDeckFromLines, type CardSpec } from "./helpers/cards";
+
+// A legal 60-card mono-red constructed decklist (9 playsets + 24 Mountains).
+const DECKLIST_60 = [
+  "4 Lightning Bolt",
+  "4 Lava Spike",
+  "4 Rift Bolt",
+  "4 Skullcrack",
+  "4 Monastery Swiftspear",
+  "4 Goblin Guide",
+  "4 Eidolon of the Great Revel",
+  "4 Boggart Ram-Gang",
+  "4 Kird Ape",
+  "24 Mountain",
+].join("\n");
+
+/** Name -> card spec lookup so parsed quantities attach to rich card data. */
+function cardLookup(name: string): CardSpec {
+  switch (name) {
+    case "Lightning Bolt":
+      return {
+        name,
+        cmc: 1,
+        colors: ["R"],
+        type_line: "Instant",
+        oracle_text: "Lightning Bolt deals 3 damage to any target.",
+      };
+    case "Lava Spike":
+      return { name, cmc: 1, colors: ["R"], type_line: "Sorcery", oracle_text: "Lava Spike deals 3 damage to target player or planeswalker." };
+    case "Rift Bolt":
+      return { name, cmc: 2, colors: ["R"], type_line: "Sorcery", oracle_text: "Rift Bolt deals 3 damage to any target." };
+    case "Skullcrack":
+      return { name, cmc: 2, colors: ["R"], type_line: "Instant", oracle_text: "Damage can't be prevented this turn." };
+    case "Monastery Swiftspear":
+      return { name, cmc: 1, colors: ["R"], type_line: "Creature — Human Monk" };
+    case "Goblin Guide":
+      return { name, cmc: 1, colors: ["R"], type_line: "Creature — Goblin Scout" };
+    case "Eidolon of the Great Revel":
+      return { name, cmc: 2, colors: ["R"], type_line: "Creature — Spirit" };
+    case "Boggart Ram-Gang":
+      return { name, cmc: 3, colors: ["R", "G"], type_line: "Creature — Goblin Warrior" };
+    case "Kird Ape":
+      return { name, cmc: 1, colors: ["R"], type_line: "Creature — Ape" };
+    case "Mountain":
+      return { name, cmc: 0, colors: [], type_line: "Basic Land — Mountain" };
+    default:
+      return { name, cmc: 2, colors: ["R"], type_line: "Creature" };
+  }
+}
+
+const CONSTRUCTED: Format = "constructed-core";
+
+describe("deck construction pipeline (parse -> validate -> analyze)", () => {
+  it("parses the decklist into the expected card set and detects MTGO-style format", () => {
+    const parsed = parseDecklist(DECKLIST_60);
+    expect(parsed).toHaveLength(10);
+    const total = parsed.reduce((sum, c) => sum + c.quantity, 0);
+    expect(total).toBe(60);
+    expect(parsed.find((c) => c.name === "Mountain")?.quantity).toBe(24);
+
+    // detectDecklistFormat sees leading "<count> <Name>" lines as MTGO format.
+    expect(detectDecklistFormat(DECKLIST_60)).toBe("mtgo");
+  });
+
+  it("validates a legal 60-card deck as legal for constructed-core", () => {
+    const cards = buildDeckFromLines(DECKLIST_60.split("\n"), cardLookup);
+    const result = validateDeckFormat(
+      cards.map((c) => ({
+        name: c.name,
+        count: c.count,
+        color_identity: c.color_identity,
+        type_line: c.type_line,
+      })),
+      CONSTRUCTED,
+    );
+
+    expect(result.isValid).toBe(true);
+    expect(result.format).toBe(CONSTRUCTED);
+    expect(result.deckSize).toBe(60);
+    expect(result.requiredSize).toBe(60);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("rejects an undersized deck with a descriptive minimum-card error", () => {
+    const undersized: DeckCard[] = [makeCard({ ...cardLookup("Mountain"), count: 24 })];
+    const result = validateDeckFormat(
+      undersized.map((c) => ({
+        name: c.name,
+        count: c.count,
+        color_identity: c.color_identity,
+        type_line: c.type_line,
+      })),
+      CONSTRUCTED,
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.deckSize).toBe(24);
+    expect(result.errors.some((e) => /at least 60/i.test(e))).toBe(true);
+  });
+
+  it("analyzes the legal deck and reports a coherent mana curve, color, and type breakdown", () => {
+    const cards = buildDeckFromLines(DECKLIST_60.split("\n"), cardLookup);
+    const analysis = analyzeDeck(cards, CONSTRUCTED);
+
+    // Overall rating is always clamped to 1..10.
+    expect(analysis.overallRating).toBeGreaterThanOrEqual(1);
+    expect(analysis.overallRating).toBeLessThanOrEqual(10);
+
+    // 36 non-land cards with a total CMC of 56 -> average ~= 1.555...
+    const totalNonLandCmc =
+      1 * 4 + // Lightning Bolt
+      1 * 4 + // Lava Spike
+      2 * 4 + // Rift Bolt
+      2 * 4 + // Skullcrack
+      1 * 4 + // Monastery Swiftspear
+      1 * 4 + // Goblin Guide
+      2 * 4 + // Eidolon
+      3 * 4 + // Boggart Ram-Gang
+      1 * 4; //  Kird Ape
+    expect(analysis.manaCurve.averageCMC).toBeCloseTo(totalNonLandCmc / 36, 5);
+
+    // Type counts flow straight from type_line classification.
+    expect(analysis.cardTypeDistribution.lands).toBe(24);
+    expect(analysis.cardTypeDistribution.spells).toBe(16); // 4 instants + 12 sorceries
+    expect(analysis.cardTypeDistribution.creatures).toBe(20);
+
+    // Red everywhere, plus green pip from Boggart Ram-Gang -> two colors.
+    expect(analysis.colorDistribution.colorCount).toBe(2);
+    expect(analysis.colorDistribution.colors.R).toBeGreaterThan(0);
+    expect(analysis.colorDistribution.colors.G).toBeGreaterThan(0);
+
+    // The analyzer always emits at least an empty suggestions array of the right shape.
+    expect(Array.isArray(analysis.suggestions)).toBe(true);
+    for (const s of analysis.suggestions) {
+      expect(["high", "medium", "low"]).toContain(s.priority);
+    }
+  });
+});

--- a/tests/helpers/cards.ts
+++ b/tests/helpers/cards.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared card fixtures for integration tests.
+ *
+ * Builds objects satisfying the `DeckCard` / `MinimalCard` shape that the
+ * deck-pipeline modules (decklist-utils, game-rules, deck-analyzer) read, so
+ * tests can drive real cross-module workflows without hitting Scryfall.
+ */
+
+import type { DeckCard } from "@/app/actions";
+
+export interface CardSpec {
+  name: string;
+  cmc?: number;
+  colors?: string[];
+  color_identity?: string[];
+  type_line?: string;
+  oracle_text?: string;
+  count?: number;
+}
+
+/** Build a single DeckCard fixture with sensible defaults. */
+export function makeCard(spec: CardSpec): DeckCard {
+  const {
+    name,
+    cmc = 0,
+    colors = [],
+    color_identity = colors,
+    type_line = "Creature",
+    oracle_text = "",
+    count = 1,
+  } = spec;
+  return {
+    id: `card-${name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
+    name,
+    cmc,
+    colors,
+    color_identity,
+    type_line,
+    oracle_text,
+    legalities: {},
+    count,
+  };
+}
+
+/** Build a DeckCard[] from "Quantity Name" lines, mapping names via a lookup. */
+export function buildDeckFromLines(
+  lines: string[],
+  lookup: (name: string) => CardSpec,
+): DeckCard[] {
+  return lines.map((line) => {
+    const match = line.trim().match(/^(\d+)\s+(.+)$/);
+    if (!match) throw new Error(`Bad decklist line: ${line}`);
+    const quantity = parseInt(match[1], 10);
+    return makeCard({ ...lookup(match[2]), count: quantity });
+  });
+}

--- a/tests/lobby-deck-validation.integration.test.ts
+++ b/tests/lobby-deck-validation.integration.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Integration test: lobby deck validation pipeline.
+ *
+ * Exercises the multi-layer flow used by the multiplayer lobby:
+ *   parsed decklist text
+ *     -> decklist-utils.parseDecklist
+ *     -> build a SavedDeck (deck-builder layer)
+ *     -> format-validator.validateDeckForLobby / canPlayerJoinWithDeck
+ *        (lobby layer, which internally delegates to game-rules.validateDeckFormat)
+ *
+ * This crosses three layers: parsing, deck construction, and lobby readiness.
+ * Resolves issue #931.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import { parseDecklist } from "@/lib/decklist-utils";
+import {
+  validateDeckForLobby,
+  canPlayerJoinWithDeck,
+  validateDeckForReadyStatus,
+  getFormatRulesSummary,
+} from "@/lib/format-validator";
+import type { SavedDeck, DeckCard } from "@/app/actions";
+import { buildDeckFromLines, type CardSpec } from "./helpers/cards";
+
+const DECKLIST_60 = [
+  "4 Lightning Bolt",
+  "4 Lava Spike",
+  "4 Rift Bolt",
+  "4 Skullcrack",
+  "4 Monastery Swiftspear",
+  "4 Goblin Guide",
+  "4 Eidolon of the Great Revel",
+  "4 Boggart Ram-Gang",
+  "4 Kird Ape",
+  "24 Mountain",
+].join("\n");
+
+function cardLookup(name: string): CardSpec {
+  switch (name) {
+    case "Lightning Bolt":
+      return { name, cmc: 1, colors: ["R"], type_line: "Instant" };
+    case "Lava Spike":
+      return { name, cmc: 1, colors: ["R"], type_line: "Sorcery" };
+    case "Rift Bolt":
+      return { name, cmc: 2, colors: ["R"], type_line: "Sorcery" };
+    case "Skullcrack":
+      return { name, cmc: 2, colors: ["R"], type_line: "Instant" };
+    case "Monastery Swiftspear":
+      return { name, cmc: 1, colors: ["R"], type_line: "Creature — Human Monk" };
+    case "Goblin Guide":
+      return { name, cmc: 1, colors: ["R"], type_line: "Creature — Goblin Scout" };
+    case "Eidolon of the Great Revel":
+      return { name, cmc: 2, colors: ["R"], type_line: "Creature — Spirit" };
+    case "Boggart Ram-Gang":
+      return { name, cmc: 3, colors: ["R", "G"], type_line: "Creature — Goblin Warrior" };
+    case "Kird Ape":
+      return { name, cmc: 1, colors: ["R"], type_line: "Creature — Ape" };
+    case "Mountain":
+      return { name, cmc: 0, colors: [], type_line: "Basic Land — Mountain" };
+    default:
+      return { name, cmc: 2, colors: ["R"], type_line: "Creature" };
+  }
+}
+
+function buildSavedDeck(format: SavedDeck["format"]): SavedDeck {
+  const parsed = parseDecklist(DECKLIST_60);
+  const byName = new Map(buildDeckFromLines(DECKLIST_60.split("\n"), cardLookup).map((c) => [c.name, c]));
+  const cards: DeckCard[] = parsed.map((p) => {
+    const base = byName.get(p.name)!;
+    return { ...base, count: p.quantity };
+  });
+  const now = new Date("2026-06-24T00:00:00.000Z").toISOString();
+  return {
+    id: "deck-burn-001",
+    name: "Mono-Red Burn",
+    format,
+    cards,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+describe("lobby deck validation pipeline (parse -> SavedDeck -> lobby readiness)", () => {
+  const deck = buildSavedDeck("constructed-core");
+
+  it("accepts a legal, format-matching deck for the lobby", () => {
+    const result = validateDeckForLobby(deck, "constructed-core");
+    expect(result.isValid).toBe(true);
+    expect(result.canPlay).toBe(true);
+
+    expect(canPlayerJoinWithDeck(deck, "constructed-core").canJoin).toBe(true);
+
+    const ready = validateDeckForReadyStatus(deck, "constructed-core");
+    expect(ready.isReady).toBe(true);
+  });
+
+  it("blocks joining when the deck format mismatches the lobby format", () => {
+    // constructed-legacy has the same 60-card floor, so the deck is still
+    // *legal* — but canPlay must be false because the formats don't match.
+    const result = validateDeckForLobby(deck, "constructed-legacy");
+    expect(result.isValid).toBe(true);
+    expect(result.canPlay).toBe(false);
+    // The lobby layer renders the lobby format via its display name ("Constructed Legacy").
+    expect(result.warnings.some((w) => /but lobby is/i.test(w))).toBe(true);
+
+    const join = canPlayerJoinWithDeck(deck, "constructed-legacy");
+    expect(join.canJoin).toBe(false);
+    expect(join.reason).toBeTruthy();
+
+    const ready = validateDeckForReadyStatus(deck, "constructed-legacy");
+    expect(ready.isReady).toBe(false);
+  });
+
+  it("refuses ready status when no deck is selected", () => {
+    const ready = validateDeckForReadyStatus(null, "constructed-core");
+    expect(ready.isReady).toBe(false);
+    expect(ready.errors).toContain("No deck selected");
+  });
+
+  it("exposes a human-readable format rules summary through the lobby layer", () => {
+    const summary = getFormatRulesSummary("constructed-core");
+    expect(summary.formatName).toBe("Constructed Core");
+    expect(summary.rules.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/turn-lifecycle.integration.test.ts
+++ b/tests/turn-lifecycle.integration.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Integration test: full turn lifecycle simulation.
+ *
+ * Rather than re-checking individual helpers (covered by unit tests), this
+ * drives the real turn-structure workflow end-to-end across two game-state
+ * modules (types.ts + turn-phases.ts):
+ *   createTurn
+ *     -> walk a complete Untap..Cleanup cycle via advancePhase / getNextPhase
+ *     -> assert spell-speed permission gating flips at the right steps
+ *        (main vs combat vs no-priority), exercising the cross-step invariants
+ *     -> startNextTurn (player handoff + draw eligibility)
+ *     -> addExtraTurn / hasExtraTurn (extra-turn accounting)
+ *
+ * Resolves issue #931.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import { Phase } from "@/lib/game-state/types";
+import {
+  createTurn,
+  advancePhase,
+  getNextPhase,
+  isMainPhase,
+  isCombatPhase,
+  isBeginningPhase,
+  isEndingPhase,
+  playersGetPriority,
+  canCastSorcerySpeedSpells,
+  canCastInstantSpeedSpells,
+  startNextTurn,
+  addExtraTurn,
+  hasExtraTurn,
+  playerDrawsCard,
+  getPhaseName,
+} from "@/lib/game-state/turn-phases";
+
+// The canonical MTG turn structure, shared by turn-phases.ts.
+const FULL_TURN_ORDER: Phase[] = [
+  Phase.UNTAP,
+  Phase.UPKEEP,
+  Phase.DRAW,
+  Phase.PRECOMBAT_MAIN,
+  Phase.BEGIN_COMBAT,
+  Phase.DECLARE_ATTACKERS,
+  Phase.DECLARE_BLOCKERS,
+  Phase.COMBAT_DAMAGE_FIRST_STRIKE,
+  Phase.COMBAT_DAMAGE,
+  Phase.END_COMBAT,
+  Phase.POSTCOMBAT_MAIN,
+  Phase.END,
+  Phase.CLEANUP,
+];
+
+describe("full turn lifecycle simulation", () => {
+  it("creates a first turn rooted at the Untap step with no draw", () => {
+    const turn = createTurn("player-1", 1, true);
+    expect(turn.activePlayerId).toBe("player-1");
+    expect(turn.turnNumber).toBe(1);
+    expect(turn.currentPhase).toBe(Phase.UNTAP);
+    expect(turn.isFirstTurn).toBe(true);
+    // On the very first turn of a game the starting player does not draw.
+    expect(playerDrawsCard(turn)).toBe(false);
+  });
+
+  it("walks the complete Untap -> Cleanup cycle with no gaps or repeats", () => {
+    // Verify the static phase chain first.
+    const chain: Phase[] = [Phase.UNTAP];
+    let cursor: Phase | null = Phase.UNTAP;
+    while ((cursor = getNextPhase(cursor)) !== null) chain.push(cursor);
+    expect(chain).toEqual(FULL_TURN_ORDER);
+    expect(getNextPhase(Phase.CLEANUP)).toBeNull();
+
+    // Now simulate driving a turn forward step by step, collecting visited phases.
+    let turn = createTurn("player-1", 1, true);
+    const visited: Phase[] = [turn.currentPhase];
+    for (let i = 0; i < FULL_TURN_ORDER.length - 1; i++) {
+      turn = advancePhase(turn);
+      visited.push(turn.currentPhase);
+    }
+    expect(turn.currentPhase).toBe(Phase.CLEANUP);
+    expect(visited).toEqual(FULL_TURN_ORDER);
+  });
+
+  it("flips spell-speed permissions correctly as the phase context changes", () => {
+    // Beginning phase: untap grants no priority; upkeep/draw do.
+    expect(playersGetPriority(Phase.UNTAP)).toBe(false);
+    expect(canCastInstantSpeedSpells(Phase.UNTAP)).toBe(false);
+    expect(canCastInstantSpeedSpells(Phase.UPKEEP)).toBe(true);
+
+    // Main phase: sorcery-speed allowed only when the stack is empty.
+    expect(isMainPhase(Phase.PRECOMBAT_MAIN)).toBe(true);
+    expect(isCombatPhase(Phase.PRECOMBAT_MAIN)).toBe(false);
+    expect(canCastSorcerySpeedSpells(Phase.PRECOMBAT_MAIN, true)).toBe(true);
+    expect(canCastSorcerySpeedSpells(Phase.PRECOMBAT_MAIN, false)).toBe(false);
+
+    // Combat phase: never sorcery-speed; instants still allowed where priority exists.
+    expect(isCombatPhase(Phase.DECLARE_ATTACKERS)).toBe(true);
+    expect(isMainPhase(Phase.DECLARE_ATTACKERS)).toBe(false);
+    expect(canCastSorcerySpeedSpells(Phase.DECLARE_ATTACKERS, true)).toBe(false);
+    expect(canCastInstantSpeedSpells(Phase.DECLARE_BLOCKERS)).toBe(true);
+
+    // Ending phase: cleanup grants no priority.
+    expect(isEndingPhase(Phase.CLEANUP)).toBe(true);
+    expect(playersGetPriority(Phase.CLEANUP)).toBe(false);
+  });
+
+  it("hands the turn to the next player and re-enables the draw", () => {
+    const firstTurn = createTurn("player-1", 1, true);
+    const secondTurn = startNextTurn(firstTurn, "player-2");
+
+    expect(secondTurn.activePlayerId).toBe("player-2");
+    expect(secondTurn.turnNumber).toBe(2);
+    expect(secondTurn.currentPhase).toBe(Phase.UNTAP);
+    expect(secondTurn.isFirstTurn).toBe(false);
+    // From the second turn onward the active player draws in their draw step.
+    expect(playerDrawsCard(secondTurn)).toBe(true);
+  });
+
+  it("accounts for extra turns across a handoff", () => {
+    let turn = createTurn("player-1", 3, false);
+    turn = addExtraTurn(turn, 1);
+    expect(hasExtraTurn(turn)).toBe(true);
+    expect(turn.extraTurns).toBe(1);
+
+    // The current player takes another turn instead of passing.
+    const next = startNextTurn(turn, "player-1");
+    expect(next.activePlayerId).toBe("player-1");
+    expect(next.extraTurns).toBe(0);
+    expect(hasExtraTurn(next)).toBe(false);
+  });
+
+  it("keeps beginning / main / combat / ending buckets mutually consistent for every phase", () => {
+    // Cross-step invariant: every phase falls into exactly the expected bucket,
+    // a property the UI relies on to render the turn wheel.
+    for (const phase of FULL_TURN_ORDER) {
+      const buckets = [isBeginningPhase(phase), isMainPhase(phase), isCombatPhase(phase), isEndingPhase(phase)];
+      // Beginning, main, combat, ending are disjoint; cleanup/end are "ending".
+      const trueCount = buckets.filter(Boolean).length;
+      expect(trueCount).toBeGreaterThanOrEqual(1);
+      // Main and combat never overlap.
+      expect(isMainPhase(phase) && isCombatPhase(phase)).toBe(false);
+      // Every phase has a display name.
+      expect(getPhaseName(phase).length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #931. The repo had **zero** integration tests: there was no `tests/` directory, and `jest.config.js` actively excluded one because `roots` was limited to `<rootDir>/src` and `testMatch` only matched `**/__tests__/**`. This PR makes a repo-root `tests/` directory discoverable and adds a meaningful integration suite that exercises real cross-module workflows (no heavy mocking).

## Jest config change (`jest.config.js`)

- `roots`: added `"<rootDir>/tests"` alongside `"<rootDir>/src"`.
- `testMatch`: added the explicit pattern `"<rootDir>/tests/**/*.test.ts"` so root-level integration tests are discovered (and only the root `tests/` dir, not nested dirs elsewhere).
- `testPathIgnorePatterns` and the CI coverage gate (`collectCoverageFrom` is `src/**`-only) are untouched, so this adds no coverage-threshold risk and doesn't un-ignore anything.

Convention: integration tests live in `tests/**/*.integration.test.ts`.

## Integration tests added (4 suites, 20 tests)

| Suite | Modules wired together | Workflow covered |
| --- | --- | --- |
| `tests/deck-construction.integration.test.ts` | `decklist-utils` → `game-rules` → `deck-analyzer` | Parse decklist text → detect format → validate constructed legality (60-card legal vs. undersized rejection) → heuristic mana-curve / color / type analysis with verified counts |
| `tests/lobby-deck-validation.integration.test.ts` | `decklist-utils` → `game-rules` → `format-validator` | Parse → build `SavedDeck` → lobby readiness: format-match join, format-mismatch block, no-deck refusal, format rules summary |
| `tests/backup-roundtrip.integration.test.ts` | `backup-compression` (pako gzip) + serialization | Compress → gzip magic-byte detection → decompress deep-equality; legacy raw-JSON backward-compat path; `ArrayBuffer` input; large-payload compression ratio; generic typed roundtrip |
| `tests/turn-lifecycle.integration.test.ts` | `game-state/types` + `game-state/turn-phases` | Full Untap→Cleanup cycle simulation with no gaps/repeats; spell-speed permission gating per phase; next-player handoff + draw eligibility; extra-turn accounting; bucket invariants |

A shared `tests/helpers/cards.ts` fixture builder keeps the deck tests DRY.

## Test results

- `npx jest tests/<the 4 suites>` → **4 suites, 20 tests passed**
- Full suite (`npx jest`) → **208 suites, 3899 passed, 0 failed** (10 skipped, 48 todo)
- `tsc --noEmit` → **clean**
- `eslint src tests` → **0 errors** (only pre-existing warnings, under the 1000 cap)

> Note: the previously-flaky `src/lib/__tests__/opponent-deck-generator.test.ts` passed on these runs; if it fails in CI it is pre-existing and unrelated to this change.