### PR TITLE
fix: correct trample damage assignment with multiple blockers (closes #978)

### DIFF
--- a/src/lib/game-state/__tests__/combat.test.ts
+++ b/src/lib/game-state/__tests__/combat.test.ts
@@ -1005,6 +1005,302 @@ describe("Combat System - Damage Resolution", () => {
       const bob = result.state.players.get(bobId)!;
       expect(bob.life).toBe(16); // 20 - 4 = 16
     });
+
+    // Issue #978: Trample with multiple blockers per CR 702.19b
+    // An attacker with trample must assign lethal damage to each blocker in
+    // the chosen order before any excess can trample to the defending player.
+    it("should assign lethal to each of two equal blockers with no trample - 6/6 vs two 3/3s (#978)", () => {
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [{ name: "Trampler", power: 6, toughness: 6, keywords: ["Trample"] }],
+        [
+          { name: "Blocker1", power: 1, toughness: 3 },
+          { name: "Blocker2", power: 1, toughness: 3 },
+        ],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerIds = bobBattlefield.cardIds;
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const blockerAssignments = new Map();
+      blockerAssignments.set(attackerId, blockerIds);
+      const blockResult = declareBlockers(
+        attackResult.state,
+        blockerAssignments,
+      );
+
+      const result = resolveCombatDamage(blockResult.state);
+      expect(result.success).toBe(true);
+
+      // Both blockers receive lethal (3 each), no excess tramples
+      const bobGraveyard = result.state.zones.get(`${bobId}-graveyard`)!;
+      expect(bobGraveyard.cardIds).toContain(blockerIds[0]);
+      expect(bobGraveyard.cardIds).toContain(blockerIds[1]);
+
+      const bob = result.state.players.get(bobId)!;
+      expect(bob.life).toBe(20); // 6 - 3 - 3 = 0 trample
+    });
+
+    it("should trample excess after lethal to two blockers - 6/6 vs two 2/2s (#978)", () => {
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [{ name: "Trampler", power: 6, toughness: 6, keywords: ["Trample"] }],
+        [
+          { name: "Blocker1", power: 1, toughness: 2 },
+          { name: "Blocker2", power: 1, toughness: 2 },
+        ],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerIds = bobBattlefield.cardIds;
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const blockerAssignments = new Map();
+      blockerAssignments.set(attackerId, blockerIds);
+      const blockResult = declareBlockers(
+        attackResult.state,
+        blockerAssignments,
+      );
+
+      const result = resolveCombatDamage(blockResult.state);
+      expect(result.success).toBe(true);
+
+      // 6 - 2 - 2 = 2 trample
+      const bob = result.state.players.get(bobId)!;
+      expect(bob.life).toBe(18); // 20 - 2 = 18
+
+      // Both blockers still die from lethal assignment
+      const bobGraveyard = result.state.zones.get(`${bobId}-graveyard`)!;
+      expect(bobGraveyard.cardIds).toContain(blockerIds[0]);
+      expect(bobGraveyard.cardIds).toContain(blockerIds[1]);
+    });
+
+    it("should assign lethal in order across three blockers - 7/7 vs three 2/2s (#978)", () => {
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [{ name: "Trampler", power: 7, toughness: 7, keywords: ["Trample"] }],
+        [
+          { name: "Blocker1", power: 1, toughness: 2 },
+          { name: "Blocker2", power: 1, toughness: 2 },
+          { name: "Blocker3", power: 1, toughness: 2 },
+        ],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerIds = bobBattlefield.cardIds;
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const blockerAssignments = new Map();
+      blockerAssignments.set(attackerId, blockerIds);
+      const blockResult = declareBlockers(
+        attackResult.state,
+        blockerAssignments,
+      );
+
+      const result = resolveCombatDamage(blockResult.state);
+      expect(result.success).toBe(true);
+
+      // 7 - 2 - 2 - 2 = 1 trample
+      const bob = result.state.players.get(bobId)!;
+      expect(bob.life).toBe(19); // 20 - 1 = 19
+    });
+
+    it("should trample nothing when blockers absorb all damage (#978)", () => {
+      // 5/5 blocked by 4/4 then 4/4: assign 4 to first, 1 to second, 0 excess
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [{ name: "Trampler", power: 5, toughness: 5, keywords: ["Trample"] }],
+        [
+          { name: "Blocker1", power: 1, toughness: 4 },
+          { name: "Blocker2", power: 1, toughness: 4 },
+        ],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerIds = bobBattlefield.cardIds;
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const blockerAssignments = new Map();
+      blockerAssignments.set(attackerId, blockerIds);
+      const blockResult = declareBlockers(
+        attackResult.state,
+        blockerAssignments,
+      );
+
+      const result = resolveCombatDamage(blockResult.state);
+      expect(result.success).toBe(true);
+
+      // No excess tramples: all 5 power absorbed by blockers
+      const bob = result.state.players.get(bobId)!;
+      expect(bob.life).toBe(20);
+
+      // First blocker (4 toughness) dies from 4 assigned; second survives (1 < 4)
+      const bobGraveyard = result.state.zones.get(`${bobId}-graveyard`)!;
+      expect(bobGraveyard.cardIds).toContain(blockerIds[0]);
+      expect(bobGraveyard.cardIds).not.toContain(blockerIds[1]);
+    });
+
+    it("should not trample when lethal cannot be assigned to all blockers (#978)", () => {
+      // 4/4 blocked by 3/3 then 3/3: 3 to first (lethal), 1 to second (non-lethal)
+      // CR 702.19b: cannot trample until ALL blockers have lethal assigned
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [{ name: "Trampler", power: 4, toughness: 4, keywords: ["Trample"] }],
+        [
+          { name: "Blocker1", power: 1, toughness: 3 },
+          { name: "Blocker2", power: 1, toughness: 3 },
+        ],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerIds = bobBattlefield.cardIds;
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const blockerAssignments = new Map();
+      blockerAssignments.set(attackerId, blockerIds);
+      const blockResult = declareBlockers(
+        attackResult.state,
+        blockerAssignments,
+      );
+
+      const result = resolveCombatDamage(blockResult.state);
+      expect(result.success).toBe(true);
+
+      // No trample: blocker 2 was not assigned lethal damage
+      const bob = result.state.players.get(bobId)!;
+      expect(bob.life).toBe(20);
+
+      // First blocker dies (3 = lethal), second survives (1 < 3)
+      const bobGraveyard = result.state.zones.get(`${bobId}-graveyard`)!;
+      expect(bobGraveyard.cardIds).toContain(blockerIds[0]);
+      expect(bobGraveyard.cardIds).not.toContain(blockerIds[1]);
+    });
+
+    it("should ignore blocker's deathtouch when assigning attacker damage (#978)", () => {
+      // CR 702.19c + CR 702.2b: a blocker's own deathtouch does not change the
+      // lethal damage the attacker must assign to it. Previously the engine
+      // over-assigned damage beyond the attacker's remaining power when a
+      // blocker had deathtouch and toughness > assigned damage.
+      // 4/4 trampler blocked by 0/5 deathtouch: assign 4 (not 5!), no trample.
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [{ name: "Trampler", power: 4, toughness: 4, keywords: ["Trample"] }],
+        [
+          { name: "Deathtouch Wall", power: 0, toughness: 5, keywords: ["Deathtouch"] },
+        ],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerId = bobBattlefield.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const blockerAssignments = new Map();
+      blockerAssignments.set(attackerId, [blockerId]);
+      const blockResult = declareBlockers(
+        attackResult.state,
+        blockerAssignments,
+      );
+
+      const result = resolveCombatDamage(blockResult.state);
+      expect(result.success).toBe(true);
+
+      // Attacker dealt at most 4 damage; blocker (5 toughness) survives
+      const bobBattlefieldAfter = result.state.zones.get(
+        `${bobId}-battlefield`,
+      )!;
+      expect(bobBattlefieldAfter.cardIds).toContain(blockerId);
+
+      // No trample because lethal (5) was not assigned
+      const bob = result.state.players.get(bobId)!;
+      expect(bob.life).toBe(20);
+    });
+
+    it("should handle deathtouch + trample across multiple blockers (#978)", () => {
+      // CR 702.2b + CR 702.19b: deathtouch attacker assigns 1 (lethal) per
+      // blocker, remainder tramples. 6/6 deathtouch trampler vs 2/2 + 3/3:
+      // 1 + 1 = 2 to blockers, 4 trample.
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [
+          {
+            name: "Deathtouch Trampler",
+            power: 6,
+            toughness: 6,
+            keywords: ["Deathtouch", "Trample"],
+          },
+        ],
+        [
+          { name: "Blocker1", power: 1, toughness: 2 },
+          { name: "Blocker2", power: 1, toughness: 3 },
+        ],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerIds = bobBattlefield.cardIds;
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const blockerAssignments = new Map();
+      blockerAssignments.set(attackerId, blockerIds);
+      const blockResult = declareBlockers(
+        attackResult.state,
+        blockerAssignments,
+      );
+
+      const result = resolveCombatDamage(blockResult.state);
+      expect(result.success).toBe(true);
+
+      // Both blockers die from 1 deathtouch damage each
+      const bobGraveyard = result.state.zones.get(`${bobId}-graveyard`)!;
+      expect(bobGraveyard.cardIds).toContain(blockerIds[0]);
+      expect(bobGraveyard.cardIds).toContain(blockerIds[1]);
+
+      // 6 - 1 - 1 = 4 trample
+      const bob = result.state.players.get(bobId)!;
+      expect(bob.life).toBe(16); // 20 - 4 = 16
+    });
   });
 });
 

--- a/src/lib/game-state/combat.ts
+++ b/src/lib/game-state/combat.ts
@@ -666,23 +666,25 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
           blockerCard,
           layerSystem,
         );
-        const blockerHasDeathtouch = hasDeathtouch(blockerCard);
         const blockerHasLifelink =
           blockerCard.cardData.keywords?.includes("Lifelink") ||
           blockerCard.cardData.oracle_text?.toLowerCase().includes("lifelink");
 
-        // Calculate damage to deal to this blocker
+        // Calculate damage to assign to this blocker.
+        // CR 702.19b (trample) + CR 510.1c (general combat): the attacker must
+        // assign lethal damage to each blocker in the chosen order before any
+        // remaining damage can be assigned to the next blocker or (with trample)
+        // to the defending player.
+        //
+        // Lethal damage to a blocker equals its toughness (minus damage already
+        // marked on it — CR 702.19c). The blocker's own deathtouch does NOT
+        // change how much damage the attacker must assign to it; only the
+        // attacker's deathtouch is relevant (CR 702.2b: any nonzero amount from
+        // a deathtouch source counts as lethal, so a deathtouch attacker
+        // assigns only 1 per blocker and tramples the rest).
         let damage: number;
         if (attackerHasDeathtouch && remainingDamage > 0) {
-          // CR 702.2b: Any nonzero amount of damage from a deathtouch source is lethal
-          // Assign only 1 damage to each blocker to maximize trample excess
           damage = 1;
-        } else if (blockerHasDeathtouch && remainingDamage > 0) {
-          // Blocker has deathtouch — ensure we assign lethal to kill it if we can
-          damage = Math.min(remainingDamage, blockerToughness);
-          if (damage > 0) {
-            damage = Math.max(damage, blockerToughness);
-          }
         } else {
           damage = Math.min(remainingDamage, blockerToughness);
         }


### PR DESCRIPTION
## Problem
When a creature with trample was blocked by multiple creatures, the damage-assignment logic in `combat.ts` contained a buggy branch that over-assigned damage beyond the attacker's remaining power whenever a blocker had deathtouch and toughness greater than the assigned damage (e.g. a 4/4 trampler blocked by a 0/5 deathtouch creature would assign **5** damage instead of 4). The blocker's own deathtouch is irrelevant to lethal assignment *to* that blocker — only the attacker's deathtouch matters (CR 702.2b + CR 702.19c).

Issue #978 also flagged that the multi-blocker trample ordering needed explicit test coverage to lock in CR 702.19b compliance.

## Changes
- **`src/lib/game-state/combat.ts`** (damage-assignment region only):
  - Removed the buggy `blockerHasDeathtouch` branch that could assign more damage than the attacker had remaining (`Math.max(damage, blockerToughness)` could exceed `remainingDamage`).
  - Collapsed damage assignment to two correct cases: attacker has deathtouch → assign 1 (lethal per CR 702.2b); otherwise → `min(remainingDamage, blockerToughness)`.
  - Added documenting comments citing CR 702.19b / CR 510.1c (lethal must be assigned to each blocker in order before trample) and CR 702.19c (lethal = toughness minus marked damage).
  - Removed the now-unused `blockerHasDeathtouch` binding.
  - Kept changes confined to the damage-assignment region to minimize overlap with sibling PR #968 (menace).

## Testing
Added 7 new tests in `src/lib/game-state/__tests__/combat.test.ts` under `Combat System - Damage Resolution`:

| Scenario | Expectation |
|---|---|
| 6/6 trampler vs two 3/3s | 3 + 3, 0 trample (acceptance criterion) |
| 6/6 trampler vs two 2/2s | 2 + 2, 2 trample (acceptance criterion) |
| 7/7 trampler vs three 2/2s | 2 + 2 + 2, 1 trample (ordering across 3 blockers) |
| 5/5 trampler vs 4/4 + 4/4 | 4 + 1, 0 trample (blockers absorb all) |
| 4/4 trampler vs 3/3 + 3/3 | 3 + 1, 0 trample (cannot assign lethal to all → no trample) |
| 4/4 trampler vs 0/5 deathtouch | 4 assigned (not 5!), 0 trample, blocker survives (regression test for the bug) |
| 6/6 deathtouch+trample vs 2/2 + 3/3 | 1 + 1, 4 trample (acceptance criterion) |

## Verification
- `npx jest combat` → **161 passed / 161** (154 baseline + 7 new) across 7 suites
- `npm run typecheck` → clean
- `eslint` on changed files → 0 errors (3 pre-existing warnings, unrelated)

Closes #978