### PR TITLE
fix(a11y): resolve #933 — keyboard-accessible deck-list controls

### DIFF
--- a/src/app/(app)/deck-builder/_components/__tests__/deck-list.test.tsx
+++ b/src/app/(app)/deck-builder/_components/__tests__/deck-list.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @fileoverview Accessibility tests for DeckList
+ *
+ * Verifies deck-list card controls are keyboard-accessible (issue #933):
+ *   1. The remove/decrease control is always visible (not hover-only).
+ *   2. Every interactive control exposes an accessible name via aria-label.
+ *   3. Quantity steppers (+/-) are rendered as real buttons that invoke the
+ *      correct handlers.
+ */
+
+import { describe, it, expect, jest } from "@jest/globals";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+jest.mock("@/components/ui/card", () => ({
+  Card: ({ children, className }: any) => (
+    <div className={className}>{children}</div>
+  ),
+  CardHeader: ({ children }: any) => <div>{children}</div>,
+  CardDescription: ({ children }: any) => <div>{children}</div>,
+  CardContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock("@/components/ui/input", () => ({
+  Input: (props: any) => <input {...props} />,
+}));
+
+jest.mock("@/components/ui/scroll-area", () => ({
+  ScrollArea: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock("@/components/ui/separator", () => ({
+  Separator: () => <hr />,
+}));
+
+jest.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, className, ...props }: any) => (
+    <button type="button" onClick={onClick} className={className} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock("lucide-react", () => ({
+  Minus: () => <svg data-testid="minus-icon" />,
+  Plus: () => <svg data-testid="plus-icon" />,
+}));
+
+import { DeckList } from "@/app/(app)/deck-builder/_components/deck-list";
+
+const bolt = {
+  id: "bolt-1",
+  name: "Lightning Bolt",
+  count: 3,
+  type_line: "Instant",
+} as any;
+
+const deck = [bolt] as any;
+
+const renderList = (overrides: any = {}) =>
+  render(
+    <DeckList
+      deck={deck}
+      deckName="My Deck"
+      onDeckNameChange={jest.fn()}
+      onRemoveCard={jest.fn()}
+      onAddCard={jest.fn()}
+      {...overrides}
+    />,
+  );
+
+describe("DeckList — card control accessibility (#933)", () => {
+  it("renders the empty-state message when the deck is empty", () => {
+    render(
+      <DeckList
+        deck={[]}
+        deckName="Empty"
+        onDeckNameChange={jest.fn()}
+        onRemoveCard={jest.fn()}
+        onAddCard={jest.fn()}
+      />,
+    );
+    expect(screen.getByText(/your deck is empty/i)).toBeInTheDocument();
+  });
+
+  it("renders the decrease control always visible (no hover-only opacity)", () => {
+    renderList();
+    const decrease = screen.getByTestId("decrease-quantity-bolt-1");
+    expect(decrease).toBeInTheDocument();
+    expect(decrease.tagName).toBe("BUTTON");
+    // Hover-only reveal used opacity-0 group-hover:opacity-100 — those must be gone.
+    expect(decrease.className).not.toMatch(/opacity-0/);
+    expect(decrease.className).not.toMatch(/group-hover:opacity-100/);
+  });
+
+  it("renders the increase control always visible (no hover-only opacity)", () => {
+    renderList();
+    const increase = screen.getByTestId("increase-quantity-bolt-1");
+    expect(increase).toBeInTheDocument();
+    expect(increase.tagName).toBe("BUTTON");
+    expect(increase.className).not.toMatch(/opacity-0/);
+    expect(increase.className).not.toMatch(/group-hover:opacity-100/);
+  });
+
+  it("exposes accessible names for both stepper buttons", () => {
+    renderList();
+    expect(
+      screen.getByRole("button", { name: "Decrease quantity of Lightning Bolt" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Increase quantity of Lightning Bolt" }),
+    ).toBeInTheDocument();
+  });
+
+  it("exposes the current quantity to assistive tech", () => {
+    renderList();
+    expect(screen.getByLabelText("Quantity 3")).toHaveTextContent("3");
+  });
+
+  it("invokes onRemoveCard with the card id when the decrease button is clicked", () => {
+    const onRemoveCard = jest.fn();
+    renderList({ onRemoveCard });
+    fireEvent.click(screen.getByTestId("decrease-quantity-bolt-1"));
+    expect(onRemoveCard).toHaveBeenCalledTimes(1);
+    expect(onRemoveCard).toHaveBeenCalledWith("bolt-1");
+  });
+
+  it("invokes onAddCard with the card when the increase button is clicked", () => {
+    const onAddCard = jest.fn();
+    renderList({ onAddCard });
+    fireEvent.click(screen.getByTestId("increase-quantity-bolt-1"));
+    expect(onAddCard).toHaveBeenCalledTimes(1);
+    expect(onAddCard).toHaveBeenCalledWith(bolt);
+  });
+});

--- a/src/app/(app)/deck-builder/_components/deck-list.tsx
+++ b/src/app/(app)/deck-builder/_components/deck-list.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
-import { MinusCircle } from "lucide-react";
+import { Minus, Plus } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 import { useMemo } from "react";
 
@@ -14,13 +14,14 @@ interface DeckListProps {
   deckName: string;
   onDeckNameChange: (name: string) => void;
   onRemoveCard: (cardId: string) => void;
+  onAddCard: (card: DeckCard) => void;
 }
 
 type CategorizedDeck = {
   [key: string]: DeckCard[];
 };
 
-export function DeckList({ deck, deckName, onDeckNameChange, onRemoveCard }: DeckListProps) {
+export function DeckList({ deck, deckName, onDeckNameChange, onRemoveCard, onAddCard }: DeckListProps) {
   const totalCards = useMemo(() => deck.reduce((sum, card) => sum + card.count, 0), [deck]);
 
   const categorizedDeck = useMemo(() => {
@@ -73,11 +74,17 @@ export function DeckList({ deck, deckName, onDeckNameChange, onRemoveCard }: Dec
                                 <h4 className="font-semibold text-muted-foreground mb-2">{category} ({categoryCount})</h4>
                                 <ul className="space-y-1">
                                     {categorizedDeck[category].sort((a: DeckCard, b: DeckCard) => a.name.localeCompare(b.name)).map(card => (
-                                        <li key={card.id} className="group flex items-center justify-between text-sm p-1 rounded-md hover:bg-secondary" data-testid={`deck-item-${card.name.toLowerCase().replace(/\s+/g, '-')}`}>
-                                            <span>{card.count}x {card.name}</span>
-                                            <Button variant="ghost" size="icon" className="size-6 opacity-0 group-hover:opacity-100" onClick={() => onRemoveCard(card.id)}>
-                                                <MinusCircle className="size-4 text-destructive"/>
-                                            </Button>
+                                        <li key={card.id} className="flex items-center justify-between text-sm p-1 rounded-md hover:bg-secondary" data-testid={`deck-item-${card.name.toLowerCase().replace(/\s+/g, '-')}`}>
+                                            <span>{card.name}</span>
+                                            <div className="flex items-center gap-1">
+                                                <Button variant="ghost" size="icon" className="size-6" aria-label={`Decrease quantity of ${card.name}`} onClick={() => onRemoveCard(card.id)} data-testid={`decrease-quantity-${card.id}`}>
+                                                    <Minus className="size-4" />
+                                                </Button>
+                                                <span className="w-5 text-center tabular-nums" aria-label={`Quantity ${card.count}`}>{card.count}</span>
+                                                <Button variant="ghost" size="icon" className="size-6" aria-label={`Increase quantity of ${card.name}`} onClick={() => onAddCard(card)} data-testid={`increase-quantity-${card.id}`}>
+                                                    <Plus className="size-4" />
+                                                </Button>
+                                            </div>
                                         </li>
                                     ))}
                                 </ul>

--- a/src/app/(app)/deck-builder/page.tsx
+++ b/src/app/(app)/deck-builder/page.tsx
@@ -436,6 +436,7 @@ export default function DeckBuilderPage() {
                   deckName={deckName}
                   onDeckNameChange={handleDeckNameChange}
                   onRemoveCard={removeCardFromDeck}
+                  onAddCard={addCardToDeck}
                 />
               </TabsContent>
               <TabsContent value="mana-curve" className="mt-4">


### PR DESCRIPTION
## Summary

Resolves #933 — makes deck-list card controls fully keyboard-accessible.

### Problems fixed
1. **Hover-only remove button** — the remove control used `opacity-0 group-hover:opacity-100`, so it was invisible to keyboard and screen-reader users. Removed the hover-only visibility; the control is now always rendered and reachable via <kbd>Tab</kbd>.
2. **Missing accessible labels** — interactive controls had no accessible names (icon-only). Added `aria-label`s to both stepper buttons (e.g. `Decrease quantity of Lightning Bolt`) and an `aria-label` on the quantity display.
3. **No quantity steppers** — there was no way to adjust card counts from the deck list without hover/drag. Added real `<button>` increment (+) and decrement (−) steppers next to each card.

### Implementation
- `deck-list.tsx`: replaced the single hover-only `MinusCircle` button with an always-visible `[−] count [+]` stepper group. Decrease reuses `onRemoveCard` (decrements; removes card at 0); increase uses a new `onAddCard` prop (wired to the existing `addCardToDeck`, which preserves format limit checks). Dropped the now-unused `group` class and `MinusCircle` import.
- `page.tsx`: passed `onAddCard={addCardToDeck}` to `DeckList`.

## Files changed
- `src/app/(app)/deck-builder/_components/deck-list.tsx`
- `src/app/(app)/deck-builder/page.tsx`
- `src/app/(app)/deck-builder/_components/__tests__/deck-list.test.tsx` (new — 7 tests)

## Test results
- New suite `deck-list.test.tsx`: **7/7 passing** (always-visible controls, no hover-only classes, aria-labels, quantity exposed, correct handlers invoked).
- Full deck-builder test suite: **34/34 passing** (3 suites), no regressions.
- `tsc --noEmit`: **no errors**.
- `eslint` (changed files): **clean** (0 warnings/errors).

## Notes / Assumptions
- Stepper decrease reuses the existing decrement-or-remove semantics of `removeCardFromDeck`; increase reuses `addCardToDeck` so format copy/deck-size limits still apply.
- Scope limited to the deck-list card controls; no unrelated components touched.
