### PR TITLE
fix: lifelink for non-combat damage from spells (closes #981)

### DIFF
--- a/src/lib/game-state/__tests__/damage-spells-target-validation.test.ts
+++ b/src/lib/game-state/__tests__/damage-spells-target-validation.test.ts
@@ -24,6 +24,10 @@ import {
   initializePlaneswalkerLoyalty,
 } from "../card-instance";
 import { dealDamageToCard } from "../keyword-actions";
+import {
+  resolvePlayerDamageEffect,
+  resolveDamageEffect,
+} from "../effect-resolution";
 import { checkStateBasedActions } from "../state-based-actions";
 import type { ScryfallCard } from "@/app/actions";
 import type { GameState, PlayerId } from "../types";
@@ -591,6 +595,179 @@ describe("Damage Spells Target Validation", () => {
       state = dealDamageToPlayer(state, bobId, 100);
       const bobLife = state.players.get(bobId)?.life ?? 20;
       expect(bobLife).toBe(0);
+    });
+  });
+
+  describe("Lifelink on non-combat (spell) damage — Issue #981", () => {
+    // CR 702.15b: Damage dealt by a source with lifelink causes that source's
+    // controller to gain that much life. CR 608.2c: this is tied to the
+    // source, so NON-combat damage from spells/abilities also triggers it.
+    // These tests exercise the spell-resolution path (resolvePlayerDamageEffect
+    // / resolveDamageEffect) which previously did not check lifelink at all.
+
+    it("lifelink source dealing spell damage to a player gains controller life", () => {
+      let state = createInitialGameState(["Alice", "Bob"], 20, false);
+      state = startGame(state);
+      const playerIds = Array.from(state.players.keys());
+      const aliceId = playerIds[0];
+      const bobId = playerIds[1];
+      const lifelinkData = createMockCreature("Blinding Angel", 3, 3, [
+        "Lifelink",
+      ]);
+      const result1 = addCardToBattlefield(state, lifelinkData, aliceId, aliceId);
+      state = result1.state;
+      const lifelinkId = result1.cardId;
+      const aliceLifeBefore = state.players.get(aliceId)?.life ?? 20;
+
+      // Spell damage (non-combat) routed through the spell resolution path.
+      const damageResult = resolvePlayerDamageEffect(
+        state,
+        lifelinkId,
+        bobId,
+        4,
+      );
+      expect(damageResult.success).toBe(true);
+      state = damageResult.state;
+
+      const bobLifeAfter = state.players.get(bobId)?.life ?? 20;
+      const aliceLifeAfter = state.players.get(aliceId)?.life ?? 20;
+      // Bob loses 4 life from the damage
+      expect(bobLifeAfter).toBe(20 - 4);
+      // Alice gains 4 life from lifelink even though damage is non-combat
+      expect(aliceLifeAfter).toBe(aliceLifeBefore + 4);
+    });
+
+    it("non-lifelink spell source deals no life gain to controller", () => {
+      let state = createInitialGameState(["Alice", "Bob"], 20, false);
+      state = startGame(state);
+      const playerIds = Array.from(state.players.keys());
+      const aliceId = playerIds[0];
+      const bobId = playerIds[1];
+      // Source without lifelink
+      const vanillaData = createMockCreature("Runeclaw Bear", 2, 2);
+      const result1 = addCardToBattlefield(state, vanillaData, aliceId, aliceId);
+      state = result1.state;
+      const sourceId = result1.cardId;
+      const aliceLifeBefore = state.players.get(aliceId)?.life ?? 20;
+
+      const damageResult = resolvePlayerDamageEffect(
+        state,
+        sourceId,
+        bobId,
+        3,
+      );
+      expect(damageResult.success).toBe(true);
+      state = damageResult.state;
+
+      const bobLifeAfter = state.players.get(bobId)?.life ?? 20;
+      const aliceLifeAfter = state.players.get(aliceId)?.life ?? 20;
+      expect(bobLifeAfter).toBe(20 - 3);
+      // No lifelink → no life gain
+      expect(aliceLifeAfter).toBe(aliceLifeBefore);
+    });
+
+    it("lifelink granted by an aura: spell damage to a creature gains controller life", () => {
+      // A creature has lifelink because an aura grants it (here the lifelink
+      // is modeled on the creature's keywords). A damage spell whose source
+      // is that creature hits another creature — controller should gain life.
+      let state = createInitialGameState(["Alice", "Bob"], 20, false);
+      state = startGame(state);
+      const playerIds = Array.from(state.players.keys());
+      const aliceId = playerIds[0];
+      const bobId = playerIds[1];
+      const lifelinkData = createMockCreature("Aura-touched Monk", 2, 2, [
+        "Lifelink",
+      ]);
+      const result1 = addCardToBattlefield(state, lifelinkData, aliceId, aliceId);
+      state = result1.state;
+      const lifelinkId = result1.cardId;
+      const targetData = createMockCreature("Hill Giant", 3, 3);
+      const result2 = addCardToBattlefield(state, targetData, bobId, bobId);
+      state = result2.state;
+      const targetId = result2.cardId;
+      const aliceLifeBefore = state.players.get(aliceId)?.life ?? 20;
+
+      // Non-combat damage to a CREATURE via the spell resolution path
+      const damageResult = resolveDamageEffect(
+        state,
+        lifelinkId,
+        targetId,
+        2,
+        false,
+      );
+      expect(damageResult.success).toBe(true);
+      state = damageResult.state;
+
+      const targetCard = state.cards.get(targetId);
+      expect(targetCard?.damage).toBe(2);
+      // Alice gains 2 life from lifelink on non-combat damage to a creature
+      const aliceLifeAfter = state.players.get(aliceId)?.life ?? 20;
+      expect(aliceLifeAfter).toBe(aliceLifeBefore + 2);
+    });
+
+    it("lifelink + prevention: controller gains only the damage actually dealt", () => {
+      // CR 702.15b + CR 614: lifelink grants life equal to the damage actually
+      // dealt (after prevention), not the original amount.
+      let state = createInitialGameState(["Alice", "Bob"], 20, false);
+      state = startGame(state);
+      const playerIds = Array.from(state.players.keys());
+      const aliceId = playerIds[0];
+      const bobId = playerIds[1];
+      const lifelinkData = createMockCreature("Lifelink Mage", 3, 3, [
+        "Lifelink",
+      ]);
+      const result1 = addCardToBattlefield(state, lifelinkData, aliceId, aliceId);
+      state = result1.state;
+      const lifelinkId = result1.cardId;
+      const aliceLifeBefore = state.players.get(aliceId)?.life ?? 20;
+
+      // Bob has a prevention shield preventing the next 3 damage to him.
+      state.replacementEffectManager.addPreventionShield(bobId, {
+        sourceId: "fog-effect",
+        amount: 3,
+        controllerId: bobId,
+      });
+
+      // Spell deals 5 damage, 3 prevented → 2 actually dealt.
+      const damageResult = resolvePlayerDamageEffect(
+        state,
+        lifelinkId,
+        bobId,
+        5,
+      );
+      expect(damageResult.success).toBe(true);
+      state = damageResult.state;
+
+      const bobLifeAfter = state.players.get(bobId)?.life ?? 20;
+      const aliceLifeAfter = state.players.get(aliceId)?.life ?? 20;
+      // Bob loses only 2 life (5 - 3 prevented)
+      expect(bobLifeAfter).toBe(20 - 2);
+      // Alice gains only 2 life (the damage actually dealt), not 5
+      expect(aliceLifeAfter).toBe(aliceLifeBefore + 2);
+    });
+
+    it("combat lifelink still works (regression) — dealDamageToPlayer with combat damage", () => {
+      // Ensures the lifelink primitive used by the combat path is unchanged.
+      let state = createInitialGameState(["Alice", "Bob"], 20, false);
+      state = startGame(state);
+      const playerIds = Array.from(state.players.keys());
+      const aliceId = playerIds[0];
+      const bobId = playerIds[1];
+      const lifelinkData = createMockCreature("Battle Messenger", 2, 2, [
+        "Lifelink",
+      ]);
+      const result1 = addCardToBattlefield(state, lifelinkData, aliceId, aliceId);
+      state = result1.state;
+      const lifelinkId = result1.cardId;
+      const aliceLifeBefore = state.players.get(aliceId)?.life ?? 20;
+
+      // Combat damage from a lifelink source to a player
+      state = dealDamageToPlayer(state, bobId, 2, true, lifelinkId);
+
+      const bobLifeAfter = state.players.get(bobId)?.life ?? 20;
+      const aliceLifeAfter = state.players.get(aliceId)?.life ?? 20;
+      expect(bobLifeAfter).toBe(20 - 2);
+      expect(aliceLifeAfter).toBe(aliceLifeBefore + 2);
     });
   });
 });

--- a/src/lib/game-state/effect-resolution.ts
+++ b/src/lib/game-state/effect-resolution.ts
@@ -16,6 +16,38 @@
 import type { GameState, PlayerId, CardInstanceId, StackEffect } from "./types";
 import { drawCards, createTokenCard, counterSpell } from "./keyword-actions";
 import { dealDamageToCard } from "./keyword-actions";
+import { hasLifelink } from "./evergreen-keywords";
+
+/**
+ * Apply lifelink life gain for damage dealt by a source with lifelink.
+ *
+ * CR 702.15b: "Damage dealt by a source with lifelink causes that source's
+ * controller to gain that much life, in addition to the damage's other effects."
+ * CR 608.2c: Lifelink is tied to the source of the damage, not the kind of
+ * damage — so non-combat damage from spells/abilities also triggers it.
+ *
+ * @returns updated state (life gained if source has lifelink, else unchanged)
+ */
+function applyLifelinkLifeGain(
+  state: GameState,
+  sourceId: CardInstanceId | undefined,
+  damageDealt: number,
+): GameState {
+  if (!sourceId || damageDealt <= 0) return state;
+  const sourceCard = state.cards.get(sourceId);
+  if (!sourceCard || !hasLifelink(sourceCard)) return state;
+  const controllerId = sourceCard.controllerId;
+  const controller = state.players.get(controllerId);
+  if (!controller) return state;
+  return {
+    ...state,
+    players: new Map(state.players).set(controllerId, {
+      ...controller,
+      life: controller.life + damageDealt,
+    }),
+    lastModifiedAt: Date.now(),
+  };
+}
 
 /**
  * Result of an effect resolution
@@ -225,6 +257,13 @@ export function resolveDamageEffect(
   amount: number,
   isCombatDamage: boolean = false,
 ): EffectResolutionResult {
+  // Capture damage marked on the target before resolution so we can derive
+  // the actual damage dealt after prevention/replacement effects. CR 702.15b:
+  // lifelink grants life equal to the damage actually dealt, not the
+  // requested amount.
+  const targetCardBefore = state.cards.get(targetId);
+  const damageBefore = targetCardBefore?.damage ?? 0;
+
   const result = dealDamageToCard(
     state,
     targetId,
@@ -233,9 +272,29 @@ export function resolveDamageEffect(
     sourceId,
   );
 
+  // dealDamageToCard marks `card.damage += actualDamage`, so the delta is the
+  // actual damage dealt. Cap at the requested amount so deathtouch's lethality
+  // bump (which marks extra damage up to toughness) does not inflate the
+  // lifelink life gain.
+  const targetCardAfter = result.state.cards.get(targetId);
+  const damageAfter = targetCardAfter?.damage ?? damageBefore;
+  const actualDamageDealt = Math.max(
+    0,
+    Math.min(damageAfter - damageBefore, amount),
+  );
+
+  // CR 702.15b / CR 608.2c: a non-combat source with lifelink (e.g. a spell
+  // or ability whose source has lifelink) grants its controller life equal to
+  // the damage dealt.
+  const stateWithLifelink = applyLifelinkLifeGain(
+    result.state,
+    sourceId,
+    actualDamageDealt,
+  );
+
   return {
     success: result.success,
-    state: result.state,
+    state: stateWithLifelink,
     description:
       result.description ||
       `${state.cards.get(targetId)?.cardData.name || "Target"} took ${amount} damage`,
@@ -263,23 +322,61 @@ export function resolvePlayerDamageEffect(
     };
   }
 
+  // Process replacement/prevention effects to determine the actual damage
+  // dealt. CR 614: prevention effects reduce damage that would be dealt.
+  // CR 702.15b: lifelink grants life equal to the damage actually dealt, so
+  // it must be computed after prevention.
+  const replacementEvent = {
+    type: "damage" as const,
+    timestamp: Date.now(),
+    sourceId,
+    targetId: targetPlayerId,
+    amount,
+    isCombatDamage: false,
+    damageTypes: ["noncombat"] as ("combat" | "noncombat")[],
+  };
+  const rem = state.replacementEffectManager;
+  const apnapOrder = rem.createAPNAPOrder(
+    state.turn.activePlayerId,
+    Array.from(state.players.keys()),
+  );
+  const processedEvent = rem.processEvent(replacementEvent, apnapOrder);
+  const actualDamage = processedEvent.amount;
+
+  if (actualDamage <= 0) {
+    return {
+      success: true,
+      state,
+      description: `Damage to ${playerData.name} was fully prevented`,
+    };
+  }
+
   // Deal damage to player - this reduces their life total
-  // For commander damage, we would track that separately
   const updatedPlayers = new Map(state.players);
   const updatedPlayer = {
     ...playerData,
-    life: Math.max(0, playerData.life - amount),
+    life: Math.max(0, playerData.life - actualDamage),
   };
   updatedPlayers.set(targetPlayerId, updatedPlayer);
 
+  let stateAfterDamage: GameState = {
+    ...state,
+    players: updatedPlayers,
+    lastModifiedAt: Date.now(),
+  };
+
+  // CR 702.15b / CR 608.2c: a source with lifelink grants its controller life
+  // equal to the damage dealt — including non-combat damage from spells.
+  stateAfterDamage = applyLifelinkLifeGain(
+    stateAfterDamage,
+    sourceId,
+    actualDamage,
+  );
+
   return {
     success: true,
-    state: {
-      ...state,
-      players: updatedPlayers,
-      lastModifiedAt: Date.now(),
-    },
-    description: `${playerData.name} took ${amount} damage${sourceId ? ` (from ${state.cards.get(sourceId)?.cardData.name || "source"})` : ""}`,
+    state: stateAfterDamage,
+    description: `${playerData.name} took ${actualDamage} damage${sourceId ? ` (from ${state.cards.get(sourceId)?.cardData.name || "source"})` : ""}`,
   };
 }
 


### PR DESCRIPTION
## Problem
Per CR 702.15b / CR 608.2c, damage dealt by a source with lifelink causes its controller to gain that much life — regardless of whether the damage is combat or non-combat. The **spell resolution path** in `effect-resolution.ts` (`resolveDamageEffect` and `resolvePlayerDamageEffect`) did not check for lifelink on the source at all, so a spell/ability whose source had lifelink (e.g. Lightning Helix cast from a lifelink creature, or a lifelink-granting aura source) never granted life to its controller.

Note: `combat.ts` already handled lifelink correctly for combat damage, and `dealDamageToPlayer` in `game-state.ts` already handled it for direct player-damage calls — only the stack/spell-resolution entry points were missing it.

## Changes
- **`src/lib/game-state/effect-resolution.ts`**
  - Added `applyLifelinkLifeGain` helper that grants the source controller life equal to the damage dealt when the source has lifelink (`hasLifelink` from `evergreen-keywords`).
  - `resolveDamageEffect` (damage to a card): computes the actual damage dealt after prevention by diffing `card.damage` before/after `dealDamageToCard` (capped at the requested amount so deathtouch's lethality bump doesn't inflate the gain), then applies lifelink.
  - `resolvePlayerDamageEffect` (damage to a player): now processes replacement/prevention effects to determine actual damage dealt, then applies lifelink on the post-prevention amount. Fully-prevented damage grants no life and returns early.
- **`src/lib/game-state/__tests__/damage-spells-target-validation.test.ts`** — added a new `Lifelink on non-combat (spell) damage — Issue #981` suite (5 tests, see Testing).

No changes to `combat.ts` were needed (its lifelink handling was already correct), which also avoids merge overlap with sibling PR #971 (landwalk).

## Testing
New tests (all pass):
1. lifelink source dealing spell damage to a player gains controller life
2. non-lifelink spell source deals no life gain to controller
3. lifelink granted by an aura: spell damage to a creature gains controller life (exercises `resolveDamageEffect` card path)
4. lifelink + prevention: controller gains only the damage actually dealt (post-prevention), not the original amount
5. combat lifelink still works (regression) — `dealDamageToPlayer` with combat damage

```
npx jest effect-resolution damage-spells combat
# 3 specific files: 123 passed
# broader run (231 suites): 4376 passed, 0 failed
npx tsc --noEmit   # No errors
npm run lint       # 0 errors
```

Closes #981