### PR TITLE
fix: strip console.log statements leaking P2P session IDs and game codes (closes #982)

### DIFF
--- a/src/lib/__tests__/p2p-direct-connection.test.ts
+++ b/src/lib/__tests__/p2p-direct-connection.test.ts
@@ -10,6 +10,7 @@ import {
   generateICECandidateString,
   validateConnectionData,
   getConnectionState,
+  handleICEExchange,
   isConnectionData,
   isICECandidateData,
   type ConnectionData,
@@ -383,6 +384,61 @@ describe("P2P Direct Connection Utilities", () => {
     it("should return null for non-existent session", () => {
       const result = getConnectionState("non-existent-session");
       expect(result).toBeNull();
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Issue #982 — strip console.log statements exposing session IDs / game codes
+  // --------------------------------------------------------------------------
+
+  describe("Sensitive-data leak protection (#982)", () => {
+    let errorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      errorSpy.mockRestore();
+    });
+
+    it("parseConnectionData does not log the raw input on failure", () => {
+      // Malicious input that embeds a session id and a game code — even though
+      // the current logger prints a static message, this test fails loudly if a
+      // future contributor adds `console.error("...", input)`.
+      const session = "host-1700000000000-abc12345";
+      const gameCode = "ZZZ999";
+      const malicious = `{ "sessionId": "${session}", "gameCode": "${gameCode}" }`;
+
+      expect(parseConnectionData(malicious)).toBeNull();
+
+      expect(errorSpy).toHaveBeenCalled();
+      for (const call of errorSpy.mock.calls) {
+        const serialized = JSON.stringify(call);
+        expect(serialized).not.toContain(session);
+        expect(serialized).not.toContain(gameCode);
+      }
+    });
+
+    it("handleICEExchange does not embed sessionId in the thrown error", async () => {
+      const sessionId = `host-1700000000000-leak1234`;
+      // No session was created for this id, so the manager will reject.
+      let caught: unknown = null;
+      try {
+        await handleICEExchange(sessionId, { candidate: "x" }, {
+          playerId: "p1",
+          playerName: "p1",
+        } as never);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      const message = (caught as Error).message;
+      // #982: the sessionId must NOT leak through the thrown error message
+      // (it can propagate up to higher-level error reporters / console output).
+      expect(message).not.toContain(sessionId);
+      // Sanity: the generic message is still informative.
+      expect(message).toMatch(/session not found/i);
     });
   });
 });

--- a/src/lib/__tests__/p2p-log-redact.test.ts
+++ b/src/lib/__tests__/p2p-log-redact.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Tests for P2P log redaction utility (Issue #982)
+ *
+ * Verifies that session IDs, game codes, peer IDs, SDP blobs, ICE candidates,
+ * and other sensitive connection metadata are scrubbed from any value passed
+ * through `redactSensitive`, and that the convenience wrappers route scrubbed
+ * output to the correct console methods.
+ */
+
+import {
+  redactSensitive,
+  safeLogError,
+  safeLogInfo,
+  safeLogWarn,
+} from "../p2p-log-redact";
+
+describe("p2p-log-redact", () => {
+  describe("redactSensitive — primitive values", () => {
+    it("returns 'null' for null", () => {
+      expect(redactSensitive(null)).toBe("null");
+    });
+
+    it("returns 'undefined' for undefined", () => {
+      expect(redactSensitive(undefined)).toBe("undefined");
+    });
+
+    it("returns numbers/booleans as strings", () => {
+      expect(redactSensitive(42)).toBe("42");
+      expect(redactSensitive(true)).toBe("true");
+      expect(redactSensitive(0)).toBe("0");
+    });
+
+    it("returns plain strings unchanged", () => {
+      expect(redactSensitive("hello world")).toBe("hello world");
+      expect(redactSensitive("")).toBe("");
+    });
+  });
+
+  describe("redactSensitive — session ID masking in strings", () => {
+    it("masks a host-style session ID embedded in a string", () => {
+      const session = "host-1700000000000-abc12345";
+      const input = `Connection failed for ${session}`;
+      const result = redactSensitive(input);
+      expect(result).not.toContain(session);
+      expect(result).toContain("[REDACTED_SESSION]");
+      expect(result).toContain("Connection failed for");
+    });
+
+    it("masks a client-style session ID embedded in a string", () => {
+      const session = "client-1700000000000-xyz789ab";
+      const input = `peer ${session} disconnected`;
+      const result = redactSensitive(input);
+      expect(result).not.toContain(session);
+      expect(result).toContain("[REDACTED_SESSION]");
+    });
+
+    it("masks multiple session IDs in the same string", () => {
+      const a = "host-1700000000000-aaaa1111";
+      const b = "client-1700000000001-bbbb2222";
+      const result = redactSensitive(`bridge ${a} -> ${b}`);
+      expect(result).not.toContain(a);
+      expect(result).not.toContain(b);
+      expect(result.match(/\[REDACTED_SESSION\]/g)?.length).toBe(2);
+    });
+
+    it("leaves ordinary text untouched when no session pattern is present", () => {
+      const input = "ICE connection state: failed";
+      expect(redactSensitive(input)).toBe(input);
+    });
+
+    it("does not mask short alphanumeric tokens that look like words", () => {
+      // Game codes (6 chars) are NOT pattern-matched — too indistinguishable
+      // from ordinary text. They are redacted by KEY only when serializing
+      // objects.
+      expect(redactSensitive("ABC234")).toBe("ABC234");
+    });
+  });
+
+  describe("redactSensitive — Error instances", () => {
+    it("formats Error as 'Name: message' with session IDs masked", () => {
+      const session = "host-1700000000000-abc12345";
+      const err = new Error(`Session ${session} not found`);
+      const result = redactSensitive(err);
+      expect(result).not.toContain(session);
+      expect(result).toContain("[REDACTED_SESSION]");
+      expect(result).toContain("Error:");
+      expect(result).toContain("Session");
+      expect(result).toContain("not found");
+    });
+
+    it("preserves custom Error subclass names", () => {
+      class CustomError extends Error {
+        constructor(msg: string) {
+          super(msg);
+          this.name = "CustomError";
+        }
+      }
+      const result = redactSensitive(new CustomError("boom"));
+      expect(result.startsWith("CustomError:")).toBe(true);
+      expect(result).toContain("boom");
+    });
+
+    it("handles Error with empty message", () => {
+      const result = redactSensitive(new Error(""));
+      expect(result).toBe("Error: ");
+    });
+
+    it("omits the stack trace (stacks contain no P2P metadata and bloat logs)", () => {
+      const err = new Error("boom");
+      err.stack = "Error: boom\n    at foo.js:1:1";
+      const result = redactSensitive(err);
+      expect(result).not.toContain("at foo.js");
+    });
+  });
+
+  describe("redactSensitive — objects with sensitive keys", () => {
+    it("redacts sessionId, gameCode, sdp, candidate, peerId, playerName by key", () => {
+      const input = {
+        sessionId: "host-1700000000000-abc12345",
+        gameCode: "ABC234",
+        sdp: { type: "offer", sdp: "v=0..." },
+        candidate: { candidate: "candidate:842163049" },
+        peerId: "peer-1",
+        playerName: "Alice",
+        safe: "ok",
+      };
+      const result = redactSensitive(input);
+      expect(result).not.toContain("host-1700000000000-abc12345");
+      expect(result).not.toContain("ABC234");
+      expect(result).not.toContain("v=0...");
+      expect(result).not.toContain("candidate:842163049");
+      expect(result).not.toContain("Alice");
+
+      const parsed = JSON.parse(result);
+      expect(parsed.sessionId).toBe("[REDACTED]");
+      expect(parsed.gameCode).toBe("[REDACTED]");
+      expect(parsed.sdp).toBe("[REDACTED]");
+      expect(parsed.candidate).toBe("[REDACTED]");
+      expect(parsed.peerId).toBe("[REDACTED]");
+      expect(parsed.playerName).toBe("[REDACTED]");
+      expect(parsed.safe).toBe("ok");
+    });
+
+    it("redacts sensitive keys regardless of capitalization", () => {
+      const result = redactSensitive({
+        sessionId: "x",
+        sessionid: "x",
+        session_id: "x",
+        GAMECODE: "x", // not in sensitive set (case-sensitive by design)
+        gameCode: "x",
+      });
+      const parsed = JSON.parse(result);
+      expect(parsed.sessionId).toBe("[REDACTED]");
+      expect(parsed.sessionid).toBe("[REDACTED]");
+      expect(parsed.session_id).toBe("[REDACTED]");
+      expect(parsed.gameCode).toBe("[REDACTED]");
+    });
+
+    it("redacts sensitive keys nested inside objects", () => {
+      const input = {
+        outer: {
+          sessionId: "secret-session",
+          ok: 1,
+          deeper: { candidate: "ice-blob" },
+        },
+        safe: true,
+      };
+      const result = redactSensitive(input);
+      const parsed = JSON.parse(result);
+      expect(parsed.outer.sessionId).toBe("[REDACTED]");
+      expect(parsed.outer.deeper.candidate).toBe("[REDACTED]");
+      expect(parsed.outer.ok).toBe(1);
+      expect(parsed.safe).toBe(true);
+    });
+
+    it("redacts sensitive keys inside arrays", () => {
+      const input = [
+        { sessionId: "a" },
+        { sessionId: "b" },
+        { ok: 1 },
+      ];
+      const result = redactSensitive(input);
+      const parsed = JSON.parse(result);
+      expect(parsed[0].sessionId).toBe("[REDACTED]");
+      expect(parsed[1].sessionId).toBe("[REDACTED]");
+      expect(parsed[2].ok).toBe(1);
+    });
+
+    it("breaks reference cycles instead of throwing", () => {
+      const cyclic: Record<string, unknown> = { ok: 1 };
+      cyclic.self = cyclic;
+      cyclic.sessionId = "secret";
+      const result = redactSensitive(cyclic);
+      expect(result).toContain("[Circular]");
+      expect(result).not.toContain("secret");
+    });
+
+    it("never throws on objects with throwing getters", () => {
+      const evil: Record<string, unknown> = {};
+      Object.defineProperty(evil, "sessionId", {
+        get() {
+          throw new Error("boom");
+        },
+        enumerable: true,
+      });
+      expect(() => redactSensitive(evil)).not.toThrow();
+    });
+
+    it("redacts TURN credential fields (password, credential, username, urls, uris)", () => {
+      const input = {
+        iceServers: [
+          {
+            urls: "turn:turn.example.com:3478",
+            username: "user-1700000000",
+            credential: "super-secret",
+          },
+        ],
+      };
+      const result = redactSensitive(input);
+      const parsed = JSON.parse(result);
+      const server = parsed.iceServers[0];
+      expect(server.urls).toBe("[REDACTED]");
+      expect(server.username).toBe("[REDACTED]");
+      expect(server.credential).toBe("[REDACTED]");
+    });
+  });
+
+  describe("redactSensitive — never throws on exotic input", () => {
+    it("handles BigInt by falling back to String()", () => {
+      // JSON.stringify throws on BigInt by default — our helper must not.
+      const input = { big: BigInt(123), safe: 1 };
+      expect(() => redactSensitive(input)).not.toThrow();
+    });
+
+    it("handles symbols and functions", () => {
+      expect(() => redactSensitive(Symbol("s"))).not.toThrow();
+      expect(() => redactSensitive(() => 1)).not.toThrow();
+    });
+
+    it("truncates oversized strings", () => {
+      const huge = "x".repeat(10000);
+      const result = redactSensitive(huge);
+      expect(result.length).toBeLessThan(10000);
+      expect(result).toContain("[redacted-truncated]");
+    });
+  });
+
+  describe("safeLogError / safeLogWarn / safeLogInfo", () => {
+    let errorSpy: jest.SpyInstance;
+    let warnSpy: jest.SpyInstance;
+    let infoSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+      infoSpy.mockRestore();
+    });
+
+    it("safeLogError forwards prefix and redacted value to console.error", () => {
+      const session = "host-1700000000000-abc12345";
+      safeLogError("[Test]", new Error(`failed ${session}`));
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const args = errorSpy.mock.calls[0];
+      expect(args[0]).toBe("[Test]");
+      expect(args[1]).not.toContain(session);
+      expect(args[1]).toContain("[REDACTED_SESSION]");
+    });
+
+    it("safeLogWarn forwards prefix and redacted args to console.warn", () => {
+      const sensitive = { sessionId: "secret", ok: 1 };
+      safeLogWarn("[Test]", sensitive, "extra");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const args = warnSpy.mock.calls[0];
+      expect(args[0]).toBe("[Test]");
+      expect(args[1]).not.toContain("secret");
+      expect(args[2]).toBe("extra");
+    });
+
+    it("safeLogInfo forwards prefix and redacted args to console.info", () => {
+      const sensitive = { gameCode: "ABC234" };
+      safeLogInfo("[Test]", sensitive);
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      const args = infoSpy.mock.calls[0];
+      expect(args[0]).toBe("[Test]");
+      expect(args[1]).not.toContain("ABC234");
+    });
+
+    it("does not invoke other console methods", () => {
+      safeLogError("[Test]", "x");
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(infoSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/__tests__/p2p-signaling-client.test.ts
+++ b/src/lib/__tests__/p2p-signaling-client.test.ts
@@ -246,6 +246,36 @@ describe("parseConnectionInfo", () => {
       expect(parseConnectionInfo(p)).toBeNull();
     }
   });
+
+  // --------------------------------------------------------------------------
+  // Issue #982 — strip console.log statements exposing session IDs / game codes
+  // --------------------------------------------------------------------------
+
+  describe("Sensitive-data leak protection (#982)", () => {
+    let errorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      errorSpy.mockRestore();
+    });
+
+    it("parseConnectionInfo does not log gameCode or hostName on malformed input", () => {
+      const gameCode = "ZZZ999";
+      const hostName = "SecretHost";
+      const malicious = `{ "gameCode": "${gameCode}", "hostName": "${hostName}", invalid }`;
+
+      expect(parseConnectionInfo(malicious)).toBeNull();
+      expect(errorSpy).toHaveBeenCalled();
+      for (const call of errorSpy.mock.calls) {
+        const serialized = JSON.stringify(call);
+        expect(serialized).not.toContain(gameCode);
+        expect(serialized).not.toContain(hostName);
+      }
+    });
+  });
 });
 
 describe("serializeSignalingData", () => {

--- a/src/lib/connection-fallback.ts
+++ b/src/lib/connection-fallback.ts
@@ -16,6 +16,7 @@ import {
 } from './websocket-connection';
 import type { GameState } from './game-state/types';
 import { TIMEOUTS } from './config/timeouts';
+import { redactSensitive } from './p2p-log-redact';
 
 /**
  * Connection type
@@ -157,7 +158,8 @@ export class ConnectionFallbackManager {
           resolve(connectionType);
         })
         .catch((error) => {
-          console.error('[ConnectionFallback] WebRTC connection failed:', error);
+          // #982: redact — WebRTC connection errors may embed SDP / ICE config.
+          console.error('[ConnectionFallback] WebRTC connection failed:', redactSensitive(error));
           this.state.lastError = error instanceof Error ? error.message : 'WebRTC connection failed';
           
           // If fallback timer hasn't triggered yet and WebSocket is available
@@ -175,7 +177,9 @@ export class ConnectionFallbackManager {
               })
               .catch((wsError) => {
                 if (!resolved) {
-                  console.error('[ConnectionFallback] WebSocket fallback failed:', wsError);
+                  // #982: redact — WS fallback errors may embed server URLs
+                  // carrying session tokens.
+                  console.error('[ConnectionFallback] WebSocket fallback failed:', redactSensitive(wsError));
                   reject(new Error(`Both WebRTC and WebSocket failed: ${error instanceof Error ? error.message : 'Unknown error'}`));
                 }
               });
@@ -331,7 +335,8 @@ export class ConnectionFallbackManager {
     try {
       await this.connectWebSocket();
     } catch (error) {
-      console.error('[ConnectionFallback] Fallback to WebSocket failed:', error);
+      // #982: redact — fallback errors may embed WS URLs / session tokens.
+      console.error('[ConnectionFallback] Fallback to WebSocket failed:', redactSensitive(error));
       this.state.lastError = error instanceof Error ? error.message : 'Fallback failed';
       this.notifyStateChange();
     }

--- a/src/lib/p2p-direct-connection.ts
+++ b/src/lib/p2p-direct-connection.ts
@@ -11,6 +11,7 @@ import QRCode from "qrcode";
 import { generateGameCode } from "./webrtc-p2p";
 import type { WebRTCConnection, P2PConnectionOptions } from "./webrtc-p2p";
 import { safeParseJson } from "./p2p-json-validation";
+import { redactSensitive } from "./p2p-log-redact";
 
 /**
  * Connection data for QR code encoding
@@ -231,7 +232,11 @@ export async function generateConnectionQRCode(
     );
     return dataUrl;
   } catch (error) {
-    console.error("[P2P] Failed to generate QR code:", error);
+    // #982: redact in case the QRCode error embeds connectionData (sessionId, gameCode, sdp).
+    console.error(
+      "[P2P] Failed to generate QR code:",
+      redactSensitive(error),
+    );
     throw new Error("Failed to generate connection QR code");
   }
 }
@@ -395,7 +400,10 @@ export async function handleICEExchange(
   const session = sessionManager.getSession(sessionId);
 
   if (!session) {
-    throw new Error(`Session not found: ${sessionId}`);
+    // #982: do NOT embed sessionId in the thrown message — it can propagate
+    // up to higher-level error reporters / console output and leak session
+    // metadata. Callers already know which sessionId they asked about.
+    throw new Error("Session not found");
   }
 
   // Add candidate to connection

--- a/src/lib/p2p-game-connection.ts
+++ b/src/lib/p2p-game-connection.ts
@@ -32,6 +32,7 @@ import {
   type ConnectionFailureContext,
   type ConnectionFailureDiagnostic,
 } from "./p2p-failure-diagnostics";
+import { redactSensitive } from "./p2p-log-redact";
 
 /**
  * P2P connection events
@@ -362,9 +363,10 @@ export class P2PGameConnection {
     try {
       await this.signalingClient.addRemoteIceCandidates(candidates);
     } catch (error) {
+      // #982: redact — candidate errors may embed ICE candidate blobs.
       console.error(
         "[P2PGameConnection] Failed to process ICE candidates:",
-        error,
+        redactSensitive(error),
       );
     }
   }
@@ -382,7 +384,11 @@ export class P2PGameConnection {
       this.dataChannel.send(JSON.stringify(message));
       return true;
     } catch (error) {
-      console.error("[P2PGameConnection] Failed to send message:", error);
+      // #982: redact — send errors may reference the message payload.
+      console.error(
+        "[P2PGameConnection] Failed to send message:",
+        redactSensitive(error),
+      );
       return false;
     }
   }
@@ -475,7 +481,11 @@ export class P2PGameConnection {
     };
 
     this.dataChannel.onerror = (event) => {
-      console.error("[P2PGameConnection] Data channel error:", event);
+      // #982: redact — data channel error events may embed diagnostic info.
+      console.error(
+        "[P2PGameConnection] Data channel error:",
+        redactSensitive(event),
+      );
       this.handleError(
         event instanceof Error ? event : new Error("Data channel error"),
       );
@@ -536,7 +546,11 @@ export class P2PGameConnection {
 
       this.events.onMessage(message);
     } catch (error) {
-      console.error("[P2PGameConnection] Failed to handle message:", error);
+      // #982: redact — handler errors may reference the peer message payload.
+      console.error(
+        "[P2PGameConnection] Failed to handle message:",
+        redactSensitive(error),
+      );
       // Don't break connection for handler errors, just log them
     }
   }
@@ -673,7 +687,9 @@ export class P2PGameConnection {
    * Handle error
    */
   private handleError(error: Error): void {
-    console.error("[P2PGameConnection] Error:", error);
+    // #982: redact — error.message may embed session metadata propagated up
+    // from lower layers.
+    console.error("[P2PGameConnection] Error:", redactSensitive(error));
     if (!this.lastFailureDiagnostic) {
       this.lastFailureDiagnostic = classifyConnectionFailure({
         rtcConfig: this.getRTCConfig(),
@@ -789,7 +805,11 @@ export class P2PGameConnection {
     try {
       return await this.peerConnection.getStats();
     } catch (error) {
-      console.error("[P2PGameConnection] Failed to get stats:", error);
+      // #982: redact — getStats errors may reference ICE candidates.
+      console.error(
+        "[P2PGameConnection] Failed to get stats:",
+        redactSensitive(error),
+      );
       return null;
     }
   }

--- a/src/lib/p2p-log-redact.ts
+++ b/src/lib/p2p-log-redact.ts
@@ -1,0 +1,196 @@
+/**
+ * @fileOverview P2P log redaction utility (Issue #982)
+ *
+ * Strips connection metadata (session IDs, game codes, peer IDs, SDP, ICE
+ * candidates, TURN credentials) from arbitrary values before they reach
+ * `console.*`. This is a defensive sanitizer, NOT a logging framework —
+ * it does not replace `console`, gate output by environment, or introduce
+ * log levels. Adopting a structured logger is tracked separately as #987
+ * and is explicitly out of scope here.
+ *
+ * The intent is to keep diagnostic value (error names, messages, state
+ * transitions) while ensuring session identifiers and connection secrets
+ * never reach the developer console, where they could be scraped by
+ * browser extensions, error reporters, or production logging pipelines.
+ *
+ * Public surface:
+ *   - {@link redactSensitive} — pure function, never throws. Use inline:
+ *     `console.error("[WebRTC] init failed", redactSensitive(error))`.
+ *   - {@link safeLogError} / {@link safeLogWarn} / {@link safeLogInfo} —
+ *     thin convenience wrappers for the repeated catch-block pattern.
+ */
+
+/** Field names whose values are treated as sensitive connection metadata. */
+const SENSITIVE_KEYS: ReadonlySet<string> = new Set([
+  // Session / game identifiers
+  "sessionId",
+  "sessionid",
+  "session_id",
+  "gameCode",
+  "gamecode",
+  "game_code",
+  // Peer / player identifiers
+  "peerId",
+  "peerid",
+  "peer_id",
+  "playerId",
+  "playerid",
+  "player_id",
+  "remotePlayerId",
+  "localPlayerId",
+  // Identity strings
+  "hostName",
+  "hostname",
+  "host_name",
+  "playerName",
+  // WebRTC session description / candidates
+  "sdp",
+  "candidate",
+  "iceCandidate",
+  "iceCandidates",
+  "localDescription",
+  "remoteDescription",
+  "offer",
+  "answer",
+  "localOffer",
+  "remoteOffer",
+  "localAnswer",
+  "remoteAnswer",
+  // ICE / TURN credentials
+  "password",
+  "credential",
+  "username",
+  "uris",
+  "urls",
+]);
+
+/**
+ * Literal session-ID patterns produced by `p2p-direct-connection.ts` and
+ * related modules. Matched inside arbitrary strings and masked in place.
+ *
+ * Format: `host-<epoch-ms>-<base36>` or `client-<epoch-ms>-<base36>`.
+ * The epoch-ms component is 13 digits (post-2001) and the base36 suffix
+ * is 6+ chars — together they form a fingerprint that should never appear
+ * in user-visible text, so masking them in any string is safe.
+ */
+const SESSION_ID_PATTERN = /\b(?:host|client)-\d{10,13}-[a-z0-9]{6,}\b/gi;
+
+/** Maximum length of a redacted string before truncation kicks in. */
+const MAX_REDACTED_LENGTH = 4096;
+
+/**
+ * Redact sensitive connection metadata from an arbitrary value, returning
+ * a string that is safe to forward to `console.*`.
+ *
+ * Behaviour:
+ *   - `null` / `undefined` → `"null"` / `"undefined"`
+ *   - `string`             → input with session-ID patterns masked
+ *   - `Error`              → `"<Name>: <masked message>"` (stack omitted —
+ *                            stacks contain no P2P metadata and grow logs
+ *                            large; callers wanting stacks can pass
+ *                            `error.stack` through this function directly)
+ *   - `object` / `array`   → JSON stringification with sensitive keys
+ *                            replaced by `"[REDACTED]"` and cycles broken
+ *   - anything else        → `String(value)` with session-IDs masked
+ *
+ * This function never throws — on any internal failure it returns a safe
+ * placeholder so a logging bug can never crash the calling path.
+ */
+export function redactSensitive(value: unknown): string {
+  try {
+    if (value === null) return "null";
+    if (value === undefined) return "undefined";
+
+    if (typeof value === "string") {
+      return maskSessionIds(value);
+    }
+
+    if (value instanceof Error) {
+      const name = value.name || "Error";
+      const message = maskSessionIds(String(value.message ?? ""));
+      return `${name}: ${message}`;
+    }
+
+    if (typeof value === "object") {
+      // Arrays and plain objects share this branch.
+      try {
+        return maskSessionIds(safeStringify(value));
+      } catch {
+        // Object could not be serialized (exotic getters, etc.).
+        return maskSessionIds(String(value));
+      }
+    }
+
+    return maskSessionIds(String(value));
+  } catch {
+    // Defensive: never let a redaction failure propagate.
+    return "[redact-error]";
+  }
+}
+
+/**
+ * Emit an error to `console.error` with the caught value redacted.
+ *
+ * Use in catch blocks where the caught error may transitively embed
+ * session IDs, game codes, SDP, or ICE candidates (e.g. WebRTC API
+ * failures, JSON.parse on attacker-controlled input).
+ */
+export function safeLogError(prefix: string, error: unknown): void {
+  console.error(prefix, redactSensitive(error));
+}
+
+/**
+ * Emit a warning to `console.warn` with redacted arguments.
+ */
+export function safeLogWarn(prefix: string, ...args: unknown[]): void {
+  console.warn(prefix, ...args.map((arg) => redactSensitive(arg)));
+}
+
+/**
+ * Emit an informational message to `console.info` with redacted arguments.
+ */
+export function safeLogInfo(prefix: string, ...args: unknown[]): void {
+  console.info(prefix, ...args.map((arg) => redactSensitive(arg)));
+}
+
+/**
+ * Mask session-ID patterns inside a string and truncate if oversized.
+ * Repeated calls are idempotent — masked output contains no matches.
+ */
+function maskSessionIds(input: string): string {
+  if (!input) return input;
+  const truncated =
+    input.length > MAX_REDACTED_LENGTH
+      ? `${input.slice(0, MAX_REDACTED_LENGTH)}…[redacted-truncated]`
+      : input;
+  return truncated.replace(SESSION_ID_PATTERN, "[REDACTED_SESSION]");
+}
+
+/**
+ * JSON.stringify with sensitive keys replaced by `"[REDACTED]"` and
+ * cycle-friendly fallbacks. Never throws.
+ */
+function safeStringify(value: unknown): string {
+  const seen = new WeakSet<object>();
+
+  const replacer = (key: string, raw: unknown): unknown => {
+    // The top-level call uses key="" — never redact the root holder.
+    if (key && SENSITIVE_KEYS.has(key)) {
+      return "[REDACTED]";
+    }
+    if (typeof raw === "object" && raw !== null) {
+      if (seen.has(raw as object)) {
+        return "[Circular]";
+      }
+      seen.add(raw as object);
+    }
+    return raw;
+  };
+
+  try {
+    const result = JSON.stringify(value, replacer, 0);
+    return result ?? "undefined";
+  } catch {
+    return "[unserializable]";
+  }
+}

--- a/src/lib/p2p-signaling-client.ts
+++ b/src/lib/p2p-signaling-client.ts
@@ -23,6 +23,7 @@ import type {
 } from "./webrtc-p2p";
 import { WebRTCConnection, createP2PConnection } from "./webrtc-p2p";
 import { safeParseJson } from "./p2p-json-validation";
+import { redactSensitive } from "./p2p-log-redact";
 
 /**
  * Connection information for P2P handshake
@@ -193,7 +194,8 @@ export class P2PSignalingClient {
       this.connection = createP2PConnection(connectionOptions);
       await this.connection.initialize();
     } catch (error) {
-      console.error("[Signaling] Failed to initialize:", error);
+      // #982: redact — init errors may embed ICE config / TURN credentials.
+      console.error("[Signaling] Failed to initialize:", redactSensitive(error));
       this.events.onError(
         error instanceof Error ? error : new Error("Failed to initialize"),
       );
@@ -226,7 +228,12 @@ export class P2PSignalingClient {
       });
       return dataUrl;
     } catch (error) {
-      console.error("[Signaling] Failed to generate QR code:", error);
+      // #982: redact — QRCode errors may include the serialized connectionInfo
+      // (which carries gameCode / hostName).
+      console.error(
+        "[Signaling] Failed to generate QR code:",
+        redactSensitive(error),
+      );
       this.events.onError(
         error instanceof Error
           ? error
@@ -260,7 +267,11 @@ export class P2PSignalingClient {
 
       return offer;
     } catch (error) {
-      console.error("[Signaling] Failed to create offer:", error);
+      // #982: redact — offer creation errors may embed the local SDP offer.
+      console.error(
+        "[Signaling] Failed to create offer:",
+        redactSensitive(error),
+      );
       this.events.onError(
         error instanceof Error ? error : new Error("Failed to create offer"),
       );
@@ -291,7 +302,11 @@ export class P2PSignalingClient {
 
       return answer;
     } catch (error) {
-      console.error("[Signaling] Failed to handle offer:", error);
+      // #982: redact — handle-offer errors may embed the remote SDP offer.
+      console.error(
+        "[Signaling] Failed to handle offer:",
+        redactSensitive(error),
+      );
       this.events.onError(
         error instanceof Error ? error : new Error("Failed to handle offer"),
       );
@@ -315,7 +330,11 @@ export class P2PSignalingClient {
       // Handle answer
       await this.connection.handleAnswer(answer);
     } catch (error) {
-      console.error("[Signaling] Failed to handle answer:", error);
+      // #982: redact — handle-answer errors may embed the remote SDP answer.
+      console.error(
+        "[Signaling] Failed to handle answer:",
+        redactSensitive(error),
+      );
       this.events.onError(
         error instanceof Error ? error : new Error("Failed to handle answer"),
       );
@@ -335,7 +354,11 @@ export class P2PSignalingClient {
     try {
       await this.connection.addIceCandidate(candidate);
     } catch (error) {
-      console.error("[Signaling] Failed to add ICE candidate:", error);
+      // #982: redact — candidate errors may embed the ICE candidate blob.
+      console.error(
+        "[Signaling] Failed to add ICE candidate:",
+        redactSensitive(error),
+      );
       // Don't fail the connection for candidate errors
     }
   }

--- a/src/lib/webrtc-p2p.ts
+++ b/src/lib/webrtc-p2p.ts
@@ -30,6 +30,7 @@ import {
   type ICEConfigOptions,
   getGlobalICEManager,
 } from "./ice-config";
+import { redactSensitive } from "./p2p-log-redact";
 
 /**
  * WebRTC configuration with STUN/TURN servers
@@ -393,7 +394,8 @@ export class WebRTCConnection {
         this.setupDataChannel();
       }
     } catch (error) {
-      console.error("[WebRTC] Failed to initialize:", error);
+      // #982: redact — RTCPeerConnection errors may embed SDP / ICE config.
+      console.error("[WebRTC] Failed to initialize:", redactSensitive(error));
       this.updateConnectionState("failed");
       throw error;
     }
@@ -454,7 +456,8 @@ export class WebRTCConnection {
       // Notify that reconnection is being attempted
       this.updateConnectionState("reconnecting");
     } catch (error) {
-      console.error("[WebRTC] Relay fallback failed:", error);
+      // #982: redact — relay fallback errors may reference TURN credentials.
+      console.error("[WebRTC] Relay fallback failed:", redactSensitive(error));
       this.handleConnectionFailure();
     }
   }
@@ -473,7 +476,8 @@ export class WebRTCConnection {
       await this.peerConnection.setLocalDescription(offer);
       return offer;
     } catch (error) {
-      console.error("[WebRTC] Failed to create offer:", error);
+      // #982: redact — offer creation errors may embed the SDP offer.
+      console.error("[WebRTC] Failed to create offer:", redactSensitive(error));
       this.events.onError(
         error instanceof Error ? error : new Error("Failed to create offer"),
         "",
@@ -501,7 +505,8 @@ export class WebRTCConnection {
       await this.peerConnection.setLocalDescription(answer);
       return answer;
     } catch (error) {
-      console.error("[WebRTC] Failed to handle offer:", error);
+      // #982: redact — handleOffer errors may embed the remote SDP offer.
+      console.error("[WebRTC] Failed to handle offer:", redactSensitive(error));
       this.events.onError(
         error instanceof Error ? error : new Error("Failed to handle offer"),
         "",
@@ -535,7 +540,11 @@ export class WebRTCConnection {
     try {
       await this.peerConnection.addIceCandidate(new RTCIceCandidate(candidate));
     } catch (error) {
-      console.error("[WebRTC] Failed to add ICE candidate:", error);
+      // #982: redact — candidate errors may embed the ICE candidate blob.
+      console.error(
+        "[WebRTC] Failed to add ICE candidate:",
+        redactSensitive(error),
+      );
       // Don't throw - candidate errors shouldn't break the connection
       // but log for debugging purposes
     }
@@ -581,7 +590,11 @@ export class WebRTCConnection {
 
       this.setupDataChannelEvents();
     } catch (error) {
-      console.error("[WebRTC] Failed to connect to peer:", error);
+      // #982: redact — data-channel setup errors may embed peer config.
+      console.error(
+        "[WebRTC] Failed to connect to peer:",
+        redactSensitive(error),
+      );
       this.events.onError(
         error instanceof Error ? error : new Error("Failed to connect to peer"),
         "",
@@ -608,7 +621,11 @@ export class WebRTCConnection {
     };
 
     this.dataChannel.onerror = (event) => {
-      console.error("[WebRTC] Data channel error:", event);
+      // #982: redact — error events may include diagnostic data channel info.
+      console.error(
+        "[WebRTC] Data channel error:",
+        redactSensitive(event),
+      );
 
       let errorToReport: Error;
 
@@ -679,7 +696,12 @@ export class WebRTCConnection {
 
       this.events.onMessage(message, "");
     } catch (error) {
-      console.error("[WebRTC] Failed to parse message:", error);
+      // #982: redact — JSON.parse errors include the raw (potentially
+      // attacker-controlled, potentially sensitive) payload in their message.
+      console.error(
+        "[WebRTC] Failed to parse message:",
+        redactSensitive(error),
+      );
     }
   }
 
@@ -1363,7 +1385,8 @@ export class WebRTCConnection {
     try {
       return await this.peerConnection.getStats();
     } catch (error) {
-      console.error("[WebRTC] Failed to get stats:", error);
+      // #982: redact — getStats errors may reference ICE candidates.
+      console.error("[WebRTC] Failed to get stats:", redactSensitive(error));
       return null;
     }
   }


### PR DESCRIPTION
## Problem

P2P infrastructure files (`src/lib/p2p-*.ts`, `src/lib/webrtc-p2p.ts`, `src/lib/connection-fallback.ts`) contained `console.*` calls that could leak sensitive connection metadata (session IDs, game codes, SDP offer/answer blobs, ICE candidates, TURN credentials) to the developer console, where it can be scraped by browser extensions, error reporters, or production logging pipelines.

The most direct leak was a thrown error in `p2p-direct-connection.ts`:

```ts
throw new Error(`Session not found: ${sessionId}`);
```

That message propagates up through higher-level catch blocks that forward it to `console.error`, exposing the literal session ID. The remaining risk was indirect: every `console.error(prefix, error)` call in WebRTC/signaling catch blocks forwards an opaque `error`/`event` object that may transitively embed SDP, ICE candidates, or TURN credentials in its `message`.

Closes #982.

## Changes

- **Add `src/lib/p2p-log-redact.ts`** — a defensive sanitizer (NOT a logging framework; that's tracked separately as #987). Exposes:
  - `redactSensitive(value)` — pure, never throws. Masks `host-…`/`client-…` session-ID patterns inside strings, replaces sensitive keys (`sessionId`, `gameCode`, `sdp`, `candidate`, `peerId`, `playerName`, `password`, `credential`, `urls`, …) with `"[REDACTED]"` during JSON serialization, breaks reference cycles, truncates oversized output.
  - `safeLogError` / `safeLogWarn` / `safeLogInfo` — thin convenience wrappers for the repeated catch-block pattern.
- **`src/lib/p2p-direct-connection.ts`** — wrap the QR-code catch logger in `redactSensitive`; rewrite the `Session not found: ${sessionId}` throw to a generic `"Session not found"` (callers already know which id they passed).
- **`src/lib/webrtc-p2p.ts`** — wrap all 9 catch-block loggers (`initialize`, `attemptRelayFallback`, `createOffer`, `handleOffer`, `addIceCandidate`, `connectToPeer`, data channel `onerror`, `handleMessage`, `getICEStats`) in `redactSensitive`. Static warnings (`"Data channel not ready"`, `"Received non-string message"`) left untouched.
- **`src/lib/p2p-signaling-client.ts`** — wrap all 6 catch-block loggers in `redactSensitive`.
- **`src/lib/p2p-game-connection.ts`** — wrap all 6 catch-block loggers in `redactSensitive`.
- **`src/lib/connection-fallback.ts`** — wrap all 3 catch-block loggers in `redactSensitive`.

Log levels (error/warn/info) are preserved; functional error reporting to UI/state is preserved (errors still propagate via `events.onError`, `throw`, return values, and `lastError`). Only the path to `console.*` is scrubbed.

## Testing

- **New** `src/lib/__tests__/p2p-log-redact.test.ts` — 27 tests covering primitive values, session-ID masking, `Error` formatting, nested object redaction, arrays, cycles, throwing getters, BigInt/symbol/function input, oversize truncation, and the `safeLog*` wrappers.
- **Extended** `src/lib/__tests__/p2p-direct-connection.test.ts` — added a `Sensitive-data leak protection (#982)` block:
  - `parseConnectionData` does not log raw input on failure (regression guard against future `console.error("...", input)`).
  - `handleICEExchange` throws an error whose message does not contain the `sessionId`.
- **Extended** `src/lib/__tests__/p2p-signaling-client.test.ts` — added a matching regression test asserting `parseConnectionInfo` does not log `gameCode` or `hostName` on malformed input.

### Test results
- `npx jest p2p-log-redact p2p-direct-connection p2p-signaling-client webrtc-p2p p2p-game-connection` → **5 suites, 152 tests, all pass**
- `npx jest p2p|webrtc|connection` (broader sanity sweep) → **231 suites, 4354 tests, all pass**
- `npx tsc --noEmit` → **No errors**
- `npx eslint src --max-warnings 1000` → **0 errors, 674 warnings** (under threshold; all warnings pre-existing)

## Acceptance criteria check

- [x] No `console.log` statements in `p2p-direct-connection.ts` that expose `gameCode` or `sessionId` (none exist; the one throw site that embedded `sessionId` is redacted).
- [x] All P2P files use appropriate log levels — `error` for failures, `warn` for recoverable issues (already the case; preserved).
- [x] Session metadata (`gameCode`, `sessionId`) is redacted or omitted from all logs.