### PR TITLE
fix: restore default TURN/STUN servers for NAT traversal (closes #983)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,12 @@ NEXT_PUBLIC_GOOGLE_API_URL=https://generativelanguage.googleapis.com/v1
 # NEXT_PUBLIC_AI_RATE_LIMIT_MAX=10
 # NEXT_PUBLIC_AI_RATE_LIMIT_WINDOW_MS=60000
 # NEXT_PUBLIC_AI_DEBOUNCE_MS=500
+
+# P2P WebRTC TURN relay (optional but recommended for production).
+# Without these, the app falls back to public OpenRelay TURN servers which are
+# rate-limited and NOT suitable for production scale. Users behind symmetric
+# NATs rely on TURN for connectivity. Comma-separate multiple URLs in
+# NEXT_PUBLIC_TURN_URL; USER/PASS are shared across all listed URLs.
+# NEXT_PUBLIC_TURN_URL=turn:turn.your-domain.com:3478,turn:turn.your-domain.com:5349
+# NEXT_PUBLIC_TURN_USER=your-username
+# NEXT_PUBLIC_TURN_PASS=your-credential

--- a/src/lib/__tests__/ice-config.test.ts
+++ b/src/lib/__tests__/ice-config.test.ts
@@ -1,0 +1,267 @@
+/**
+ * @fileOverview Tests for ICE / STUN / TURN configuration.
+ *
+ * Issue #983: DEFAULT_TURN_SERVERS returned an empty array when TURN env
+ * vars were unset, leaving users behind symmetric NATs with no relay
+ * fallback and 100% connection failure. These tests pin the fix: the
+ * default TURN set is always non-empty, env overrides work, and a warning
+ * is surfaced when only the public fallback is in use.
+ */
+
+import {
+  DEFAULT_STUN_SERVERS,
+  DEFAULT_TURN_SERVERS,
+  PUBLIC_FALLBACK_TURN_SERVERS,
+  ICEConfigurationManager,
+  resolveTurnServers,
+  warnIfNoEnvTurnConfigured,
+  __resetTurnWarningGuard,
+  type ICEServerConfig,
+} from '../ice-config';
+
+function isTurnScheme(url: unknown): boolean {
+  if (typeof url !== 'string') return false;
+  return url.startsWith('turn:') || url.startsWith('turns:');
+}
+
+describe('DEFAULT_STUN_SERVERS', () => {
+  it('is non-empty', () => {
+    expect(DEFAULT_STUN_SERVERS.length).toBeGreaterThan(0);
+  });
+
+  it('contains only stun: URLs', () => {
+    for (const server of DEFAULT_STUN_SERVERS) {
+      const url = typeof server.urls === 'string' ? server.urls : '';
+      expect(url.startsWith('stun:')).toBe(true);
+    }
+  });
+});
+
+describe('PUBLIC_FALLBACK_TURN_SERVERS', () => {
+  it('is non-empty', () => {
+    expect(PUBLIC_FALLBACK_TURN_SERVERS.length).toBeGreaterThan(0);
+  });
+
+  it('every server is a turn/turns URL with password credentials', () => {
+    for (const server of PUBLIC_FALLBACK_TURN_SERVERS) {
+      expect(isTurnScheme(server.urls)).toBe(true);
+      expect(typeof server.username).toBe('string');
+      expect(server.username!.length).toBeGreaterThan(0);
+      expect(typeof server.credential).toBe('string');
+      expect(server.credential!.length).toBeGreaterThan(0);
+      expect(server.credentialType).toBe('password');
+    }
+  });
+});
+
+describe('DEFAULT_TURN_SERVERS', () => {
+  it('is non-empty (NAT traversal relay fallback) — regression for #983', () => {
+    expect(DEFAULT_TURN_SERVERS.length).toBeGreaterThan(0);
+  });
+
+  it('contains only turn:/turns: URLs', () => {
+    for (const server of DEFAULT_TURN_SERVERS) {
+      const url = typeof server.urls === 'string' ? server.urls : '';
+      expect(isTurnScheme(url)).toBe(true);
+    }
+  });
+
+  it('every server has username + credential', () => {
+    for (const server of DEFAULT_TURN_SERVERS) {
+      expect(server.username).toBeTruthy();
+      expect(server.credential).toBeTruthy();
+      expect(server.credentialType).toBe('password');
+    }
+  });
+});
+
+describe('resolveTurnServers', () => {
+  afterEach(() => {
+    __resetTurnWarningGuard();
+  });
+
+  it('returns env-configured servers when all three env vars are set', () => {
+    const result = resolveTurnServers({
+      NEXT_PUBLIC_TURN_URL: 'turn:turn.example.com:3478',
+      NEXT_PUBLIC_TURN_USER: 'alice',
+      NEXT_PUBLIC_TURN_PASS: 's3cret',
+    });
+
+    expect(result.usedFallback).toBe(false);
+    expect(result.servers).toHaveLength(1);
+    expect(result.servers[0]).toEqual({
+      urls: 'turn:turn.example.com:3478',
+      username: 'alice',
+      credential: 's3cret',
+      credentialType: 'password',
+    });
+  });
+
+  it('supports comma-separated TURN URLs sharing one credential set', () => {
+    const result = resolveTurnServers({
+      NEXT_PUBLIC_TURN_URL:
+        'turn:a.example.com:3478, turns:b.example.com:5349, turn:c.example.com:3478',
+      NEXT_PUBLIC_TURN_USER: 'u',
+      NEXT_PUBLIC_TURN_PASS: 'p',
+    });
+
+    expect(result.usedFallback).toBe(false);
+    expect(result.servers).toHaveLength(3);
+    expect(result.servers.map((s) => s.urls)).toEqual([
+      'turn:a.example.com:3478',
+      'turns:b.example.com:5349',
+      'turn:c.example.com:3478',
+    ]);
+    for (const server of result.servers) {
+      expect(server.username).toBe('u');
+      expect(server.credential).toBe('p');
+      expect(server.credentialType).toBe('password');
+    }
+  });
+
+  it('trims whitespace and ignores empty entries in the URL list', () => {
+    const result = resolveTurnServers({
+      NEXT_PUBLIC_TURN_URL: ' turn:a.example.com:3478 , , turn:b.example.com:3478 ',
+      NEXT_PUBLIC_TURN_USER: 'u',
+      NEXT_PUBLIC_TURN_PASS: 'p',
+    });
+
+    expect(result.servers).toHaveLength(2);
+    expect(result.servers[0].urls).toBe('turn:a.example.com:3478');
+    expect(result.servers[1].urls).toBe('turn:b.example.com:3478');
+  });
+
+  it('falls back to public TURN servers when env vars are absent', () => {
+    const result = resolveTurnServers({});
+
+    expect(result.usedFallback).toBe(true);
+    expect(result.servers.length).toBe(PUBLIC_FALLBACK_TURN_SERVERS.length);
+    for (const server of result.servers) {
+      expect(isTurnScheme(server.urls)).toBe(true);
+      expect(server.username).toBeTruthy();
+      expect(server.credential).toBeTruthy();
+    }
+  });
+
+  it('falls back when only some env vars are set (no partial credentials)', () => {
+    const onlyUrl = resolveTurnServers({
+      NEXT_PUBLIC_TURN_URL: 'turn:turn.example.com:3478',
+    });
+    expect(onlyUrl.usedFallback).toBe(true);
+
+    const urlAndUser = resolveTurnServers({
+      NEXT_PUBLIC_TURN_URL: 'turn:turn.example.com:3478',
+      NEXT_PUBLIC_TURN_USER: 'u',
+    });
+    expect(urlAndUser.usedFallback).toBe(true);
+  });
+
+  it('falls back when NEXT_PUBLIC_TURN_URL is empty/whitespace', () => {
+    const result = resolveTurnServers({
+      NEXT_PUBLIC_TURN_URL: '   ',
+      NEXT_PUBLIC_TURN_USER: 'u',
+      NEXT_PUBLIC_TURN_PASS: 'p',
+    });
+    expect(result.usedFallback).toBe(true);
+  });
+
+  it('returns fresh array copies (mutating results does not affect fallbacks)', () => {
+    const a = resolveTurnServers({});
+    const b = resolveTurnServers({});
+    expect(a.servers).not.toBe(b.servers);
+    expect(a.servers[0]).not.toBe(PUBLIC_FALLBACK_TURN_SERVERS[0]);
+
+    a.servers[0].username = 'mutated';
+    expect(PUBLIC_FALLBACK_TURN_SERVERS[0].username).toBe('openrelayproject');
+    expect(b.servers[0].username).toBe('openrelayproject');
+  });
+});
+
+describe('warnIfNoEnvTurnConfigured', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    __resetTurnWarningGuard();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    __resetTurnWarningGuard();
+  });
+
+  it('warns when the public fallback is in use', () => {
+    warnIfNoEnvTurnConfigured(resolveTurnServers({}));
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = warnSpy.mock.calls[0][0] as string;
+    expect(message).toContain('TURN');
+    expect(message).toContain('NEXT_PUBLIC_TURN_URL');
+  });
+
+  it('does not warn when env-configured servers are in use', () => {
+    warnIfNoEnvTurnConfigured(
+      resolveTurnServers({
+        NEXT_PUBLIC_TURN_URL: 'turn:turn.example.com:3478',
+        NEXT_PUBLIC_TURN_USER: 'u',
+        NEXT_PUBLIC_TURN_PASS: 'p',
+      }),
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns only once across calls unless forced', () => {
+    warnIfNoEnvTurnConfigured(resolveTurnServers({}));
+    warnIfNoEnvTurnConfigured(resolveTurnServers({}));
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnIfNoEnvTurnConfigured(resolveTurnServers({}), true);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('ICEConfigurationManager integration with default TURN', () => {
+  it('default manager has TURN servers (NAT traversal works out of the box)', () => {
+    const manager = new ICEConfigurationManager();
+    expect(manager.hasTurnServers()).toBe(true);
+  });
+
+  it('default RTCConfiguration includes at least one turn/turns server', () => {
+    const manager = new ICEConfigurationManager();
+    const config = manager.getRTCConfiguration();
+    const iceServers = config.iceServers ?? [];
+
+    expect(iceServers.length).toBeGreaterThan(0);
+
+    const hasTurn = iceServers.some((server) => {
+      const urls = Array.isArray(server.urls) ? server.urls : [server.urls];
+      return urls.some((url) => isTurnScheme(url));
+    });
+    expect(hasTurn).toBe(true);
+  });
+
+  it('still allows callers to override with their own TURN servers', () => {
+    const custom: ICEServerConfig[] = [
+      {
+        urls: 'turn:custom.example.com:3478',
+        username: 'me',
+        credential: 'pw',
+        credentialType: 'password',
+      },
+    ];
+    const manager = new ICEConfigurationManager({ customTurnServers: custom });
+    expect(manager.getTurnServers()).toEqual(custom);
+  });
+
+  it('turn-relay mode surfaces TURN servers for forced relay', () => {
+    const manager = new ICEConfigurationManager({ mode: 'turn-relay' });
+    const config = manager.getRTCConfiguration();
+    expect(config.iceTransportPolicy).toBe('relay');
+    const iceServers = config.iceServers ?? [];
+    expect(iceServers.length).toBeGreaterThan(0);
+    const allTurn = iceServers.every((server) => {
+      const urls = Array.isArray(server.urls) ? server.urls : [server.urls];
+      return urls.every((url) => isTurnScheme(url));
+    });
+    expect(allTurn).toBe(true);
+  });
+});

--- a/src/lib/ice-config.ts
+++ b/src/lib/ice-config.ts
@@ -65,27 +65,149 @@ export const DEFAULT_STUN_SERVERS: ICEServerConfig[] = [
 ];
 
 /**
- * Default TURN servers - populated from environment variables when available.
- * Users behind symmetric NATs require TURN servers for connectivity.
- * Set NEXT_PUBLIC_TURN_URL, NEXT_PUBLIC_TURN_USER, NEXT_PUBLIC_TURN_PASS to configure.
+ * Public free TURN servers used as a last-resort fallback.
+ *
+ * These are the OpenRelay public relay servers operated by Metered
+ * (https://github.com/ metered-test-hosting / openrelay) explicitly published
+ * with shared community credentials (`openrelayproject` / `openrelayproject`)
+ * for development, testing, and small-scale production use. They are NOT
+ * secrets — the credentials are intentionally public so clients can embed
+ * them. They provide a relay fallback so users behind symmetric NATs are not
+ * left with zero connectivity when no private TURN infrastructure is
+ * configured via environment variables.
+ *
+ * For production deployments, set NEXT_PUBLIC_TURN_URL / USER / PASS to your
+ * own TURN infrastructure for reliable, rate-limit-free NAT traversal.
  */
-export const DEFAULT_TURN_SERVERS: ICEServerConfig[] = (() => {
-  const turnUrl = process.env.NEXT_PUBLIC_TURN_URL;
-  const turnUser = process.env.NEXT_PUBLIC_TURN_USER;
-  const turnPass = process.env.NEXT_PUBLIC_TURN_PASS;
+export const PUBLIC_FALLBACK_TURN_SERVERS: ICEServerConfig[] = [
+  {
+    urls: 'turn:openrelay.metered.ca:80',
+    username: 'openrelayproject',
+    credential: 'openrelayproject',
+    credentialType: 'password',
+  },
+  {
+    urls: 'turn:openrelay.metered.ca:443',
+    username: 'openrelayproject',
+    credential: 'openrelayproject',
+    credentialType: 'password',
+  },
+  {
+    urls: 'turn:openrelay.metered.ca:443?transport=tcp',
+    username: 'openrelayproject',
+    credential: 'openrelayproject',
+    credentialType: 'password',
+  },
+];
+
+/**
+ * Environment variable record shape used for TURN resolution.
+ */
+type TurnEnvRecord = Record<string, string | undefined>;
+
+/**
+ * Result of resolving TURN servers from the environment.
+ */
+export interface ResolveTurnServersResult {
+  /** Resolved TURN server configurations (never empty). */
+  servers: ICEServerConfig[];
+  /**
+   * `true` when servers came from the public fallback rather than env vars.
+   * Consumers use this to decide whether to emit a configuration warning.
+   */
+  usedFallback: boolean;
+}
+
+/**
+ * Resolve TURN servers from environment variables, falling back to public
+ * relay servers so NAT traversal always has a relay option.
+ *
+ * Reads:
+ *  - NEXT_PUBLIC_TURN_URL  (comma-separated list of turn:/turns: URLs)
+ *  - NEXT_PUBLIC_TURN_USER (username shared across all URLs)
+ *  - NEXT_PUBLIC_TURN_PASS (credential shared across all URLs)
+ *
+ * All three must be present to use env-configured servers; otherwise the
+ * public fallback is used. Partial credentials are ignored to avoid
+ * half-configured, broken relay attempts.
+ *
+ * @param env Environment record (defaults to `process.env`).
+ */
+export function resolveTurnServers(
+  env: TurnEnvRecord = process.env,
+): ResolveTurnServersResult {
+  const turnUrl = env.NEXT_PUBLIC_TURN_URL;
+  const turnUser = env.NEXT_PUBLIC_TURN_USER;
+  const turnPass = env.NEXT_PUBLIC_TURN_PASS;
 
   if (turnUrl && turnUser && turnPass) {
-    return [
-      {
-        urls: turnUrl,
+    const urls = turnUrl
+      .split(',')
+      .map((u) => u.trim())
+      .filter(Boolean);
+
+    if (urls.length > 0) {
+      const servers: ICEServerConfig[] = urls.map((url) => ({
+        urls: url,
         username: turnUser,
         credential: turnPass,
         credentialType: 'password',
-      },
-    ];
+      }));
+      return { servers, usedFallback: false };
+    }
   }
 
-  return [];
+  return { servers: PUBLIC_FALLBACK_TURN_SERVERS.map((s) => ({ ...s })), usedFallback: true };
+}
+
+let turnConfigWarningEmitted = false;
+
+/**
+ * Reset the one-time "no TURN env" warning guard. Intended for tests.
+ * @internal
+ */
+export function __resetTurnWarningGuard(): void {
+  turnConfigWarningEmitted = false;
+}
+
+/**
+ * Emit a one-time warning when TURN servers are coming from the public
+ * fallback rather than environment-configured infrastructure. This surfaces
+ * the configuration gap called out by issue #983 so operators notice that
+ * they should set their own TURN credentials for production reliability.
+ *
+ * @param result Resolution result from {@link resolveTurnServers}.
+ * @param force Emit even if already emitted (use sparingly).
+ */
+export function warnIfNoEnvTurnConfigured(
+  result: ResolveTurnServersResult,
+  force = false,
+): void {
+  if (!result.usedFallback) return;
+  if (turnConfigWarningEmitted && !force) return;
+  turnConfigWarningEmitted = true;
+  console.warn(
+    '[ICE] No TURN servers configured via NEXT_PUBLIC_TURN_URL / ' +
+      'NEXT_PUBLIC_TURN_USER / NEXT_PUBLIC_TURN_PASS. Falling back to public ' +
+      'OpenRelay TURN servers, which are rate-limited and not suitable for ' +
+      'production scale. Set these environment variables to your own TURN ' +
+      'infrastructure for reliable NAT traversal behind symmetric NATs.',
+  );
+}
+
+/**
+ * Default TURN servers - resolved from environment variables with a public
+ * relay fallback so the array is never empty.
+ *
+ * Users behind symmetric NATs require TURN servers for connectivity; an empty
+ * default (the previous behavior) caused 100% connection failure for them.
+ * Set NEXT_PUBLIC_TURN_URL, NEXT_PUBLIC_TURN_USER, NEXT_PUBLIC_TURN_PASS to
+ * override the public fallback with your own TURN infrastructure.
+ */
+export const DEFAULT_TURN_SERVERS: ICEServerConfig[] = (() => {
+  const result = resolveTurnServers();
+  warnIfNoEnvTurnConfigured(result);
+  return result.servers;
 })();
 
 /**


### PR DESCRIPTION
## Problem
`DEFAULT_TURN_SERVERS` in `src/lib/ice-config.ts` returned an **empty array** whenever `NEXT_PUBLIC_TURN_URL` / `NEXT_PUBLIC_TURN_USER` / `NEXT_PUBLIC_TURN_PASS` were unset (the default deployment). With no relay fallback in `RTCConfiguration`, users behind symmetric NATs experienced ~100% P2P connection failure — there was no TURN path to fall back to when host/srflx candidates failed.

Refs: `src/lib/ice-config.ts`, `QUICK_WINS_GAPS.md` §3, issue #983.

## Changes
- **`src/lib/ice-config.ts`**
  - Added `PUBLIC_FALLBACK_TURN_SERVERS` — the public OpenRelay relay servers (operated by Metered with intentionally-public community credentials `openrelayproject`/`openrelayproject`, designed for embedding in clients). These provide a never-empty relay fallback so symmetric-NAT users always have a TURN path.
  - Added `resolveTurnServers(env?)` — a pure, testable resolver that:
    - Reads the three `NEXT_PUBLIC_TURN_*` env vars,
    - Supports **comma-separated multi-URL** deployments sharing one credential set (trimmed/filtered),
    - Returns env-configured servers when **all three** vars are present (partial credentials are ignored to avoid half-broken relay attempts),
    - Falls back to the public relay servers otherwise.
  - Added `warnIfNoEnvTurnConfigured(result, force?)` — emits a one-time `console.warn` surfacing the configuration gap (issue #983 acceptance criterion) so operators notice they should set their own TURN creds for production scale. Includes a `__resetTurnWarningGuard()` test hook.
  - `DEFAULT_TURN_SERVERS` now resolves via `resolveTurnServers()` + emits the warning, so it is **never empty** (the core #983 regression).
  - Backward compatible: `DEFAULT_TURN_SERVERS` is still an `ICEServerConfig[]`; consumers (`webrtc-p2p.ts`, `p2p-game-connection.ts`) are unaffected.
- **`.env.example`** — documented the three `NEXT_PUBLIC_TURN_*` variables, multi-URL comma syntax, and the production-recommendation note (acceptance criterion #3: documentation).
- **`src/lib/__tests__/ice-config.test.ts`** (new) — 21 tests covering: STUN/TURN defaults non-empty & well-formed; env override path (single URL, comma-separated, whitespace trimming, empty-list handling); fallback behavior when env absent / partial / blank; fresh-array-copy isolation; one-time warning semantics (`force`, suppress-on-success); `ICEConfigurationManager` integration (default has TURN, `turn-relay` mode, custom override still works).

## Security note
The OpenRelay credentials embedded here are **public by design** — Metered publishes them for community/dev use and they are documented across WebRTC tutorials. They are **not secrets**. No private production TURN credentials are committed. Operators are warned to set their own `NEXT_PUBLIC_TURN_*` for production scale/rate-limits.

## Testing
- `npx jest ice-config` → **21/21 passed**
- `npx jest webrtc-p2p p2p-game-connection` (consumers of `ice-config`) → **44/44 passed**
- `npx tsc --noEmit` → clean (0 errors)
- `npm run lint` → 0 errors (no new warnings introduced by changed files)

Closes #983