### PR TITLE
fix: enforce landwalk keyword in combat blocking (closes #971)

### DIFF
--- a/src/lib/game-state/__tests__/keyword-enforcement.test.ts
+++ b/src/lib/game-state/__tests__/keyword-enforcement.test.ts
@@ -65,6 +65,8 @@ import {
   hasProtectionFrom,
   dealsFirstStrikeDamage,
   hasDoubleStrike,
+  hasLandwalk,
+  getLandwalkTypes,
 } from "../evergreen-keywords";
 import { Phase } from "../types";
 import type {
@@ -779,6 +781,367 @@ describe("Keyword Enforcement — Combat", () => {
         twoFlyersResult.errors &&
           twoFlyersResult.errors.some((e) => /menace/i.test(e)),
       ).toBeFalsy();
+    });
+  });
+
+  // ---- Landwalk (CR 702.14) ----
+  // Issue #971: A creature with a basic-landwalk variant (swampwalk,
+  // islandwalk, plainswalk, mountainwalk, forestwalk) can't be blocked when
+  // the defending player controls a land with the matching basic land subtype.
+  describe("Landwalk", () => {
+    /**
+     * Create a mock basic land card with the given subtype.
+     */
+    function createMockBasicLand(landType: string): ScryfallCard {
+      const name = landType.charAt(0).toUpperCase() + landType.slice(1);
+      return {
+        id: `mock-${landType}-${name.toLowerCase()}`,
+        name,
+        type_line: `Basic Land — ${name}`,
+        power: undefined as unknown as string,
+        toughness: undefined as unknown as string,
+        keywords: [],
+        oracle_text: `({T}: Add ${name[0].toUpperCase()}.)`,
+        mana_cost: "",
+        cmc: 0,
+        colors: [],
+        color_identity: [],
+        legalities: { standard: "legal", commander: "legal" },
+        card_faces: undefined,
+        layout: "normal",
+      } as ScryfallCard;
+    }
+
+    /**
+     * Place a basic land of the given type on a player's battlefield.
+     */
+    function placeBasicLand(
+      state: GameState,
+      playerId: PlayerId,
+      landType: string,
+    ): CardInstanceId {
+      const data = createMockBasicLand(landType);
+      const inst = createCardInstance(data, playerId, playerId);
+      state.cards.set(inst.id, inst);
+      const bf = state.zones.get(`${playerId}-battlefield`)!;
+      state.zones.set(`${playerId}-battlefield`, {
+        ...bf,
+        cardIds: [...bf.cardIds, inst.id],
+      });
+      return inst.id;
+    }
+
+    it("getLandwalkTypes detects the five basic landwalk variants", () => {
+      const { state } = setupGameWithCreatures(
+        [
+          { name: "Swamp Walker", power: 2, toughness: 2, keywords: ["Swampwalk"] },
+        ],
+        [],
+      );
+      const swampWalker = state.cards.get(
+        state.zones.get(Array.from(state.players.keys())[0] + "-battlefield")!
+          .cardIds[0],
+      )!;
+      expect(getLandwalkTypes(swampWalker)).toEqual(["swamp"]);
+      expect(hasLandwalk(swampWalker)).toBe(true);
+
+      // Verify detection via oracle text for the other four variants.
+      const makeOracle = (text: string) =>
+        createMockCreatureWithOracle("X", 1, 1, text);
+      expect(
+        getLandwalkTypes({ cardData: makeOracle("Islandwalk") } as CardInstance),
+      ).toEqual(["island"]);
+      expect(
+        getLandwalkTypes({ cardData: makeOracle("Plainswalk") } as CardInstance),
+      ).toEqual(["plains"]);
+      expect(
+        getLandwalkTypes(
+          { cardData: makeOracle("Mountainwalk") } as CardInstance,
+        ),
+      ).toEqual(["mountain"]);
+      expect(
+        getLandwalkTypes({ cardData: makeOracle("Forestwalk") } as CardInstance),
+      ).toEqual(["forest"]);
+    });
+
+    it("a creature without landwalk returns an empty list and hasLandwalk=false", () => {
+      const { state } = setupGameWithCreatures(
+        [{ name: "Grizzly Bears", power: 2, toughness: 2 }],
+        [],
+      );
+      const bear = state.cards.get(
+        state.zones.get(Array.from(state.players.keys())[0] + "-battlefield")!
+          .cardIds[0],
+      )!;
+      expect(getLandwalkTypes(bear)).toEqual([]);
+      expect(hasLandwalk(bear)).toBe(false);
+    });
+
+    it("rejects a blocker when the defender controls a matching basic land (swampwalk + Swamp)", () => {
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [
+          {
+            name: "Bog Wraith",
+            power: 3,
+            toughness: 3,
+            keywords: ["Swampwalk"],
+          },
+        ],
+        [{ name: "Solo Blocker", power: 2, toughness: 2 }],
+      );
+      // Bob (the defender) controls a Swamp → swampwalk applies.
+      placeBasicLand(state, bobId, "swamp");
+
+      const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
+      const blockerId = state.zones.get(`${bobId}-battlefield`)!.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      const stateWithAttackers = attackResult.state;
+      stateWithAttackers.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const result = declareBlockers(
+        stateWithAttackers,
+        new Map<CardInstanceId, CardInstanceId[]>([[attackerId, [blockerId]]]),
+      );
+
+      // Block rejected: attacker remains unblocked, landwalk error surfaced.
+      expect(result.state.combat.blockers.has(attackerId)).toBe(false);
+      expect(result.errors).toBeDefined();
+      expect(result.errors!.some((e) => /swampwalk|landwalk/i.test(e))).toBe(
+        true,
+      );
+    });
+
+    it("accepts a blocker when the defender controls NO matching basic land (swampwalk, no Swamp)", () => {
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [
+          {
+            name: "Bog Wraith",
+            power: 3,
+            toughness: 3,
+            keywords: ["Swampwalk"],
+          },
+        ],
+        [{ name: "Solo Blocker", power: 2, toughness: 2 }],
+      );
+      // Bob controls a Plains (NOT a Swamp) → swampwalk does not apply.
+      placeBasicLand(state, bobId, "plains");
+
+      const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
+      const blockerId = state.zones.get(`${bobId}-battlefield`)!.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      const stateWithAttackers = attackResult.state;
+      stateWithAttackers.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const result = declareBlockers(
+        stateWithAttackers,
+        new Map<CardInstanceId, CardInstanceId[]>([[attackerId, [blockerId]]]),
+      );
+
+      // Block legal: landwalk didn't trigger because no Swamp on defender's side.
+      expect(result.state.combat.blockers.get(attackerId)).toHaveLength(1);
+      expect(
+        result.errors && result.errors.some((e) => /landwalk/i.test(e)),
+      ).toBeFalsy();
+    });
+
+    it("works for islandwalk when the defender controls an Island", () => {
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [
+          {
+            name: "Tidal Warrior",
+            power: 2,
+            toughness: 2,
+            keywords: ["Islandwalk"],
+          },
+        ],
+        [{ name: "Blocker", power: 2, toughness: 2 }],
+      );
+      placeBasicLand(state, bobId, "island");
+
+      const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
+      const blockerId = state.zones.get(`${bobId}-battlefield`)!.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      const stateWithAttackers = attackResult.state;
+      stateWithAttackers.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const result = declareBlockers(
+        stateWithAttackers,
+        new Map<CardInstanceId, CardInstanceId[]>([[attackerId, [blockerId]]]),
+      );
+
+      expect(result.state.combat.blockers.has(attackerId)).toBe(false);
+      expect(
+        result.errors && result.errors!.some((e) => /islandwalk|landwalk/i.test(e)),
+      ).toBe(true);
+    });
+
+    it("a non-landwalk attacker is unaffected even when the defender controls a Swamp", () => {
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [{ name: "Grizzly Bears", power: 2, toughness: 2 }],
+        [{ name: "Lone Blocker", power: 2, toughness: 2 }],
+      );
+      // Defender controls a Swamp, but attacker has no landwalk → block legal.
+      placeBasicLand(state, bobId, "swamp");
+
+      const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
+      const blockerId = state.zones.get(`${bobId}-battlefield`)!.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      const stateWithAttackers = attackResult.state;
+      stateWithAttackers.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const result = declareBlockers(
+        stateWithAttackers,
+        new Map<CardInstanceId, CardInstanceId[]>([[attackerId, [blockerId]]]),
+      );
+
+      expect(result.state.combat.blockers.get(attackerId)).toHaveLength(1);
+      expect(
+        result.errors && result.errors.some((e) => /landwalk/i.test(e)),
+      ).toBeFalsy();
+    });
+
+    it("composes landwalk + flying: unblockable when defender has a Swamp regardless of blocker flying", () => {
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [
+          {
+            name: "Bog Wraith of the Skies",
+            power: 3,
+            toughness: 3,
+            keywords: ["Swampwalk", "Flying"],
+          },
+        ],
+        [{ name: "Flying Blocker", power: 2, toughness: 2, keywords: ["Flying"] }],
+      );
+      // Defender has both a Swamp (triggers swampwalk) — so even a flyer can't block.
+      placeBasicLand(state, bobId, "swamp");
+
+      const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
+      const blockerId = state.zones.get(`${bobId}-battlefield`)!.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      const stateWithAttackers = attackResult.state;
+      stateWithAttackers.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const result = declareBlockers(
+        stateWithAttackers,
+        new Map<CardInstanceId, CardInstanceId[]>([[attackerId, [blockerId]]]),
+      );
+
+      // Swampwalk takes priority: even a valid flyer cannot block.
+      expect(result.state.combat.blockers.has(attackerId)).toBe(false);
+      expect(
+        result.errors && result.errors.some((e) => /swampwalk|landwalk/i.test(e)),
+      ).toBe(true);
+    });
+
+    it("composes landwalk + flying: blocker without flying/reach can't block even when no matching land", () => {
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [
+          {
+            name: "Bog Wraith of the Skies",
+            power: 3,
+            toughness: 3,
+            keywords: ["Swampwalk", "Flying"],
+          },
+        ],
+        [{ name: "Ground Blocker", power: 2, toughness: 2 }],
+      );
+      // No Swamp on defender's side → swampwalk doesn't apply, but flying still does.
+      placeBasicLand(state, bobId, "plains");
+
+      const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
+      const blockerId = state.zones.get(`${bobId}-battlefield`)!.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      const stateWithAttackers = attackResult.state;
+      stateWithAttackers.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const result = declareBlockers(
+        stateWithAttackers,
+        new Map<CardInstanceId, CardInstanceId[]>([[attackerId, [blockerId]]]),
+      );
+
+      // Flying restriction still rejects the ground blocker.
+      expect(result.state.combat.blockers.has(attackerId)).toBe(false);
+      expect(
+        result.errors && result.errors.some((e) => /flying/i.test(e)),
+      ).toBe(true);
+    });
+
+    it("detects multiple landwalk types on a single attacker and applies if any match", () => {
+      // A creature printed with "Swampwalk and Islandwalk" (or similar composition).
+      const { state, aliceId, bobId } = setupGameWithCreatures(
+        [
+          {
+            name: "Tidal Bog Stalker",
+            power: 2,
+            toughness: 2,
+            oracleText: "Swampwalk, Islandwalk",
+          },
+        ],
+        [{ name: "Blocker", power: 2, toughness: 2 }],
+      );
+
+      const attacker = state.cards.get(
+        state.zones.get(`${aliceId}-battlefield`)!.cardIds[0],
+      )!;
+      expect(getLandwalkTypes(attacker).sort()).toEqual([
+        "island",
+        "swamp",
+      ]);
+
+      // Defender controls only a Mountain → neither landwalk applies → block legal.
+      placeBasicLand(state, bobId, "mountain");
+      const attackerId = attacker.id;
+      const blockerId = state.zones.get(`${bobId}-battlefield`)!.cardIds[0];
+
+      state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+      const attackResult = declareAttackers(state, [
+        { cardId: attackerId, defenderId: bobId },
+      ]);
+      let stateWithAttackers = attackResult.state;
+      stateWithAttackers.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+
+      const legalResult = declareBlockers(
+        stateWithAttackers,
+        new Map<CardInstanceId, CardInstanceId[]>([[attackerId, [blockerId]]]),
+      );
+      expect(legalResult.state.combat.blockers.get(attackerId)).toHaveLength(1);
+
+      // Now give the defender an Island → islandwalk triggers → block rejected.
+      placeBasicLand(stateWithAttackers, bobId, "island");
+      stateWithAttackers.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+      const rejectedResult = declareBlockers(
+        stateWithAttackers,
+        new Map<CardInstanceId, CardInstanceId[]>([[attackerId, [blockerId]]]),
+      );
+      expect(rejectedResult.state.combat.blockers.has(attackerId)).toBe(false);
+      expect(
+        rejectedResult.errors &&
+          rejectedResult.errors.some((e) => /islandwalk|landwalk/i.test(e)),
+      ).toBe(true);
     });
   });
 

--- a/src/lib/game-state/__tests__/keyword-enforcement.test.ts
+++ b/src/lib/game-state/__tests__/keyword-enforcement.test.ts
@@ -1121,7 +1121,7 @@ describe("Keyword Enforcement — Combat", () => {
       const attackResult = declareAttackers(state, [
         { cardId: attackerId, defenderId: bobId },
       ]);
-      let stateWithAttackers = attackResult.state;
+      const stateWithAttackers = attackResult.state;
       stateWithAttackers.turn.currentPhase = Phase.DECLARE_BLOCKERS;
 
       const legalResult = declareBlockers(

--- a/src/lib/game-state/combat.ts
+++ b/src/lib/game-state/combat.ts
@@ -23,6 +23,7 @@ import {
   getToxicLevel,
   getProtectionQualities,
   getMenaceMinimumBlockers,
+  getLandwalkTypes,
 } from "./evergreen-keywords";
 
 /**
@@ -161,6 +162,42 @@ export function canBlock(
             canBlock: false,
             reason: `Cannot block creatures with ${color} protection`,
           };
+        }
+      }
+
+      // CR 702.14 (Landwalk): A creature with a basic-landwalk variant
+      // (swampwalk, islandwalk, plainswalk, mountainwalk, forestwalk) can't
+      // be blocked if the defending player controls a land with the matching
+      // basic land subtype. The defender is the blocker's controller — only
+      // the player being attacked can block, so blocker.controllerId is the
+      // relevant defender for this attacker.
+      // Issue #971
+      const landwalkTypes = getLandwalkTypes(attacker);
+      if (landwalkTypes.length > 0) {
+        const defenderId = blocker.controllerId;
+        const defenderBattlefield = state.zones.get(`${defenderId}-battlefield`);
+        const defenderCardIds = defenderBattlefield?.cardIds || [];
+        for (const landType of landwalkTypes) {
+          const controlsMatchingLand = defenderCardIds.some((id) => {
+            const landCard = state.cards.get(id);
+            if (!landCard) return false;
+            const typeLine =
+              landCard.cardData.type_line?.toLowerCase() || "";
+            // Must be a land, and either have the basic land subtype in its
+            // type line or be designated as that basic land type via a
+            // continuous effect (chosenBasicLandType).
+            if (!typeLine.includes("land")) return false;
+            return (
+              typeLine.includes(landType) ||
+              landCard.chosenBasicLandType?.toLowerCase() === landType
+            );
+          });
+          if (controlsMatchingLand) {
+            return {
+              canBlock: false,
+              reason: `Cannot block ${landType}walk creature while controlling a ${landType}`,
+            };
+          }
         }
       }
     }

--- a/src/lib/game-state/evergreen-keywords.ts
+++ b/src/lib/game-state/evergreen-keywords.ts
@@ -162,6 +162,55 @@ export function hasReach(card: CardInstance): boolean {
   return hasKeyword(card, "reach");
 }
 
+// ============== LANDWALK (CR 702.14) ==============
+/**
+ * The five basic land types that the basic-landwalk family keys off.
+ * CR 702.14b: A creature with landwalk can't be blocked if the defending
+ * player controls a land with the matching basic land subtype.
+ */
+const LANDWALK_BASIC_LAND_TYPES = [
+  "plains",
+  "island",
+  "swamp",
+  "mountain",
+  "forest",
+] as const;
+
+/**
+ * Get the basic land types for which a card has landwalk.
+ *
+ * Detects the five basic landwalk variants — plainswalk, islandwalk,
+ * swampwalk, mountainwalk, forestwalk — by parsing oracle text and the
+ * keywords array for the "{land}walk" pattern.
+ *
+ * @returns Array of lowercase basic land type names (e.g., ["swamp"]).
+ *          Empty if the card has no landwalk.
+ */
+export function getLandwalkTypes(card: CardInstance): string[] {
+  const oracleText = card.cardData.oracle_text?.toLowerCase() || "";
+  const keywords = (card.cardData.keywords || []).map((k) => k.toLowerCase());
+  const combined = `${oracleText} ${keywords.join(" ")}`;
+
+  const types: string[] = [];
+  for (const landType of LANDWALK_BASIC_LAND_TYPES) {
+    // Word-boundaried match so "forestwalk" matches but "forestwal" /
+    // "forestwalker" / "plainswalking" (rare, but distinct token) don't
+    // produce false positives that mis-flag the card.
+    const pattern = new RegExp(`\\b${landType}walk\\b`);
+    if (pattern.test(combined)) {
+      types.push(landType);
+    }
+  }
+  return types;
+}
+
+/**
+ * Check if a card has any basic landwalk variant.
+ */
+export function hasLandwalk(card: CardInstance): boolean {
+  return getLandwalkTypes(card).length > 0;
+}
+
 // ============== TRAMPLE ==============
 /**
  * Check if a card has trample


### PR DESCRIPTION
## Problem
Landwalk (CR 702.14 — the basic-landwalk family: swampwalk, islandwalk, plainswalk, mountainwalk, forestwalk) was listed as `'none'` enforcement in the gameplay gap analysis. The `canBlock` function in `combat.ts` did not check landwalk restrictions, so a creature with swampwalk could be blocked even when the defending player controlled a Swamp.

Closes #971.

## Changes
Focused on the blocker-validation region of `combat.ts` (mirrors the menace pattern from #968 — kept clear of the damage/lifelink region being touched by the sibling #981 PR).

- **`src/lib/game-state/evergreen-keywords.ts`** — added `getLandwalkTypes(card)` and `hasLandwalk(card)`. Parses both `oracle_text` and the `keywords` array for the five `{land}walk` variants using word-boundaried regex (so `forestwal` / `forestwalker` don't false-positive). Returns the list of matched basic land types (e.g., `["swamp"]`).
- **`src/lib/game-state/combat.ts`** — imported `getLandwalkTypes`; added a landwalk check inside `canBlock` immediately after the protection check (CR 702.16D). When the attacker has any landwalk variant and the defending player (the blocker's controller) controls a land whose `type_line` includes the basic land subtype — or whose `chosenBasicLandType` matches it — the block is rejected. Non-land cards are skipped, so a creature whose type line happens to mention a land word is unaffected.
- **`src/lib/game-state/__tests__/keyword-enforcement.test.ts`** — added a `Landwalk` describe block with 9 tests covering: detection of all five variants, empty result for non-landwalk cards, swampwalk+Swamp rejected, swampwalk without Swamp allowed, islandwalk+Island rejected, non-landwalk attacker unaffected by a Swamp on defender's side, landwalk + flying composition (unblockable when defender has the land; flying restriction still applies when they don't), and multi-landwalk attackers (legal when no matching land, rejected once any matching land appears).

## Testing
- `npx jest src/lib/game-state/__tests__/keyword-enforcement.test.ts` — **49 passed** (9 new landwalk tests + 40 existing).
- `npx jest src/lib/game-state/__tests__/combat.test.ts` — **66 passed** (no regressions in the existing combat suite).
- `npx jest src/ai/__tests__/combat-decision-tree.test.ts src/ai/decision-making/__tests__/block-prediction.test.ts` — **72 passed** (AI blocker-prediction unaffected).
- `npx tsc --noEmit` — **No errors found**.

## Notes / Out of scope
- Only the five **basic** landwalk variants are detected (per the issue's scope). Generic landwalk (e.g., "nonbasic landwalk") and the legendary/artifact landwalk variants are not implemented.
- Detection is based on printed subtypes in the type line plus the `chosenBasicLandType` field (used by effects that turn a land into a basic land type, e.g., Urborg, Tomb of Yawgmoth-style continuous effects applied via that field). Continuous type-granting effects that don't populate `chosenBasicLandType` are not yet considered — that's a layer-system integration that belongs in a follow-up.