### PR TITLE
fix: implement first strike / double strike combat damage steps (closes #969)

### DIFF
--- a/src/lib/game-state/__tests__/combat.test.ts
+++ b/src/lib/game-state/__tests__/combat.test.ts
@@ -30,6 +30,7 @@ import {
 import { Phase, CardInstanceId } from "../types";
 import { layerSystem, createPowerToughnessModifyEffect } from "../layer-system";
 import { checkStateBasedActions } from "../state-based-actions";
+import { shouldHaveFirstStrikeStep } from "../turn-phases";
 import type { ScryfallCard } from "@/app/actions";
 
 // Helper function to create a mock creature card
@@ -2388,8 +2389,6 @@ describe("Combat System - Deathtouch and Indestructible (#669)", () => {
     });
 
     it("shouldHaveFirstStrikeStep returns false when no creature has first/double strike, true otherwise (#969)", () => {
-      const { shouldHaveFirstStrikeStep } = require("../turn-phases");
-
       // No first/double strike anywhere.
       const { state, aliceId, bobId } = setupGameWithCreatures(
         [{ name: "Attacker", power: 2, toughness: 2 }],

--- a/src/lib/game-state/__tests__/combat.test.ts
+++ b/src/lib/game-state/__tests__/combat.test.ts
@@ -21,6 +21,7 @@ import {
   getAvailableAttackers,
   getAvailableBlockers,
 } from "../combat";
+import type { CombatActionResult } from "../combat";
 import { createInitialGameState, startGame } from "../game-state";
 import {
   createCardInstance,
@@ -2117,6 +2118,347 @@ describe("Combat System - Deathtouch and Indestructible (#669)", () => {
       // (CR 306.7: Damage marked on creature doesn't reduce planeswalker loyalty separately)
       const attacker = resolveResult.state.cards.get(attackerId);
       expect(attacker?.damage).toBe(0);
+    });
+  });
+
+  // Issue #969: First Strike / Double Strike combat damage step gating (CR 702.7, CR 702.4)
+  describe("First Strike / Double Strike damage step gating (#969)", () => {
+    // Helper: run both combat damage steps starting from a post-declare-blockers state.
+    function runBothDamageSteps(
+      stateAfterBlockers: import("../types").GameState,
+    ): { firstStrike: CombatActionResult; regular: CombatActionResult } {
+      const stateFirstStrike = {
+        ...stateAfterBlockers,
+        turn: {
+          ...stateAfterBlockers.turn,
+          currentPhase: Phase.COMBAT_DAMAGE_FIRST_STRIKE,
+        },
+      };
+      const firstStrike = resolveCombatDamage(stateFirstStrike);
+      expect(firstStrike.success).toBe(true);
+      const stateRegular = {
+        ...firstStrike.state,
+        turn: {
+          ...firstStrike.state.turn,
+          currentPhase: Phase.COMBAT_DAMAGE,
+        },
+      };
+      const regular = resolveCombatDamage(stateRegular);
+      expect(regular.success).toBe(true);
+      return { firstStrike, regular };
+    }
+
+    it("first-strike attacker kills a regular blocker before the blocker deals any damage (#969)", () => {
+      // 2/2 first strike vs 2/2 regular blocker. First striker kills the
+      // blocker in the first-strike step; the blocker never deals its
+      // damage back because it is dead before the regular damage step.
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [
+          {
+            name: "FS Attacker",
+            power: 2,
+            toughness: 2,
+            keywords: ["First Strike"],
+          },
+        ],
+        [{ name: "Regular Blocker", power: 2, toughness: 2 }],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerId = bobBattlefield.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+      const blockResult = declareBlockers(
+        attackResult.state,
+        new Map([[attackerId, [blockerId]]]),
+      );
+
+      const { firstStrike, regular } = runBothDamageSteps(blockResult.state);
+
+      // Blocker died in the first-strike step.
+      const bobGraveyard = firstStrike.state.zones.get(
+        `${bobId}-graveyard`,
+      )!;
+      expect(bobGraveyard.cardIds).toContain(blockerId);
+
+      // Attacker survived the whole combat — the regular blocker never dealt
+      // its 2 damage because it was already dead before the regular step.
+      const aliceBfAfter = regular.state.zones.get(
+        `${aliceId}-battlefield`,
+      )!;
+      expect(aliceBfAfter.cardIds).toContain(attackerId);
+      const attackerAfter = regular.state.cards.get(attackerId)!;
+      expect(attackerAfter.damage).toBe(0);
+    });
+
+    it("double-strike attacker deals damage in BOTH first-strike and regular steps (#969)", () => {
+      // 2/2 double strike, unblocked, attacks player.
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [
+          {
+            name: "DS Attacker",
+            power: 2,
+            toughness: 2,
+            keywords: ["Double Strike"],
+          },
+        ],
+        [],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+
+      const { firstStrike, regular } = runBothDamageSteps(attackResult.state);
+
+      // 2 damage in the first-strike step.
+      const bobAfterFirst = firstStrike.state.players.get(bobId)!;
+      expect(bobAfterFirst.life).toBe(18);
+      // +2 more damage in the regular step (4 total).
+      const bobAfterRegular = regular.state.players.get(bobId)!;
+      expect(bobAfterRegular.life).toBe(16);
+    });
+
+    it("a double-strike attacker killed in the first-strike step does NOT deal damage in the regular step (#969)", () => {
+      // 2/2 double strike attacker blocked by a 3/3 first-strike blocker.
+      // Step 1 (first strike): attacker deals 2 to blocker (not lethal); blocker
+      // deals 3 to attacker → attacker dies. Step 2 (regular): the dead double-
+      // strike attacker must NOT deal its second hit.
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [
+          {
+            name: "DS Attacker",
+            power: 2,
+            toughness: 2,
+            keywords: ["Double Strike"],
+          },
+        ],
+        [
+          {
+            name: "FS Blocker",
+            power: 3,
+            toughness: 3,
+            keywords: ["First Strike"],
+          },
+        ],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerId = bobBattlefield.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+      const blockResult = declareBlockers(
+        attackResult.state,
+        new Map([[attackerId, [blockerId]]]),
+      );
+
+      const { firstStrike, regular } = runBothDamageSteps(blockResult.state);
+
+      // Attacker died in the first-strike step.
+      const aliceGraveyard = firstStrike.state.zones.get(
+        `${aliceId}-graveyard`,
+      )!;
+      expect(aliceGraveyard.cardIds).toContain(attackerId);
+      // Blocker survived the first-strike step with exactly 2 damage marked.
+      const blockerAfterFirst = firstStrike.state.cards.get(blockerId)!;
+      expect(blockerAfterFirst.damage).toBe(2);
+
+      // After the regular step, the blocker must still only have 2 damage —
+      // the dead double-strike attacker did not deal its second hit.
+      const blockerAfterRegular = regular.state.cards.get(blockerId)!;
+      expect(blockerAfterRegular.damage).toBe(2);
+      const bobBfAfter = regular.state.zones.get(`${bobId}-battlefield`)!;
+      expect(bobBfAfter.cardIds).toContain(blockerId);
+    });
+
+    it("a double-strike blocker killed in the first-strike step does NOT deal damage in the regular step (#969)", () => {
+      // 3/3 first-strike attacker blocked by a 2/2 double-strike blocker.
+      // Step 1: attacker deals 3 to blocker (lethal, dies); blocker deals 2 to
+      // attacker. Step 2: the dead double-strike blocker must NOT deal its
+      // second hit. The attacker (first-strike-only) also does not act again,
+      // so the attacker ends with exactly 2 marked damage.
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [
+          {
+            name: "FS Attacker",
+            power: 3,
+            toughness: 3,
+            keywords: ["First Strike"],
+          },
+        ],
+        [
+          {
+            name: "DS Blocker",
+            power: 2,
+            toughness: 2,
+            keywords: ["Double Strike"],
+          },
+        ],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerId = bobBattlefield.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+      const blockResult = declareBlockers(
+        attackResult.state,
+        new Map([[attackerId, [blockerId]]]),
+      );
+
+      const { firstStrike, regular } = runBothDamageSteps(blockResult.state);
+
+      // Blocker died in the first-strike step.
+      const bobGraveyard = firstStrike.state.zones.get(`${bobId}-graveyard`)!;
+      expect(bobGraveyard.cardIds).toContain(blockerId);
+
+      // After the regular step, the attacker has only 2 damage (single hit
+      // from the blocker in the first-strike step). If the dead double-strike
+      // blocker incorrectly dealt its second hit, the attacker would have 4.
+      const attackerAfterRegular = regular.state.cards.get(attackerId)!;
+      expect(attackerAfterRegular.damage).toBe(2);
+      const aliceBfAfter = regular.state.zones.get(`${aliceId}-battlefield`)!;
+      expect(aliceBfAfter.cardIds).toContain(attackerId);
+    });
+
+    it("normal combat (no first/double strike) is unaffected: only one effective damage step (#969)", () => {
+      // 2/2 attacker vs 2/2 blocker, no keywords. Both should die after a
+      // single (regular) combat damage step. The first-strike step, if run,
+      // must be a no-op (no participants).
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [{ name: "Attacker", power: 2, toughness: 2 }],
+        [{ name: "Blocker", power: 2, toughness: 2 }],
+      );
+
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerId = bobBattlefield.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+      const blockResult = declareBlockers(
+        attackResult.state,
+        new Map([[attackerId, [blockerId]]]),
+      );
+
+      const { firstStrike, regular } = runBothDamageSteps(blockResult.state);
+
+      // First-strike step is a no-op: nothing dies, no damage marked.
+      const aliceBfAfterFs = firstStrike.state.zones.get(
+        `${aliceId}-battlefield`,
+      )!;
+      const bobBfAfterFs = firstStrike.state.zones.get(
+        `${bobId}-battlefield`,
+      )!;
+      expect(aliceBfAfterFs.cardIds).toContain(attackerId);
+      expect(bobBfAfterFs.cardIds).toContain(blockerId);
+      expect(firstStrike.state.cards.get(attackerId)!.damage).toBe(0);
+      expect(firstStrike.state.cards.get(blockerId)!.damage).toBe(0);
+
+      // Regular step: both deal damage simultaneously and both die.
+      const aliceGraveyard = regular.state.zones.get(`${aliceId}-graveyard`)!;
+      const bobGraveyard = regular.state.zones.get(`${bobId}-graveyard`)!;
+      expect(aliceGraveyard.cardIds).toContain(attackerId);
+      expect(bobGraveyard.cardIds).toContain(blockerId);
+    });
+
+    it("shouldHaveFirstStrikeStep returns false when no creature has first/double strike, true otherwise (#969)", () => {
+      const { shouldHaveFirstStrikeStep } = require("../turn-phases");
+
+      // No first/double strike anywhere.
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [{ name: "Attacker", power: 2, toughness: 2 }],
+        [{ name: "Blocker", power: 2, toughness: 2 }],
+      );
+      const aliceBattlefield = state.zones.get(`${aliceId}-battlefield`)!;
+      const bobBattlefield = state.zones.get(`${bobId}-battlefield`)!;
+      const attackerId = aliceBattlefield.cardIds[0];
+      const blockerId = bobBattlefield.cardIds[0];
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      attackResult.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+      const blockResult = declareBlockers(
+        attackResult.state,
+        new Map([[attackerId, [blockerId]]]),
+      );
+      expect(shouldHaveFirstStrikeStep(blockResult.state)).toBe(false);
+
+      // First-strike attacker present → true.
+      const fsState = setupGameWithCreatures(
+        [
+          {
+            name: "FS Attacker",
+            power: 2,
+            toughness: 2,
+            keywords: ["First Strike"],
+          },
+        ],
+        [],
+      );
+      const fsAttackerId = fsState.state.zones.get(
+        `${fsState.aliceId}-battlefield`,
+      )!.cardIds[0];
+      fsState.state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const fsAtk = declareAttackers(fsState.state, [
+        { cardId: fsAttackerId, defenderId: fsState.bobId },
+      ]);
+      expect(shouldHaveFirstStrikeStep(fsAtk.state)).toBe(true);
+
+      // Double-strike blocker present → true.
+      const dsState = setupGameWithCreatures(
+        [{ name: "Attacker", power: 2, toughness: 2 }],
+        [
+          {
+            name: "DS Blocker",
+            power: 2,
+            toughness: 2,
+            keywords: ["Double Strike"],
+          },
+        ],
+      );
+      const dsAttackerId = dsState.state.zones.get(
+        `${dsState.aliceId}-battlefield`,
+      )!.cardIds[0];
+      const dsBlockerId = dsState.state.zones.get(
+        `${dsState.bobId}-battlefield`,
+      )!.cardIds[0];
+      dsState.state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const dsAtk = declareAttackers(dsState.state, [
+        { cardId: dsAttackerId, defenderId: dsState.bobId },
+      ]);
+      dsAtk.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+      const dsBlk = declareBlockers(
+        dsAtk.state,
+        new Map([[dsAttackerId, [dsBlockerId]]]),
+      );
+      expect(shouldHaveFirstStrikeStep(dsBlk.state)).toBe(true);
     });
   });
 });

--- a/src/lib/game-state/combat.ts
+++ b/src/lib/game-state/combat.ts
@@ -6,7 +6,7 @@
  */
 
 import type { GameState, CardInstanceId, PlayerId } from "./types";
-import { Phase } from "./types";
+import { Phase, isOnBattlefield } from "./types";
 import { isCreature, getPower, getToughness } from "./card-instance";
 import { dealDamageToCard } from "./keyword-actions";
 import { checkStateBasedActions } from "./state-based-actions";
@@ -458,13 +458,23 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
   // CR 702.4b: Double strike creatures deal damage in BOTH steps
   // In first strike step: creatures with first strike OR double strike deal damage
   // In regular damage step: surviving creatures with double strike OR regular creatures deal damage
+  // CR 510.1c: A creature that has left the battlefield cannot deal combat damage.
+  // Issue #969: creatures that died in the first-strike step must NOT deal damage
+  // again in the regular step, even if they have double strike.
   const attackersDealingDamage = state.combat.attackers.filter((attacker) => {
+    // A creature no longer on the battlefield cannot deal combat damage.
+    // This gates the regular step against creatures killed in the first-strike
+    // step, and also guards against any creature removed mid-combat.
+    if (!isOnBattlefield(state, attacker.cardId)) {
+      return false;
+    }
     if (isFirstStrikeStep) {
       // First strike step: only first strike or double strike
       return attacker.hasFirstStrike || attacker.hasDoubleStrike;
     } else {
       // Regular damage step: only double strike OR no first strike
-      // Exclude creatures that died in first strike step (they won't be on battlefield)
+      // First-strike-only creatures are excluded (they already dealt damage).
+      // Double-strike creatures that survived the first-strike step deal again.
       return !attacker.hasFirstStrike || attacker.hasDoubleStrike;
     }
   });
@@ -771,7 +781,16 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
       // CR 702.4b: Blockers with first strike deal damage in first strike step
       // CR 702.4b: Blockers with double strike deal damage in BOTH steps
       // In regular step: Only surviving blockers deal damage
+      // Issue #969: blockers that died in the first-strike step must NOT deal
+      // damage in the regular step, even if they have double strike.
       for (const blocker of sortedBlockers) {
+        // A blocker no longer on the battlefield cannot deal combat damage.
+        // This gates the regular step against blockers killed in the
+        // first-strike step (CR 510.1c).
+        if (!isOnBattlefield(updatedState, blocker.cardId)) {
+          continue;
+        }
+
         const blockerCard = updatedState.cards.get(blocker.cardId);
         if (!blockerCard) continue;
 

--- a/src/lib/game-state/game-state.ts
+++ b/src/lib/game-state/game-state.ts
@@ -10,6 +10,7 @@ import type {
   Zone,
   Player,
 } from "./types";
+import { Phase } from "./types";
 import type { ScryfallCard } from "@/app/actions";
 import {
   createCardInstance,
@@ -23,6 +24,7 @@ import {
   advancePhase,
   startNextTurn,
   playerDrawsCard,
+  shouldHaveFirstStrikeStep,
 } from "./turn-phases";
 import { emptyAllManaPools } from "./mana";
 import {
@@ -503,7 +505,21 @@ export function processUntapStep(state: GameState): UntapStepResult {
  * Advance to the next phase
  */
 function advanceToNextPhase(state: GameState): GameState {
-  const nextPhase = advancePhase(state.turn);
+  let nextPhase = advancePhase(state.turn);
+
+  // CR 510.5 (First Strike step skipping): if we are about to enter the
+  // first-strike combat damage step but no attacker or blocker has first
+  // strike or double strike, skip it and advance directly to the regular
+  // combat damage step. Issue #969.
+  if (
+    nextPhase.currentPhase === Phase.COMBAT_DAMAGE_FIRST_STRIKE &&
+    !shouldHaveFirstStrikeStep(state)
+  ) {
+    const skipped = advancePhase(nextPhase);
+    if (skipped.currentPhase !== nextPhase.currentPhase) {
+      nextPhase = skipped;
+    }
+  }
 
   // Reset priority passes
   let updatedPlayers = new Map(state.players);

--- a/src/lib/game-state/turn-phases.ts
+++ b/src/lib/game-state/turn-phases.ts
@@ -2,7 +2,7 @@
  * Turn phase and step management
  */
 
-import type { PlayerId, Turn } from "./types";
+import type { PlayerId, Turn, GameState } from "./types";
 import { Phase } from "./types";
 
 /**
@@ -214,6 +214,38 @@ export function isCombatDamageStep(phase: Phase): boolean {
     phase === Phase.COMBAT_DAMAGE_FIRST_STRIKE ||
     phase === Phase.COMBAT_DAMAGE
   );
+}
+
+/**
+ * Determine whether a first-strike combat damage step should occur.
+ *
+ * CR 510.5: The first-strike step is an additional combat damage step that
+ * only happens if at least one attacking or blocking creature has first
+ * strike (CR 702.7) or double strike (CR 702.4). When no creature in combat
+ * has either ability, the first-strike step is skipped and combat proceeds
+ * directly from Declare Blockers to the (single) Combat Damage step.
+ *
+ * Issue #969: gate the first-strike combat damage step so it is only entered
+ * when it would actually have participants.
+ *
+ * @param state the game state to inspect (must have combat attackers/blockers populated)
+ * @returns true if at least one attacker or blocker deals first-strike damage
+ */
+export function shouldHaveFirstStrikeStep(state: GameState): boolean {
+  const { attackers, blockers } = state.combat;
+  for (const attacker of attackers) {
+    if (attacker.hasFirstStrike || attacker.hasDoubleStrike) {
+      return true;
+    }
+  }
+  for (const blockerList of blockers.values()) {
+    for (const blocker of blockerList) {
+      if (blocker.hasFirstStrike || blocker.hasDoubleStrike) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Problem

The combat system in `combat.ts` did not properly gate which creatures deal damage in each combat damage step (CR 702.7 First Strike, CR 702.4 Double Strike, CR 510.5). Specifically:

- A creature with **double strike that died in the first-strike step** was still dealing its second hit in the regular combat damage step (it remained in `state.cards` after being moved to the graveyard, and the existing filter `!hasFirstStrike || hasDoubleStrike` did not verify the creature was still on the battlefield).
- The same bug applied to **double-strike blockers** killed in the first-strike step — they kept dealing damage to the attacker in the regular step.
- The engine always entered the `COMBAT_DAMAGE_FIRST_STRIKE` step even when no attacker or blocker had first strike / double strike, violating CR 510.5 (the step should be skipped entirely when no participant has either ability).

## Changes

Kept changes focused on **damage-step sequencing / gating** (per coordination note, multi-blocker assignment ordering is #979's scope):

- **`src/lib/game-state/combat.ts`**
  - `resolveCombatDamage` now filters attackers with `isOnBattlefield(...)` so creatures that left the battlefield (e.g. died in the first-strike step) do not deal combat damage in the current step (CR 510.1c). This gates the regular step against dead double-strike creatures.
  - The blocker→attacker damage loop now skips any blocker no longer on the battlefield, so a double-strike blocker killed in the first-strike step does not get a second hit.
- **`src/lib/game-state/turn-phases.ts`**
  - Added `shouldHaveFirstStrikeStep(state)` helper implementing CR 510.5: returns `true` iff at least one attacker or blocker has first strike or double strike.
- **`src/lib/game-state/game-state.ts`**
  - `advanceToNextPhase` now consults `shouldHaveFirstStrikeStep`; when transitioning into `COMBAT_DAMAGE_FIRST_STRIKE` with no qualifying creature, it skips directly to `COMBAT_DAMAGE`.

## Testing

Added a new `describe` block "First Strike / Double Strike damage step gating (#969)" in `src/lib/game-state/__tests__/combat.test.ts` with 6 tests:

1. First-strike attacker kills a regular blocker before the blocker deals any damage.
2. Double-strike attacker deals damage in **both** first-strike and regular steps.
3. A double-strike attacker killed in the first-strike step does **not** deal damage in the regular step (the bug repro).
4. A double-strike blocker killed in the first-strike step does **not** deal damage in the regular step.
5. Normal combat (no first/double strike) is unaffected — the first-strike step is a no-op and both creatures trade in the single regular step.
6. `shouldHaveFirstStrikeStep` returns `false` when no creature has first/double strike and `true` otherwise (covering first-strike attacker and double-strike blocker cases).

**Commands run:**
- `npx jest src/lib/game-state/__tests__/combat.test.ts` → 61 passed, 0 failed (55 pre-existing + 6 new)
- `npx jest src/lib/game-state/` → 1878 passed, 0 failed
- `npx jest` (full repo) → 4308 passed, 0 failed
- `npx tsc --noEmit` → no errors
- `npx eslint <changed files>` → exit 0

Closes #969
