### PR TITLE
feat: resolve #932 — deck-builder keyboard shortcuts

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -33,16 +33,19 @@
 3. Run the installer following platform-specific instructions:
 
 **Windows**:
+
 - Double-click the `.exe` file
 - If SmartScreen warns, click "More info" → "Run anyway"
 - Follow installation prompts
 
 **macOS**:
+
 - Open the `.dmg` file
 - Drag Planar Nexus to Applications folder
 - If blocked, right-click → Open → Open
 
 **Linux**:
+
 ```bash
 # Debian/Ubuntu
 sudo dpkg -i planar-nexus_1.0.0_amd64.deb
@@ -88,6 +91,7 @@ chmod +x Planar-Nexus.AppImage
 ```
 
 **Main Navigation**:
+
 - **Dashboard**: Overview and quick access to features
 - **Deck Builder**: Create and manage decks
 - **AI Coach**: Get deck analysis and recommendations
@@ -152,54 +156,62 @@ The deck validator runs automatically as you build:
 #### Real-time Feedback
 
 **Deck Status Panel** shows:
+
 - **Card Count**: Current/Required (e.g., "98/100" for Commander)
 - **Format Compliance**: ✓ Legal or ✗ Illegal
 - **Warnings**: Issues that need attention
 
 #### Common Validation Issues
 
-| Issue | Description | Solution |
-|-------|-------------|----------|
-| **Too few cards** | Deck has fewer than minimum | Add more cards (100 for Commander, 60 for Standard) |
-| **Too many cards** | Deck exceeds maximum | Remove cards (100 max for Commander) |
-| **Illegal cards** | Cards not legal in format | Remove or replace with legal cards |
-| **Color identity violation** | Cards outside commander's colors | Remove cards with conflicting colors |
-| **Duplicate legendary cards** | More than one copy of legendary | Reduce to 1 copy |
+| Issue                         | Description                      | Solution                                            |
+| ----------------------------- | -------------------------------- | --------------------------------------------------- |
+| **Too few cards**             | Deck has fewer than minimum      | Add more cards (100 for Commander, 60 for Standard) |
+| **Too many cards**            | Deck exceeds maximum             | Remove cards (100 max for Commander)                |
+| **Illegal cards**             | Cards not legal in format        | Remove or replace with legal cards                  |
+| **Color identity violation**  | Cards outside commander's colors | Remove cards with conflicting colors                |
+| **Duplicate legendary cards** | More than one copy of legendary  | Reduce to 1 copy                                    |
 
 ### 2.4 Deck Statistics
 
 View deck analytics in the **Statistics Panel**:
 
 #### Mana Curve
+
 - Bar chart showing card distribution by CMC
 - Ideal curves vary by archetype (Aggro: low CMC, Control: higher CMC)
 
 #### Color Distribution
+
 - Pie chart showing color breakdown
 - Helps identify color balance
 
 #### Card Type Distribution
+
 - Breakdown by creature, spell, land, etc.
 - Ensure adequate land count (typically 35-40 for Commander)
 
 ### 2.5 Saving and Managing Decks
 
 #### Auto-Save
+
 - Decks auto-save on every change
 - No manual save required during editing
 
 #### Manual Save
+
 - Press `Ctrl+S` to force save
 - Click **"Save Deck"** button
 
 #### Organize Decks
 
 **Deck Library** shows all saved decks:
+
 - **Search**: Filter by deck name
 - **Sort**: By name, date modified, or format
 - **Folders**: Create folders to organize decks (optional)
 
 #### Delete a Deck
+
 1. Find deck in library
 2. Click the **⋮** menu
 3. Select **"Delete"**
@@ -230,6 +242,7 @@ View deck analytics in the **Statistics Panel**:
 The AI Coach report includes several sections:
 
 #### Archetype Badge
+
 ```
 ┌─────────────────────────┐
 │  🔥 BURN                │
@@ -243,6 +256,7 @@ The AI Coach report includes several sections:
 - **Secondary**: Alternative archetype classification
 
 **Detected Archetypes** (18 total):
+
 - **Aggro**: Burn, Zoo, Sligh
 - **Control**: Draw-Go, Stax, Prison
 - **Midrange**: Good Stuff, Rock, Value
@@ -251,6 +265,7 @@ The AI Coach report includes several sections:
 - **Special**: Lands, Superfriends
 
 #### Synergy List
+
 ```
 Synergies Found (4):
 ┌────────────────────────────────────────────┐
@@ -270,6 +285,7 @@ Synergies Found (4):
 - **Description**: Why this synergy matters
 
 #### Missing Synergies
+
 ```
 Missing Synergies (2):
 ┌────────────────────────────────────────────┐
@@ -290,6 +306,7 @@ Missing Synergies (2):
 - **Suggestion**: Specific cards to consider
 
 #### Key Cards
+
 ```
 Key Cards (5):
 ┌────────────────────────────────────────────┐
@@ -305,6 +322,7 @@ Key Cards (5):
 - **Role**: Why this card matters to your strategy
 
 #### Improvement Suggestions
+
 ```
 Suggestions:
 • Consider adding 2-3 more burn spells for consistency
@@ -315,16 +333,19 @@ Suggestions:
 ### 3.3 Exporting Reports
 
 #### Export as Text
+
 1. Click **"Export"** button in report header
 2. Select **"Download as Text"**
 3. Save `.txt` file to your computer
 
 #### Export as PDF
+
 1. Click **"Export"** button
 2. Select **"Print to PDF"**
 3. Use browser's print dialog to save as PDF
 
 #### Share Report
+
 - Copy report text to clipboard
 - Share via email, Discord, or forum posts
 - Include decklist for context
@@ -362,6 +383,7 @@ Suggestions:
 ### 4.2 Playing a Game
 
 #### Game Interface
+
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │  Opponent (Life: 20)                                        │
@@ -419,21 +441,25 @@ Suggestions:
 ### 4.3 Difficulty Levels Explained
 
 #### Easy
+
 - **Behavior**: Makes obvious mistakes, inefficient plays
 - **Best For**: Learning game mechanics, testing combos
 - **Tips**: Focus on fundamentals, practice sequencing
 
 #### Medium
+
 - **Behavior**: Reasonable plays, occasional blunders
 - **Best For**: Casual play, deck testing
 - **Tips**: Respect their threats, plan ahead
 
 #### Hard
+
 - **Behavior**: Strong plays, rare mistakes, punishes errors
 - **Best For**: Experienced players, serious testing
 - **Tips**: Play around their outs, maximize value
 
 #### Expert
+
 - **Behavior**: Near-optimal play, deep planning
 - **Best For**: Challenge, high-level testing
 - **Tips**: Perfect play required, no room for error
@@ -441,6 +467,7 @@ Suggestions:
 ### 4.4 Game History
 
 #### View Past Games
+
 1. After game ends, click **"View History"**
 2. See list of recent games with:
    - Opponent and difficulty
@@ -449,6 +476,7 @@ Suggestions:
    - Date played
 
 #### Replay a Game
+
 1. Select a game from history
 2. Click **"Replay"**
 3. Watch game unfold turn by turn
@@ -491,16 +519,19 @@ Suggestions:
 ### 5.3 Playing Multiplayer
 
 #### Team Mode (2v2)
+
 - You and your partner share turns
 - Attack either opponent
 - Win by eliminating both opponents
 
 #### Free-for-All (4-player)
+
 - Each player takes individual turns
 - Attack any opponent
 - Last player standing wins
 
 #### Spectator Mode
+
 - Watch games without playing
 - See all hands and board states
 - Chat with other spectators
@@ -512,6 +543,7 @@ Suggestions:
 ### 6.1 Importing Decklists
 
 #### From Clipboard
+
 1. Copy decklist from any source
 2. Click **"Import"** → **"From Clipboard"**
 3. Paste decklist
@@ -519,6 +551,7 @@ Suggestions:
 5. Review and confirm
 
 **Supported Formats**:
+
 ```
 # Standard format
 4 Lightning Bolt
@@ -534,11 +567,13 @@ Suggestions:
 ```
 
 #### From File
+
 1. Click **"Import"** → **"From File"**
 2. Select `.txt` or `.json` file
 3. Decklist is parsed and loaded
 
 #### From URL
+
 1. Click **"Import"** → **"From URL"**
 2. Paste URL (e.g., MTGGoldfish, TappedOut)
 3. Decklist is fetched and parsed
@@ -546,16 +581,19 @@ Suggestions:
 ### 6.2 Exporting Decks
 
 #### Export as Text
+
 1. Open deck in Deck Builder
 2. Click **"Export"** → **"Text"**
 3. Copy or download decklist
 
 #### Export as JSON
+
 1. Click **"Export"** → **"JSON"**
 2. Download `.json` file with full deck data
 3. Includes metadata and notes
 
 #### Export as Share Link
+
 1. Click **"Export"** → **"Share Link"**
 2. Copy generated URL
 3. Share with others (they can import)
@@ -567,11 +605,13 @@ Suggestions:
 ### 7.1 General Settings
 
 **Appearance**:
+
 - **Theme**: Light or Dark mode
 - **Card Size**: Small, Medium, Large
 - **Animations**: Enable/disable visual effects
 
 **Behavior**:
+
 - **Auto-Save**: Enable/disable automatic deck saving
 - **Confirm Actions**: Require confirmation for destructive actions
 - **Sound Effects**: Enable/disable game sounds
@@ -579,6 +619,7 @@ Suggestions:
 ### 7.2 AI Settings
 
 **API Key Configuration**:
+
 1. Navigate to **Settings → AI**
 2. Select AI provider
 3. Enter your API key
@@ -586,12 +627,14 @@ Suggestions:
 5. Click **"Save"**
 
 **Supported Providers**:
+
 - **Gemini**: Google AI (free tier available)
 - **Claude**: Anthropic (paid)
 - **OpenAI**: GPT models (paid)
 - **Z.ai**: GLM models (paid)
 
 **Usage Tracking**:
+
 - View API usage statistics
 - Set spending limits (optional)
 - Clear usage history
@@ -599,21 +642,25 @@ Suggestions:
 ### 7.3 Card Database
 
 **Database Status**:
+
 - View total card count
 - Check database health
 - Last import date
 
 **Import Cards**:
+
 1. Click **"Import Cards"**
 2. Select JSON file from card fetch script
 3. Wait for import to complete
 
 **Clear Database**:
+
 - ⚠️ **Warning**: This cannot be undone
 - Click **"Clear Database"** in Danger Zone
 - Confirm action
 
 **Clear Image Cache**:
+
 - Removes cached card images
 - Frees up storage space
 - Images re-download as needed
@@ -621,11 +668,13 @@ Suggestions:
 ### 7.4 Network Settings
 
 **Multiplayer**:
+
 - **Username**: Display name for multiplayer
 - **Status**: Online/Away/Do Not Disturb
 - **Friends**: Manage friend list
 
 **Privacy**:
+
 - **Show Online Status**: Visible to friends
 - **Allow Game Invites**: Receive invitations
 - **Show Match History**: Public or private
@@ -636,46 +685,47 @@ Suggestions:
 
 ### Global Shortcuts
 
-| Shortcut | Action |
-|----------|--------|
-| `Ctrl+N` | New Deck |
-| `Ctrl+S` | Save Deck |
-| `Ctrl+O` | Open Deck |
-| `Ctrl+F` | Search Cards |
-| `Ctrl+I` | Import Decklist |
-| `Ctrl+E` | Export Deck |
-| `Ctrl+,` | Open Settings |
-| `F1` | Open Help |
-| `F5` | Refresh |
-| `Esc` | Close Dialog / Cancel Action |
+| Shortcut | Action                       |
+| -------- | ---------------------------- |
+| `Ctrl+N` | New Deck                     |
+| `Ctrl+S` | Save Deck                    |
+| `Ctrl+O` | Open Deck                    |
+| `Ctrl+F` | Search Cards                 |
+| `Ctrl+I` | Import Decklist              |
+| `Ctrl+E` | Export Deck                  |
+| `Ctrl+,` | Open Settings                |
+| `F1`     | Open Help                    |
+| `F5`     | Refresh                      |
+| `Esc`    | Close Dialog / Cancel Action |
 
 ### Deck Builder Shortcuts
 
-| Shortcut | Action |
-|----------|--------|
-| `+` | Add Card to Deck |
-| `-` | Remove Card from Deck |
-| `Shift++` | Add Maximum Copies |
-| `Shift+-` | Remove All Copies |
-| `Arrow Keys` | Navigate Cards |
-| `Enter` | View Card Details |
+| Shortcut     | Action                     |
+| ------------ | -------------------------- |
+| `+`          | Add Card to Deck           |
+| `-`          | Remove Card from Deck      |
+| `Shift++`    | Add Maximum Copies         |
+| `Shift+-`    | Remove All Copies          |
+| `Arrow Keys` | Navigate Cards             |
+| `Enter`      | Add Focused Card / Confirm |
 
 ### Game Shortcuts
 
-| Shortcut | Action |
-|----------|--------|
-| `Space` | End Turn |
-| `A` | Attack with Selected |
-| `B` | Block with Selected |
-| `T` | Target Selection |
-| `U` | Untap Permanent |
-| `Ctrl+Z` | Undo Last Action |
+| Shortcut | Action               |
+| -------- | -------------------- |
+| `Space`  | End Turn             |
+| `A`      | Attack with Selected |
+| `B`      | Block with Selected  |
+| `T`      | Target Selection     |
+| `U`      | Untap Permanent      |
+| `Ctrl+Z` | Undo Last Action     |
 
 ---
 
 ## Appendix A: Format Rules
 
 ### Commander
+
 - **Deck Size**: Exactly 100 cards (including commander)
 - **Card Limits**: 1 copy per card (except basic lands)
 - **Color Identity**: Cards must match commander's colors
@@ -683,12 +733,14 @@ Suggestions:
 - **Commander Damage**: 21 damage from one commander is lethal
 
 ### Standard
+
 - **Deck Size**: Minimum 60 cards
 - **Card Limits**: 4 copies per card (except basic lands)
 - **Sideboard**: Optional, exactly 15 cards
 - **Starting Life**: 20
 
 ### Modern
+
 - **Deck Size**: Minimum 60 cards
 - **Card Limits**: 4 copies per card (except basic lands)
 - **Sideboard**: Optional, exactly 15 cards
@@ -699,13 +751,13 @@ Suggestions:
 
 ## Appendix B: Troubleshooting Quick Reference
 
-| Issue | Quick Fix |
-|-------|-----------|
-| Cards not loading | Check database status in Settings |
-| AI not responding | Verify API key in Settings → AI |
+| Issue                  | Quick Fix                                   |
+| ---------------------- | ------------------------------------------- |
+| Cards not loading      | Check database status in Settings           |
+| AI not responding      | Verify API key in Settings → AI             |
 | Can't join multiplayer | Check internet connection, verify game code |
-| Deck validation fails | Review format rules, check card legality |
-| App runs slowly | Clear image cache, restart app |
+| Deck validation fails  | Review format rules, check card legality    |
+| App runs slowly        | Clear image cache, restart app              |
 
 For detailed troubleshooting, see [Troubleshooting Guide](TROUBLESHOOTING.md).
 

--- a/src/app/(app)/deck-builder/_components/card-search.tsx
+++ b/src/app/(app)/deck-builder/_components/card-search.tsx
@@ -1,17 +1,41 @@
 "use client";
 
-import { useState, useTransition, useCallback, useEffect, forwardRef, useImperativeHandle, useRef } from "react";
-import { useVirtualizer } from '@tanstack/react-virtual';
+import {
+  useState,
+  useTransition,
+  useCallback,
+  useEffect,
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+} from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import type { ScryfallCard } from "@/app/actions";
-import { initializeCardDatabase, getDatabaseStatus, searchCardsOffline, getAllCards } from "@/lib/card-database";
+import {
+  initializeCardDatabase,
+  getDatabaseStatus,
+  searchCardsOffline,
+  getAllCards,
+} from "@/lib/card-database";
 import type { MinimalCard } from "@/lib/card-database";
 import { type Format } from "@/lib/game-rules";
 import { useCardFilters } from "@/hooks/use-card-filters";
 import { useSearchPresets } from "@/hooks/use-search-presets";
-import { QUICK_PRESETS, getPresetsByCategory, type QuickPreset } from "@/lib/search/quick-presets";
+import {
+  QUICK_PRESETS,
+  getPresetsByCategory,
+  type QuickPreset,
+} from "@/lib/search/quick-presets";
 import { Input } from "@/components/ui/input";
 import { Search, Database, Loader2, X, Save, Trash2 } from "lucide-react";
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { useDebounce } from "use-debounce";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -36,6 +60,12 @@ interface CardSearchHandle {
 
 interface CardSearchProps {
   onAddCard: (card: ScryfallCard) => void;
+  /**
+   * Called whenever the highlighted search result changes (including to null
+   * when nothing is selected). Drives the page-level keyboard shortcuts that
+   * operate on the "currently focused/selected" card (+, -, Enter).
+   */
+  onSelectedCardChange?: (card: ScryfallCard | null) => void;
 }
 
 /**
@@ -48,7 +78,7 @@ function toMinimalCard(card: ScryfallCard): MinimalCard {
     set: card.set,
     collector_number: card.collector_number,
     cmc: card.cmc,
-    type_line: card.type_line || '',
+    type_line: card.type_line || "",
     oracle_text: card.oracle_text,
     colors: card.colors || [],
     color_identity: card.color_identity || [],
@@ -62,644 +92,740 @@ function toMinimalCard(card: ScryfallCard): MinimalCard {
   };
 }
 
-export const CardSearch = forwardRef<CardSearchHandle, CardSearchProps>(function CardSearch({ onAddCard }, ref) {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const [query, setQuery] = useState("");
-  const [results, setResults] = useState<ScryfallCard[]>([]);
-  const [isPending, startTransition] = useTransition();
-  const [isInitializing, setIsInitializing] = useState(true);
-  const [dbStatus, setDbStatus] = useState<{ loaded: boolean; cardCount: number }>({ loaded: false, cardCount: 0 });
-  const { toast } = useToast();
+export const CardSearch = forwardRef<CardSearchHandle, CardSearchProps>(
+  function CardSearch({ onAddCard, onSelectedCardChange }, ref) {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [query, setQuery] = useState("");
+    const [results, setResults] = useState<ScryfallCard[]>([]);
+    const [isPending, startTransition] = useTransition();
+    const [isInitializing, setIsInitializing] = useState(true);
+    const [dbStatus, setDbStatus] = useState<{
+      loaded: boolean;
+      cardCount: number;
+    }>({ loaded: false, cardCount: 0 });
+    const { toast } = useToast();
 
-  // Initialize filter hook for advanced filtering
-  const { filters, setFilter, sortConfig, setSort, hasActiveFilters, search: filterSearch, resetFilters } = useCardFilters();
-  
-  // Quick presets state
-  const [selectedPresetId, setSelectedPresetId] = useState<string | null>(null);
-  const presetsByCategory = getPresetsByCategory();
-  
-  // Saved search presets
-  const { presets: savedPresets, isLoading: isLoadingPresets, savePreset, deletePreset } = useSearchPresets();
-  const [selectedSavedPresetId, setSelectedSavedPresetId] = useState<string | null>(null);
-  const [isSavePresetDialogOpen, setIsSavePresetDialogOpen] = useState(false);
-  const [newPresetName, setNewPresetName] = useState("");
-  
-  // Store all cards for filtering
-  const [allCards, setAllCards] = useState<MinimalCard[]>([]);
-  
-  // Keyboard navigation state
-  const [selectedIndex, setSelectedIndex] = useState<number>(-1);
+    // Initialize filter hook for advanced filtering
+    const {
+      filters,
+      setFilter,
+      sortConfig,
+      setSort,
+      hasActiveFilters,
+      search: filterSearch,
+      resetFilters,
+    } = useCardFilters();
 
-  // Flash state for visual feedback when card is added
-  const [flashCardId, setFlashCardId] = useState<string | null>(null);
+    // Quick presets state
+    const [selectedPresetId, setSelectedPresetId] = useState<string | null>(
+      null,
+    );
+    const presetsByCategory = getPresetsByCategory();
 
-  // Virtual scrolling refs and state
-  const parentRef = useRef<HTMLDivElement>(null);
-  const [columnCount, setColumnCount] = useState(3);
+    // Saved search presets
+    const {
+      presets: savedPresets,
+      isLoading: isLoadingPresets,
+      savePreset,
+      deletePreset,
+    } = useSearchPresets();
+    const [selectedSavedPresetId, setSelectedSavedPresetId] = useState<
+      string | null
+    >(null);
+    const [isSavePresetDialogOpen, setIsSavePresetDialogOpen] = useState(false);
+    const [newPresetName, setNewPresetName] = useState("");
 
-  // Update column count based on window size
-  useEffect(() => {
-    const updateColumnCount = () => {
-      if (typeof window === 'undefined') return;
-      if (window.innerWidth >= 1536) setColumnCount(5);
-      else if (window.innerWidth >= 1280) setColumnCount(4);
-      else if (window.innerWidth >= 1024) setColumnCount(3);
-      else if (window.innerWidth >= 768) setColumnCount(4);
-      else setColumnCount(3);
-    };
+    // Store all cards for filtering
+    const [allCards, setAllCards] = useState<MinimalCard[]>([]);
 
-    updateColumnCount();
-    window.addEventListener('resize', updateColumnCount);
-    return () => window.removeEventListener('resize', updateColumnCount);
-  }, []);
+    // Keyboard navigation state
+    const [selectedIndex, setSelectedIndex] = useState<number>(-1);
 
-  // Virtualizer for large result sets
-  const rowVirtualizer = useVirtualizer({
-    count: results.length,
-    getScrollElement: () => parentRef.current,
-    estimateSize: () => 280, // Card height + gap
-    overscan: 5,
-  });
+    // Flash state for visual feedback when card is added
+    const [flashCardId, setFlashCardId] = useState<string | null>(null);
 
-  // Trigger flash effect for a card
-  const triggerFlash = useCallback((cardId: string) => {
-    setFlashCardId(cardId);
-    setTimeout(() => setFlashCardId(null), 400);
-  }, []);
+    // Virtual scrolling refs and state
+    const parentRef = useRef<HTMLDivElement>(null);
+    const [columnCount, setColumnCount] = useState(3);
 
-  // Expose focus method to parent
-  useImperativeHandle(ref, () => ({
-    focus: () => inputRef.current?.focus(),
-  }), []);
+    // Update column count based on window size
+    useEffect(() => {
+      const updateColumnCount = () => {
+        if (typeof window === "undefined") return;
+        if (window.innerWidth >= 1536) setColumnCount(5);
+        else if (window.innerWidth >= 1280) setColumnCount(4);
+        else if (window.innerWidth >= 1024) setColumnCount(3);
+        else if (window.innerWidth >= 768) setColumnCount(4);
+        else setColumnCount(3);
+      };
 
-  // Handle applying a quick preset
-  const handleQuickPreset = useCallback((presetId: string) => {
-    if (presetId === 'clear') {
-      // Clear all filters
-      resetFilters();
-      setSelectedPresetId(null);
-      return;
-    }
+      updateColumnCount();
+      window.addEventListener("resize", updateColumnCount);
+      return () => window.removeEventListener("resize", updateColumnCount);
+    }, []);
 
-    const preset = QUICK_PRESETS.find(p => p.id === presetId);
-    if (!preset) return;
-
-    // Clear existing filters first
-    resetFilters();
-
-    // Apply each filter from the preset
-    Object.entries(preset.filters).forEach(([key, value]) => {
-      if (value !== undefined) {
-        setFilter(key as keyof typeof filters, value);
-      }
+    // Virtualizer for large result sets
+    const rowVirtualizer = useVirtualizer({
+      count: results.length,
+      getScrollElement: () => parentRef.current,
+      estimateSize: () => 280, // Card height + gap
+      overscan: 5,
     });
 
-    setSelectedPresetId(presetId);
-  }, [resetFilters, setFilter]);
+    // Trigger flash effect for a card
+    const triggerFlash = useCallback((cardId: string) => {
+      setFlashCardId(cardId);
+      setTimeout(() => setFlashCardId(null), 400);
+    }, []);
 
-  // Update selected preset when filters change externally
-  useEffect(() => {
-    if (!hasActiveFilters) {
-      setSelectedPresetId(null);
-      return;
-    }
+    // Expose focus method to parent
+    useImperativeHandle(
+      ref,
+      () => ({
+        focus: () => inputRef.current?.focus(),
+      }),
+      [],
+    );
 
-    // Check if current filters match any preset
-    const match = QUICK_PRESETS.find(preset => {
-      const presetFilters = preset.filters;
-      return Object.entries(presetFilters).every(([key, value]) => {
-        if (value === undefined) return true;
-        const currentValue = filters[key as keyof typeof filters];
-        return JSON.stringify(currentValue) === JSON.stringify(value);
-      });
-    });
-
-    setSelectedPresetId(match?.id || null);
-  }, [filters, hasActiveFilters]);
-
-  // Handle saving a preset
-  const handleSavePreset = useCallback(async () => {
-    if (!newPresetName.trim()) {
-      toast({
-        title: "Preset name required",
-        description: "Please enter a name for your preset.",
-        variant: "destructive",
-      });
-      return;
-    }
-
-    try {
-      await savePreset(newPresetName.trim(), filters, sortConfig.option, sortConfig.direction);
-      setNewPresetName("");
-      setIsSavePresetDialogOpen(false);
-      toast({
-        title: "Preset saved",
-        description: `"${newPresetName.trim()}" has been saved.`,
-      });
-    } catch (error) {
-      toast({
-        title: "Failed to save preset",
-        description: "There was an error saving your preset.",
-        variant: "destructive",
-      });
-    }
-  }, [newPresetName, filters, sortConfig, savePreset, toast]);
-
-  // Handle loading a saved preset
-  const handleLoadSavedPreset = useCallback((presetId: string) => {
-    const preset = savedPresets.find(p => p.id === presetId);
-    if (!preset) return;
-
-    // Clear existing filters first
-    resetFilters();
-
-    // Apply filters from the saved preset
-    if (preset.filters) {
-      Object.entries(preset.filters).forEach(([key, value]) => {
-        if (value !== undefined) {
-          setFilter(key as keyof typeof filters, value);
+    // Handle applying a quick preset
+    const handleQuickPreset = useCallback(
+      (presetId: string) => {
+        if (presetId === "clear") {
+          // Clear all filters
+          resetFilters();
+          setSelectedPresetId(null);
+          return;
         }
-      });
-    }
 
-    // Apply sort if present
-    if (preset.sortOption || preset.sortDirection) {
-      setSort({
-        option: preset.sortOption || 'name',
-        direction: preset.sortDirection || 'asc',
-      });
-    }
+        const preset = QUICK_PRESETS.find((p) => p.id === presetId);
+        if (!preset) return;
 
-    setSelectedSavedPresetId(presetId);
-    setSelectedPresetId(null); // Clear quick preset selection
-  }, [savedPresets, resetFilters, setFilter, setSort]);
+        // Clear existing filters first
+        resetFilters();
 
-  // Handle deleting a saved preset
-  const handleDeleteSavedPreset = useCallback(async (presetId: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    
-    try {
-      await deletePreset(presetId);
-      if (selectedSavedPresetId === presetId) {
-        setSelectedSavedPresetId(null);
+        // Apply each filter from the preset
+        Object.entries(preset.filters).forEach(([key, value]) => {
+          if (value !== undefined) {
+            setFilter(key as keyof typeof filters, value);
+          }
+        });
+
+        setSelectedPresetId(presetId);
+      },
+      [resetFilters, setFilter],
+    );
+
+    // Update selected preset when filters change externally
+    useEffect(() => {
+      if (!hasActiveFilters) {
+        setSelectedPresetId(null);
+        return;
       }
-      toast({
-        title: "Preset deleted",
-        description: "The preset has been removed.",
+
+      // Check if current filters match any preset
+      const match = QUICK_PRESETS.find((preset) => {
+        const presetFilters = preset.filters;
+        return Object.entries(presetFilters).every(([key, value]) => {
+          if (value === undefined) return true;
+          const currentValue = filters[key as keyof typeof filters];
+          return JSON.stringify(currentValue) === JSON.stringify(value);
+        });
       });
-    } catch (error) {
-      toast({
-        title: "Failed to delete preset",
-        description: "There was an error deleting the preset.",
-        variant: "destructive",
-      });
-    }
-  }, [deletePreset, selectedSavedPresetId, toast]);
 
-  // Handle keyboard navigation in search results
-  const handleSearchKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (results.length === 0) return;
-    
-    switch (e.key) {
-      case 'ArrowDown':
-        e.preventDefault();
-        setSelectedIndex(prev => 
-          prev < results.length - 1 ? prev + 1 : 0
-        );
-        break;
-      case 'ArrowUp':
-        e.preventDefault();
-        setSelectedIndex(prev => 
-          prev > 0 ? prev - 1 : results.length - 1
-        );
-        break;
-      case 'Enter':
-        e.preventDefault();
-        if (selectedIndex >= 0 && results[selectedIndex]) {
-          onAddCard(results[selectedIndex]);
-        }
-        break;
-    }
-  }, [results, selectedIndex, onAddCard]);
+      setSelectedPresetId(match?.id || null);
+    }, [filters, hasActiveFilters]);
 
-  // Reset selectedIndex when results change
-  useEffect(() => {
-    setSelectedIndex(-1);
-  }, [results]);
+    // Handle saving a preset
+    const handleSavePreset = useCallback(async () => {
+      if (!newPresetName.trim()) {
+        toast({
+          title: "Preset name required",
+          description: "Please enter a name for your preset.",
+          variant: "destructive",
+        });
+        return;
+      }
 
-  // Scroll selected card into view using virtualizer
-  useEffect(() => {
-    if (selectedIndex >= 0 && rowVirtualizer) {
-      rowVirtualizer.scrollToIndex(selectedIndex);
-    }
-  }, [selectedIndex, rowVirtualizer]);
-
-  // Initialize database on mount
-  useEffect(() => {
-    async function initDB() {
       try {
-        await initializeCardDatabase();
-        const status = await getDatabaseStatus();
-        setDbStatus(status);
-        
-        // Load all cards for filtering
-        const cards = await getAllCards();
-        setAllCards(cards);
+        await savePreset(
+          newPresetName.trim(),
+          filters,
+          sortConfig.option,
+          sortConfig.direction,
+        );
+        setNewPresetName("");
+        setIsSavePresetDialogOpen(false);
+        toast({
+          title: "Preset saved",
+          description: `"${newPresetName.trim()}" has been saved.`,
+        });
       } catch (error) {
-        console.error("Failed to initialize card database:", error);
-      } finally {
-        setIsInitializing(false);
+        toast({
+          title: "Failed to save preset",
+          description: "There was an error saving your preset.",
+          variant: "destructive",
+        });
       }
-    }
+    }, [newPresetName, filters, sortConfig, savePreset, toast]);
 
-    initDB();
-  }, []);
+    // Handle loading a saved preset
+    const handleLoadSavedPreset = useCallback(
+      (presetId: string) => {
+        const preset = savedPresets.find((p) => p.id === presetId);
+        if (!preset) return;
 
-  // Debounce the query for search
-  const [debouncedQuery] = useDebounce(query, 300);
+        // Clear existing filters first
+        resetFilters();
 
-  // Apply search and filtering when query or filters change
-  useEffect(() => {
-    if (!dbStatus.loaded) return;
-    
-    startTransition(async () => {
-      let searchResults: ScryfallCard[];
-      
-      if (debouncedQuery.length >= 2) {
-        // Perform name-based search first
-        searchResults = await searchCardsOffline(debouncedQuery, {
-          maxCards: 50,
-          format: 'commander' as Format,
-          includeImages: true,
-        }) as ScryfallCard[];
-      } else {
-        // No query - get a subset of cards or empty
-        searchResults = [];
+        // Apply filters from the saved preset
+        if (preset.filters) {
+          Object.entries(preset.filters).forEach(([key, value]) => {
+            if (value !== undefined) {
+              setFilter(key as keyof typeof filters, value);
+            }
+          });
+        }
+
+        // Apply sort if present
+        if (preset.sortOption || preset.sortDirection) {
+          setSort({
+            option: preset.sortOption || "name",
+            direction: preset.sortDirection || "asc",
+          });
+        }
+
+        setSelectedSavedPresetId(presetId);
+        setSelectedPresetId(null); // Clear quick preset selection
+      },
+      [savedPresets, resetFilters, setFilter, setSort],
+    );
+
+    // Handle deleting a saved preset
+    const handleDeleteSavedPreset = useCallback(
+      async (presetId: string, e: React.MouseEvent) => {
+        e.stopPropagation();
+
+        try {
+          await deletePreset(presetId);
+          if (selectedSavedPresetId === presetId) {
+            setSelectedSavedPresetId(null);
+          }
+          toast({
+            title: "Preset deleted",
+            description: "The preset has been removed.",
+          });
+        } catch (error) {
+          toast({
+            title: "Failed to delete preset",
+            description: "There was an error deleting the preset.",
+            variant: "destructive",
+          });
+        }
+      },
+      [deletePreset, selectedSavedPresetId, toast],
+    );
+
+    // Handle keyboard navigation in search results
+    const handleSearchKeyDown = useCallback(
+      (e: React.KeyboardEvent) => {
+        if (results.length === 0) return;
+
+        switch (e.key) {
+          case "ArrowDown":
+            e.preventDefault();
+            setSelectedIndex((prev) =>
+              prev < results.length - 1 ? prev + 1 : 0,
+            );
+            break;
+          case "ArrowUp":
+            e.preventDefault();
+            setSelectedIndex((prev) =>
+              prev > 0 ? prev - 1 : results.length - 1,
+            );
+            break;
+          case "Enter":
+            e.preventDefault();
+            if (selectedIndex >= 0 && results[selectedIndex]) {
+              onAddCard(results[selectedIndex]);
+            }
+            break;
+        }
+      },
+      [results, selectedIndex, onAddCard],
+    );
+
+    // Reset selectedIndex when results change
+    useEffect(() => {
+      setSelectedIndex(-1);
+    }, [results]);
+
+    // Report the currently highlighted card to the parent for keyboard shortcuts.
+    useEffect(() => {
+      onSelectedCardChange?.(
+        selectedIndex >= 0 ? (results[selectedIndex] ?? null) : null,
+      );
+    }, [selectedIndex, results, onSelectedCardChange]);
+
+    // Scroll selected card into view using virtualizer
+    useEffect(() => {
+      if (selectedIndex >= 0 && rowVirtualizer) {
+        rowVirtualizer.scrollToIndex(selectedIndex);
       }
-      
-      // Apply additional filters from the hook if active
-      if (hasActiveFilters && searchResults.length > 0) {
-        // Convert to MinimalCard for filtering
-        const minimalCards = searchResults.map(toMinimalCard);
-        
-        // Apply filters and sorting using the hook
-        const filtered = filterSearch(debouncedQuery, minimalCards);
-        
-        // Get IDs of filtered cards
-        const filteredIds = new Set(filtered.map(c => c.id));
-        
-        // Keep only filtered results
-        searchResults = searchResults.filter(card => filteredIds.has(card.id));
+    }, [selectedIndex, rowVirtualizer]);
+
+    // Initialize database on mount
+    useEffect(() => {
+      async function initDB() {
+        try {
+          await initializeCardDatabase();
+          const status = await getDatabaseStatus();
+          setDbStatus(status);
+
+          // Load all cards for filtering
+          const cards = await getAllCards();
+          setAllCards(cards);
+        } catch (error) {
+          console.error("Failed to initialize card database:", error);
+        } finally {
+          setIsInitializing(false);
+        }
       }
-      
-      setResults(searchResults);
-    });
-  }, [debouncedQuery, filters, sortConfig, dbStatus.loaded, hasActiveFilters, filterSearch]);
 
-  const { synergyData } = useSynergy();
+      initDB();
+    }, []);
 
-  return (
-    <div className="flex flex-col h-full" role="search" aria-label="Card search">
-      {/* Database Status Header */}
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Database className="h-4 w-4" />
-          <span>
-            {isInitializing ? (
-              <span className="flex items-center gap-2">
-                <Loader2 className="h-3 w-3 animate-spin" />
-                Initializing database...
-              </span>
-            ) : (
-              <>
-                Local Database
-                {dbStatus.loaded && (
-                  <Badge variant="secondary" className="ml-2">
-                    {dbStatus.cardCount} cards
-                  </Badge>
-                )}
-              </>
+    // Debounce the query for search
+    const [debouncedQuery] = useDebounce(query, 300);
+
+    // Apply search and filtering when query or filters change
+    useEffect(() => {
+      if (!dbStatus.loaded) return;
+
+      startTransition(async () => {
+        let searchResults: ScryfallCard[];
+
+        if (debouncedQuery.length >= 2) {
+          // Perform name-based search first
+          searchResults = (await searchCardsOffline(debouncedQuery, {
+            maxCards: 50,
+            format: "commander" as Format,
+            includeImages: true,
+          })) as ScryfallCard[];
+        } else {
+          // No query - get a subset of cards or empty
+          searchResults = [];
+        }
+
+        // Apply additional filters from the hook if active
+        if (hasActiveFilters && searchResults.length > 0) {
+          // Convert to MinimalCard for filtering
+          const minimalCards = searchResults.map(toMinimalCard);
+
+          // Apply filters and sorting using the hook
+          const filtered = filterSearch(debouncedQuery, minimalCards);
+
+          // Get IDs of filtered cards
+          const filteredIds = new Set(filtered.map((c) => c.id));
+
+          // Keep only filtered results
+          searchResults = searchResults.filter((card) =>
+            filteredIds.has(card.id),
+          );
+        }
+
+        setResults(searchResults);
+      });
+    }, [
+      debouncedQuery,
+      filters,
+      sortConfig,
+      dbStatus.loaded,
+      hasActiveFilters,
+      filterSearch,
+    ]);
+
+    const { synergyData } = useSynergy();
+
+    return (
+      <div
+        className="flex flex-col h-full"
+        role="search"
+        aria-label="Card search"
+      >
+        {/* Database Status Header */}
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Database className="h-4 w-4" />
+            <span>
+              {isInitializing ? (
+                <span className="flex items-center gap-2">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  Initializing database...
+                </span>
+              ) : (
+                <>
+                  Local Database
+                  {dbStatus.loaded && (
+                    <Badge variant="secondary" className="ml-2">
+                      {dbStatus.cardCount} cards
+                    </Badge>
+                  )}
+                </>
+              )}
+            </span>
+          </div>
+          {dbStatus.loaded && (
+            <span className="text-xs text-muted-foreground">Offline ready</span>
+          )}
+        </div>
+
+        {/* Search Input and Quick Filters */}
+        <div className="space-y-3 mb-4">
+          {/* Search Input */}
+          <div className="relative">
+            <Search
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <Input
+              ref={inputRef}
+              type="search"
+              placeholder="Search for cards (e.g., 'Sol Ring') + Ctrl+F"
+              className="pl-10"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleSearchKeyDown}
+              aria-label="Search cards by name"
+              aria-describedby="search-hint"
+              disabled={isInitializing}
+              data-testid="card-search-input"
+            />
+          </div>
+
+          {/* Quick Presets Dropdown */}
+          <div className="flex items-center gap-2">
+            <Select
+              value={selectedPresetId || ""}
+              onValueChange={handleQuickPreset}
+            >
+              <SelectTrigger className="w-full" aria-label="Quick filters">
+                <SelectValue placeholder="Quick Filters" />
+              </SelectTrigger>
+              <SelectContent>
+                {/* CMC Presets */}
+                <SelectGroup>
+                  <SelectLabel>Converted Mana Cost</SelectLabel>
+                  {presetsByCategory.cmc.map((preset) => (
+                    <SelectItem key={preset.id} value={preset.id}>
+                      {preset.name}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+
+                {/* Type Presets */}
+                <SelectGroup>
+                  <SelectLabel>Card Type</SelectLabel>
+                  {presetsByCategory.type.map((preset) => (
+                    <SelectItem key={preset.id} value={preset.id}>
+                      {preset.name}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+
+                {/* Rarity Presets */}
+                <SelectGroup>
+                  <SelectLabel>Rarity</SelectLabel>
+                  {presetsByCategory.rarity.map((preset) => (
+                    <SelectItem key={preset.id} value={preset.id}>
+                      {preset.name}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+
+                {/* Color Presets */}
+                <SelectGroup>
+                  <SelectLabel>Color</SelectLabel>
+                  {presetsByCategory.color.map((preset) => (
+                    <SelectItem key={preset.id} value={preset.id}>
+                      {preset.name}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+
+                {/* Clear Filters Option */}
+                <SelectItem value="clear" className="text-muted-foreground">
+                  Clear Filters
+                </SelectItem>
+              </SelectContent>
+            </Select>
+
+            {/* Active Filters Badge */}
+            {hasActiveFilters && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  resetFilters();
+                  setSelectedPresetId(null);
+                }}
+                className="shrink-0"
+                aria-label="Clear all filters"
+              >
+                <X className="h-4 w-4 mr-1" />
+                Clear
+              </Button>
             )}
-          </span>
-        </div>
-        {dbStatus.loaded && (
-          <span className="text-xs text-muted-foreground">Offline ready</span>
-        )}
-      </div>
+          </div>
 
-      {/* Search Input and Quick Filters */}
-      <div className="space-y-3 mb-4">
-        {/* Search Input */}
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
-          <Input
-            ref={inputRef}
-            type="search"
-            placeholder="Search for cards (e.g., 'Sol Ring') + Ctrl+F"
-            className="pl-10"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={handleSearchKeyDown}
-            aria-label="Search cards by name"
-            aria-describedby="search-hint"
-            disabled={isInitializing}
-            data-testid="card-search-input"
-          />
-        </div>
-
-        {/* Quick Presets Dropdown */}
-        <div className="flex items-center gap-2">
-          <Select value={selectedPresetId || ''} onValueChange={handleQuickPreset}>
-            <SelectTrigger className="w-full" aria-label="Quick filters">
-              <SelectValue placeholder="Quick Filters" />
-            </SelectTrigger>
-            <SelectContent>
-              {/* CMC Presets */}
-              <SelectGroup>
-                <SelectLabel>Converted Mana Cost</SelectLabel>
-                {presetsByCategory.cmc.map((preset) => (
-                  <SelectItem key={preset.id} value={preset.id}>
-                    {preset.name}
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-
-              {/* Type Presets */}
-              <SelectGroup>
-                <SelectLabel>Card Type</SelectLabel>
-                {presetsByCategory.type.map((preset) => (
-                  <SelectItem key={preset.id} value={preset.id}>
-                    {preset.name}
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-
-              {/* Rarity Presets */}
-              <SelectGroup>
-                <SelectLabel>Rarity</SelectLabel>
-                {presetsByCategory.rarity.map((preset) => (
-                  <SelectItem key={preset.id} value={preset.id}>
-                    {preset.name}
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-
-              {/* Color Presets */}
-              <SelectGroup>
-                <SelectLabel>Color</SelectLabel>
-                {presetsByCategory.color.map((preset) => (
-                  <SelectItem key={preset.id} value={preset.id}>
-                    {preset.name}
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-
-              {/* Clear Filters Option */}
-              <SelectItem value="clear" className="text-muted-foreground">
-                Clear Filters
-              </SelectItem>
-            </SelectContent>
-          </Select>
-
-          {/* Active Filters Badge */}
-          {hasActiveFilters && (
+          {/* Saved Presets Controls */}
+          <div className="flex items-center gap-2 flex-wrap">
+            {/* Save Preset Button */}
             <Button
               variant="outline"
               size="sm"
-              onClick={() => {
-                resetFilters();
-                setSelectedPresetId(null);
-              }}
-              className="shrink-0"
-              aria-label="Clear all filters"
+              onClick={() => setIsSavePresetDialogOpen(true)}
+              disabled={isInitializing || !hasActiveFilters}
+              className="flex items-center gap-1"
             >
-              <X className="h-4 w-4 mr-1" />
-              Clear
+              <Save className="h-4 w-4" />
+              Save
             </Button>
-          )}
-        </div>
 
-        {/* Saved Presets Controls */}
-        <div className="flex items-center gap-2 flex-wrap">
-          {/* Save Preset Button */}
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setIsSavePresetDialogOpen(true)}
-            disabled={isInitializing || !hasActiveFilters}
-            className="flex items-center gap-1"
-          >
-            <Save className="h-4 w-4" />
-            Save
-          </Button>
-
-          {/* Load Saved Preset Dropdown */}
-          <Select
-            value={selectedSavedPresetId || ""}
-            onValueChange={(value) => {
-              if (value) {
-                handleLoadSavedPreset(value);
-              }
-            }}
-            disabled={isInitializing || isLoadingPresets || savedPresets.length === 0}
-          >
-            <SelectTrigger className="w-[180px]">
-              <SelectValue placeholder="Load saved preset" />
-            </SelectTrigger>
-            <SelectContent>
-              {savedPresets.map((preset) => (
-                <SelectItem key={preset.id} value={preset.id} className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <span>{preset.name}</span>
-                    <button
-                      onClick={(e) => handleDeleteSavedPreset(preset.id, e)}
-                      className="p-1 hover:bg-destructive hover:text-destructive-foreground rounded"
-                      aria-label={`Delete ${preset.name}`}
-                    >
-                      <Trash2 className="h-3 w-3" />
-                    </button>
-                  </div>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
-          {savedPresets.length === 0 && !isLoadingPresets && (
-            <span className="text-xs text-muted-foreground">No saved presets</span>
-          )}
-        </div>
-      </div>
-
-      {/* Save Preset Dialog */}
-      <Dialog open={isSavePresetDialogOpen} onOpenChange={setIsSavePresetDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Save Filter Preset</DialogTitle>
-            <DialogDescription>
-              Save your current filter configuration for quick access later.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="py-4">
-            <Input
-              placeholder="Preset name (e.g., 'Blue Control')"
-              value={newPresetName}
-              onChange={(e) => setNewPresetName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  handleSavePreset();
+            {/* Load Saved Preset Dropdown */}
+            <Select
+              value={selectedSavedPresetId || ""}
+              onValueChange={(value) => {
+                if (value) {
+                  handleLoadSavedPreset(value);
                 }
               }}
-            />
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setIsSavePresetDialogOpen(false)}>
-              Cancel
-            </Button>
-            <Button onClick={handleSavePreset}>
-              Save Preset
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* Search Results - Virtualized for performance */}
-      <div
-        ref={parentRef}
-        className="flex-grow rounded-lg border bg-card overflow-auto"
-        role="list"
-        aria-label="Search results"
-      >
-        {/* Loading state */}
-        {isInitializing && (
-          <div className="p-4">
-            <div className="text-center text-muted-foreground py-10">
-              <Loader2 className="h-8 w-8 animate-spin mx-auto mb-2" />
-              <p>Initializing offline card database...</p>
-            </div>
-            <div 
-              className="grid gap-4"
-              style={{ gridTemplateColumns: `repeat(${columnCount}, 1fr)` }}
+              disabled={
+                isInitializing || isLoadingPresets || savedPresets.length === 0
+              }
             >
-              {Array.from({ length: 8 }).map((_, i) => (
-                <Skeleton key={i} className="aspect-[5/7] rounded-lg" aria-hidden="true" />
-              ))}
-            </div>
-          </div>
-        )}
+              <SelectTrigger className="w-[180px]">
+                <SelectValue placeholder="Load saved preset" />
+              </SelectTrigger>
+              <SelectContent>
+                {savedPresets.map((preset) => (
+                  <SelectItem
+                    key={preset.id}
+                    value={preset.id}
+                    className="flex items-center justify-between"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span>{preset.name}</span>
+                      <button
+                        onClick={(e) => handleDeleteSavedPreset(preset.id, e)}
+                        className="p-1 hover:bg-destructive hover:text-destructive-foreground rounded"
+                        aria-label={`Delete ${preset.name}`}
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </button>
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
 
-        {/* Pending state */}
-        {!isInitializing && isPending && (
-          <div className="p-4">
-            <div 
-              className="grid gap-4"
-              style={{ gridTemplateColumns: `repeat(${columnCount}, 1fr)` }}
-            >
-              {Array.from({ length: 8 }).map((_, i) => (
-                <Skeleton key={i} className="aspect-[5/7] rounded-lg" aria-hidden="true" />
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Empty results state */}
-        {!isInitializing && !isPending && results.length === 0 && (
-          <div
-            className="text-center text-muted-foreground py-10 px-4"
-            role="status"
-            aria-live="polite"
-          >
-            <p id="search-hint">
-              {debouncedQuery.length > 2
-                ? "No cards found in local database."
-                : "Enter a search term to find cards."}
-            </p>
-            {debouncedQuery.length > 2 && (
-              <div className="mt-4 p-4 bg-muted rounded-lg max-w-md mx-auto">
-                <p className="text-sm mb-2">
-                  <strong>Local Database Active</strong>
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  Search results come from your offline card database. The current database contains essential commander cards. More cards can be added via bulk import in future updates.
-                </p>
-              </div>
+            {savedPresets.length === 0 && !isLoadingPresets && (
+              <span className="text-xs text-muted-foreground">
+                No saved presets
+              </span>
             )}
           </div>
-        )}
+        </div>
 
-        {/* Virtualized card grid */}
-        {!isInitializing && !isPending && results.length > 0 && (
-          <div
-            className="relative p-4"
-            style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
-          >
-            {rowVirtualizer.getVirtualItems().map((virtualItem) => {
-              const rowIndex = Math.floor(virtualItem.index / columnCount);
-              const colIndex = virtualItem.index % columnCount;
-              const card = results[virtualItem.index];
-              const synergy = synergyData.get(card.id);
-              const isSelected = selectedIndex === virtualItem.index;
-              const hasHighSynergy = synergy && synergy.score >= 60;
+        {/* Save Preset Dialog */}
+        <Dialog
+          open={isSavePresetDialogOpen}
+          onOpenChange={setIsSavePresetDialogOpen}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Save Filter Preset</DialogTitle>
+              <DialogDescription>
+                Save your current filter configuration for quick access later.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="py-4">
+              <Input
+                placeholder="Preset name (e.g., 'Blue Control')"
+                value={newPresetName}
+                onChange={(e) => setNewPresetName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    handleSavePreset();
+                  }
+                }}
+              />
+            </div>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setIsSavePresetDialogOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button onClick={handleSavePreset}>Save Preset</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
 
-              return (
-                <button
-                  key={card.id}
-                  data-card-index={virtualItem.index}
-                  onClick={(e) => {
-                    // Trigger flash effect
-                    triggerFlash(card.id);
-                    // Shift+Click adds 4 copies (max allowed)
-                    if (e.shiftKey) {
-                      const MAX_QUICK_ADD = 4;
-                      for (let i = 0; i < MAX_QUICK_ADD; i++) {
+        {/* Search Results - Virtualized for performance */}
+        <div
+          ref={parentRef}
+          className="flex-grow rounded-lg border bg-card overflow-auto"
+          role="list"
+          aria-label="Search results"
+        >
+          {/* Loading state */}
+          {isInitializing && (
+            <div className="p-4">
+              <div className="text-center text-muted-foreground py-10">
+                <Loader2 className="h-8 w-8 animate-spin mx-auto mb-2" />
+                <p>Initializing offline card database...</p>
+              </div>
+              <div
+                className="grid gap-4"
+                style={{ gridTemplateColumns: `repeat(${columnCount}, 1fr)` }}
+              >
+                {Array.from({ length: 8 }).map((_, i) => (
+                  <Skeleton
+                    key={i}
+                    className="aspect-[5/7] rounded-lg"
+                    aria-hidden="true"
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Pending state */}
+          {!isInitializing && isPending && (
+            <div className="p-4">
+              <div
+                className="grid gap-4"
+                style={{ gridTemplateColumns: `repeat(${columnCount}, 1fr)` }}
+              >
+                {Array.from({ length: 8 }).map((_, i) => (
+                  <Skeleton
+                    key={i}
+                    className="aspect-[5/7] rounded-lg"
+                    aria-hidden="true"
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Empty results state */}
+          {!isInitializing && !isPending && results.length === 0 && (
+            <div
+              className="text-center text-muted-foreground py-10 px-4"
+              role="status"
+              aria-live="polite"
+            >
+              <p id="search-hint">
+                {debouncedQuery.length > 2
+                  ? "No cards found in local database."
+                  : "Enter a search term to find cards."}
+              </p>
+              {debouncedQuery.length > 2 && (
+                <div className="mt-4 p-4 bg-muted rounded-lg max-w-md mx-auto">
+                  <p className="text-sm mb-2">
+                    <strong>Local Database Active</strong>
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Search results come from your offline card database. The
+                    current database contains essential commander cards. More
+                    cards can be added via bulk import in future updates.
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Virtualized card grid */}
+          {!isInitializing && !isPending && results.length > 0 && (
+            <div
+              className="relative p-4"
+              style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+            >
+              {rowVirtualizer.getVirtualItems().map((virtualItem) => {
+                const rowIndex = Math.floor(virtualItem.index / columnCount);
+                const colIndex = virtualItem.index % columnCount;
+                const card = results[virtualItem.index];
+                const synergy = synergyData.get(card.id);
+                const isSelected = selectedIndex === virtualItem.index;
+                const hasHighSynergy = synergy && synergy.score >= 60;
+
+                return (
+                  <button
+                    key={card.id}
+                    data-card-index={virtualItem.index}
+                    onClick={(e) => {
+                      // Trigger flash effect
+                      triggerFlash(card.id);
+                      // Shift+Click adds 4 copies (max allowed)
+                      if (e.shiftKey) {
+                        const MAX_QUICK_ADD = 4;
+                        for (let i = 0; i < MAX_QUICK_ADD; i++) {
+                          onAddCard(card);
+                        }
+                      } else {
                         onAddCard(card);
                       }
-                    } else {
-                      onAddCard(card);
-                    }
-                  }}
-                  className={`absolute aspect-[5/7] transform transition-transform duration-200 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background rounded-lg touch-manipulation group ${isSelected ? 'ring-4 ring-primary ring-offset-2' : ''} ${flashCardId === card.id ? 'ring-4 ring-green-500 ring-offset-2' : ''}`}
-                  style={{
-                    height: `${virtualItem.size}px`,
-                    transform: `translateY(${virtualItem.start}px)`,
-                    left: `${(colIndex / columnCount) * 100}%`,
-                    width: `${100 / columnCount}%`,
-                    padding: '0 8px',
-                    boxSizing: 'border-box',
-                  }}
-                  title={`Add ${card.name} to deck${hasHighSynergy ? ` (Synergy: ${Math.round(synergy.score)}%)` : ''} - Shift+Click for 4-of`}
-                  aria-label={`Add ${card.name} to deck${hasHighSynergy ? ` (Synergy: ${Math.round(synergy.score)}%)` : ''} - Shift+Click for 4-of${isSelected ? ' (selected)' : ''}`}
-                  data-testid={`card-result-${card.name.toLowerCase().replace(/\s+/g, '-')}`}
-                >
-                  {card.image_uris?.large || card.image_uris?.normal ? (
-                    <Image
-                      src={card.image_uris?.normal || ''}
-                      alt={card.name}
-                      fill
-                      sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
-                      className="rounded-lg object-cover"
-                    />
-                  ) : (
-                    <div className="flex h-full w-full items-center justify-center rounded-lg bg-secondary text-center text-secondary-foreground p-2 text-sm">
-                      {card.name}
-                    </div>
-                  )}
+                    }}
+                    className={`absolute aspect-[5/7] transform transition-transform duration-200 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background rounded-lg touch-manipulation group ${isSelected ? "ring-4 ring-primary ring-offset-2" : ""} ${flashCardId === card.id ? "ring-4 ring-green-500 ring-offset-2" : ""}`}
+                    style={{
+                      height: `${virtualItem.size}px`,
+                      transform: `translateY(${virtualItem.start}px)`,
+                      left: `${(colIndex / columnCount) * 100}%`,
+                      width: `${100 / columnCount}%`,
+                      padding: "0 8px",
+                      boxSizing: "border-box",
+                    }}
+                    title={`Add ${card.name} to deck${hasHighSynergy ? ` (Synergy: ${Math.round(synergy.score)}%)` : ""} - Shift+Click for 4-of`}
+                    aria-label={`Add ${card.name} to deck${hasHighSynergy ? ` (Synergy: ${Math.round(synergy.score)}%)` : ""} - Shift+Click for 4-of${isSelected ? " (selected)" : ""}`}
+                    data-testid={`card-result-${card.name.toLowerCase().replace(/\s+/g, "-")}`}
+                  >
+                    {card.image_uris?.large || card.image_uris?.normal ? (
+                      <Image
+                        src={card.image_uris?.normal || ""}
+                        alt={card.name}
+                        fill
+                        sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+                        className="rounded-lg object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center rounded-lg bg-secondary text-center text-secondary-foreground p-2 text-sm">
+                        {card.name}
+                      </div>
+                    )}
 
-                  {hasHighSynergy && (
-                    <div className="absolute top-2 right-2 z-10" data-testid="synergy-badge">
-                      <Badge 
-                        variant={synergy.score >= 80 ? "default" : "secondary"}
-                        className={`${synergy.score >= 80 ? 'bg-green-600 hover:bg-green-700' : 'bg-orange-500 hover:bg-orange-600'} text-white border-none shadow-sm text-[10px] px-1.5 py-0`}
+                    {hasHighSynergy && (
+                      <div
+                        className="absolute top-2 right-2 z-10"
+                        data-testid="synergy-badge"
                       >
-                        {Math.round(synergy.score)}%
-                      </Badge>
-                    </div>
-                  )}
-                </button>
-              );
-            })}
-          </div>
-        )}
+                        <Badge
+                          variant={
+                            synergy.score >= 80 ? "default" : "secondary"
+                          }
+                          className={`${synergy.score >= 80 ? "bg-green-600 hover:bg-green-700" : "bg-orange-500 hover:bg-orange-600"} text-white border-none shadow-sm text-[10px] px-1.5 py-0`}
+                        >
+                          {Math.round(synergy.score)}%
+                        </Badge>
+                      </div>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  },
+);

--- a/src/app/(app)/deck-builder/_lib/__tests__/deck-builder-shortcuts.test.ts
+++ b/src/app/(app)/deck-builder/_lib/__tests__/deck-builder-shortcuts.test.ts
@@ -1,0 +1,219 @@
+import {
+  resolveDeckBuilderShortcut,
+  isEditableTarget,
+} from "../deck-builder-shortcuts";
+import type { ScryfallCard } from "@/app/actions";
+
+const card: ScryfallCard = {
+  id: "card-1",
+  name: "Sol Ring",
+  set: "cmr",
+  collector_number: "1",
+  cmc: 1,
+  type_line: "Artifact",
+  oracle_text: "Tap for 2.",
+  colors: [],
+  color_identity: [],
+  rarity: "uncommon",
+  legalities: {},
+} as unknown as ScryfallCard;
+
+/** Build a KeyboardEvent with an overridable target (jsdom-friendly). */
+function keyEvent(
+  key: string,
+  opts: {
+    ctrlKey?: boolean;
+    metaKey?: boolean;
+    shiftKey?: boolean;
+    target?: EventTarget | null;
+  } = {},
+): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    ctrlKey: !!opts.ctrlKey,
+    metaKey: !!opts.metaKey,
+    shiftKey: !!opts.shiftKey,
+    bubbles: true,
+    cancelable: true,
+  });
+  if (opts.target !== undefined) {
+    Object.defineProperty(event, "target", { value: opts.target });
+  }
+  return event;
+}
+
+describe("resolveDeckBuilderShortcut", () => {
+  describe("add card (+ / =)", () => {
+    it("treats unshifted '=' as add-one", () => {
+      const action = resolveDeckBuilderShortcut(keyEvent("="), {
+        selectedCard: card,
+      });
+      expect(action).toEqual({ type: "addCard", card, max: false });
+    });
+
+    it("treats shifted '+' (Shift+=) as add-maximum", () => {
+      const action = resolveDeckBuilderShortcut(
+        keyEvent("+", { shiftKey: true }),
+        {
+          selectedCard: card,
+        },
+      );
+      expect(action).toEqual({ type: "addCard", card, max: true });
+    });
+
+    it("does nothing when no card is selected", () => {
+      expect(
+        resolveDeckBuilderShortcut(keyEvent("="), { selectedCard: null }),
+      ).toEqual({ type: "none" });
+    });
+  });
+
+  describe("remove card (- / _)", () => {
+    it("treats unshifted '-' as remove-one", () => {
+      const action = resolveDeckBuilderShortcut(keyEvent("-"), {
+        selectedCard: card,
+      });
+      expect(action).toEqual({ type: "removeCard", card, all: false });
+    });
+
+    it("treats shifted '_' (Shift+-) as remove-all", () => {
+      const action = resolveDeckBuilderShortcut(
+        keyEvent("_", { shiftKey: true }),
+        {
+          selectedCard: card,
+        },
+      );
+      expect(action).toEqual({ type: "removeCard", card, all: true });
+    });
+
+    it("does nothing when no card is selected", () => {
+      expect(
+        resolveDeckBuilderShortcut(keyEvent("-"), { selectedCard: null }),
+      ).toEqual({ type: "none" });
+    });
+  });
+
+  describe("Enter", () => {
+    it("adds the focused card (confirm)", () => {
+      const action = resolveDeckBuilderShortcut(keyEvent("Enter"), {
+        selectedCard: card,
+      });
+      expect(action).toEqual({ type: "addCard", card, max: false });
+    });
+
+    it("does nothing when no card is selected", () => {
+      expect(
+        resolveDeckBuilderShortcut(keyEvent("Enter"), { selectedCard: null }),
+      ).toEqual({ type: "none" });
+    });
+  });
+
+  describe("Ctrl/Cmd+N — new deck", () => {
+    it("triggers new deck on Ctrl+N", () => {
+      expect(
+        resolveDeckBuilderShortcut(keyEvent("n", { ctrlKey: true }), {
+          selectedCard: null,
+        }),
+      ).toEqual({ type: "newDeck" });
+    });
+
+    it("triggers new deck on Cmd+N (mac) with uppercase key", () => {
+      expect(
+        resolveDeckBuilderShortcut(keyEvent("N", { metaKey: true }), {
+          selectedCard: card,
+        }),
+      ).toEqual({ type: "newDeck" });
+    });
+
+    it("ignores lone 'n' without a modifier", () => {
+      expect(
+        resolveDeckBuilderShortcut(keyEvent("n"), { selectedCard: card }),
+      ).toEqual({ type: "none" });
+    });
+  });
+
+  describe("modifier passthrough", () => {
+    it("leaves Ctrl+S to its own listener", () => {
+      expect(
+        resolveDeckBuilderShortcut(keyEvent("s", { ctrlKey: true }), {
+          selectedCard: card,
+        }),
+      ).toEqual({ type: "none" });
+    });
+
+    it("leaves Ctrl+F to its own listener", () => {
+      expect(
+        resolveDeckBuilderShortcut(keyEvent("f", { ctrlKey: true }), {
+          selectedCard: card,
+        }),
+      ).toEqual({ type: "none" });
+    });
+  });
+
+  describe("unrelated keys", () => {
+    it("ignores keys that are not shortcuts", () => {
+      for (const key of ["a", "x", "1", "ArrowLeft", " "]) {
+        expect(
+          resolveDeckBuilderShortcut(keyEvent(key), { selectedCard: card }),
+        ).toEqual({ type: "none" });
+      }
+    });
+  });
+
+  describe("suppresses shortcuts while typing", () => {
+    it.each(["INPUT", "TEXTAREA", "SELECT"])(
+      "ignores '+' from a %s element",
+      (tagName) => {
+        const el = document.createElement(tagName);
+        expect(
+          resolveDeckBuilderShortcut(keyEvent("+", { target: el }), {
+            selectedCard: card,
+          }),
+        ).toEqual({ type: "none" });
+      },
+    );
+
+    it("ignores Ctrl+N from an input element", () => {
+      const input = document.createElement("input");
+      expect(
+        resolveDeckBuilderShortcut(
+          keyEvent("n", { ctrlKey: true, target: input }),
+          { selectedCard: card },
+        ),
+      ).toEqual({ type: "none" });
+    });
+
+    it("ignores Enter from a contentEditable element", () => {
+      const div = document.createElement("div");
+      div.setAttribute("contenteditable", "true");
+      expect(
+        resolveDeckBuilderShortcut(keyEvent("Enter", { target: div }), {
+          selectedCard: card,
+        }),
+      ).toEqual({ type: "none" });
+    });
+  });
+});
+
+describe("isEditableTarget", () => {
+  it("returns false for non-element targets", () => {
+    expect(isEditableTarget(null)).toBe(false);
+  });
+
+  it("returns true for form fields", () => {
+    expect(isEditableTarget(document.createElement("input"))).toBe(true);
+    expect(isEditableTarget(document.createElement("textarea"))).toBe(true);
+    expect(isEditableTarget(document.createElement("select"))).toBe(true);
+  });
+
+  it("returns true for contentEditable regions", () => {
+    const div = document.createElement("div");
+    div.setAttribute("contenteditable", "true");
+    expect(isEditableTarget(div)).toBe(true);
+  });
+
+  it("returns false for generic elements", () => {
+    expect(isEditableTarget(document.createElement("div"))).toBe(false);
+    expect(isEditableTarget(document.createElement("button"))).toBe(false);
+  });
+});

--- a/src/app/(app)/deck-builder/_lib/deck-builder-shortcuts.ts
+++ b/src/app/(app)/deck-builder/_lib/deck-builder-shortcuts.ts
@@ -1,0 +1,87 @@
+import type { ScryfallCard } from "@/app/actions";
+
+export type DeckBuilderShortcutAction =
+  | { type: "addCard"; card: ScryfallCard; max: boolean }
+  | { type: "removeCard"; card: ScryfallCard; all: boolean }
+  | { type: "newDeck" }
+  | { type: "none" };
+
+export interface DeckBuilderShortcutContext {
+  /** The card currently focused/selected in the search results, if any. */
+  selectedCard: ScryfallCard | null;
+}
+
+/** Element tags where keyboard input should not trigger shortcuts. */
+const EDITABLE_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT", "OPTION"]);
+
+/** True when a key event originated from a form field / editable region. */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (EDITABLE_TAGS.has(target.tagName)) return true;
+  if (target.isContentEditable) return true;
+  return target.getAttribute("contenteditable") === "true";
+}
+
+/**
+ * Resolve a keyboard event into a deck-builder shortcut action.
+ *
+ * Documented shortcuts (docs/USER_GUIDE.md §8 "Keyboard Shortcuts"):
+ *   +                Add Card to Deck
+ *   -                Remove Card from Deck
+ *   Shift++          Add Maximum Copies
+ *   Shift+-          Remove All Copies
+ *   Enter            Confirm / add the focused card
+ *   Ctrl/Cmd+N       New Deck
+ *
+ * On a US keyboard the unshifted "+/=" key reports "=". Shift+"=" reports "+",
+ * and Shift+"-" reports "_". We therefore treat "=" as "add one" and "+" as
+ * "add max" (and "-" / "_" the same way for removal) — this matches the
+ * documented "+" (add) / "Shift++" (add max) pair while staying usable on the
+ * physical keys people actually press.
+ */
+export function resolveDeckBuilderShortcut(
+  event: KeyboardEvent,
+  ctx: DeckBuilderShortcutContext,
+): DeckBuilderShortcutAction {
+  // Never fire shortcuts while the user is typing in a form field.
+  if (isEditableTarget(event.target)) {
+    return { type: "none" };
+  }
+
+  const key = event.key;
+  const modifier = event.ctrlKey || event.metaKey;
+
+  // Ctrl/Cmd+N — New Deck (documented global shortcut).
+  if (modifier && (key === "n" || key === "N")) {
+    return { type: "newDeck" };
+  }
+
+  // Let other modifier combos (Ctrl+S, Ctrl+F, ...) be handled by their own
+  // listeners so we never double-trigger documented global shortcuts.
+  if (modifier) {
+    return { type: "none" };
+  }
+
+  const { selectedCard } = ctx;
+
+  // "+" (Shift held on US layout) -> add maximum; "=" (unshifted) -> add one.
+  if (key === "+" || key === "=") {
+    if (!selectedCard) return { type: "none" };
+    return { type: "addCard", card: selectedCard, max: key === "+" };
+  }
+
+  // "_" (Shift held) -> remove all; "-" (unshifted) -> remove one.
+  if (key === "-" || key === "_") {
+    if (!selectedCard) return { type: "none" };
+    return { type: "removeCard", card: selectedCard, all: key === "_" };
+  }
+
+  // Enter — confirm / add the focused card (mirrors the in-search Enter which
+  // adds the highlighted result).
+  if (key === "Enter") {
+    if (!selectedCard) return { type: "none" };
+    return { type: "addCard", card: selectedCard, max: false };
+  }
+
+  return { type: "none" };
+}

--- a/src/app/(app)/deck-builder/_lib/use-deck-builder-shortcuts.ts
+++ b/src/app/(app)/deck-builder/_lib/use-deck-builder-shortcuts.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect } from "react";
+import type { ScryfallCard } from "@/app/actions";
+import {
+  resolveDeckBuilderShortcut,
+  type DeckBuilderShortcutContext,
+} from "./deck-builder-shortcuts";
+
+export interface UseDeckBuilderShortcutsHandlers {
+  /** Add a card. When `max` is true, add up to the maximum allowed copies. */
+  addCard: (card: ScryfallCard, max: boolean) => void;
+  /** Remove a card. When `all` is true, remove every copy of it. */
+  removeCard: (card: ScryfallCard, all: boolean) => void;
+  /** Create a fresh, empty deck. */
+  newDeck: () => void;
+}
+
+export interface UseDeckBuilderShortcutsOptions
+  extends DeckBuilderShortcutContext, UseDeckBuilderShortcutsHandlers {}
+
+/**
+ * Installs a scoped (window-level) keydown listener that maps the documented
+ * deck-builder shortcuts (+, -, Shift++/Shift+-, Enter, Ctrl/Cmd+N) onto the
+ * provided handlers. Shortcuts are suppressed while typing in form fields.
+ *
+ * Scoping: this hook is only mounted by the deck-builder page, so the listener
+ * is automatically removed when navigating away from the page.
+ */
+export function useDeckBuilderShortcuts(
+  options: UseDeckBuilderShortcutsOptions,
+): void {
+  const { selectedCard, addCard, removeCard, newDeck } = options;
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const action = resolveDeckBuilderShortcut(event, { selectedCard });
+
+      switch (action.type) {
+        case "addCard":
+          event.preventDefault();
+          addCard(action.card, action.max);
+          break;
+        case "removeCard":
+          event.preventDefault();
+          removeCard(action.card, action.all);
+          break;
+        case "newDeck":
+          event.preventDefault();
+          newDeck();
+          break;
+        case "none":
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [selectedCard, addCard, removeCard, newDeck]);
+}

--- a/src/app/(app)/deck-builder/page.tsx
+++ b/src/app/(app)/deck-builder/page.tsx
@@ -12,6 +12,7 @@ import {
 import { CardSearch } from "./_components/card-search";
 import { DeckList } from "./_components/deck-list";
 import { ImportExportControls } from "./_components/import-export-controls";
+import { useDeckBuilderShortcuts } from "./_lib/use-deck-builder-shortcuts";
 import {
   Select,
   SelectContent,
@@ -42,6 +43,10 @@ export default function DeckBuilderPage() {
   // Defensive: ensure savedDecks is always an array (guards against corrupted storage)
   const savedDecks = Array.isArray(savedDecksRaw) ? savedDecksRaw : [];
   const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
+  // The card currently highlighted in CardSearch — the target for the +, - and
+  // Enter shortcuts. Lifted from CardSearch so the page-level keydown listener
+  // (installed by useDeckBuilderShortcuts) can act on it.
+  const [selectedCard, setSelectedCard] = useState<ScryfallCard | null>(null);
   const searchInputRef = useRef<{ focus: () => void }>(null);
 
   const { toast } = useToast();
@@ -97,10 +102,13 @@ export default function DeckBuilderPage() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, []); // Empty deps - handlers are stable
 
-  const handleDeckChange = (updater: (prevDeck: DeckCard[]) => DeckCard[]) => {
-    setDeck(updater);
-    setIsDeckSaved(false);
-  };
+  const handleDeckChange = useCallback(
+    (updater: (prevDeck: DeckCard[]) => DeckCard[]) => {
+      setDeck(updater);
+      setIsDeckSaved(false);
+    },
+    [],
+  );
 
   const handleDeckNameChange = (name: string) => {
     setDeckName(name);
@@ -112,61 +120,67 @@ export default function DeckBuilderPage() {
     setIsDeckSaved(false);
   };
 
-  const addCardToDeck = (card: ScryfallCard) => {
-    const gameModeId = getGameModeIdFromFormatName(format);
-    const rules = formatRules[gameModeId as keyof typeof formatRules];
+  const addCardToDeck = useCallback(
+    (card: ScryfallCard) => {
+      const gameModeId = getGameModeIdFromFormatName(format);
+      const rules = formatRules[gameModeId as keyof typeof formatRules];
 
-    handleDeckChange((prevDeck) => {
-      const existingCard = prevDeck.find((c) => c.id === card.id);
-      const isBasicResource = card.type_line?.includes("Basic Resource");
+      handleDeckChange((prevDeck) => {
+        const existingCard = prevDeck.find((c) => c.id === card.id);
+        const isBasicResource = card.type_line?.includes("Basic Resource");
 
-      if (
-        !isBasicResource &&
-        existingCard &&
-        existingCard.count >= rules.maxCopies
-      ) {
-        toast({
-          variant: "destructive",
-          title: "Card Limit Reached",
-          description: `You can only have ${rules.maxCopies} cop${rules.maxCopies > 1 ? "ies" : "y"} of "${card.name}" in a ${format} deck.`,
-        });
-        return prevDeck;
-      }
+        if (
+          !isBasicResource &&
+          existingCard &&
+          existingCard.count >= rules.maxCopies
+        ) {
+          toast({
+            variant: "destructive",
+            title: "Card Limit Reached",
+            description: `You can only have ${rules.maxCopies} cop${rules.maxCopies > 1 ? "ies" : "y"} of "${card.name}" in a ${format} deck.`,
+          });
+          return prevDeck;
+        }
 
-      const totalCards = prevDeck.reduce((sum, c) => sum + c.count, 0);
-      if (rules.maxCards && totalCards >= rules.maxCards) {
-        toast({
-          variant: "destructive",
-          title: "Deck Limit Reached",
-          description: `A ${format} deck cannot have more than ${rules.maxCards} cards.`,
-        });
-        return prevDeck;
-      }
+        const totalCards = prevDeck.reduce((sum, c) => sum + c.count, 0);
+        if (rules.maxCards && totalCards >= rules.maxCards) {
+          toast({
+            variant: "destructive",
+            title: "Deck Limit Reached",
+            description: `A ${format} deck cannot have more than ${rules.maxCards} cards.`,
+          });
+          return prevDeck;
+        }
 
-      if (existingCard) {
-        return prevDeck.map((c) =>
-          c.id === card.id ? { ...c, count: c.count + 1 } : c,
-        );
-      } else {
-        return [...prevDeck, { ...card, count: 1 }];
-      }
-    });
-  };
+        if (existingCard) {
+          return prevDeck.map((c) =>
+            c.id === card.id ? { ...c, count: c.count + 1 } : c,
+          );
+        } else {
+          return [...prevDeck, { ...card, count: 1 }];
+        }
+      });
+    },
+    [format, handleDeckChange, toast],
+  );
 
-  const removeCardFromDeck = (cardId: string) => {
-    handleDeckChange((prevDeck) => {
-      const existingCard = prevDeck.find((c) => c.id === cardId);
-      if (existingCard && existingCard.count > 1) {
-        return prevDeck.map((c) =>
-          c.id === cardId ? { ...c, count: c.count - 1 } : c,
-        );
-      } else {
-        return prevDeck.filter((c) => c.id !== cardId);
-      }
-    });
-  };
+  const removeCardFromDeck = useCallback(
+    (cardId: string) => {
+      handleDeckChange((prevDeck) => {
+        const existingCard = prevDeck.find((c) => c.id === cardId);
+        if (existingCard && existingCard.count > 1) {
+          return prevDeck.map((c) =>
+            c.id === cardId ? { ...c, count: c.count - 1 } : c,
+          );
+        } else {
+          return prevDeck.filter((c) => c.id !== cardId);
+        }
+      });
+    },
+    [handleDeckChange],
+  );
 
-  const clearDeck = () => {
+  const clearDeck = useCallback(() => {
     setDeck([]);
     setDeckName("New Deck");
     setActiveDeckId(null);
@@ -174,7 +188,42 @@ export default function DeckBuilderPage() {
       title: "Deck Cleared",
       description: "Your deck has been emptied.",
     });
-  };
+  }, [toast]);
+
+  // Maximum copies added by the "Shift++" (add max) shortcut. Matches the
+  // Shift+Click quick-add behaviour in CardSearch.
+  const MAX_QUICK_ADD = 4;
+
+  const handleShortcutAdd = useCallback(
+    (card: ScryfallCard, max: boolean) => {
+      const copies = max ? MAX_QUICK_ADD : 1;
+      for (let i = 0; i < copies; i++) addCardToDeck(card);
+    },
+    [addCardToDeck],
+  );
+
+  const handleShortcutRemove = useCallback(
+    (card: ScryfallCard, all: boolean) => {
+      if (all) {
+        handleDeckChange((prev) => prev.filter((c) => c.id !== card.id));
+      } else {
+        removeCardFromDeck(card.id);
+      }
+    },
+    [removeCardFromDeck, handleDeckChange],
+  );
+
+  // Ctrl/Cmd+N — documented as "New Deck". Wraps clearDeck so a future confirm
+  // prompt can be added in one place.
+  const handleNewDeck = useCallback(() => clearDeck(), [clearDeck]);
+
+  // Documented deck-builder shortcuts: +, -, Shift++/Shift+-, Enter, Ctrl/Cmd+N.
+  useDeckBuilderShortcuts({
+    selectedCard,
+    addCard: handleShortcutAdd,
+    removeCard: handleShortcutRemove,
+    newDeck: handleNewDeck,
+  });
 
   const importDeck = (
     decklist: string,
@@ -365,7 +414,11 @@ export default function DeckBuilderPage() {
         </div>
         <div className="flex-grow grid grid-cols-1 lg:grid-cols-4 gap-6">
           <div className="lg:col-span-2">
-            <CardSearch ref={searchInputRef} onAddCard={addCardToDeck} />
+            <CardSearch
+              ref={searchInputRef}
+              onAddCard={addCardToDeck}
+              onSelectedCardChange={setSelectedCard}
+            />
           </div>
           <div className="lg:col-span-1 flex flex-col gap-6">
             <Tabs defaultValue="deck" className="w-full">


### PR DESCRIPTION
## Summary

Resolves #932. The deck-builder page documented keyboard shortcuts in `docs/USER_GUIDE.md §8` (and the search placeholder) that were never wired up — pressing `+`, `-`, `Enter`, or `Ctrl+N` did nothing. This PR implements them so the documented behavior actually works.

## Shortcuts implemented

All shortcuts are scoped to the deck-builder page (the listener is only mounted there) and are **suppressed while typing in form fields** (`INPUT`/`TEXTAREA`/`SELECT`/`contenteditable`).

| Shortcut | Action |
|----------|--------|
| `+` / `=` | Add one copy of the focused (highlighted) search card |
| `Shift++` | Add maximum copies (4-of) of the focused card |
| `-` / `_` | Remove one copy of the focused card |
| `Shift+-` | Remove **all** copies of the focused card |
| `Enter` | Add / confirm the focused card (mirrors the existing in-search `Enter`) |
| `Ctrl/Cmd+N` | New deck (clears to a fresh empty deck) |

**Key-mapping note:** On a US keyboard the unshifted `+/=` key reports `=`, and `Shift` reports `+` (likewise `-` → `_`). So `=` adds one / `+` adds max, and `-` removes one / `_` removes all — which matches the documented `+` / `Shift++` pair. Both shifted and unshifted forms are accepted.

`Ctrl+S` (save), `Ctrl+F` (focus search) and `Esc` (close dialog) were already implemented and are left untouched.

## How it works

- `src/app/(app)/deck-builder/_lib/deck-builder-shortcuts.ts` — **pure, framework-agnostic** `resolveDeckBuilderShortcut(event, ctx)` + `isEditableTarget()`. Maps a `KeyboardEvent` to a typed action (`addCard`/`removeCard`/`newDeck`/`none`). Fully unit-testable.
- `src/app/(app)/deck-builder/_lib/use-deck-builder-shortcuts.ts` — thin React hook that installs a scoped `window` keydown listener and dispatches resolved actions to the provided handlers.
- `card-search.tsx` — lifts the currently-highlighted result (`selectedIndex`) up to the page via a new `onSelectedCardChange` callback, so the page-level shortcut knows which card `+`/`-`/`Enter` target.
- `page.tsx` — memoizes `addCardToDeck`/`removeCardFromDeck`/`clearDeck` (`useCallback`), adds `selectedCard` state, and wires the shortcut handlers (max-add reuses the existing 4-of quick-add; remove-all filters the deck).
- `docs/USER_GUIDE.md` — corrected the `Enter` row from "View Card Details" (a viewer that doesn't exist) to the implemented "Add Focused Card / Confirm" so docs match reality.

## Files changed

- `src/app/(app)/deck-builder/_lib/deck-builder-shortcuts.ts` (new)
- `src/app/(app)/deck-builder/_lib/use-deck-builder-shortcuts.ts` (new)
- `src/app/(app)/deck-builder/_lib/__tests__/deck-builder-shortcuts.test.ts` (new — 23 tests)
- `src/app/(app)/deck-builder/_components/card-search.tsx`
- `src/app/(app)/deck-builder/page.tsx`
- `docs/USER_GUIDE.md`

## Test results

- `npx jest deck-builder-shortcuts` → **23/23 pass** (covers all shortcuts, no-selection cases, modifier passthrough, and form-field suppression).
- `tsc --noEmit` → **no errors**.
- `eslint` on changed files → **0 errors, 0 warnings** (remaining warnings in the dir are pre-existing in untouched files).
- Full suite: my new tests pass; the only failure (`game-state.test.ts`) is a pre-existing random/flaky engine test — passes 67/67 in isolation and is unrelated to deck-builder.

Closes #932.
