### PR TITLE
perf: resolve #1020 — remove pretty-print JSON serialization from game state

### DIFF
--- a/src/lib/game-state/__tests__/game-state-compression.test.ts
+++ b/src/lib/game-state/__tests__/game-state-compression.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview Tests for game-state JSON compression
+ *
+ * Issue #1020: saved-game gameStateJson is gzip-compressed (base64-enveloped)
+ * at the IndexedDB storage boundary. These tests cover the round-trip, the
+ * size reduction, and backward compatibility with legacy uncompressed saves.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import {
+  compressGameStateJson,
+  decompressGameStateJson,
+  isCompressedGameState,
+  COMPRESSED_MARKER,
+} from "../game-state-compression";
+
+/** Build a realistically-sized, highly-repetitive serialized game state. */
+function makeGameStateJson(): string {
+  const players = Array.from({ length: 4 }, (_, i) => ({
+    id: `player-${i}`,
+    name: `Player ${i}`,
+    life: 40,
+    commanderDamage: Array.from({ length: 60 }, (_, c) => ({
+      sourceId: `commander-${c}`,
+      amount: c % 5,
+    })),
+    hand: Array.from({ length: 7 }, (_, c) => ({
+      id: `card-${i}-${c}`,
+      name: `Island ${c % 3}`,
+    })),
+  }));
+
+  return JSON.stringify({
+    gameId: "game-1020",
+    status: "in_progress",
+    turn: { turnNumber: 12, currentPhase: "PRECOMBAT_MAIN", priorityPlayer: "player-0" },
+    players,
+    zones: Array.from({ length: 8 }, (_, z) => ({
+      id: `zone-${z}`,
+      cardIds: Array.from({ length: 30 }, (_, c) => `card-${z}-${c}`),
+    })),
+    cards: Array.from({ length: 200 }, (_, c) => ({
+      id: `card-${c}`,
+      ownerId: `player-${c % 4}`,
+      cardData: { id: `oracle-${c % 10}`, name: `Repeated Card Name ${c % 5}` },
+    })),
+  });
+}
+
+describe("game-state-compression (issue #1020)", () => {
+  describe("isCompressedGameState", () => {
+    it("detects the marker prefix", () => {
+      expect(isCompressedGameState(compressGameStateJson("{}"))).toBe(true);
+    });
+
+    it("returns false for legacy JSON (compact or pretty)", () => {
+      expect(isCompressedGameState('{"gameId":"legacy"}')).toBe(false);
+      expect(isCompressedGameState('{\n  "gameId": "legacy"\n}')).toBe(false);
+    });
+
+    it("returns false for empty input", () => {
+      expect(isCompressedGameState("")).toBe(false);
+    });
+  });
+
+  describe("compressGameStateJson / decompressGameStateJson", () => {
+    it("marks the payload with the compression marker", () => {
+      const compressed = compressGameStateJson('{"gameId":"x"}');
+      expect(compressed.startsWith(COMPRESSED_MARKER)).toBe(true);
+    });
+
+    it("round-trips a realistic game-state payload", () => {
+      const json = makeGameStateJson();
+      const restored = decompressGameStateJson(compressGameStateJson(json));
+      expect(restored).toBe(json);
+      expect(JSON.parse(restored)).toEqual(JSON.parse(json));
+    });
+
+    it("compresses repetitive game-state JSON by more than 50%", () => {
+      const json = makeGameStateJson();
+      const compressed = compressGameStateJson(json);
+      // Even after base64 (4/3) expansion, gzip on highly-repetitive JSON
+      // yields a large net reduction.
+      expect(compressed.length).toBeLessThan(json.length * 0.5);
+    });
+
+    it("decompresses legacy uncompressed JSON unchanged (backward compat)", () => {
+      const legacyPretty = JSON.stringify({ gameId: "legacy" }, null, 2);
+      const legacyCompact = JSON.stringify({ gameId: "legacy" });
+
+      expect(decompressGameStateJson(legacyPretty)).toBe(legacyPretty);
+      expect(decompressGameStateJson(legacyCompact)).toBe(legacyCompact);
+    });
+
+    it("preserves Map-encoded structures through a round-trip", () => {
+      // Mirror the mapReplacer output shape used by serializeGameState.
+      const json = JSON.stringify({
+        gameId: "g1",
+        players: { dataType: "Map", value: [["p1", { life: 40 }]] },
+      });
+      const restored = decompressGameStateJson(compressGameStateJson(json));
+      expect(JSON.parse(restored)).toEqual(JSON.parse(json));
+    });
+  });
+});

--- a/src/lib/game-state/__tests__/golden-scenarios.test.ts
+++ b/src/lib/game-state/__tests__/golden-scenarios.test.ts
@@ -163,10 +163,10 @@ describe("Golden Scenarios", () => {
     state.cards.set(card.id, card);
     state.zones.get(`${aliceId}-battlefield`)!.cardIds.push(card.id);
 
-    // Serialize
+    // Serialize (compact, no indentation — see state-serialization.ts)
     const json = serializeGameState(state);
     expect(json).toContain("commanderDamage");
-    expect(json).toContain('"dataType": "Map"');
+    expect(json).toContain('"dataType":"Map"');
 
     // Deserialize
     const newState = deserializeGameState(json);

--- a/src/lib/game-state/__tests__/state-serialization.test.ts
+++ b/src/lib/game-state/__tests__/state-serialization.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @fileOverview Tests for compact GameState serialization
+ *
+ * Issue #1020: serializeGameState must emit compact (non-pretty) JSON so that
+ * WebRTC sync messages and saved-game payloads avoid the ~30% whitespace
+ * overhead, while a dedicated pretty-print helper remains available for
+ * debugging.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import {
+  serializeGameState,
+  deserializeGameState,
+  prettyPrintGameState,
+  cloneGameState,
+} from "../state-serialization";
+import { createInitialGameState } from "../game-state";
+import { Phase } from "../types";
+
+describe("state-serialization (issue #1020)", () => {
+  describe("serializeGameState", () => {
+    it("emits compact JSON with no indentation", () => {
+      const state = createInitialGameState(["Alice", "Bob"]);
+      const json = serializeGameState(state);
+
+      expect(json).not.toContain("\n");
+      // Compact JSON separates keys and values with ":" (no space); the
+      // players Map is serialized via mapReplacer.
+      expect(json).toContain('"dataType":"Map"');
+    });
+
+    it("does not retain the legacy pretty-print separator", () => {
+      const state = createInitialGameState(["Alice", "Bob"]);
+      const json = serializeGameState(state);
+      expect(json).not.toContain('"dataType": "Map"');
+    });
+
+    it("is smaller than the pretty-printed representation", () => {
+      const state = createInitialGameState(["Alice", "Bob"]);
+      const compact = serializeGameState(state);
+      const pretty = prettyPrintGameState(state);
+      expect(compact.length).toBeLessThan(pretty.length);
+    });
+
+    it("round-trips through deserializeGameState preserving Maps", () => {
+      const state = createInitialGameState(["Alice", "Bob"]);
+      state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+      state.turn.turnNumber = 4;
+
+      const restored = deserializeGameState(serializeGameState(state));
+
+      expect(restored.gameId).toBe(state.gameId);
+      expect(restored.players).toBeInstanceOf(Map);
+      expect(restored.players.size).toBe(2);
+      expect(restored.turn.currentPhase).toBe(Phase.PRECOMBAT_MAIN);
+      expect(restored.turn.turnNumber).toBe(4);
+    });
+  });
+
+  describe("prettyPrintGameState", () => {
+    it("emits indented, human-readable JSON for debugging", () => {
+      const state = createInitialGameState(["Alice", "Bob"]);
+      const pretty = prettyPrintGameState(state);
+
+      expect(pretty).toContain("\n");
+      expect(pretty).toContain('  ');
+
+      // Pretty and compact must decode to the same structure.
+      const compact = serializeGameState(state);
+      expect(JSON.parse(pretty)).toEqual(JSON.parse(compact));
+    });
+  });
+
+  describe("cloneGameState", () => {
+    it("produces an equal but structurally independent copy", () => {
+      const state = createInitialGameState(["Alice", "Bob"]);
+      const clone = cloneGameState(state);
+
+      expect(clone.gameId).toBe(state.gameId);
+      expect(clone.players).not.toBe(state.players);
+      expect(clone.players.size).toBe(state.players.size);
+    });
+  });
+});

--- a/src/lib/game-state/game-state-compression.ts
+++ b/src/lib/game-state/game-state-compression.ts
@@ -1,0 +1,87 @@
+/**
+ * @fileoverview Game State JSON Compression
+ *
+ * Issue #1020: Reduce saved-game storage footprint.
+ *
+ * Compresses the compact game-state JSON emitted by {@link serializeGameState}
+ * into a gzip stream and envelopes it as base64 text so it can live in the
+ * existing string-typed {@code gameStateJson} storage field without rippling
+ * type changes through consumers.
+ *
+ * Format:
+ * - New format: the literal {@link COMPRESSED_MARKER} prefix followed by the
+ *   base64 encoding of an RFC 1952 gzip stream wrapping the compact JSON.
+ * - Legacy format: raw UTF-8 JSON text (pretty-printed or compact) written by
+ *   prior versions. Such payloads always begin with "{" (0x7b), so they never
+ *   collide with the marker and are returned unchanged for backward
+ *   compatibility.
+ */
+
+import { gzip, ungzip } from "pako";
+
+/**
+ * Prefix marking a compressed payload. base64 output never starts with these
+ * characters and raw JSON objects always begin with "{", so detection is
+ * unambiguous.
+ */
+export const COMPRESSED_MARKER = "gzn:";
+
+/** Base64 chunk size kept below the Function call limit to avoid stack overflow. */
+const B64_CHUNK = 0x8000;
+
+/**
+ * Encode a byte buffer to a base64 string. Uses chunked {@code fromCharCode}
+ * to stay within call-stack limits for large payloads.
+ */
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += B64_CHUNK) {
+    binary += String.fromCharCode.apply(
+      null,
+      Array.from(bytes.subarray(i, i + B64_CHUNK)),
+    );
+  }
+  return btoa(binary);
+}
+
+/** Decode a base64 string into a byte buffer. */
+function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/**
+ * Determine whether a stored {@code gameStateJson} value holds a
+ * gzip-compressed payload.
+ */
+export function isCompressedGameState(value: string): boolean {
+  return typeof value === "string" && value.startsWith(COMPRESSED_MARKER);
+}
+
+/**
+ * Compress a compact game-state JSON string into the enveloped base64/gzip
+ * storage format.
+ */
+export function compressGameStateJson(json: string): string {
+  const compressed = gzip(json);
+  return COMPRESSED_MARKER + bytesToBase64(compressed);
+}
+
+/**
+ * Decompress a stored {@code gameStateJson} value back into JSON text.
+ *
+ * Accepts both the new compressed format and legacy raw JSON for backward
+ * compatibility with saves written by prior versions. Legacy payloads are
+ * returned unchanged.
+ */
+export function decompressGameStateJson(value: string): string {
+  if (!isCompressedGameState(value)) {
+    return value;
+  }
+  const b64 = value.slice(COMPRESSED_MARKER.length);
+  return ungzip(base64ToBytes(b64), { to: "string" }) as string;
+}

--- a/src/lib/game-state/state-serialization.ts
+++ b/src/lib/game-state/state-serialization.ts
@@ -34,9 +34,25 @@ export function mapReviver(_key: string, value: unknown): unknown {
 }
 
 /**
- * Serialize GameState to a JSON string
+ * Serialize GameState to a compact JSON string.
+ *
+ * Indentation is intentionally omitted: the serialized payload is used for
+ * WebRTC sync messages and IndexedDB storage, where whitespace only inflates
+ * size (~30%) without any benefit. Use {@link prettyPrintGameState} when a
+ * human-readable representation is required (e.g. debugging).
  */
 export function serializeGameState(state: GameState): string {
+  return JSON.stringify(state, mapReplacer);
+}
+
+/**
+ * Serialize GameState to a pretty-printed JSON string for debugging only.
+ *
+ * This is intentionally NOT used by any persistence or transport path; it
+ * exists so logs and dev tooling can render readable state snapshots without
+ * regressing the compact serialization used elsewhere.
+ */
+export function prettyPrintGameState(state: GameState): string {
   return JSON.stringify(state, mapReplacer, 2);
 }
 

--- a/src/lib/saved-games.ts
+++ b/src/lib/saved-games.ts
@@ -22,6 +22,10 @@ import {
   mapReplacer,
   mapReviver,
 } from "./game-state/state-serialization";
+import {
+  compressGameStateJson,
+  decompressGameStateJson,
+} from "./game-state/game-state-compression";
 
 export interface SavedGame {
   /** Unique identifier */
@@ -112,21 +116,34 @@ class SavedGamesManager {
   }
 
   /**
-   * Convert SavedGame to StoredGame for IndexedDB
+   * Convert SavedGame to StoredGame for IndexedDB.
+   *
+   * The compact {@code gameStateJson} is gzip-compressed (base64-enveloped) at
+   * this storage boundary so IndexedDB holds a much smaller payload. The
+   * in-memory {@link SavedGame} contract (a directly JSON-parseable string)
+   * is preserved by {@link fromStoredGame} on read.
    */
   private toStoredGame(game: SavedGame): StoredGame {
     return {
       ...game,
+      gameStateJson: compressGameStateJson(game.gameStateJson),
       metadata: {},
     };
   }
 
   /**
-   * Convert StoredGame to SavedGame from IndexedDB
+   * Convert StoredGame to SavedGame from IndexedDB.
+   *
+   * Decompresses the {@code gameStateJson} written by {@link toStoredGame}.
+   * Legacy uncompressed saves (pretty-printed or compact JSON) pass through
+   * unchanged for backward compatibility.
    */
   private fromStoredGame(stored: StoredGame): SavedGame {
-    const { metadata: _, ...game } = stored;
-    return game;
+    const { metadata: _, gameStateJson, ...rest } = stored;
+    return {
+      ...rest,
+      gameStateJson: decompressGameStateJson(gameStateJson),
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

Resolves #1020.

Removes pretty-print (indent: 2) from game-state JSON serialization and adds gzip compression at the saved-game IndexedDB storage boundary.

## Problem

`serializeGameState` used `JSON.stringify(state, mapReplacer, 2)`, inflating every WebRTC sync message and IndexedDB saved-game payload by ~30% whitespace overhead with no runtime benefit.

## Changes

- **`src/lib/game-state/state-serialization.ts`** — `serializeGameState` now emits compact JSON (`JSON.stringify(state, mapReplacer)`). Added `prettyPrintGameState()` as a dedicated debug-only helper.
- **`src/lib/game-state/game-state-compression.ts`** (new) — `compressGameStateJson` / `decompressGameStateJson` using `pako` gzip + base64 string envelope. A `gzn:` marker distinguishes compressed payloads from legacy JSON for backward compatibility (mirrors the `backup-compression.ts` pattern from #918).
- **`src/lib/saved-games.ts`** — Compression is applied at the **IndexedDB storage boundary** (`toStoredGame`/`fromStoredGame`), so the in-memory `SavedGame.gameStateJson` keeps its directly-JSON-parseable contract. This avoids touching any consumer (`page.tsx`, export/import, tests) and gives free backward-compat for existing uncompressed saves.
- **`golden-scenarios.test.ts`** — Updated the `'dataType':'Map'` assertion to the compact form (this suite is currently in `testPathIgnorePatterns`; kept consistent regardless).

## Acceptance criteria

- [x] Game state JSON has no unnecessary whitespace
- [x] Saved games use compressed JSON storage (gzip+base64 at IndexedDB boundary, legacy passthrough on read)
- [x] WebRTC game state sync messages are smaller

## Tests

- New: `state-serialization.test.ts`, `game-state-compression.test.ts` (round-trip, marker detection, >50% size reduction, legacy backward-compat).
- Full suite: **201 suites / 3824 tests pass**; `tsc --noEmit` clean; `eslint src` 0 errors (678 warnings, under threshold).