### PR TITLE
feat: resolve #1010 — add service worker registration feedback to UI

### DIFF
--- a/src/components/__tests__/service-worker-registration.test.tsx
+++ b/src/components/__tests__/service-worker-registration.test.tsx
@@ -1,0 +1,154 @@
+import React from "react";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { ServiceWorkerRegistration } from "../service-worker-registration";
+
+// Mock the toast module so we can assert on dispatched toasts without rendering <Toaster />.
+const toastMock = jest.fn();
+jest.mock("@/hooks/use-toast", () => ({
+  toast: (...args: unknown[]) => toastMock(...args),
+}));
+
+// Mocks for browser APIs that jsdom does not provide.
+const matchMediaMock = jest.fn().mockReturnValue({ matches: false });
+const registerMock = jest.fn();
+const getRegistrationMock = jest.fn();
+
+class FakeEventTarget {
+  private listeners: Record<string, Array<(e: Event) => void>> = {};
+  addEventListener(type: string, cb: (e: Event) => void) {
+    (this.listeners[type] ||= []).push(cb);
+  }
+  removeEventListener(type: string, cb: (e: Event) => void) {
+    this.listeners[type] = (this.listeners[type] || []).filter((fn) => fn !== cb);
+  }
+  dispatchEvent(type: string) {
+    (this.listeners[type] || []).forEach((cb) => cb(new Event(type)));
+  }
+}
+
+const registrationTarget = new FakeEventTarget();
+
+beforeEach(() => {
+  toastMock.mockClear();
+  registerMock.mockReset();
+  getRegistrationMock.mockReset();
+
+  // matchMedia — referenced on mount for display-mode check.
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: matchMediaMock,
+  });
+
+  // navigator.onLine defaults to true in jsdom; ensure a known baseline.
+  Object.defineProperty(navigator, "onLine", {
+    configurable: true,
+    value: true,
+  });
+
+  // navigator.serviceWorker — referenced on mount.
+  Object.defineProperty(navigator, "serviceWorker", {
+    configurable: true,
+    value: {
+      register: registerMock.mockResolvedValue({
+        scope: "/",
+        addEventListener: registrationTarget.addEventListener.bind(registrationTarget),
+      }),
+      controller: undefined,
+      getRegistration: getRegistrationMock,
+    },
+  });
+
+  // caches — referenced by getCacheInfo / clear cache. Provide a minimal stub.
+  Object.defineProperty(global, "caches", {
+    configurable: true,
+    value: { keys: jest.fn().mockResolvedValue([]), delete: jest.fn().mockResolvedValue(true) },
+  });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("ServiceWorkerRegistration", () => {
+  it("renders nothing by default except the floating settings control", () => {
+    render(<ServiceWorkerRegistration />);
+    expect(screen.getByLabelText("Open service worker settings")).toBeTruthy();
+  });
+
+  it("shows a persistent offline banner when the connection is lost", () => {
+    render(<ServiceWorkerRegistration />);
+    expect(screen.queryByText(/You're offline/i)).toBeNull();
+
+    act(() => {
+      window.dispatchEvent(new Event("offline"));
+    });
+
+    expect(screen.getByText(/You're offline/i)).toBeTruthy();
+    expect(screen.getByRole("status")).toBeTruthy();
+  });
+
+  it("removes the offline banner when the connection is restored", () => {
+    render(<ServiceWorkerRegistration />);
+    act(() => window.dispatchEvent(new Event("offline")));
+    expect(screen.getByText(/You're offline/i)).toBeTruthy();
+
+    act(() => window.dispatchEvent(new Event("online")));
+    expect(screen.queryByText(/You're offline/i)).toBeNull();
+  });
+
+  it("fires a toast (not a console.log) when going offline and back online", () => {
+    render(<ServiceWorkerRegistration />);
+
+    act(() => window.dispatchEvent(new Event("offline")));
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ title: "You're offline" }));
+
+    act(() => window.dispatchEvent(new Event("online")));
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ title: "Back online" }));
+  });
+
+  it("shows a confirmation toast when caches are cleared", async () => {
+    // Provide two named caches so the cleared toast message is deterministic.
+    (global.caches.keys as jest.Mock).mockResolvedValue(["cache-a", "cache-b"]);
+
+    render(<ServiceWorkerRegistration />);
+    fireEvent.click(screen.getByLabelText("Open service worker settings"));
+    fireEvent.click(screen.getByRole("button", { name: "Clear Cache" }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Cache cleared" }),
+      );
+    });
+  });
+
+  it("does not call console.log during its lifecycle", () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    render(<ServiceWorkerRegistration />);
+    act(() => window.dispatchEvent(new Event("offline")));
+    act(() => window.dispatchEvent(new Event("online")));
+    act(() => window.dispatchEvent(new Event("appinstalled")));
+
+    expect(logSpy).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
+  it("renders the PWA install prompt when beforeinstallprompt fires", () => {
+    render(<ServiceWorkerRegistration />);
+
+    const promptEvent = new Event("beforeinstallprompt");
+    Object.assign(promptEvent, {
+      platforms: ["browser"],
+      userChoice: Promise.resolve({ outcome: "dismissed" as const, platform: "browser" }),
+      prompt: jest.fn().mockResolvedValue(undefined),
+      preventDefault: jest.fn(),
+    });
+
+    act(() => {
+      window.dispatchEvent(promptEvent);
+    });
+
+    expect(screen.getByLabelText("Install Planar Nexus as an app")).toBeTruthy();
+  });
+});

--- a/src/components/service-worker-registration.tsx
+++ b/src/components/service-worker-registration.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import { WifiOff } from "lucide-react";
+import { toast } from "@/hooks/use-toast";
 
 interface BeforeInstallPromptEvent extends Event {
   readonly platforms: string[];
@@ -9,11 +11,6 @@ interface BeforeInstallPromptEvent extends Event {
     platform: string;
   }>;
   prompt(): Promise<void>;
-}
-
-interface CacheInfo {
-  name: string;
-  size: number;
 }
 
 interface ServiceWorkerStatus {
@@ -41,15 +38,22 @@ export function ServiceWorkerRegistration() {
       setIsInstalled(true);
     }
 
-    // Track online/offline status
+    // Track online/offline status — surface as a persistent banner + toast
     const handleOnline = () => {
       setSwStatus(prev => ({ ...prev, isOnline: true }));
-      console.log("[SW] Connection restored");
+      toast({
+        title: "Back online",
+        description: "Your connection has been restored.",
+      });
     };
 
     const handleOffline = () => {
       setSwStatus(prev => ({ ...prev, isOnline: false }));
-      console.log("[SW] Connection lost");
+      toast({
+        title: "You're offline",
+        description: "Changes will sync when you reconnect.",
+        variant: "destructive",
+      });
     };
 
     window.addEventListener("online", handleOnline);
@@ -63,7 +67,10 @@ export function ServiceWorkerRegistration() {
       navigator.serviceWorker
         .register("/sw.js")
         .then((registration) => {
-          console.log("Service Worker registered:", registration.scope);
+          toast({
+            title: "Ready for offline use",
+            description: "Planar Nexus is cached and can run without a connection.",
+          });
 
           // Get cache information
           getCacheInfo();
@@ -76,6 +83,10 @@ export function ServiceWorkerRegistration() {
                 if (newWorker.state === "installed" && navigator.serviceWorker.controller) {
                   setIsUpdateAvailable(true);
                   setSwStatus(prev => ({ ...prev, lastUpdated: Date.now() }));
+                  toast({
+                    title: "Update available",
+                    description: "A new version is ready. Reload to update.",
+                  });
                 }
               });
             }
@@ -96,7 +107,10 @@ export function ServiceWorkerRegistration() {
     const handleAppInstalled = () => {
       setIsInstalled(true);
       setDeferredPrompt(null);
-      console.log("[SW] App installed successfully");
+      toast({
+        title: "Installed",
+        description: "Planar Nexus has been added to your device.",
+      });
     };
 
     window.addEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
@@ -112,6 +126,7 @@ export function ServiceWorkerRegistration() {
       window.removeEventListener("offline", handleOffline);
       clearInterval(intervalId);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Get cache information
@@ -187,7 +202,10 @@ export function ServiceWorkerRegistration() {
         cacheNames: [],
       }));
 
-      console.log("[SW] All caches cleared");
+      toast({
+        title: "Cache cleared",
+        description: `${cacheNames.length} cache${cacheNames.length === 1 ? "" : "s"} removed.`,
+      });
       setShowSettings(false);
     } catch (error) {
       console.error("[SW] Failed to clear caches:", error);
@@ -209,112 +227,120 @@ export function ServiceWorkerRegistration() {
     }
   }, []);
 
-  // Show install prompt button if not installed and prompt available
-  if (deferredPrompt && !isInstalled) {
-    return (
-      <div
-        className="fixed bottom-4 right-4 z-50"
-        role="complementary"
-        aria-label="Install app"
-      >
-        <button
-          onClick={handleInstallClick}
-          className="px-4 py-2 bg-primary text-primary-foreground rounded-lg shadow-lg hover:bg-primary/90 transition-colors text-sm font-medium"
-          aria-label="Install Planar Nexus as an app"
-        >
-          Install App
-        </button>
-      </div>
-    );
-  }
-
-  // Show update button if update available
-  if (isUpdateAvailable) {
-    return (
-      <div
-        className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 items-end"
-        role="complementary"
-        aria-label="Update available"
-      >
-        <button
-          onClick={handleUpdateClick}
-          className="px-4 py-2 bg-yellow-600 text-white rounded-lg shadow-lg hover:bg-yellow-700 transition-colors text-sm font-medium"
-          aria-label="Update to latest version"
-        >
-          Update Available
-        </button>
-      </div>
-    );
-  }
-
-  // Show settings button
   return (
-    <div className="fixed bottom-4 left-4 z-50">
-      <button
-        onClick={() => setShowSettings(!showSettings)}
-        className="px-3 py-2 bg-background/80 backdrop-blur-sm border border-border rounded-lg shadow-lg hover:bg-background/90 transition-colors text-xs font-medium flex items-center gap-2"
-        aria-label="Open service worker settings"
-      >
-        <div className={`w-2 h-2 rounded-full ${swStatus.isOnline ? "bg-green-500" : "bg-red-500"}`} />
-        {formatBytes(swStatus.cacheSize)}
-      </button>
-
-      {showSettings && (
-        <div className="absolute bottom-full left-0 mb-2 w-72 bg-background border border-border rounded-lg shadow-xl p-4">
-          <div className="flex items-center justify-between mb-3">
-            <h3 className="text-sm font-semibold">Service Worker</h3>
-            <button
-              onClick={() => setShowSettings(false)}
-              className="text-gray-500 hover:text-gray-700"
-              aria-label="Close settings"
-            >
-              ✕
-            </button>
-          </div>
-
-          {/* Online Status */}
-          <div className="flex items-center gap-2 mb-3 p-2 bg-muted rounded">
-            <div className={`w-3 h-3 rounded-full ${swStatus.isOnline ? "bg-green-500" : "bg-red-500"}`} />
-            <span className="text-sm">
-              {swStatus.isOnline ? "Online" : "Offline"}
-            </span>
-          </div>
-
-          {/* Cache Information */}
-          <div className="mb-3">
-            <div className="flex items-center justify-between text-sm mb-1">
-              <span>Cache Size:</span>
-              <span className="font-medium">{formatBytes(swStatus.cacheSize)}</span>
-            </div>
-            <div className="flex items-center justify-between text-sm mb-1">
-              <span>Caches:</span>
-              <span className="font-medium">{swStatus.cacheNames.length}</span>
-            </div>
-            {swStatus.lastUpdated && (
-              <div className="flex items-center justify-between text-xs text-muted-foreground">
-                <span>Last Update:</span>
-                <span>{new Date(swStatus.lastUpdated).toLocaleTimeString()}</span>
-              </div>
-            )}
-          </div>
-
-          {/* Actions */}
-          <div className="space-y-2">
-            <button
-              onClick={handleClearCache}
-              className="w-full px-3 py-2 bg-destructive text-destructive-foreground rounded-md hover:bg-destructive/90 transition-colors text-sm"
-            >
-              Clear Cache
-            </button>
-            <button
-              onClick={handleForceUpdate}
-              className="w-full px-3 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors text-sm"
-            >
-              Force Update
-            </button>
-          </div>
+    <>
+      {/* Persistent offline banner — the primary visual indicator for lost connectivity */}
+      {!swStatus.isOnline && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed top-0 inset-x-0 z-[60] flex items-center justify-center gap-2 bg-yellow-600 text-white px-4 py-2 text-sm font-medium shadow-md"
+        >
+          <WifiOff className="h-4 w-4" aria-hidden="true" />
+          You&apos;re offline — changes will sync when you reconnect
         </div>
       )}
-    </div>
+
+      {/* Show install prompt button if not installed and prompt available */}
+      {deferredPrompt && !isInstalled ? (
+        <div
+          className="fixed bottom-4 right-4 z-50"
+          role="complementary"
+          aria-label="Install app"
+        >
+          <button
+            onClick={handleInstallClick}
+            className="px-4 py-2 bg-primary text-primary-foreground rounded-lg shadow-lg hover:bg-primary/90 transition-colors text-sm font-medium"
+            aria-label="Install Planar Nexus as an app"
+          >
+            Install App
+          </button>
+        </div>
+      ) : isUpdateAvailable ? (
+        /* Show update button if update available */
+        <div
+          className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 items-end"
+          role="complementary"
+          aria-label="Update available"
+        >
+          <button
+            onClick={handleUpdateClick}
+            className="px-4 py-2 bg-yellow-600 text-white rounded-lg shadow-lg hover:bg-yellow-700 transition-colors text-sm font-medium"
+            aria-label="Update to latest version"
+          >
+            Update Available
+          </button>
+        </div>
+      ) : (
+        /* Show settings button */
+        <div className="fixed bottom-4 left-4 z-50">
+          <button
+            onClick={() => setShowSettings(!showSettings)}
+            className="px-3 py-2 bg-background/80 backdrop-blur-sm border border-border rounded-lg shadow-lg hover:bg-background/90 transition-colors text-xs font-medium flex items-center gap-2"
+            aria-label="Open service worker settings"
+          >
+            <div className={`w-2 h-2 rounded-full ${swStatus.isOnline ? "bg-green-500" : "bg-red-500"}`} />
+            {formatBytes(swStatus.cacheSize)}
+          </button>
+
+          {showSettings && (
+            <div className="absolute bottom-full left-0 mb-2 w-72 bg-background border border-border rounded-lg shadow-xl p-4">
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-sm font-semibold">Service Worker</h3>
+                <button
+                  onClick={() => setShowSettings(false)}
+                  className="text-gray-500 hover:text-gray-700"
+                  aria-label="Close settings"
+                >
+                  ✕
+                </button>
+              </div>
+
+              {/* Online Status */}
+              <div className="flex items-center gap-2 mb-3 p-2 bg-muted rounded">
+                <div className={`w-3 h-3 rounded-full ${swStatus.isOnline ? "bg-green-500" : "bg-red-500"}`} />
+                <span className="text-sm">
+                  {swStatus.isOnline ? "Online" : "Offline"}
+                </span>
+              </div>
+
+              {/* Cache Information */}
+              <div className="mb-3">
+                <div className="flex items-center justify-between text-sm mb-1">
+                  <span>Cache Size:</span>
+                  <span className="font-medium">{formatBytes(swStatus.cacheSize)}</span>
+                </div>
+                <div className="flex items-center justify-between text-sm mb-1">
+                  <span>Caches:</span>
+                  <span className="font-medium">{swStatus.cacheNames.length}</span>
+                </div>
+                {swStatus.lastUpdated && (
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span>Last Update:</span>
+                    <span>{new Date(swStatus.lastUpdated).toLocaleTimeString()}</span>
+                  </div>
+                )}
+              </div>
+
+              {/* Actions */}
+              <div className="space-y-2">
+                <button
+                  onClick={handleClearCache}
+                  className="w-full px-3 py-2 bg-destructive text-destructive-foreground rounded-md hover:bg-destructive/90 transition-colors text-sm"
+                >
+                  Clear Cache
+                </button>
+                <button
+                  onClick={handleForceUpdate}
+                  className="w-full px-3 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors text-sm"
+                >
+                  Force Update
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Resolves #1010

Replaces the 5 `console.log` statements in `service-worker-registration.tsx` with visible user-facing feedback.

## Changes
- **`src/components/service-worker-registration.tsx`**
  - Removed all 5 `console.log` calls (kept `console.error` for genuine failures).
  - Added a persistent **offline banner** (`role="status"`, `aria-live="polite"`) shown when the connection is lost and removed when restored.
  - Wired SW lifecycle events to the existing shadcn `toast()` (`@/hooks/use-toast`):
    - `Ready for offline use` on successful SW registration
    - `Update available` on `updatefound` → `installed`
    - `Installed` on `appinstalled`
    - `You're offline` / `Back online` on connectivity changes
    - `Cache cleared` after clearing caches
  - Restructured the early returns into a single fragment so the offline banner always renders alongside the floating controls (behavior otherwise unchanged).
  - Removed the pre-existing dead `CacheInfo` interface.
  - **PWA install prompt** already existed; a success toast was added on `appinstalled`.
- **`src/components/__tests__/service-worker-registration.test.tsx`** (new) — 7 tests: offline banner show/hide, online/offline toasts, cache-cleared toast, install prompt render, and an assertion that `console.log` is never invoked.

## Verification
- `npm run typecheck` — pass
- `eslint` (local v9, flat config) on changed files — 0 problems
- `jest` (new test file) — 7/7 pass

## Note on scope
The issue suggested wiring SW events into `sync-status-indicator.tsx`. That component is a **multiplayer peer-desync** indicator (props are `StateSyncStatus`/`DesyncAlert` from `use-state-sync`), not a network/SW-lifecycle indicator. Forcing browser online/offline state into it would misrepresent its purpose, so SW feedback is surfaced via toasts + a dedicated offline banner within the SW component — the single source of truth for SW/network state. This satisfies all acceptance criteria.