### PR TITLE
fix: per-commander-per-opponent damage tracking (closes #977)

### DIFF
--- a/src/lib/game-state/__tests__/commander-damage.test.ts
+++ b/src/lib/game-state/__tests__/commander-damage.test.ts
@@ -16,6 +16,8 @@ import {
   registerCommander,
   dealCommanderDamage,
   getCommanderDamage,
+  getCommanderDamageToOpponent,
+  getCommanderDamageMatrix,
   getTotalCommanderDamage,
   hasLostFromCommanderDamage,
   resetCommanderDamage,
@@ -598,5 +600,218 @@ describe('Commander Damage System - resetCommanderDamage', () => {
     
     const damage = getCommanderDamage(result, commanderId, bobId);
     expect(damage).toBe(0);
+  });
+});
+
+/**
+ * Issue #977: per-commander-per-opponent damage tracking.
+ *
+ * The (commander, opponent) matrix is the source of truth for "damage from
+ * commander X to opponent Y". These tests verify that:
+ * - damage from commander A to opponent X is tracked separately from commander
+ *   A to opponent Y, and from commander B to either;
+ * - getCommanderDamageMatrix exposes the full matrix;
+ * - getCommanderDamageToOpponent reads individual cells;
+ * - getCommanderDamageSummary correctly attributes damage by commander owner
+ *   and opponent (the previous implementation mislabelled receivers);
+ * - per-opponent totals (getTotalCommanderDamage) and the per-commander 21-loss
+ *   threshold (hasLostFromCommanderDamage) remain consistent with the matrix,
+ *   composing with the #976 summation fix.
+ */
+describe('Commander Damage System - issue #977 per-commander-per-opponent matrix', () => {
+  let state: ReturnType<typeof createInitialGameState>;
+  let aliceId: string;
+  let bobId: string;
+  let carolId: string;
+  let daveId: string;
+
+  beforeEach(() => {
+    state = createInitialGameState(['Alice', 'Bob', 'Carol', 'Dave'], 20, true);
+    state = startGame(state);
+
+    const playerIds = Array.from(state.players.keys());
+    aliceId = playerIds[0];
+    bobId = playerIds[1];
+    carolId = playerIds[2];
+    daveId = playerIds[3];
+  });
+
+  function makeCommander(name: string, ownerId: string) {
+    const commander = createCardInstance(
+      createMockCommander(name, 'Legendary Creature — Human', ['W']),
+      ownerId,
+      ownerId,
+    );
+    state.cards.set(commander.id, commander);
+    return commander;
+  }
+
+  it('tracks damage from commander A to opponent X separately from opponent Y', () => {
+    const commanderA = makeCommander('Commander A', aliceId);
+    state = registerCommander(state, aliceId, commanderA.id);
+
+    state = dealCommanderDamage(state, commanderA.id, bobId, 7).state;
+    state = dealCommanderDamage(state, commanderA.id, carolId, 4).state;
+
+    // Same commander, different opponents — independent tallies.
+    expect(getCommanderDamageToOpponent(state, commanderA.id, bobId)).toBe(7);
+    expect(getCommanderDamageToOpponent(state, commanderA.id, carolId)).toBe(4);
+    // Bob and Carol do not leak into each other.
+    expect(getCommanderDamageToOpponent(state, commanderA.id, daveId)).toBe(0);
+  });
+
+  it('tracks damage from commander A and commander B independently (the matrix)', () => {
+    const commanderA = makeCommander('Commander A', aliceId);
+    const commanderB = makeCommander('Commander B', aliceId);
+    state = registerCommander(state, aliceId, commanderA.id);
+    state = registerCommander(state, aliceId, commanderB.id);
+
+    state = dealCommanderDamage(state, commanderA.id, bobId, 5).state;
+    state = dealCommanderDamage(state, commanderB.id, bobId, 9).state;
+    state = dealCommanderDamage(state, commanderA.id, carolId, 3).state;
+
+    // (commander, opponent) cells are all distinct.
+    expect(getCommanderDamageToOpponent(state, commanderA.id, bobId)).toBe(5);
+    expect(getCommanderDamageToOpponent(state, commanderB.id, bobId)).toBe(9);
+    expect(getCommanderDamageToOpponent(state, commanderA.id, carolId)).toBe(3);
+    expect(getCommanderDamageToOpponent(state, commanderB.id, carolId)).toBe(0);
+  });
+
+  it('exposes the full (commander, opponent) matrix via getCommanderDamageMatrix', () => {
+    const commanderA = makeCommander('Commander A', aliceId);
+    const commanderB = makeCommander('Commander B', bobId);
+    state = registerCommander(state, aliceId, commanderA.id);
+    state = registerCommander(state, bobId, commanderB.id);
+
+    state = dealCommanderDamage(state, commanderA.id, bobId, 6).state;
+    state = dealCommanderDamage(state, commanderA.id, carolId, 2).state;
+    state = dealCommanderDamage(state, commanderB.id, carolId, 11).state;
+
+    const matrix = getCommanderDamageMatrix(state);
+
+    // Both commanders that have dealt damage appear as rows.
+    expect(matrix.has(commanderA.id)).toBe(true);
+    expect(matrix.has(commanderB.id)).toBe(true);
+    // Commanders with no incoming recorded damage to anyone do not appear.
+    expect(matrix.has('nonexistent-commander')).toBe(false);
+
+    // commanderA row: { bob: 6, carol: 2 }
+    const rowA = matrix.get(commanderA.id)!;
+    expect(rowA.get(bobId)).toBe(6);
+    expect(rowA.get(carolId)).toBe(2);
+    expect(rowA.has(aliceId)).toBe(false); // attacker not self-damaged
+
+    // commanderB row: { carol: 11 }
+    const rowB = matrix.get(commanderB.id)!;
+    expect(rowB.get(carolId)).toBe(11);
+    expect(rowB.has(bobId)).toBe(false); // Bob's own commander didn't hit Bob
+  });
+
+  it('returns an empty matrix when no commander damage has been dealt', () => {
+    const matrix = getCommanderDamageMatrix(state);
+    expect(matrix.size).toBe(0);
+  });
+
+  it('returns 0 for unknown commander or opponent cells', () => {
+    const commanderA = makeCommander('Commander A', aliceId);
+    state = registerCommander(state, aliceId, commanderA.id);
+    state = dealCommanderDamage(state, commanderA.id, bobId, 4).state;
+
+    expect(getCommanderDamageToOpponent(state, 'no-such-commander', bobId)).toBe(0);
+    expect(getCommanderDamageToOpponent(state, commanderA.id, 'no-such-opponent')).toBe(0);
+  });
+
+  it('keeps per-opponent totals consistent with the matrix (#976 composition)', () => {
+    const commanderA = makeCommander('Commander A', aliceId);
+    const commanderB = makeCommander('Commander B', aliceId);
+    state = registerCommander(state, aliceId, commanderA.id);
+    state = registerCommander(state, aliceId, commanderB.id);
+
+    state = dealCommanderDamage(state, commanderA.id, bobId, 6).state;
+    state = dealCommanderDamage(state, commanderB.id, bobId, 4).state;
+    state = dealCommanderDamage(state, commanderA.id, carolId, 8).state;
+
+    // Bob's per-opponent total = sum over commanders that hit Bob.
+    expect(getTotalCommanderDamage(state, bobId)).toBe(10);
+    // Carol's per-opponent total only reflects damage to Carol.
+    expect(getTotalCommanderDamage(state, carolId)).toBe(8);
+
+    // The matrix cells sum to the same per-opponent totals.
+    const matrix = getCommanderDamageMatrix(state);
+    let bobSum = 0;
+    for (const row of matrix.values()) {
+      const v = row.get(bobId);
+      if (typeof v === 'number') bobSum += v;
+    }
+    expect(bobSum).toBe(10);
+  });
+
+  it('keeps the per-commander 21-loss threshold consistent with the matrix (#976 composition)', () => {
+    const commanderA = makeCommander('Commander A', aliceId);
+    const commanderB = makeCommander('Commander B', aliceId);
+    state = registerCommander(state, aliceId, commanderA.id);
+    state = registerCommander(state, aliceId, commanderB.id);
+
+    // Split damage across two commanders: 12 from A + 12 from B = 24 total, but
+    // neither commander alone reaches 21, so no loss (CR 903.9a).
+    state = dealCommanderDamage(state, commanderA.id, bobId, 12).state;
+    state = dealCommanderDamage(state, commanderB.id, bobId, 12).state;
+
+    expect(getTotalCommanderDamage(state, bobId)).toBe(24);
+    expect(hasLostFromCommanderDamage(state, bobId)).toBe(false);
+    expect(getCommanderDamageToOpponent(state, commanderA.id, bobId)).toBe(12);
+    expect(getCommanderDamageToOpponent(state, commanderB.id, bobId)).toBe(12);
+
+    // Push commander A alone to 21 — Bob now loses from THAT commander's tally.
+    state = dealCommanderDamage(state, commanderA.id, bobId, 9).state;
+    expect(getCommanderDamageToOpponent(state, commanderA.id, bobId)).toBe(21);
+    expect(hasLostFromCommanderDamage(state, bobId)).toBe(true);
+    // Carol is untouched.
+    expect(hasLostFromCommanderDamage(state, carolId)).toBe(false);
+  });
+
+  it('attributes summary damage to the commander owner and lists each opponent (fixes mislabelling)', () => {
+    const commanderA = makeCommander('Commander A', aliceId);
+    const commanderB = makeCommander('Commander B', bobId);
+    state = registerCommander(state, aliceId, commanderA.id);
+    state = registerCommander(state, bobId, commanderB.id);
+
+    state = dealCommanderDamage(state, commanderA.id, bobId, 5).state;
+    state = dealCommanderDamage(state, commanderA.id, carolId, 3).state;
+    state = dealCommanderDamage(state, commanderB.id, carolId, 7).state;
+
+    const summary = getCommanderDamageSummary(state);
+
+    // Only owners whose commanders have dealt damage appear.
+    const aliceSummary = summary.find((s) => s.playerId === aliceId);
+    const bobSummary = summary.find((s) => s.playerId === bobId);
+    expect(aliceSummary).toBeDefined();
+    expect(bobSummary).toBeDefined();
+    expect(summary.find((s) => s.playerId === carolId)).toBeUndefined();
+
+    // Alice owns commanderA, which hit Bob (5) and Carol (3) — total 8.
+    const aliceCmdA = aliceSummary!.commanders.find(
+      (c) => c.commanderId === commanderA.id,
+    );
+    expect(aliceCmdA).toBeDefined();
+    expect(aliceCmdA!.damageToOpponents.get(bobId)).toBe(5);
+    expect(aliceCmdA!.damageToOpponents.get(carolId)).toBe(3);
+    expect(aliceCmdA!.totalDamage).toBe(8);
+    expect(aliceSummary!.totalDamageDealt).toBe(8);
+
+    // Bob owns commanderB, which hit Carol (7) — NOT Bob (the old bug).
+    const bobCmdB = bobSummary!.commanders.find(
+      (c) => c.commanderId === commanderB.id,
+    );
+    expect(bobCmdB).toBeDefined();
+    expect(bobCmdB!.damageToOpponents.get(carolId)).toBe(7);
+    expect(bobCmdB!.damageToOpponents.has(bobId)).toBe(false);
+    expect(bobCmdB!.totalDamage).toBe(7);
+  });
+
+  it('returns an empty summary array when no commander damage has been dealt', () => {
+    const summary = getCommanderDamageSummary(state);
+    expect(Array.isArray(summary)).toBe(true);
+    expect(summary.length).toBe(0);
   });
 });

--- a/src/lib/game-state/commander-damage.ts
+++ b/src/lib/game-state/commander-damage.ts
@@ -248,6 +248,65 @@ export function getCommanderDamage(
 }
 
 /**
+ * Query a single cell of the (commander, opponent) damage matrix (CR 903.9a).
+ *
+ * Returns the cumulative combat damage that `commanderId` has dealt to
+ * `opponentId`. This is the canonical per-commander-per-opponent lookup — the
+ * matrix is distributed across the receivers' `commanderDamage` maps (each
+ * opponent independently tallies damage from every commander that has hit
+ * them), and this accessor reads the relevant cell directly.
+ *
+ * Use {@link getCommanderDamageMatrix} to obtain the full matrix.
+ */
+export function getCommanderDamageToOpponent(
+  state: GameState,
+  commanderId: CardInstanceId,
+  opponentId: PlayerId,
+): number {
+  const opponent = state.players.get(opponentId);
+  if (!opponent) return 0;
+
+  const cell = opponent.commanderDamage.get(commanderId);
+  return typeof cell === "number" && Number.isFinite(cell) ? cell : 0;
+}
+
+/**
+ * Build the full (commander, opponent) damage matrix (CR 903.9a, issue #977).
+ *
+ * Returns `Map<CardInstanceId, Map<PlayerId, number>>` where the outer key is
+ * the source commander, the inner key is the opponent (receiver) the commander
+ * dealt combat damage to, and the value is the cumulative damage. This is the
+ * same shape declared by {@link CommanderDamageState.damageByCommander}, and is
+ * the source of truth for "damage from commander X to opponent Y".
+ *
+ * The matrix is derived from the distributed per-player `commanderDamage`
+ * maps (receiver-side), which {@link dealCommanderDamage} writes to. Only
+ * commanders that have dealt damage to at least one opponent appear as outer
+ * keys.
+ */
+export function getCommanderDamageMatrix(
+  state: GameState,
+): Map<CardInstanceId, Map<PlayerId, number>> {
+  const matrix = new Map<CardInstanceId, Map<PlayerId, number>>();
+
+  for (const [opponentId, opponent] of state.players) {
+    for (const [commanderId, damage] of opponent.commanderDamage) {
+      if (typeof damage !== "number" || !Number.isFinite(damage)) {
+        continue;
+      }
+      let row = matrix.get(commanderId);
+      if (!row) {
+        row = new Map<PlayerId, number>();
+        matrix.set(commanderId, row);
+      }
+      row.set(opponentId, damage);
+    }
+  }
+
+  return matrix;
+}
+
+/**
  * Get total commander damage dealt to a player across ALL commanders
  *
  * `Player.commanderDamage` is a `Map<CardInstanceId, number>` keyed by the
@@ -406,42 +465,65 @@ export interface CommanderDamageSummary {
 }
 
 /**
- * Get full commander damage summary for a game
+ * Get full commander damage summary for a game (issue #977).
+ *
+ * Builds the per-owner summary from the (commander, opponent) damage matrix
+ * (see {@link getCommanderDamageMatrix}). Each entry represents a player who
+ * owns one or more commanders, listing — for each of their commanders — the
+ * damage it dealt to every opponent, plus that commander's total. Commanders
+ * are attributed to their controller (falling back to owner), matching the
+ * attribution used by {@link dealCommanderDamage}. Only commanders that have
+ * actually dealt damage appear.
  */
 export function getCommanderDamageSummary(
   state: GameState,
 ): CommanderDamageSummary[] {
-  const summaries: CommanderDamageSummary[] = [];
+  const matrix = getCommanderDamageMatrix(state);
 
-  for (const [playerId, player] of state.players) {
-    const commanders: CommanderDamageSummary["commanders"] = [];
-    let totalDamageDealt = 0;
+  const owners = new Map<PlayerId, CommanderDamageSummary>();
 
-    for (const [commanderId, damage] of player.commanderDamage) {
-      const commander = state.cards.get(commanderId);
+  for (const [commanderId, opponents] of matrix) {
+    const commander = state.cards.get(commanderId);
+    const ownerId: PlayerId | undefined =
+      commander?.controllerId || commander?.ownerId;
 
-      const damageToOpponents = new Map<PlayerId, number>();
-      damageToOpponents.set(playerId, damage);
-
-      commanders.push({
-        commanderId,
-        commanderName: commander?.cardData.name || "Unknown Commander",
-        damageToOpponents,
-        totalDamage: damage,
-      });
-
-      totalDamageDealt += damage;
+    if (ownerId === undefined) {
+      continue;
     }
 
-    summaries.push({
-      playerId,
-      playerName: player.name,
-      commanders,
-      totalDamageDealt,
+    const owner = state.players.get(ownerId);
+    if (!owner) {
+      continue;
+    }
+
+    let summary = owners.get(ownerId);
+    if (!summary) {
+      summary = {
+        playerId: ownerId,
+        playerName: owner.name,
+        commanders: [],
+        totalDamageDealt: 0,
+      };
+      owners.set(ownerId, summary);
+    }
+
+    const damageToOpponents = new Map<PlayerId, number>();
+    let totalDamage = 0;
+    for (const [opponentId, damage] of opponents) {
+      damageToOpponents.set(opponentId, damage);
+      totalDamage += damage;
+    }
+
+    summary.commanders.push({
+      commanderId,
+      commanderName: commander?.cardData.name || "Unknown Commander",
+      damageToOpponents,
+      totalDamage,
     });
+    summary.totalDamageDealt += totalDamage;
   }
 
-  return summaries;
+  return Array.from(owners.values());
 }
 
 /**


### PR DESCRIPTION
## Problem

Issue #977: Commander damage must be tracked as a **(commander, opponent) matrix** (CR 903.9a) — damage from EACH commander to EACH opponent separately. The previous code had no explicit matrix accessor, and `getCommanderDamageSummary` was broken: it iterated receivers and mislabelled each receiver's `playerId` as the opponent while attributing incoming damage as if the receiver had dealt it.

The `CommanderDamageState.damageByCommander` field already declared the matrix shape (`Map<CardInstanceId, Map<PlayerId, number>>`) but it was unused dead code with no accessors.

## Changes

Focused entirely on `src/lib/game-state/commander-damage.ts` (no storage-shape change, so the 24+ files that read `Player.commanderDamage` are untouched and #976's just-stabilized accessors are preserved):

- **`getCommanderDamageToOpponent(state, commanderId, opponentId)`** — canonical single-cell query of the (commander, opponent) matrix. Reads the receiver-side tally directly.
- **`getCommanderDamageMatrix(state)`** — builds and returns the full `Map<CardInstanceId, Map<PlayerId, number>>` matrix from the distributed per-player state. This is the explicit source of truth for "damage from commander X to opponent Y" and matches the shape declared by `CommanderDamageState.damageByCommander`.
- **`getCommanderDamageSummary`** — rewritten to derive from the matrix and attribute each commander's damage to its **owner** (`controllerId || ownerId`, matching `dealCommanderDamage`), correctly listing damage to each opponent. Fixes the prior mislabelling bug.
- Defensive guards against non-numeric / non-finite map values retained from #976.

### Design note
`Player.commanderDamage: Map<CardInstanceId, number>` (receiver-side) already encodes the matrix distributively — each opponent independently tallies damage from every commander that has hit them. Rather than introduce a redundant inner `Map<PlayerId, number>` per player (which would require touching 24+ files and re-litigate #976), the matrix is surfaced via derived accessors. This satisfies the issue's acceptance criteria while keeping the change focused.

## Testing

New `describe` block **"issue #977 per-commander-per-opponent matrix"** (9 tests):
- damage from commander A to opponent X tracked separately from opponent Y, and from commander B (the matrix);
- `getCommanderDamageMatrix` exposes the full matrix with correct cells and excludes commanders with no recorded damage;
- `getCommanderDamageToOpponent` reads individual cells and returns 0 for unknown commander/opponent;
- per-opponent totals (`getTotalCommanderDamage`) and the per-commander 21-loss threshold (`hasLostFromCommanderDamage`) remain consistent with the matrix — **composes with #976**;
- `getCommanderDamageSummary` attributes damage by owner and lists each opponent (regression test for the mislabelling fix).

```
npx jest commander-damage   → 3 suites, 68 tests, all PASS
npx jest combat             → 7 suites, 161 tests, all PASS (combat.ts calls dealCommanderDamage)
npx tsc --noEmit            → No errors found
```

Closes #977.