### PR TITLE
fix: replace jarring alert-style P2P placeholder UI (closes #984)

### DIFF
--- a/src/app/(app)/multiplayer/host/page.tsx
+++ b/src/app/(app)/multiplayer/host/page.tsx
@@ -28,6 +28,7 @@ import {
   type DirectConnectionState,
 } from '@/lib/p2p-direct-connection';
 import { QRCodeDisplay } from '@/components/qr-code-display';
+import { P2PStatusBanner } from '@/components/p2p-status-banner';
 
 export default function HostLobbyPage() {
   const { 
@@ -666,9 +667,12 @@ export default function HostLobbyPage() {
           </Card>
         </div>
 
-        <p className="text-xs text-muted-foreground mt-6 text-center">
-          Note: This lobby uses P2P networking (WebRTC) for multiplayer connections.
-        </p>
+        <P2PStatusBanner
+          className="mt-6"
+          status="in-development"
+          title="P2P Lobby (Prototype)"
+          description="This lobby uses WebRTC peer-to-peer networking. Connections are local during the prototype phase — full cross-player sync is arriving in a future release."
+        />
       </div>
     );
   }

--- a/src/app/(app)/multiplayer/join/page.tsx
+++ b/src/app/(app)/multiplayer/join/page.tsx
@@ -18,8 +18,10 @@ import { ArrowLeft, Users, Crown, Check, Info, Eye, Clock } from 'lucide-react';
 import { publicLobbyBrowser, PublicGameInfo } from '@/lib/public-lobby-browser';
 import { DeckSelectorWithValidation } from '@/components/deck-selector-with-validation';
 import { ConnectionDataEntry } from '@/components/connection-data-entry';
+import { P2PStatusBanner } from '@/components/p2p-status-banner';
 import { GameFormat } from '@/lib/multiplayer-types';
 import { validateDeckForLobby } from '@/lib/format-validator';
+import { useToast } from '@/hooks/use-toast';
 import type { SavedDeck } from '@/app/actions';
 import {
   createClientConnection,
@@ -37,17 +39,18 @@ interface JoinState {
 function JoinGameContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  
+  const { toast } = useToast();
+
   // Initialize with code from URL if present
   const initialCode = searchParams.get('code') || '';
-  
+
   const [joinState, setJoinState] = useState<JoinState>({
     step: initialCode ? 'name' : 'code',
     gameCode: initialCode,
     playerName: '',
     game: null,
   });
-  
+
   const [playerNameInput, setPlayerNameInput] = useState('');
   const [selectedDeck, setSelectedDeck] = useState<SavedDeck | null>(null);
   const [deckValidation, setDeckValidation] = useState<{ isValid: boolean; errors: string[] }>({ isValid: true, errors: [] });
@@ -56,7 +59,6 @@ function JoinGameContent() {
   const [ready, setReady] = useState(false);
   const [showP2pEntry, setShowP2pEntry] = useState(false);
   const [p2pConnectionState, setP2pConnectionState] = useState<DirectConnectionState>('idle');
-  const [showP2pUnavailable, setShowP2pUnavailable] = useState(false);
 
   // Format display names
   const formatDisplayNames: Record<GameFormat, string> = {
@@ -171,47 +173,23 @@ function JoinGameContent() {
   };
 
   const handleReady = () => {
-    // Show P2P unavailable placeholder instead of alert
-    setShowP2pUnavailable(true);
-  };
-
-  const handleDismissP2pUnavailable = () => {
-    setShowP2pUnavailable(false);
+    // P2P sync is not yet implemented — toggle local ready state and surface
+    // a non-blocking, in-app toast instead of the old jarring alert-style modal.
+    const newReady = !ready;
+    setReady(newReady);
+    if (newReady) {
+      toast({
+        title: 'P2P Multiplayer Coming Soon',
+        description:
+          'Your ready status is local-only for now. WebRTC peer sync arrives in a future release.',
+      });
+    }
   };
 
   const handleLeave = () => {
     localStorage.removeItem('planar_nexus_joined_game');
     router.push('/multiplayer');
   };
-
-  // P2P unavailable placeholder modal
-  if (showP2pUnavailable) {
-    return (
-      <div className="flex-1 p-4 md:p-6 max-w-md mx-auto">
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Info className="w-5 h-5" />
-              Feature Not Available
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <p className="text-sm text-muted-foreground">
-              P2P networking (WebRTC) is not yet implemented in this prototype. 
-              The ready status cannot be synchronized with other players yet.
-            </p>
-            <p className="text-xs text-muted-foreground">
-              This is a demo build. Full multiplayer support with WebRTC 
-              peer-to-peer connections is planned for a future release.
-            </p>
-            <Button onClick={handleDismissP2pUnavailable} className="w-full">
-              Got It
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
 
   // Step 1: Enter game code
   if (joinState.step === 'code') {
@@ -445,10 +423,7 @@ function JoinGameContent() {
         </Card>
       </div>
 
-      <p className="text-xs text-muted-foreground mt-6 text-center">
-        Note: This is a prototype lobby. P2P networking (WebRTC) is not yet implemented.
-        Deck selection is stored locally for demonstration.
-      </p>
+      <P2PStatusBanner className="mt-6" />
     </div>
   );
 }

--- a/src/components/__tests__/p2p-status-banner.test.tsx
+++ b/src/components/__tests__/p2p-status-banner.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import {
+  P2PStatusBanner,
+  type P2PStatus,
+} from '../p2p-status-banner';
+
+describe('P2PStatusBanner', () => {
+  it('renders the default "Coming Soon" status', () => {
+    render(<P2PStatusBanner />);
+    expect(
+      screen.getByText(/P2P Multiplayer Coming Soon/i),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('p2p-status-badge')).toHaveTextContent(
+      'Coming Soon',
+    );
+  });
+
+  it.each<[P2PStatus, string]>([
+    ['unavailable', 'Unavailable'],
+    ['coming-soon', 'Coming Soon'],
+    ['in-development', 'In Development'],
+  ])('renders the correct badge label for status "%s"', (status, label) => {
+    render(<P2PStatusBanner status={status} />);
+    expect(screen.getByTestId('p2p-status-badge')).toHaveTextContent(label);
+  });
+
+  it('renders custom title and description', () => {
+    render(
+      <P2PStatusBanner
+        title="Custom Heading"
+        description="Custom body copy explaining the state."
+      />,
+    );
+    expect(
+      screen.getByRole('heading', { name: /Custom Heading/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Custom body copy/i)).toBeInTheDocument();
+  });
+
+  it('hides the description in compact mode but keeps the status badge', () => {
+    render(<P2PStatusBanner compact />);
+    expect(
+      screen.queryByText(/WebRTC peer-to-peer sync is not yet available/i),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('p2p-status-badge')).toHaveTextContent(
+      'Coming Soon',
+    );
+  });
+
+  it('renders the Learn More link pointing at the P2P docs by default', () => {
+    render(<P2PStatusBanner />);
+    const link = screen.getByTestId('p2p-learn-more-link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(link.getAttribute('href')).toContain(
+      'PHASE-4-5-P2P-NETWORKING-RESEARCH.md',
+    );
+  });
+
+  it('honors a custom learnMoreUrl', () => {
+    render(<P2PStatusBanner learnMoreUrl="https://example.com/roadmap" />);
+    expect(screen.getByTestId('p2p-learn-more-link')).toHaveAttribute(
+      'href',
+      'https://example.com/roadmap',
+    );
+  });
+
+  it('hides the Learn More link when learnMoreUrl is empty', () => {
+    render(<P2PStatusBanner learnMoreUrl="" />);
+    expect(screen.queryByTestId('p2p-learn-more-link')).not.toBeInTheDocument();
+  });
+
+  it('opens the link on click without throwing', async () => {
+    const user = userEvent.setup();
+    render(<P2PStatusBanner learnMoreUrl="https://example.com/p2p" />);
+    const link = screen.getByTestId('p2p-learn-more-link');
+    await user.click(link);
+    // The anchor exists and is clickable; jsdom noop for navigation.
+    expect(link).toHaveAttribute('href', 'https://example.com/p2p');
+  });
+
+  it('exposes a polite live region for assistive tech', () => {
+    render(<P2PStatusBanner />);
+    expect(screen.getByRole('status')).toHaveAttribute(
+      'aria-live',
+      'polite',
+    );
+  });
+
+  it('applies a custom className', () => {
+    const { container } = render(
+      <P2PStatusBanner className="custom-class" />,
+    );
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+});

--- a/src/components/p2p-status-banner.tsx
+++ b/src/components/p2p-status-banner.tsx
@@ -1,0 +1,101 @@
+/**
+ * P2PStatusBanner
+ *
+ * Polished, in-app "Coming Soon" status surface for the (not-yet-implemented)
+ * WebRTC peer-to-peer multiplayer feature. Replaces the previous jarring,
+ * full-screen alert-style modal on the multiplayer join flow.
+ *
+ * Shows:
+ *   - a connection-status indicator (Badge) reflecting the actual P2P state
+ *   - clear, non-blocking messaging about feature availability
+ *   - an optional "Learn More" link to the P2P roadmap documentation
+ *
+ * See: https://github.com/anchapin/planar-nexus/issues/984
+ */
+
+'use client';
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { Radio, ExternalLink, Construction } from 'lucide-react';
+
+export type P2PStatus = 'unavailable' | 'coming-soon' | 'in-development';
+
+export interface P2PStatusBannerProps {
+  /** Reflects the actual P2P implementation state. Defaults to 'coming-soon'. */
+  status?: P2PStatus;
+  /** Optional heading override. */
+  title?: string;
+  /** Optional body copy override. */
+  description?: string;
+  /**
+   * URL opened by the "Learn More" link. Set to empty string to hide the link.
+   * Defaults to the project's P2P networking research document.
+   */
+  learnMoreUrl?: string;
+  /** Compact variant renders a single inline row (no description block). */
+  compact?: boolean;
+  className?: string;
+}
+
+const STATUS_META: Record<
+  P2PStatus,
+  { label: string; variant: 'default' | 'secondary' | 'destructive' | 'outline' }
+> = {
+  unavailable: { label: 'Unavailable', variant: 'destructive' },
+  'coming-soon': { label: 'Coming Soon', variant: 'secondary' },
+  'in-development': { label: 'In Development', variant: 'default' },
+};
+
+const DEFAULT_LEARN_MORE_URL =
+  'https://github.com/anchapin/planar-nexus/blob/main/docs/PHASE-4-5-P2P-NETWORKING-RESEARCH.md';
+
+export function P2PStatusBanner({
+  status = 'coming-soon',
+  title,
+  description,
+  learnMoreUrl = DEFAULT_LEARN_MORE_URL,
+  compact = false,
+  className,
+}: P2PStatusBannerProps) {
+  const meta = STATUS_META[status];
+
+  const heading =
+    title ?? 'P2P Multiplayer Coming Soon';
+  const body =
+    description ??
+    'WebRTC peer-to-peer sync is not yet available in this build. Lobby and deck choices are stored locally for now and will sync across players once multiplayer ships.';
+
+  return (
+    <Alert className={cn('gap-2', className)} role="status" aria-live="polite">
+      <Construction className="h-4 w-4" aria-hidden="true" />
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <AlertTitle className="flex flex-wrap items-center gap-2">
+            {heading}
+            <Badge variant={meta.variant} data-testid="p2p-status-badge">
+              <Radio className="mr-1 h-3 w-3" aria-hidden="true" />
+              {meta.label}
+            </Badge>
+          </AlertTitle>
+          {!compact && <AlertDescription>{body}</AlertDescription>}
+        </div>
+        {learnMoreUrl ? (
+          <a
+            href={learnMoreUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex shrink-0 items-center gap-1 text-sm font-medium text-primary underline-offset-4 hover:underline"
+            data-testid="p2p-learn-more-link"
+          >
+            Learn More
+            <ExternalLink className="h-3 w-3" aria-hidden="true" />
+          </a>
+        ) : null}
+      </div>
+    </Alert>
+  );
+}
+
+export default P2PStatusBanner;


### PR DESCRIPTION
## Problem
The multiplayer join flow surfaced the not-yet-implemented WebRTC feature via a harsh, **full-screen modal `Card`** (`"Feature Not Available"`) that hijacked the entire page when a player clicked **Ready Up**. This created a jarring, alert-style UX that blocked the join flow and gave no clear indication of actual P2P status. The host lobby showed only a terse, easy-to-miss footnote.

Issue: #984

## Changes
- **New `src/components/p2p-status-banner.tsx`** — a polished, reusable in-app "Coming Soon" status surface built on the existing `Alert`/`Badge` primitives. It renders:
  - a **connection-status indicator** (Badge) reflecting the real P2P state (`unavailable` / `coming-soon` / `in-development`),
  - clear, non-blocking messaging,
  - a **"Learn More"** link to the project's P2P roadmap doc (`docs/PHASE-4-5-P2P-NETWORKING-RESEARCH.md`),
  - an `aria-live="polite"` region for assistive tech, and a compact mode.
- **`src/app/(app)/multiplayer/join/page.tsx`**
  - Removed the jarring `showP2pUnavailable` full-screen modal block entirely.
  - **Ready Up** now toggles local ready state and surfaces a **non-blocking toast** ("P2P Multiplayer Coming Soon") via the app's existing `useToast` — the lobby stays fully visible and usable.
  - Replaced the prototype footnote with a `<P2PStatusBanner />` so the join lobby always shows current P2P status inline.
- **`src/app/(app)/multiplayer/host/page.tsx`** — replaced the single-line prototype note with a `<P2PStatusBanner status="in-development" />` for consistent, informative status messaging across both flows.

`alert()`/`confirm()` calls were not introduced; this leans on in-app toast + banner primitives (aligned with the #1100 native-alert removal effort). `src/lib/connection-fallback.ts` is untouched (sibling #985).

## Testing
- New suite `src/components/__tests__/p2p-status-banner.test.tsx` (12 tests): status-badge variants, custom title/description, compact mode, Learn More link (default/custom/hidden), click handling, live region, and className pass-through.
- **Full suite:** `npx jest` → 233 suites passed, **4418 passed** (10 skipped, 48 todo), 0 failed.
- `tsc --noEmit` → clean.
- `eslint` on changed files → 0 errors (5 pre-existing warnings in untouched P2P callback code).

## Acceptance Criteria
- [x] Join page shows polished placeholder UI instead of alert-style modal
- [x] Connection attempt gracefully shows current P2P implementation status (toast + status badge)
- [x] UI provides clear feedback when P2P features are unavailable (inline banner + Learn More)

Closes #984