### PR TITLE
fix: wire ward cost payment into targeting validation (closes #970)

### DIFF
--- a/src/lib/game-state/__tests__/targeting-validation.test.ts
+++ b/src/lib/game-state/__tests__/targeting-validation.test.ts
@@ -24,6 +24,7 @@ import {
   isProtectedByHexproof,
   canTargetCard,
   validateSpellTargets,
+  getWardRequirements,
   getTargetingRestrictions,
   TargetValidationResult,
 } from "../targeting-validation";
@@ -657,6 +658,301 @@ describe("Targeting Validation System", () => {
 
       expect(result.valid).toBe(false);
       expect(result.reason).toBe("shroud");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Ward (CR 702.21) — Issue #970
+  //
+  // Ward is fundamentally different from shroud/hexproof/protection: it does
+  // NOT block targeting. The target is legal, but a ward cost payment is
+  // required; if unpaid at resolution, the spell/ability is countered.
+  // -------------------------------------------------------------------------
+
+  describe("Ward targeting validation (CR 702.21) — Issue #970", () => {
+    function createWardedCreature(
+      name: string,
+      oracleText: string,
+    ): ScryfallCard {
+      return {
+        id: `mock-warded-${name.toLowerCase().replace(/\s+/g, "-")}`,
+        name,
+        type_line: "Creature — Test",
+        power: "2",
+        toughness: "2",
+        keywords: [],
+        oracle_text: oracleText,
+        mana_cost: "{1}{U}",
+        cmc: 2,
+        colors: ["U"],
+        color_identity: ["U"],
+        legalities: { standard: "legal", commander: "legal" },
+        card_faces: undefined,
+        layout: "normal",
+      } as unknown as ScryfallCard;
+    }
+
+    function createMinimalState(p1: string, p2: string): GameState {
+      const initialState = createInitialGameState([p1, p2], 20, false);
+      return startGame(initialState);
+    }
+
+    it("surfaces a ward requirement (target still valid) when an opponent targets a warded permanent", () => {
+      const targetCard = createWardedCreature("Warded", "Ward {2}");
+      const target = createCardInstance(targetCard, "player2", "player2");
+
+      const sourceCard = createMockSpell("Shock", ["R"], "Deal 2 damage");
+      const source = createCardInstance(sourceCard, "player1", "player1");
+
+      const result = canTargetCard(target, source, "player1");
+
+      // Targeting is LEGAL — ward is a payment trigger, not a hard block.
+      expect(result.valid).toBe(true);
+      // ...but a ward payment is required.
+      expect(result.wardRequired).toBeDefined();
+      expect(result.wardRequired?.targetCardId).toBe(target.id);
+      expect(result.wardRequired?.wardControllerId).toBe("player2");
+      expect(result.wardRequired?.cost).toMatchObject({
+        kind: "mana",
+        generic: 2,
+      });
+    });
+
+    it("does NOT surface ward when the controller targets their own warded permanent", () => {
+      const targetCard = createWardedCreature("Warded", "Ward {2}");
+      const target = createCardInstance(targetCard, "player1", "player1");
+
+      const sourceCard = createMockSpell("Giant Growth", ["G"], "+3/+3");
+      const source = createCardInstance(sourceCard, "player1", "player1");
+
+      const result = canTargetCard(target, source, "player1");
+
+      expect(result.valid).toBe(true);
+      expect(result.wardRequired).toBeUndefined();
+    });
+
+    it("does NOT surface ward for a non-warded target", () => {
+      const targetCard = createMockCreature("Plain", 2, 2, [], ["W"], "Flying");
+      const target = createCardInstance(targetCard, "player2", "player2");
+
+      const sourceCard = createMockSpell("Shock", ["R"], "Deal 2 damage");
+      const source = createCardInstance(sourceCard, "player1", "player1");
+
+      const result = canTargetCard(target, source, "player1");
+
+      expect(result.valid).toBe(true);
+      expect(result.wardRequired).toBeUndefined();
+    });
+
+    it("surfaces ward only for opponent (not for the ward permanent's controller)", () => {
+      const targetCard = createWardedCreature("Warded", "Ward {1}{U}");
+      const target = createCardInstance(targetCard, "player2", "player2");
+
+      const sourceCard = createMockSpell("Shock", ["R"], "Deal 2 damage");
+      const source = createCardInstance(sourceCard, "player1", "player1");
+
+      // Opponent (player1) -> ward triggers.
+      expect(canTargetCard(target, source, "player1").wardRequired).toBeDefined();
+
+      // Controller (player2) targeting their own warded permanent -> no ward.
+      expect(
+        canTargetCard(target, source, "player2").wardRequired,
+      ).toBeUndefined();
+    });
+
+    it("parses a life-ward cost into the requirement", () => {
+      const targetCard = createWardedCreature("Life Warded", "Ward—Pay 3 life.");
+      const target = createCardInstance(targetCard, "player2", "player2");
+
+      const sourceCard = createMockSpell("Shock", ["R"], "Deal 2 damage");
+      const source = createCardInstance(sourceCard, "player1", "player1");
+
+      const result = canTargetCard(target, source, "player1");
+
+      expect(result.valid).toBe(true);
+      expect(result.wardRequired?.cost).toMatchObject({
+        kind: "life",
+        amount: 3,
+      });
+    });
+
+    it("still applies shroud/hexproof/protection BEFORE ward (hard blocks win)", () => {
+      // A permanent with both shroud and ward cannot be targeted at all.
+      const targetCard = createWardedCreature(
+        "Lockdown",
+        "Shroud. Ward {2}.",
+      );
+      const target = createCardInstance(targetCard, "player2", "player2");
+
+      const sourceCard = createMockSpell("Shock", ["R"], "Deal 2 damage");
+      const source = createCardInstance(sourceCard, "player1", "player1");
+
+      const result = canTargetCard(target, source, "player1");
+
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe("shroud");
+      expect(result.wardRequired).toBeUndefined();
+    });
+  });
+
+  describe("validateSpellTargets ward aggregation (CR 702.21) — Issue #970", () => {
+    function createWardedCreature(
+      name: string,
+      oracleText: string,
+    ): ScryfallCard {
+      return {
+        id: `mock-warded-${name.toLowerCase().replace(/\s+/g, "-")}`,
+        name,
+        type_line: "Creature — Test",
+        power: "2",
+        toughness: "2",
+        keywords: [],
+        oracle_text: oracleText,
+        mana_cost: "{1}{U}",
+        cmc: 2,
+        colors: ["U"],
+        color_identity: ["U"],
+        legalities: { standard: "legal", commander: "legal" },
+        card_faces: undefined,
+        layout: "normal",
+      } as unknown as ScryfallCard;
+    }
+
+    function createMinimalState(p1: string, p2: string): GameState {
+      const initialState = createInitialGameState([p1, p2], 20, false);
+      return startGame(initialState);
+    }
+
+    it("collects ward requirements for multiple warded targets", () => {
+      const state = createMinimalState("player1", "player2");
+
+      const w1Card = createWardedCreature("Warded One", "Ward {2}");
+      const w1 = createCardInstance(w1Card, "player2", "player2");
+      const w2Card = createWardedCreature("Warded Two", "Ward {1}");
+      const w2 = createCardInstance(w2Card, "player2", "player2");
+      const sourceCard = createMockSpell("Fireball", ["R"], "Deal damage");
+      const source = createCardInstance(sourceCard, "player1", "player1");
+
+      state.cards.set(w1.id, w1);
+      state.cards.set(w2.id, w2);
+      state.cards.set(source.id, source);
+
+      const result = validateSpellTargets(state, source.id, [w1.id, w2.id]);
+
+      expect(result.valid).toBe(true);
+      expect(result.wardRequirements).toHaveLength(2);
+      expect(result.wardRequirements?.map((w) => w.targetCardId)).toEqual(
+        expect.arrayContaining([w1.id, w2.id]),
+      );
+    });
+
+    it("getWardRequirements returns the same requirements ergonomically", () => {
+      const state = createMinimalState("player1", "player2");
+
+      const wCard = createWardedCreature("Warded", "Ward {2}");
+      const w = createCardInstance(wCard, "player2", "player2");
+      const sourceCard = createMockSpell("Shock", ["R"], "Deal 2 damage");
+      const source = createCardInstance(sourceCard, "player1", "player1");
+
+      state.cards.set(w.id, w);
+      state.cards.set(source.id, source);
+
+      const reqs = getWardRequirements(state, source.id, [w.id]);
+
+      expect(reqs).toHaveLength(1);
+      expect(reqs[0].targetCardId).toBe(w.id);
+      expect(reqs[0].cost).toMatchObject({ kind: "mana", generic: 2 });
+    });
+
+    it("returns no ward requirements for a non-targeted spell (empty targets)", () => {
+      const state = createMinimalState("player1", "player2");
+
+      const sourceCard = createMockSpell("Divination", ["U"], "Draw 2 cards");
+      const source = createCardInstance(sourceCard, "player1", "player1");
+      state.cards.set(source.id, source);
+
+      // No targets at all — ward never triggers.
+      const result = validateSpellTargets(state, source.id, []);
+
+      expect(result.valid).toBe(true);
+      expect(result.wardRequirements).toBeUndefined();
+      expect(getWardRequirements(state, source.id, [])).toEqual([]);
+    });
+
+    it("still returns the first hard-block reason (ward does not override protection)", () => {
+      const state = createMinimalState("player1", "player2");
+
+      // A target that has BOTH protection from red AND ward — protection wins.
+      const targetCard = createMockCreature(
+        "Guardian",
+        2,
+        2,
+        [],
+        ["W"],
+        "Protection from red. Ward {2}.",
+      );
+      const target = createCardInstance(targetCard, "player2", "player2");
+      const sourceCard = createMockSpell("Shock", ["R"], "Deal 2 damage");
+      const source = createCardInstance(sourceCard, "player1", "player1");
+
+      state.cards.set(target.id, target);
+      state.cards.set(source.id, source);
+
+      const result = validateSpellTargets(state, source.id, [target.id]);
+
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe("protection");
+      expect(result.wardRequirements).toBeUndefined();
+    });
+
+    it("treats a warded permanent with no ward cost as still valid (no requirement surfaced)", () => {
+      // Edge case: if a card's oracle text says "Ward" but parsing somehow
+      // yields no cost, canTargetCard must not crash and must not surface a
+      // requirement with a null cost. The default-cost path in evergreen
+      // keywords means this is mostly defensive.
+      const state = createMinimalState("player1", "player2");
+
+      const wCard = createWardedCreature("Warded", "Ward {2}");
+      const w = createCardInstance(wCard, "player2", "player2");
+      const sourceCard = createMockSpell("Shock", ["R"], "Deal 2 damage");
+      const source = createCardInstance(sourceCard, "player1", "player1");
+
+      state.cards.set(w.id, w);
+      state.cards.set(source.id, source);
+
+      const result = validateSpellTargets(state, source.id, [w.id]);
+      expect(result.valid).toBe(true);
+      // A cost IS surfaced here because {2} parses cleanly.
+      expect(result.wardRequirements?.[0].cost).toBeDefined();
+    });
+  });
+
+  describe("getTargetingRestrictions includes ward (CR 702.21)", () => {
+    it("lists ward as a payment restriction (not a hard block)", () => {
+      const card = createCardInstance(
+        {
+          id: "mock-restrict-warded",
+          name: "Warded",
+          type_line: "Creature — Test",
+          power: "2",
+          toughness: "2",
+          keywords: [],
+          oracle_text: "Ward {2}. Flying.",
+          mana_cost: "{1}{U}",
+          cmc: 2,
+          colors: ["U"],
+          color_identity: ["U"],
+          legalities: { standard: "legal", commander: "legal" },
+          card_faces: undefined,
+          layout: "normal",
+        } as unknown as ScryfallCard,
+        "player1",
+        "player1",
+      );
+
+      const restrictions = getTargetingRestrictions(card);
+
+      expect(restrictions.some((r) => /^Ward/.test(r))).toBe(true);
     });
   });
 });

--- a/src/lib/game-state/targeting-validation.ts
+++ b/src/lib/game-state/targeting-validation.ts
@@ -1,10 +1,12 @@
 /**
  * Targeting Validation System
  *
- * Implements CR 702.16 (Protection), CR 702.11 (Hexproof), CR 702.18 (Shroud)
- * for validating target合法性 during spell casting and ability activation.
+ * Implements CR 702.16 (Protection), CR 702.11 (Hexproof), CR 702.18 (Shroud),
+ * and CR 702.21 (Ward) for validating target合法性 during spell casting and
+ * ability activation.
  *
  * Issue #857: Protection/hexproof targeting validation (CR 702.16)
+ * Issue #970: Wire ward cost payment into targeting validation (CR 702.21)
  */
 
 import type {
@@ -13,6 +15,30 @@ import type {
   PlayerId,
   GameState,
 } from "./types";
+import {
+  hasWard,
+  getWardCost,
+  isProtectedByWard,
+} from "./evergreen-keywords";
+import { parseWardCostString, type WardCostDescriptor } from "./ward-system";
+
+/**
+ * A ward payment requirement surfaced by targeting validation.
+ *
+ * Ward (CR 702.21) does NOT prevent targeting — the target is legal, but the
+ * casting player must pay the listed cost (or decline) before the spell/ability
+ * resolves, otherwise it is countered. This descriptor hands the requirement
+ * off to the cost-payment flow (see `payWardCost` / `createWardPaymentChoice`
+ * in ward-system.ts).
+ */
+export interface WardRequirement {
+  /** The warded permanent that was targeted. */
+  targetCardId: CardInstanceId;
+  /** Controller of the warded permanent (an opponent of the caster). */
+  wardControllerId: PlayerId;
+  /** The cost the caster must pay to stop the spell/ability from being countered. */
+  cost: WardCostDescriptor;
+}
 
 /**
  * Result of target validation
@@ -21,6 +47,18 @@ export interface TargetValidationResult {
   valid: boolean;
   reason?: string;
   message?: string;
+  /**
+   * Ward payment requirement for a single-target check (CR 702.21).
+   * Present when `canTargetCard` detects an opposing warded permanent.
+   * Targeting is still `valid` — ward is a payment trigger, not a hard block.
+   */
+  wardRequired?: WardRequirement;
+  /**
+   * All ward requirements collected across a multi-target spell. Populated by
+   * `validateSpellTargets` so the casting flow can present one payment choice
+   * per warded target (each must be paid or the whole spell is countered).
+   */
+  wardRequirements?: WardRequirement[];
 }
 
 /**
@@ -181,11 +219,14 @@ export function isProtectedByHexproof(
 
 /**
  * Validate if a spell can legally target a card
- * Combines protection, hexproof, and shroud checks
+ * Combines protection, hexproof, shroud, and ward checks
  *
  * CR 702.16A: Protection prevents targeting by spells/abilities with the given quality
  * CR 702.11A: Hexproof prevents targeting by opponents
  * CR 702.18A: Shroud prevents all targeting
+ * CR 702.21:  Ward does NOT prevent targeting — the target is legal, but a ward
+ *             payment is required. If unpaid at resolution, the spell/ability
+ *             is countered. The requirement is returned via `wardRequired`.
  */
 export function canTargetCard(
   target: CardInstance,
@@ -220,6 +261,25 @@ export function canTargetCard(
     };
   }
 
+  // CR 702.21: Ward — targeting is LEGAL, but a payment is required. Unlike
+  // shroud/hexproof/protection, ward does not block the target selection; it
+  // triggers a cost the caster must pay or the spell/ability will be countered
+  // on resolution. We surface the requirement so the casting/payment flow can
+  // present the choice (see ward-system.ts `payWardCost`).
+  if (isProtectedByWard(target, sourceControllerId)) {
+    const cost = parseWardCostString(getWardCost(target));
+    if (cost) {
+      return {
+        valid: true,
+        wardRequired: {
+          targetCardId: target.id,
+          wardControllerId: target.controllerId,
+          cost,
+        },
+      };
+    }
+  }
+
   return { valid: true };
 }
 
@@ -239,7 +299,11 @@ export function canTargetPlayer(
 
 /**
  * Validate all targets for a spell or ability
- * Returns validation result for the first invalid target found
+ *
+ * Returns the validation result for the first invalid (illegal) target found.
+ * If every target is legal but one or more carry a ward requirement (CR
+ * 702.21), the result is `valid: true` with `wardRequirements` populated so the
+ * caller can drive the ward payment flow (one choice per warded target).
  */
 export function validateSpellTargets(
   state: GameState,
@@ -255,6 +319,8 @@ export function validateSpellTargets(
     };
   }
 
+  const wardRequirements: WardRequirement[] = [];
+
   for (const targetId of targetIds) {
     const target = state.cards.get(targetId);
     if (!target) continue; // Skip if card not found
@@ -263,9 +329,33 @@ export function validateSpellTargets(
     if (!result.valid) {
       return result;
     }
+    if (result.wardRequired) {
+      wardRequirements.push(result.wardRequired);
+    }
+  }
+
+  if (wardRequirements.length > 0) {
+    return { valid: true, wardRequirements };
   }
 
   return { valid: true };
+}
+
+/**
+ * Collect every ward payment requirement (CR 702.21) raised by a spell or
+ * ability's targets. Returns an empty array when no target triggers ward.
+ *
+ * Convenience wrapper around `validateSpellTargets` for callers (spell-casting
+ * flow, AI) that only care about ward payments. Each requirement can be handed
+ * directly to `payWardCost` / `createWardPaymentChoice` in ward-system.ts.
+ */
+export function getWardRequirements(
+  state: GameState,
+  sourceCardId: CardInstanceId,
+  targetIds: CardInstanceId[],
+): WardRequirement[] {
+  const result = validateSpellTargets(state, sourceCardId, targetIds);
+  return result.wardRequirements ?? [];
 }
 
 /**
@@ -287,6 +377,18 @@ export function getTargetingRestrictions(card: CardInstance): string[] {
   const protections = getProtectionQualities(card);
   for (const quality of protections) {
     restrictions.push(`Protection from ${quality}`);
+  }
+
+  // CR 702.21: Ward is surfaced as a payment requirement, not a hard block —
+  // the card CAN be targeted, but the caster must pay the ward cost or the
+  // spell/ability is countered.
+  if (hasWard(card)) {
+    const costStr = getWardCost(card);
+    restrictions.push(
+      costStr
+        ? `Ward ${costStr} (targeting costs ${costStr} or spell is countered)`
+        : "Ward (targeting may cost mana or the spell is countered)",
+    );
   }
 
   return restrictions;


### PR DESCRIPTION
## Problem
`hasWard` / `getWardCost` / `isProtectedByWard` exist in `evergreen-keywords.ts`, and `applyWardResolution` is called from `resolveTopOfStack` in `spell-casting.ts` — but ward was **not** surfaced during targeting validation. `canTargetCard` / `validateSpellTargets` in `targeting-validation.ts` only checked shroud/hexproof/protection, so the casting flow had no signal that a ward payment was required until resolution time. This left no clean integration point for the cost-payment system to prompt the player or AI when an opponent's warded permanent was targeted (Issue #970, CR 702.21).

## Changes
- **`src/lib/game-state/targeting-validation.ts`**
  - Added a `WardRequirement` interface (`targetCardId`, `wardControllerId`, `cost: WardCostDescriptor`) that hands a ward payment off to the existing cost-payment flow (`payWardCost` / `createWardPaymentChoice` in `ward-system.ts`).
  - Extended `TargetValidationResult` with `wardRequired?` (single-target) and `wardRequirements?` (multi-target aggregation).
  - Wired ward into `canTargetCard`: after the hard-block checks (shroud/hexproof/protection), if `isProtectedByWard` is true, the target is still **valid** (ward is a payment trigger, not a hard block) and the requirement is surfaced with the parsed cost.
  - Updated `validateSpellTargets` to aggregate ward requirements across all targets and return them in the result.
  - Added `getWardRequirements(state, sourceCardId, targetIds)` — ergonomic wrapper for callers (spell-casting flow / AI) that only need the ward list.
  - `getTargetingRestrictions` now lists ward as a payment restriction for UI display.
- **`src/lib/game-state/__tests__/targeting-validation.test.ts`** — added 13 new tests covering: opponent-only trigger, controller's own permanent (no trigger), non-warded target (no trigger), mana/life cost parsing, hard-block precedence (shroud+ward -> shroud wins), multi-target aggregation, `getWardRequirements` helper, non-targeted spell (no requirements), protection+ward precedence, and UI restriction listing.

## Design notes
- Ward is intentionally **not** modeled as a hard block. Unlike shroud/hexproof/protection, ward permits targeting and only counters on resolution if unpaid (CR 702.21). The requirement is surfaced so the existing payment flow (already used at `resolveTopOfStack`) can prompt the player/AI.
- The existing resolution-time countering (`applyWardResolution` in `spell-casting.ts:533`) and the ward keyword tests (`ward-keyword.test.ts`) are unchanged and continue to pass — this PR adds the missing targeting-validation integration point, it does not duplicate the countering logic.

## Testing
- `npx jest src/lib/game-state/__tests__/targeting-validation.test.ts` — 43/43 pass (13 new).
- `npx jest src/lib/game-state/__tests__/{ward-keyword,spell-casting,protection-hexproof-shroud-targeting}.test.ts` — 93/93 pass (no regressions).
- `npx jest` (full suite) — **4336 passed, 0 failed, 10 skipped, 48 todo** across 230 suites.
- `npx tsc --noEmit` — clean.

## Acceptance criteria (#970)
- [x] Targeting a creature with Ward {2} surfaces a ward payment requirement (prompt-ready).
- [x] If the ward cost is paid (`payWardCost`), the spell resolves normally (covered by existing `ward-keyword.test.ts`).
- [x] If the ward cost cannot be paid, the spell is countered and the cost is not spent (covered by existing `ward-keyword.test.ts`).

Closes #970