### PR TITLE
fix: comprehensive error handling in connection-fallback async methods (closes #985)

### DIFF
--- a/src/lib/__tests__/connection-fallback.test.ts
+++ b/src/lib/__tests__/connection-fallback.test.ts
@@ -1,0 +1,938 @@
+/**
+ * Connection Fallback Manager — error-handling coverage (#985).
+ *
+ * Verifies the post-#985 behaviour:
+ *   - Every async method (initialize / connectWithFallback / connectWebRTC /
+ *     connectWebSocket / attemptFallback / forceFallback) wraps in try/catch
+ *     and surfaces failures via the `onError` event callback.
+ *   - Failures carry a stable {@link ConnectionErrorCode} via
+ *     {@link ConnectionError}; `instanceof ConnectionError` works.
+ *   - connectWebRTC retries with exponential backoff before bubbling.
+ *   - connectWithFallback falls back to WebSocket on WebRTC failure or
+ *     timeout, and rejects with BOTH_FAILED when both transports fail.
+ *   - The send* methods catch transport throws and route them through
+ *     onError without rethrowing.
+ *   - #982 log redaction is preserved: error logs never leak session IDs.
+ *
+ * WebRTC/WebSocket transports are mocked so we can drive each failure mode
+ * without a real network or browser APIs.
+ */
+
+// --- Mock setup -----------------------------------------------------------
+// Module-level mock fns so we can reconfigure them in individual tests.
+// Jest hoists `jest.mock(...)` above imports; only `mock*`-prefixed
+// variables are accessible inside the factory.
+
+const mockWebRTCInitialize = jest.fn();
+const mockWebRTCClose = jest.fn();
+const mockWebRTCIsConnected = jest.fn();
+const mockWebRTCSend = jest.fn();
+const mockWebRTCSendGameState = jest.fn();
+const mockWebRTCSendPlayerAction = jest.fn();
+const mockWebRTCSendChat = jest.fn();
+const mockWebRTCSendEmote = jest.fn();
+const mockWebRTCConstructor = jest.fn();
+
+jest.mock('../webrtc-p2p', () => ({
+  WebRTCConnection: function (options: unknown) {
+    // Delegate to the constructor mock so each test can configure
+    // a fresh behaviour via mockWebRTCConstructor.mockImplementationOnce.
+    return mockWebRTCConstructor(options);
+  },
+}));
+
+jest.mock('../websocket-connection', () => ({
+  WebSocketConnection: function (config: unknown, events: unknown) {
+    return mockWSConstructor(config, events);
+  },
+  isWebSocketAvailable: () => mockIsWebSocketAvailable(),
+}));
+
+const mockWSConnect = jest.fn();
+const mockWSDisconnect = jest.fn();
+const mockWSIsConnected = jest.fn();
+const mockWSSend = jest.fn();
+const mockWSSendGameState = jest.fn();
+const mockWSSendPlayerAction = jest.fn();
+const mockWSSendChat = jest.fn();
+const mockWSSendEmote = jest.fn();
+const mockWSConstructor = jest.fn();
+const mockIsWebSocketAvailable = jest.fn();
+
+// --- Imports (resolved after mocks are in place) --------------------------
+
+import {
+  ConnectionFallbackManager,
+  ConnectionError,
+  ConnectionErrorCode,
+  createConnectionFallbackManager,
+  isConnectionAvailable,
+  type ConnectionFallbackEvents,
+  type ConnectionFallbackOptions,
+} from '../connection-fallback';
+import type { P2PMessage } from '../webrtc-p2p';
+import type { GameState } from '../game-state/types';
+
+// --- Helpers --------------------------------------------------------------
+
+/** Build a working WebRTC-shaped mock object. */
+function makeWebRTCMock(): Record<string, jest.Mock> {
+  return {
+    initialize: mockWebRTCInitialize,
+    close: mockWebRTCClose,
+    isConnected: mockWebRTCIsConnected,
+    send: mockWebRTCSend,
+    sendGameState: mockWebRTCSendGameState,
+    sendPlayerAction: mockWebRTCSendPlayerAction,
+    sendChat: mockWebRTCSendChat,
+    sendEmote: mockWebRTCSendEmote,
+  };
+}
+
+/** Build a working WebSocket-shaped mock object. */
+function makeWSMock(): Record<string, jest.Mock> {
+  return {
+    connect: mockWSConnect,
+    disconnect: mockWSDisconnect,
+    isConnected: mockWSIsConnected,
+    send: mockWSSend,
+    sendGameState: mockWSSendGameState,
+    sendPlayerAction: mockWSSendPlayerAction,
+    sendChat: mockWSSendChat,
+    sendEmote: mockWSSendEmote,
+  };
+}
+
+/** Build an options bag with jest.fn event callbacks. */
+function makeOptions(
+  overrides: Partial<ConnectionFallbackOptions> = {},
+): ConnectionFallbackOptions & {
+  events: ConnectionFallbackEvents & {
+    [K in keyof ConnectionFallbackEvents]: jest.Mock;
+  };
+} {
+  const events = {
+    onConnectionStateChange: jest.fn(),
+    onConnectionTypeChange: jest.fn(),
+    onMessage: jest.fn(),
+    onGameStateSync: jest.fn(),
+    onError: jest.fn(),
+    onPeerConnected: jest.fn(),
+    onPeerDisconnected: jest.fn(),
+  };
+  return {
+    playerId: 'player-1',
+    playerName: 'Tester',
+    isHost: true,
+    gameCode: 'ABC234',
+    websocketUrl: 'wss://example.test/socket',
+    events,
+    fallbackTimeout: 50,
+    retryBaseDelayMs: 1, // tests should never wait on real backoff
+    ...overrides,
+  } as ConnectionFallbackOptions & {
+    events: ConnectionFallbackEvents & {
+      [K in keyof ConnectionFallbackEvents]: jest.Mock;
+    };
+  };
+}
+
+/** Install RTCPeerConnection on the global so isWebRTCAvailable() is true. */
+function enableWebRTCGlobal(): void {
+  (globalThis as Record<string, unknown>).RTCPeerConnection = function () {
+    return {};
+  };
+}
+
+function disableWebRTCGlobal(): void {
+  delete (globalThis as Record<string, unknown>).RTCPeerConnection;
+}
+
+/** Drain pending microtasks/timers so async paths finish. */
+function flushTimers(ms = 0): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// --- Test lifecycle -------------------------------------------------------
+
+describe('connection-fallback — error handling (#985)', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
+  let consoleInfoSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Default: WebRTC + WebSocket both "available" at the env level.
+    enableWebRTCGlobal();
+    mockIsWebSocketAvailable.mockReturnValue(true);
+
+    // Default transports: WebRTC initialise succeeds, WS connect succeeds.
+    mockWebRTCInitialize.mockResolvedValue(undefined);
+    mockWebRTCClose.mockImplementation(() => {});
+    mockWebRTCIsConnected.mockReturnValue(true);
+    mockWebRTCConstructor.mockImplementation(() => makeWebRTCMock());
+
+    mockWSConnect.mockResolvedValue(undefined);
+    mockWSDisconnect.mockImplementation(() => {});
+    mockWSIsConnected.mockReturnValue(true);
+    mockWSConstructor.mockImplementation(() => makeWSMock());
+
+    // Silence diagnostic logs in test output (they're tested separately).
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    consoleInfoSpy.mockRestore();
+    disableWebRTCGlobal();
+  });
+
+  // --- Typed error primitives -------------------------------------------
+
+  describe('ConnectionError / ConnectionErrorCode', () => {
+    it('exposes the documented error codes', () => {
+      // The issue spec calls out ICE_FAILED, WEBRTC_FAILED, WEBSOCKET_FAILED.
+      expect(ConnectionErrorCode.ICE_FAILED).toBe('ICE_FAILED');
+      expect(ConnectionErrorCode.WEBRTC_FAILED).toBe('WEBRTC_FAILED');
+      expect(ConnectionErrorCode.WEBSOCKET_FAILED).toBe('WEBSOCKET_FAILED');
+      // Plus the additional structural codes this PR introduces.
+      expect(ConnectionErrorCode.BOTH_FAILED).toBe('BOTH_FAILED');
+      expect(ConnectionErrorCode.NO_CONNECTION_METHOD).toBe('NO_CONNECTION_METHOD');
+      expect(ConnectionErrorCode.SEND_FAILED).toBe('SEND_FAILED');
+      expect(ConnectionErrorCode.RETRY_EXHAUSTED).toBe('RETRY_EXHAUSTED');
+      expect(ConnectionErrorCode.TIMEOUT).toBe('TIMEOUT');
+      expect(ConnectionErrorCode.WEBSOCKET_UNAVAILABLE).toBe('WEBSOCKET_UNAVAILABLE');
+      expect(ConnectionErrorCode.WEBRTC_UNAVAILABLE).toBe('WEBRTC_UNAVAILABLE');
+    });
+
+    it('preserves code + cause + name on a ConnectionError', () => {
+      const cause = new Error('underlying');
+      const err = new ConnectionError(
+        ConnectionErrorCode.WEBRTC_FAILED,
+        'boom',
+        cause,
+      );
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(ConnectionError);
+      expect(err.code).toBe(ConnectionErrorCode.WEBRTC_FAILED);
+      expect(err.message).toBe('boom');
+      expect(err.cause).toBe(cause);
+      expect(err.name).toBe('ConnectionError');
+    });
+
+    it('supports instanceof across try/catch boundaries', () => {
+      function throwIt(): never {
+        throw new ConnectionError(ConnectionErrorCode.ICE_FAILED, 'x');
+      }
+      let caught: unknown;
+      try {
+        throwIt();
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(ConnectionError);
+      expect((caught as ConnectionError).code).toBe(ConnectionErrorCode.ICE_FAILED);
+    });
+  });
+
+  // --- initialize() — no-connection & preferWebSocket ------------------
+
+  describe('initialize() — failure modes', () => {
+    it('throws NO_CONNECTION_METHOD when neither transport is available', async () => {
+      disableWebRTCGlobal();
+      mockIsWebSocketAvailable.mockReturnValue(false);
+      const opts = makeOptions({ websocketUrl: '' });
+
+      const manager = new ConnectionFallbackManager(opts);
+      await expect(manager.initialize()).rejects.toBeInstanceOf(ConnectionError);
+      await expect(manager.initialize()).rejects.toMatchObject({
+        code: ConnectionErrorCode.NO_CONNECTION_METHOD,
+      });
+
+      // Host observes the error via onError too.
+      expect(opts.events.onError).toHaveBeenCalled();
+      const arg = opts.events.onError.mock.calls[0][0];
+      expect(arg).toBeInstanceOf(ConnectionError);
+      expect(arg.code).toBe(ConnectionErrorCode.NO_CONNECTION_METHOD);
+    });
+
+    it('throws NO_CONNECTION_METHOD when preferWebSocket but no URL configured', async () => {
+      disableWebRTCGlobal();
+      const opts = makeOptions({ preferWebSocket: true, websocketUrl: '' });
+      const manager = new ConnectionFallbackManager(opts);
+      await expect(manager.initialize()).rejects.toMatchObject({
+        code: ConnectionErrorCode.NO_CONNECTION_METHOD,
+      });
+    });
+
+    it('routes through connectWebSocket when preferWebSocket is true', async () => {
+      const opts = makeOptions({ preferWebSocket: true });
+      const manager = new ConnectionFallbackManager(opts);
+      const type = await manager.initialize();
+      expect(type).toBe('websocket');
+      expect(mockWSConnect).toHaveBeenCalledTimes(1);
+      expect(opts.events.onConnectionTypeChange).toHaveBeenCalledWith('websocket');
+    });
+
+    it('routes through connectWebSocket when WebRTC is unavailable', async () => {
+      disableWebRTCGlobal();
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+      const type = await manager.initialize();
+      expect(type).toBe('websocket');
+    });
+
+    it('wraps unexpected throw inside initialize as ConnectionError', async () => {
+      // Force the WebRTC constructor itself to throw — this is an
+      // uncaught (non-Connection) error that the top-level safety net
+      // must wrap.
+      mockWebRTCConstructor.mockImplementation(() => {
+        throw new Error('constructor boom');
+      });
+      // Disable fallback so we don't recover via WS.
+      const opts = makeOptions({ enableFallback: false, websocketUrl: '' });
+      const manager = new ConnectionFallbackManager(opts);
+
+      await expect(manager.initialize()).rejects.toBeInstanceOf(ConnectionError);
+      // Already-typed errors pass through.
+      expect(opts.events.onError).toHaveBeenCalled();
+    });
+  });
+
+  // --- connectWebRTC — retry / backoff ----------------------------------
+
+  describe('connectWebRTC — retry with exponential backoff', () => {
+    it('does not retry by default (maxRetries=0) and throws WEBRTC_FAILED', async () => {
+      mockWebRTCInitialize.mockRejectedValue(new Error('ice fail'));
+      const opts = makeOptions({ enableFallback: false, websocketUrl: '' });
+      const manager = new ConnectionFallbackManager(opts);
+
+      await expect(manager.initialize()).rejects.toMatchObject({
+        code: ConnectionErrorCode.WEBRTC_FAILED,
+      });
+      // Initial attempt only — no retries by default.
+      expect(mockWebRTCInitialize).toHaveBeenCalledTimes(1);
+      // Each attempt surfaces to onError.
+      expect(opts.events.onError).toHaveBeenCalled();
+    });
+
+    it('retries maxRetries times, then bubbles RETRY_EXHAUSTED', async () => {
+      mockWebRTCInitialize.mockRejectedValue(new Error('transient'));
+      const opts = makeOptions({
+        enableFallback: false,
+        websocketUrl: '',
+        maxRetries: 2,
+        retryBaseDelayMs: 1,
+      });
+      const manager = new ConnectionFallbackManager(opts);
+
+      await expect(manager.initialize()).rejects.toMatchObject({
+        code: ConnectionErrorCode.RETRY_EXHAUSTED,
+      });
+      // 1 initial + 2 retries = 3 attempts.
+      expect(mockWebRTCInitialize).toHaveBeenCalledTimes(3);
+      // Each failed attempt surfaces to onError.
+      expect(opts.events.onError.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('recovers on a later attempt without bubbling', async () => {
+      // Fail twice then succeed.
+      mockWebRTCInitialize
+        .mockRejectedValueOnce(new Error('first'))
+        .mockRejectedValueOnce(new Error('second'))
+        .mockResolvedValueOnce(undefined);
+      const opts = makeOptions({
+        maxRetries: 3,
+        retryBaseDelayMs: 1,
+      });
+      const manager = new ConnectionFallbackManager(opts);
+
+      const type = await manager.initialize();
+      expect(type).toBe('webrtc');
+      expect(mockWebRTCInitialize).toHaveBeenCalledTimes(3);
+      expect(opts.events.onConnectionTypeChange).toHaveBeenCalledWith('webrtc');
+    });
+
+    it('exponential backoff uses base * 2^attempt', async () => {
+      // Spy setTimeout to capture requested delays without actually waiting.
+      const delays: number[] = [];
+      const origSetTimeout = setTimeout;
+      jest
+        .spyOn(global, 'setTimeout')
+        .mockImplementation(((cb: TimerHandler, ms?: number) => {
+          if (typeof ms === 'number' && ms > 0) delays.push(ms);
+          return origSetTimeout(cb, ms ?? 0);
+        }) as typeof setTimeout);
+
+      mockWebRTCInitialize.mockRejectedValue(new Error('x'));
+      const opts = makeOptions({
+        enableFallback: false,
+        websocketUrl: '',
+        maxRetries: 2,
+        retryBaseDelayMs: 10,
+      });
+      const manager = new ConnectionFallbackManager(opts);
+      await expect(manager.initialize()).rejects.toThrow();
+
+      // Delays should be 10 (attempt 0) and 20 (attempt 1).
+      expect(delays).toContain(10);
+      expect(delays).toContain(20);
+      jest.restoreAllMocks();
+    });
+
+    it('surfaces the underlying cause when retries exhausted', async () => {
+      const underlying = new Error('ICE_TIMEOUT');
+      mockWebRTCInitialize.mockRejectedValue(underlying);
+      const opts = makeOptions({
+        enableFallback: false,
+        websocketUrl: '',
+        maxRetries: 1,
+      });
+      const manager = new ConnectionFallbackManager(opts);
+
+      try {
+        await manager.initialize();
+        fail('expected initialize to reject');
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConnectionError);
+        const err = e as ConnectionError;
+        expect(err.code).toBe(ConnectionErrorCode.RETRY_EXHAUSTED);
+        expect(err.cause).toBeInstanceOf(Error);
+        expect((err.cause as Error).message).toContain('ICE_TIMEOUT');
+      }
+    });
+
+    it('cleans up partially-initialised WebRTC connection before retry', async () => {
+      mockWebRTCInitialize.mockRejectedValue(new Error('x'));
+      const opts = makeOptions({
+        enableFallback: false,
+        websocketUrl: '',
+        maxRetries: 1,
+      });
+      const manager = new ConnectionFallbackManager(opts);
+      await expect(manager.initialize()).rejects.toThrow();
+      // close() should have been called for each failed attempt's cleanup.
+      expect(mockWebRTCClose).toHaveBeenCalled();
+    });
+  });
+
+  // --- connectWebSocket — failure modes ---------------------------------
+
+  describe('connectWebSocket — failure modes', () => {
+    it('throws WEBSOCKET_UNAVAILABLE when WS reports unavailable mid-flow', async () => {
+      // connectWebSocket's unavailable check is only reachable via the
+      // fallback paths (initialize bails earlier with NO_CONNECTION_METHOD).
+      // Establish a WebRTC connection, then make WS report unavailable and
+      // call forceFallback — connectWebSocket should throw
+      // WEBSOCKET_UNAVAILABLE.
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+      await manager.initialize(); // WebRTC succeeds
+      mockIsWebSocketAvailable.mockReturnValue(false);
+      await expect(manager.forceFallback()).rejects.toMatchObject({
+        code: ConnectionErrorCode.WEBSOCKET_UNAVAILABLE,
+      });
+    });
+
+    it('throws WEBSOCKET_FAILED when connect() rejects', async () => {
+      mockWSConnect.mockRejectedValue(new Error('ECONNREFUSED'));
+      const opts = makeOptions({ preferWebSocket: true });
+      const manager = new ConnectionFallbackManager(opts);
+
+      try {
+        await manager.initialize();
+        fail('expected initialize to reject');
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConnectionError);
+        const err = e as ConnectionError;
+        expect(err.code).toBe(ConnectionErrorCode.WEBSOCKET_FAILED);
+        expect(err.cause).toBeInstanceOf(Error);
+        expect((err.cause as Error).message).toContain('ECONNREFUSED');
+      }
+      // WS failure surfaces via onError too.
+      expect(opts.events.onError).toHaveBeenCalled();
+    });
+
+    it('throws WEBSOCKET_FAILED for non-Error rejection payloads', async () => {
+      mockWSConnect.mockRejectedValue('string error');
+      const opts = makeOptions({ preferWebSocket: true });
+      const manager = new ConnectionFallbackManager(opts);
+
+      await expect(manager.initialize()).rejects.toMatchObject({
+        code: ConnectionErrorCode.WEBSOCKET_FAILED,
+      });
+    });
+
+    it('tears down half-constructed socket on failure so retries are clean', async () => {
+      mockWSConnect.mockRejectedValue(new Error('boom'));
+      const opts = makeOptions({ preferWebSocket: true });
+      const manager = new ConnectionFallbackManager(opts);
+      await expect(manager.initialize()).rejects.toThrow();
+      expect(mockWSDisconnect).toHaveBeenCalled();
+    });
+  });
+
+  // --- connectWithFallback — fallback behaviour -------------------------
+
+  describe('connectWithFallback — fallback orchestration', () => {
+    it('succeeds via WebRTC when it connects first', async () => {
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+      const type = await manager.initialize();
+      expect(type).toBe('webrtc');
+      // Fallback timer should have been cleared.
+      expect(mockWSConnect).not.toHaveBeenCalled();
+    });
+
+    it('falls back to WebSocket when WebRTC fails', async () => {
+      mockWebRTCInitialize.mockRejectedValue(new Error('webrtc down'));
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+
+      const type = await manager.initialize();
+      expect(type).toBe('websocket');
+      expect(mockWSConnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to WebSocket after fallback timeout elapses', async () => {
+      // WebRTC hangs forever; the timer should fire and force a fallback.
+      mockWebRTCInitialize.mockImplementation(
+        () => new Promise(() => {}),
+      );
+      const opts = makeOptions({ fallbackTimeout: 20 });
+      const manager = new ConnectionFallbackManager(opts);
+
+      const type = await manager.initialize();
+      expect(type).toBe('websocket');
+    });
+
+    it('rejects with BOTH_FAILED when WebRTC and WS both fail', async () => {
+      mockWebRTCInitialize.mockRejectedValue(new Error('rtc down'));
+      mockWSConnect.mockRejectedValue(new Error('ws down'));
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+
+      try {
+        await manager.initialize();
+        fail('expected initialize to reject');
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConnectionError);
+        const err = e as ConnectionError;
+        expect(err.code).toBe(ConnectionErrorCode.BOTH_FAILED);
+        // Cause chain should reference the WS failure.
+        expect(err.cause).toBeInstanceOf(ConnectionError);
+        expect((err.cause as ConnectionError).code).toBe(
+          ConnectionErrorCode.WEBSOCKET_FAILED,
+        );
+      }
+    });
+
+    it('rejects cleanly with WEBRTC_FAILED when fallback is disabled', async () => {
+      mockWebRTCInitialize.mockRejectedValue(new Error('rtc down'));
+      const opts = makeOptions({ enableFallback: false });
+      const manager = new ConnectionFallbackManager(opts);
+
+      await expect(manager.initialize()).rejects.toMatchObject({
+        code: ConnectionErrorCode.WEBRTC_FAILED,
+      });
+      expect(mockWSConnect).not.toHaveBeenCalled();
+    });
+
+    it('clears the fallback timer when WebRTC wins the race', async () => {
+      const opts = makeOptions({ fallbackTimeout: 5000 });
+      const manager = new ConnectionFallbackManager(opts);
+      const type = await manager.initialize();
+      expect(type).toBe('webrtc');
+      // Wait past where the timer would have fired; WS must not be invoked.
+      await flushTimers(10);
+      expect(mockWSConnect).not.toHaveBeenCalled();
+    });
+
+    it('does not double-settle when WebRTC fails after fallback succeeds', async () => {
+      // WebRTC hangs, fallback timer fires WS which succeeds, then WebRTC
+      // eventually rejects. The promise must resolve exactly once with WS.
+      let rejectWebRTC: (err: Error) => void = () => {};
+      mockWebRTCInitialize.mockImplementation(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectWebRTC = reject;
+          }),
+      );
+      const opts = makeOptions({ fallbackTimeout: 10 });
+      const manager = new ConnectionFallbackManager(opts);
+
+      const resultPromise = manager.initialize();
+      await flushTimers(20); // let timer fire and WS succeed
+      rejectWebRTC(new Error('late failure'));
+
+      const type = await resultPromise;
+      expect(type).toBe('websocket');
+      // onConnectionTypeChange should be called for WS exactly once.
+      const typeChanges = opts.events.onConnectionTypeChange.mock.calls.filter(
+        (c) => c[0] === 'websocket',
+      );
+      expect(typeChanges.length).toBe(1);
+    });
+
+    it('never produces an unhandled rejection on WebRTC path', async () => {
+      // Sanity check: errors flow through onError and the rejection.
+      mockWebRTCInitialize.mockRejectedValue(new Error('x'));
+      mockWSConnect.mockRejectedValue(new Error('y'));
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+      // Capture unhandled rejections during this test.
+      const unhandled: unknown[] = [];
+      const handler = (reason: unknown) => unhandled.push(reason);
+      process.on('unhandledRejection', handler);
+      try {
+        await expect(manager.initialize()).rejects.toThrow();
+        await flushTimers(10);
+      } finally {
+        process.off('unhandledRejection', handler);
+      }
+      expect(unhandled).toHaveLength(0);
+    });
+  });
+
+  // --- forceFallback() ----------------------------------------------------
+
+  describe('forceFallback()', () => {
+    it('is a no-op when already on WebSocket', async () => {
+      const opts = makeOptions({ preferWebSocket: true });
+      const manager = new ConnectionFallbackManager(opts);
+      await manager.initialize();
+      mockWSConnect.mockClear();
+      await manager.forceFallback();
+      expect(mockWSConnect).not.toHaveBeenCalled();
+    });
+
+    it('throws ConnectionError(WEBSOCKET_FAILED) when the WS fails', async () => {
+      // First connect via WebRTC.
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+      await manager.initialize();
+
+      mockWSConnect.mockRejectedValue(new Error('no relay'));
+      await expect(manager.forceFallback()).rejects.toMatchObject({
+        code: ConnectionErrorCode.WEBSOCKET_FAILED,
+      });
+      expect(opts.events.onError).toHaveBeenCalled();
+    });
+
+    it('closes the WebRTC connection during forceFallback', async () => {
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+      await manager.initialize();
+      mockWebRTCClose.mockClear();
+      await manager.forceFallback();
+      expect(mockWebRTCClose).toHaveBeenCalled();
+    });
+  });
+
+  // --- attemptFallback (private path, via state 'failed' event) ---------
+
+  describe('attemptFallback — auto-fallback from WebRTC failed state', () => {
+    it('catches WS failures and surfaces them via onError without throwing', async () => {
+      mockWebRTCInitialize.mockImplementation(async () => {
+        // Simulate the WebRTC connection reporting a 'failed' state after
+        // initialisation by triggering the fallback path manually via
+        // the public forceFallback() entry point.
+      });
+      mockWSConnect.mockRejectedValue(new Error('ws down'));
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+      await manager.initialize(); // WebRTC succeeds
+      // Force fallback to a broken WS — should not throw out of the
+      // auto-fallback code path; we use forceFallback which DOES throw,
+      // so verify the host receives a typed error.
+      await expect(manager.forceFallback()).rejects.toMatchObject({
+        code: ConnectionErrorCode.WEBSOCKET_FAILED,
+      });
+      const calls = opts.events.onError.mock.calls;
+      const last = calls[calls.length - 1][0];
+      expect(last).toBeInstanceOf(ConnectionError);
+      expect(last.code).toBe(ConnectionErrorCode.WEBSOCKET_FAILED);
+    });
+  });
+
+  // --- send* methods (graceful degradation) ------------------------------
+
+  describe('send* methods — graceful degradation', () => {
+    it('send() catches transport throw and routes via onError', () => {
+      mockWebRTCSend.mockImplementation(() => {
+        throw new Error('data channel closed');
+      });
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+      // Establish WebRTC first.
+      return manager
+        .initialize()
+        .then(() => {
+          const msg: P2PMessage = {
+            type: 'chat',
+            senderId: 'p1',
+            timestamp: Date.now(),
+            payload: { text: 'hi' },
+          };
+          expect(() => manager.send(msg)).not.toThrow();
+          expect(opts.events.onError).toHaveBeenCalled();
+          const err = opts.events.onError.mock.calls[
+            opts.events.onError.mock.calls.length - 1
+          ][0];
+          expect(err).toBeInstanceOf(ConnectionError);
+          expect(err.code).toBe(ConnectionErrorCode.SEND_FAILED);
+        });
+    });
+
+    it('sendGameState() catches transport throw', async () => {
+      mockWSSendGameState.mockImplementation(() => {
+        throw new Error('socket gone');
+      });
+      const opts = makeOptions({ preferWebSocket: true });
+      const manager = new ConnectionFallbackManager(opts);
+      await manager.initialize();
+      const gs = { players: [] } as unknown as GameState;
+      expect(() => manager.sendGameState(gs, true)).not.toThrow();
+      const calls = opts.events.onError.mock.calls;
+      const last = calls[calls.length - 1][0];
+      expect(last.code).toBe(ConnectionErrorCode.SEND_FAILED);
+    });
+
+    it('sendPlayerAction/sendChat/sendEmote all swallow throws', async () => {
+      const opts = makeOptions({ preferWebSocket: true });
+      const manager = new ConnectionFallbackManager(opts);
+      await manager.initialize();
+
+      mockWSSendPlayerAction.mockImplementation(() => {
+        throw new Error('x');
+      });
+      mockWSSendChat.mockImplementation(() => {
+        throw new Error('x');
+      });
+      mockWSSendEmote.mockImplementation(() => {
+        throw new Error('x');
+      });
+
+      expect(() => manager.sendPlayerAction('pass', null)).not.toThrow();
+      expect(() => manager.sendChat('hi')).not.toThrow();
+      expect(() => manager.sendEmote('wave')).not.toThrow();
+
+      // Three SEND_FAILED errors should have surfaced.
+      const sendErrors = opts.events.onError.mock.calls
+        .map((c) => c[0])
+        .filter(
+          (e) =>
+            e instanceof ConnectionError &&
+            e.code === ConnectionErrorCode.SEND_FAILED,
+        );
+      expect(sendErrors.length).toBe(3);
+    });
+
+    it('send() with no active connection logs a warning (no throw)', () => {
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+      expect(() =>
+        manager.send({
+          type: 'chat',
+          senderId: 'p',
+          timestamp: Date.now(),
+          payload: { text: 'x' },
+        }),
+      ).not.toThrow();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('No active connection'),
+      );
+    });
+  });
+
+  // --- isConnected / disconnect / cleanup --------------------------------
+
+  describe('isConnected() / disconnect() — defensive', () => {
+    it('isConnected() returns false when no active connection', () => {
+      const manager = new ConnectionFallbackManager(makeOptions());
+      expect(manager.isConnected()).toBe(false);
+    });
+
+    it('isConnected() swallows throw from the transport', async () => {
+      mockWebRTCIsConnected.mockImplementation(() => {
+        throw new Error('wut');
+      });
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+      await manager.initialize();
+      expect(manager.isConnected()).toBe(false);
+      expect(consoleWarnSpy).toHaveBeenCalled();
+    });
+
+    it('disconnect() clears timers and closes both transports', async () => {
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+      await manager.initialize();
+      manager.disconnect();
+      expect(mockWebRTCClose).toHaveBeenCalled();
+      expect(opts.events.onConnectionStateChange).toHaveBeenCalled();
+      const lastState = opts.events.onConnectionStateChange.mock.calls[
+        opts.events.onConnectionStateChange.mock.calls.length - 1
+      ][0];
+      expect(lastState.activeConnection).toBe('none');
+    });
+
+    it('cleanup helpers swallow close() failures', async () => {
+      mockWebRTCClose.mockImplementation(() => {
+        throw new Error('close failed');
+      });
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+      await manager.initialize();
+      expect(() => manager.disconnect()).not.toThrow();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('cleanup'),
+        expect.any(String),
+      );
+    });
+  });
+
+  // --- #982 redaction preservation --------------------------------------
+
+  describe('#982 redaction preservation', () => {
+    it('WebRTC failures log redacted error (no session ID leak)', async () => {
+      // Build an error whose message embeds a host-style session ID.
+      const sessionId = 'host-1700000000000-abc12345';
+      mockWebRTCInitialize.mockRejectedValue(new Error(`ICE fail for ${sessionId}`));
+      const opts = makeOptions({ enableFallback: false, websocketUrl: '' });
+      const manager = new ConnectionFallbackManager(opts);
+
+      await expect(manager.initialize()).rejects.toThrow();
+      // Locate the WebRTC failure log.
+      const calls = consoleErrorSpy.mock.calls;
+      const flat = JSON.stringify(calls);
+      expect(flat).not.toContain(sessionId);
+      expect(flat).toContain('[REDACTED_SESSION]');
+    });
+
+    it('WebSocket failures log redacted error', async () => {
+      const sessionId = 'host-1700000000000-abc12345';
+      mockWSConnect.mockRejectedValue(
+        new Error(`WS handshake failed for ${sessionId}`),
+      );
+      const opts = makeOptions({ preferWebSocket: true });
+      const manager = new ConnectionFallbackManager(opts);
+
+      await expect(manager.initialize()).rejects.toThrow();
+      const flat = JSON.stringify(consoleErrorSpy.mock.calls);
+      expect(flat).not.toContain(sessionId);
+      expect(flat).toContain('[REDACTED_SESSION]');
+    });
+
+    it('send() failures log redacted error', async () => {
+      const sessionId = 'host-1700000000000-abc12345';
+      mockWebRTCSend.mockImplementation(() => {
+        throw new Error(`channel closed for ${sessionId}`);
+      });
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+      await manager.initialize();
+      manager.send({
+        type: 'chat',
+        senderId: 'p',
+        timestamp: Date.now(),
+        payload: { text: 'hi' },
+      });
+      const flat = JSON.stringify(consoleErrorSpy.mock.calls);
+      expect(flat).not.toContain(sessionId);
+      expect(flat).toContain('[REDACTED_SESSION]');
+    });
+  });
+
+  // --- State machine: every error updates lastError ----------------------
+
+  describe('state machine — lastError tracking', () => {
+    it('updates lastError on every failure path', async () => {
+      mockWSConnect.mockRejectedValue(new Error('boom'));
+      const opts = makeOptions({ preferWebSocket: true });
+      const manager = new ConnectionFallbackManager(opts);
+      await expect(manager.initialize()).rejects.toThrow();
+      expect(manager.getState().lastError).toBeTruthy();
+      expect(manager.getState().lastError).toContain('WebSocket');
+    });
+
+    it('onError always receives Error instances (never strings)', async () => {
+      mockWSConnect.mockRejectedValue('string error');
+      const opts = makeOptions({ preferWebSocket: true });
+      const manager = new ConnectionFallbackManager(opts);
+      await expect(manager.initialize()).rejects.toThrow();
+      for (const call of opts.events.onError.mock.calls) {
+        expect(call[0]).toBeInstanceOf(Error);
+      }
+    });
+  });
+
+  // --- Factory + availability helpers ------------------------------------
+
+  describe('module exports', () => {
+    it('createConnectionFallbackManager returns a manager instance', () => {
+      const manager = createConnectionFallbackManager(makeOptions());
+      expect(manager).toBeInstanceOf(ConnectionFallbackManager);
+    });
+
+    it('isConnectionAvailable returns true when WebRTC global exists', () => {
+      enableWebRTCGlobal();
+      expect(isConnectionAvailable()).toBe(true);
+    });
+
+    it('isConnectionAvailable returns true when only WS is available', () => {
+      disableWebRTCGlobal();
+      mockIsWebSocketAvailable.mockReturnValue(true);
+      expect(isConnectionAvailable()).toBe(true);
+    });
+
+    it('isConnectionAvailable returns false when neither is available', () => {
+      disableWebRTCGlobal();
+      mockIsWebSocketAvailable.mockReturnValue(false);
+      expect(isConnectionAvailable()).toBe(false);
+    });
+  });
+
+  // --- Coverage of branch combinations -----------------------------------
+
+  describe('branch coverage — degenerate inputs', () => {
+    it('handles non-Error rejections from initialize() top-level net', async () => {
+      // Throw a non-Error from the constructor to bypass typed paths.
+      mockWebRTCConstructor.mockImplementation(() => {
+        // Throw a non-Error value — must still be wrapped safely.
+        throw 'string thrown';
+      });
+      const opts = makeOptions({ enableFallback: false, websocketUrl: '' });
+      const manager = new ConnectionFallbackManager(opts);
+      await expect(manager.initialize()).rejects.toBeInstanceOf(ConnectionError);
+    });
+
+    it('forceFallback resets fallbackAttempted so re-forcing works', async () => {
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+      await manager.initialize();
+      // After first forceFallback (which would go to WS), forcing again is
+      // a no-op because we're already on WS — but the reset ensures it
+      // doesn't bail on the fallbackAttempted guard inside connectWebSocket.
+      await manager.forceFallback();
+      expect(mockWSConnect).toHaveBeenCalled();
+    });
+
+    it('attemptFallback (via state) is a no-op once fallbackAttempted', async () => {
+      // Indirect: after a successful fallback via initialize, forcing
+      // fallback again should not re-trigger another connectWebSocket.
+      mockWebRTCInitialize.mockRejectedValue(new Error('rtc down'));
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+      const type = await manager.initialize();
+      expect(type).toBe('websocket');
+      const firstCount = mockWSConnect.mock.calls.length;
+      await manager.forceFallback(); // already on websocket — no-op
+      expect(mockWSConnect.mock.calls.length).toBe(firstCount);
+    });
+  });
+});

--- a/src/lib/connection-fallback.ts
+++ b/src/lib/connection-fallback.ts
@@ -1,9 +1,17 @@
 /**
  * Connection Fallback Manager
  * Issue #304: Add WebSocket fallback for non-P2P scenarios
- * 
+ * Issue #985: Comprehensive error handling for async methods
+ *
  * This module provides automatic fallback from WebRTC P2P to WebSocket
  * when direct peer-to-peer connections cannot be established.
+ *
+ * #985 — Every async method is wrapped in try/catch, failures are surfaced
+ * to the host application via the `onError` event callback, and structured
+ * {@link ConnectionError} instances (carrying a stable {@link ConnectionErrorCode})
+ * are thrown so callers can branch on failure mode. Transient WebRTC failures
+ * are retried with exponential backoff. The redaction added by #982 is
+ * preserved on every diagnostic log call.
  */
 
 import { WebRTCConnection, type P2PConnectionState, type P2PMessage, type P2PEvents } from './webrtc-p2p';
@@ -22,6 +30,59 @@ import { redactSensitive } from './p2p-log-redact';
  * Connection type
  */
 export type ConnectionType = 'webrtc' | 'websocket' | 'none';
+
+/**
+ * Structured failure codes for the connection state machine (#985).
+ *
+ * Callers can `instanceof ConnectionError` + switch on `code` to react to
+ * distinct failure modes (retry WebRTC, surface a "network down" banner,
+ * disable the join button, etc.).
+ */
+export enum ConnectionErrorCode {
+  /** ICE negotiation failed or the peer connection never opened. */
+  ICE_FAILED = 'ICE_FAILED',
+  /** WebRTC connection failed (initialization, data channel, or retries exhausted). */
+  WEBRTC_FAILED = 'WEBRTC_FAILED',
+  /** WebRTC is not available in this environment (e.g. no `RTCPeerConnection`). */
+  WEBRTC_UNAVAILABLE = 'WEBRTC_UNAVAILABLE',
+  /** The WebSocket transport failed (`new WebSocket(...)` or `connect()` rejected). */
+  WEBSOCKET_FAILED = 'WEBSOCKET_FAILED',
+  /** No `websocketUrl` was configured or `isWebSocketAvailable()` returned false. */
+  WEBSOCKET_UNAVAILABLE = 'WEBSOCKET_UNAVAILABLE',
+  /** A connection attempt exceeded its configured timeout. */
+  TIMEOUT = 'TIMEOUT',
+  /** Neither WebRTC nor WebSocket is available. */
+  NO_CONNECTION_METHOD = 'NO_CONNECTION_METHOD',
+  /** Both WebRTC and WebSocket were tried and neither connected. */
+  BOTH_FAILED = 'BOTH_FAILED',
+  /** The retry budget for a transient failure was exhausted. */
+  RETRY_EXHAUSTED = 'RETRY_EXHAUSTED',
+  /** A `send*` call could not be delivered because the active transport threw. */
+  SEND_FAILED = 'SEND_FAILED',
+}
+
+/**
+ * Typed connection error. Carries a stable {@link ConnectionErrorCode} and,
+ * when chained from an underlying transport error, the original `cause`
+ * (preserved verbatim — never reaches `console.*` without going through
+ * {@link redactSensitive} first).
+ */
+export class ConnectionError extends Error {
+  readonly code: ConnectionErrorCode;
+  readonly cause?: Error;
+
+  constructor(code: ConnectionErrorCode, message: string, cause?: Error) {
+    super(message);
+    this.name = 'ConnectionError';
+    this.code = code;
+    if (cause) {
+      this.cause = cause;
+    }
+    // Restore prototype chain across transpilation targets — required for
+    // `instanceof ConnectionError` to work on ES5 targets.
+    Object.setPrototypeOf(this, ConnectionError.prototype);
+  }
+}
 
 /**
  * Connection fallback state
@@ -65,7 +126,22 @@ export interface ConnectionFallbackOptions {
   enableFallback?: boolean;
   /** Prefer WebSocket over WebRTC */
   preferWebSocket?: boolean;
+  /**
+   * Maximum number of WebRTC retry attempts after the initial failure
+   * before bubbling the error up (#985). Defaults to 0 to preserve the
+   * pre-#985 single-attempt behaviour; set to ≥1 to enable retry/backoff.
+   */
+  maxRetries?: number;
+  /**
+   * Base delay (ms) for exponential backoff between WebRTC retries
+   * (#985). Actual delay is `retryBaseDelayMs * 2^attempt`. Defaults
+   * to 1000ms; tests usually set this to a small value to run fast.
+   */
+  retryBaseDelayMs?: number;
 }
+
+/** Default backoff base delay for {@link ConnectionFallbackOptions.retryBaseDelayMs}. */
+const DEFAULT_RETRY_BASE_DELAY_MS = 1000;
 
 /**
  * Connection Fallback Manager
@@ -89,6 +165,8 @@ export class ConnectionFallbackManager {
       fallbackTimeout: options.fallbackTimeout ?? TIMEOUTS.P2P_FALLBACK_TIMEOUT_MS,
       enableFallback: options.enableFallback ?? true,
       preferWebSocket: options.preferWebSocket ?? false,
+      maxRetries: options.maxRetries ?? 0,
+      retryBaseDelayMs: options.retryBaseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS,
     };
 
     this.state = {
@@ -102,105 +180,235 @@ export class ConnectionFallbackManager {
   }
 
   /**
-   * Initialize the connection with automatic fallback
+   * Initialize the connection with automatic fallback.
+   *
+   * #985: every branch is wrapped in try/catch; failures surface to the
+   * caller as {@link ConnectionError} and to the host via `onError`.
    */
   async initialize(): Promise<ConnectionType> {
-    // If WebSocket is preferred or WebRTC is not available, start with WebSocket
-    if (this.options.preferWebSocket || !this.isWebRTCAvailable()) {
-      if (isWebSocketAvailable() && this.options.websocketUrl) {
-        return this.connectWebSocket();
-      }
-      throw new Error('No connection method available');
-    }
-
-    // Try WebRTC first with fallback to WebSocket
     try {
-      return await this.connectWithFallback();
+      // If WebSocket is preferred or WebRTC is not available, start with WebSocket
+      if (this.options.preferWebSocket || !this.isWebRTCAvailable()) {
+        if (isWebSocketAvailable() && this.options.websocketUrl) {
+          return await this.connectWebSocket();
+        }
+        const err = new ConnectionError(
+          ConnectionErrorCode.NO_CONNECTION_METHOD,
+          'No connection method available',
+        );
+        this.recordError(err);
+        throw err;
+      }
+
+      // Try WebRTC first with fallback to WebSocket
+      try {
+        return await this.connectWithFallback();
+      } catch (error) {
+        if (error instanceof ConnectionError) {
+          throw error;
+        }
+        const wrapped = new ConnectionError(
+          ConnectionErrorCode.WEBRTC_FAILED,
+          `Failed to establish connection: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          error instanceof Error ? error : undefined,
+        );
+        this.recordError(wrapped);
+        throw wrapped;
+      }
     } catch (error) {
-      throw new Error(`Failed to establish connection: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      // Top-level safety net: never let an unexpected exception escape
+      // untyped or unobserved. Already-typed ConnectionErrors pass through.
+      if (error instanceof ConnectionError) {
+        throw error;
+      }
+      const wrapped = new ConnectionError(
+        ConnectionErrorCode.WEBRTC_FAILED,
+        error instanceof Error ? error.message : String(error),
+        error instanceof Error ? error : undefined,
+      );
+      this.recordError(wrapped);
+      throw wrapped;
     }
   }
 
   /**
-   * Connect with automatic fallback
+   * Connect with automatic fallback (#985).
+   *
+   * Refactored to guarantee:
+   *   - the fallback timer is always cleared on settle (no leaked timers);
+   *   - exactly one of resolve/reject is invoked (no double-settle);
+   *   - unhandled promise rejections cannot escape — every `.then` has a
+   *     paired `.catch` that feeds the central settle path;
+   *   - both-failed cases reject with {@link ConnectionErrorCode.BOTH_FAILED}.
    */
   private connectWithFallback(): Promise<ConnectionType> {
+    // Single-shot race; every async branch terminates via the shared settle
+    // helpers below. Promise executor is synchronous — the inner async work
+    // is kicked off and resolved/rejected through settle{Resolve,Reject}.
     return new Promise<ConnectionType>((resolve, reject) => {
-      let resolved = false;
+      let settled = false;
 
-      // Set up fallback timer
+      const settleResolve = (type: ConnectionType): void => {
+        if (settled) return;
+        settled = true;
+        this.clearFallbackTimer();
+        resolve(type);
+      };
+
+      const settleReject = (err: Error): void => {
+        if (settled) return;
+        settled = true;
+        this.clearFallbackTimer();
+        reject(err);
+      };
+
+      // Try the WebSocket fallback now (or after a delay). Cleans up the
+      // pending WebRTC attempt first to avoid overlapping transports.
+      // Precondition: fallback is enabled & WS is available — callers
+      // (catch handler / fallback timer) check this before invoking.
+      const attemptFallback = (reason: string): void => {
+        if (settled) return;
+        this.clearFallbackTimer();
+        // Mark fallbackAttempted so a late WebRTC failure doesn't retrigger.
+        this.state.fallbackAttempted = true;
+        this.connectWebSocket()
+          .then(settleResolve)
+          .catch((wsError) => {
+            const wrapped =
+              wsError instanceof ConnectionError
+                ? wsError
+                : new ConnectionError(
+                    ConnectionErrorCode.WEBSOCKET_FAILED,
+                    wsError instanceof Error ? wsError.message : String(wsError),
+                    wsError instanceof Error ? wsError : undefined,
+                  );
+            settleReject(
+              new ConnectionError(
+                ConnectionErrorCode.BOTH_FAILED,
+                `WebRTC and WebSocket both failed: ${reason}`,
+                wrapped,
+              ),
+            );
+          });
+      };
+
+      // Set up fallback timer (only when a fallback is possible)
       if (this.options.enableFallback && isWebSocketAvailable() && this.options.websocketUrl) {
         this.fallbackTimer = setTimeout(() => {
-          if (!resolved && this.state.activeConnection !== 'webrtc') {
-            console.info('[ConnectionFallback] WebRTC connection timeout, falling back to WebSocket');
-            this.connectWebSocket()
-              .then((connectionType) => {
-                resolved = true;
-                resolve(connectionType);
-              })
-              .catch((error) => {
-                if (!resolved) {
-                  reject(error);
-                }
-              });
-          }
+          if (settled || this.state.activeConnection === 'webrtc') return;
+          console.info('[ConnectionFallback] WebRTC connection timeout, falling back to WebSocket');
+          attemptFallback('WebRTC connection timed out');
         }, this.options.fallbackTimeout);
       }
 
-      // Try WebRTC connection
+      // Try WebRTC connection. Any rejection is logged with #982 redaction
+      // and surfaced to the host via onError, then routed through the
+      // fallback decision above.
       this.connectWebRTC()
-        .then((connectionType) => {
-          if (this.fallbackTimer) {
-            clearTimeout(this.fallbackTimer);
-            this.fallbackTimer = null;
-          }
-          resolved = true;
-          resolve(connectionType);
-        })
+        .then(settleResolve)
         .catch((error) => {
           // #982: redact — WebRTC connection errors may embed SDP / ICE config.
           console.error('[ConnectionFallback] WebRTC connection failed:', redactSensitive(error));
           this.state.lastError = error instanceof Error ? error.message : 'WebRTC connection failed';
-          
-          // If fallback timer hasn't triggered yet and WebSocket is available
-          if (!resolved && this.options.enableFallback && isWebSocketAvailable() && this.options.websocketUrl) {
-            // Clear the timer and try WebSocket immediately
-            if (this.fallbackTimer) {
-              clearTimeout(this.fallbackTimer);
-              this.fallbackTimer = null;
-            }
+          this.options.events.onError(error instanceof Error ? error : new Error(String(error)));
 
-            this.connectWebSocket()
-              .then((connectionType) => {
-                resolved = true;
-                resolve(connectionType);
-              })
-              .catch((wsError) => {
-                if (!resolved) {
-                  // #982: redact — WS fallback errors may embed server URLs
-                  // carrying session tokens.
-                  console.error('[ConnectionFallback] WebSocket fallback failed:', redactSensitive(wsError));
-                  reject(new Error(`Both WebRTC and WebSocket failed: ${error instanceof Error ? error.message : 'Unknown error'}`));
-                }
-              });
-          } else if (!resolved && !this.options.enableFallback) {
-            reject(error);
+          // If no fallback is possible, bubble the original (already-typed)
+          // error verbatim — this preserves RETRY_EXHAUSTED / WEBRTC_FAILED
+          // for the caller instead of masking it.
+          if (
+            !this.options.enableFallback ||
+            !isWebSocketAvailable() ||
+            !this.options.websocketUrl
+          ) {
+            settleReject(
+              error instanceof Error
+                ? error
+                : new ConnectionError(
+                    ConnectionErrorCode.WEBRTC_FAILED,
+                    String(error),
+                  ),
+            );
+            return;
           }
+
+          attemptFallback(
+            error instanceof Error ? error.message : 'WebRTC connection failed',
+          );
         });
     });
   }
 
   /**
-   * Connect using WebRTC
+   * Connect using WebRTC (#985).
+   *
+   * Wraps the underlying `establishWebRTC` in a retry loop with exponential
+   * backoff for transient failures. After {@link ConnectionFallbackOptions.maxRetries}
+   * retries, throws a typed {@link ConnectionError} with code
+   * {@link ConnectionErrorCode.WEBRTC_FAILED}.
    */
   private async connectWebRTC(): Promise<ConnectionType> {
+    const maxAttempts = 1 + this.options.maxRetries; // initial attempt + retries
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        return await this.establishWebRTC();
+      } catch (error) {
+        lastError = error;
+        // Record the failure so the host can observe intermediate retries.
+        const msg = error instanceof Error ? error.message : String(error);
+        this.state.lastError = msg;
+        // Surface each attempt failure to UI, but keep retrying.
+        this.options.events.onError(
+          new ConnectionError(
+            ConnectionErrorCode.WEBRTC_FAILED,
+            `WebRTC attempt ${attempt + 1}/${maxAttempts} failed: ${msg}`,
+            error instanceof Error ? error : undefined,
+          ),
+        );
+
+        if (attempt < maxAttempts - 1) {
+          // Exponential backoff: base * 2^attempt
+          const delay = this.options.retryBaseDelayMs * Math.pow(2, attempt);
+          try {
+            await this.sleep(delay);
+          } catch {
+            // sleep does not throw in practice; ignore.
+          }
+          continue;
+        }
+      }
+    }
+
+    const message =
+      lastError instanceof Error ? lastError.message : 'Unknown error';
+    throw new ConnectionError(
+      this.options.maxRetries > 0
+        ? ConnectionErrorCode.RETRY_EXHAUSTED
+        : ConnectionErrorCode.WEBRTC_FAILED,
+      `WebRTC connection failed after ${maxAttempts} attempt(s): ${message}`,
+      lastError instanceof Error ? lastError : undefined,
+    );
+  }
+
+  /**
+   * Establish a fresh WebRTC connection (single attempt). Throws on any
+   * failure; {@link connectWebRTC} handles retry/backoff.
+   */
+  private async establishWebRTC(): Promise<ConnectionType> {
     const events: P2PEvents = {
       onConnectionStateChange: (state, _peerId) => {
         this.state.webrtcState = state;
         this.notifyStateChange();
-        
+
         if (state === 'failed' && this.options.enableFallback && !this.state.fallbackAttempted) {
-          this.attemptFallback();
+          this.attemptFallback().catch((err) => {
+            // Already logged inside attemptFallback; suppress unhandled rejection.
+            console.error(
+              '[ConnectionFallback] Unhandled error in auto-fallback:',
+              redactSensitive(err),
+            );
+          });
         }
       },
       onMessage: (message, _peerId) => {
@@ -246,38 +454,58 @@ export class ConnectionFallbackManager {
       },
     };
 
-    this.webrtcConnection = new WebRTCConnection({
-      playerId: this.options.playerId,
-      playerName: this.options.playerName,
-      isHost: this.options.isHost,
-      gameCode: this.options.gameCode,
-      rtcConfig: this.options.webrtcConfig,
-      events,
-    });
+    try {
+      this.webrtcConnection = new WebRTCConnection({
+        playerId: this.options.playerId,
+        playerName: this.options.playerName,
+        isHost: this.options.isHost,
+        gameCode: this.options.gameCode,
+        rtcConfig: this.options.webrtcConfig,
+        events,
+      });
 
-    await this.webrtcConnection.initialize();
-    this.state.activeConnection = 'webrtc';
-    this.notifyStateChange();
-    this.options.events.onConnectionTypeChange('webrtc');
+      await this.webrtcConnection.initialize();
+      this.state.activeConnection = 'webrtc';
+      this.notifyStateChange();
+      this.options.events.onConnectionTypeChange('webrtc');
 
-    return 'webrtc';
+      return 'webrtc';
+    } catch (error) {
+      // Clean up partially-initialised connection so a retry starts clean.
+      this.cleanupWebRTC();
+      // #982: redact — underlying errors may embed SDP / ICE config.
+      console.error(
+        '[ConnectionFallback] WebRTC establishment failed:',
+        redactSensitive(error),
+      );
+      throw error instanceof Error
+        ? error
+        : new Error(String(error));
+    }
   }
 
   /**
-   * Connect using WebSocket
+   * Connect using WebSocket (#985).
+   *
+   * Surfaces connect failures as {@link ConnectionError} with codes
+   * {@link ConnectionErrorCode.WEBSOCKET_UNAVAILABLE} or
+   * {@link ConnectionErrorCode.WEBSOCKET_FAILED}.
    */
   private async connectWebSocket(): Promise<ConnectionType> {
     if (!isWebSocketAvailable() || !this.options.websocketUrl) {
-      throw new Error('WebSocket is not available');
+      throw new ConnectionError(
+        ConnectionErrorCode.WEBSOCKET_UNAVAILABLE,
+        'WebSocket is not available',
+      );
     }
 
     const events: WebSocketEvents = {
       onConnectionStateChange: (state) => {
         this.state.websocketState = state;
         this.notifyStateChange();
-        
+
         if (state === 'failed') {
-          this.options.events.onError(new Error('WebSocket connection failed'));
+          this.recordError(new Error('WebSocket connection failed'));
         }
       },
       onMessage: (message) => {
@@ -287,9 +515,7 @@ export class ConnectionFallbackManager {
         this.options.events.onGameStateSync(gameState);
       },
       onError: (error) => {
-        this.state.lastError = error.message;
-        this.notifyStateChange();
-        this.options.events.onError(error);
+        this.recordError(error);
       },
       onPlayerJoined: (playerId, playerName) => {
         this.options.events.onPeerConnected(playerId, playerName);
@@ -304,8 +530,25 @@ export class ConnectionFallbackManager {
       autoReconnect: true,
     };
 
-    this.websocketConnection = new WebSocketConnection(config, events);
-    await this.websocketConnection.connect();
+    try {
+      this.websocketConnection = new WebSocketConnection(config, events);
+      await this.websocketConnection.connect();
+    } catch (error) {
+      // Tear down the half-constructed socket so callers can retry cleanly.
+      this.cleanupWebSocket();
+      // #982: redact — WS fallback errors may embed server URLs carrying session tokens.
+      console.error(
+        '[ConnectionFallback] WebSocket connection failed:',
+        redactSensitive(error),
+      );
+      const wrapped = new ConnectionError(
+        ConnectionErrorCode.WEBSOCKET_FAILED,
+        `WebSocket connection failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        error instanceof Error ? error : undefined,
+      );
+      this.recordError(wrapped);
+      throw wrapped;
+    }
 
     this.state.activeConnection = 'websocket';
     this.state.fallbackAttempted = true;
@@ -316,7 +559,11 @@ export class ConnectionFallbackManager {
   }
 
   /**
-   * Attempt fallback to WebSocket
+   * Attempt fallback to WebSocket (#985).
+   *
+   * Surfaces failures via `onError`. Never throws to the caller of an
+   * auto-fallback (it's invoked from event handlers); explicit
+   * {@link forceFallback} surfaces the typed error.
    */
   private async attemptFallback(): Promise<void> {
     if (this.state.fallbackAttempted) {
@@ -327,18 +574,22 @@ export class ConnectionFallbackManager {
     this.state.fallbackAttempted = true;
 
     // Clean up WebRTC connection
-    if (this.webrtcConnection) {
-      this.webrtcConnection.close();
-      this.webrtcConnection = null;
-    }
+    this.cleanupWebRTC();
 
     try {
       await this.connectWebSocket();
     } catch (error) {
       // #982: redact — fallback errors may embed WS URLs / session tokens.
       console.error('[ConnectionFallback] Fallback to WebSocket failed:', redactSensitive(error));
-      this.state.lastError = error instanceof Error ? error.message : 'Fallback failed';
-      this.notifyStateChange();
+      const wrapped =
+        error instanceof ConnectionError
+          ? error
+          : new ConnectionError(
+              ConnectionErrorCode.WEBSOCKET_FAILED,
+              error instanceof Error ? error.message : String(error),
+              error instanceof Error ? error : undefined,
+            );
+      this.recordError(wrapped);
     }
   }
 
@@ -357,62 +608,158 @@ export class ConnectionFallbackManager {
   }
 
   /**
-   * Send a message through the active connection
+   * Record an error in the shared state and notify the host (#985).
+   * Centralises the "set lastError + onError" pattern.
+   */
+  private recordError(error: Error): void {
+    this.state.lastError = error.message;
+    this.notifyStateChange();
+    this.options.events.onError(error);
+  }
+
+  /** Clear the fallback timer if it is pending. */
+  private clearFallbackTimer(): void {
+    if (this.fallbackTimer) {
+      clearTimeout(this.fallbackTimer);
+      this.fallbackTimer = null;
+    }
+  }
+
+  /** Tear down a WebRTC connection (if any), ignoring close() failures. */
+  private cleanupWebRTC(): void {
+    if (!this.webrtcConnection) return;
+    try {
+      this.webrtcConnection.close();
+    } catch (err) {
+      console.warn(
+        '[ConnectionFallback] Error closing WebRTC connection during cleanup:',
+        redactSensitive(err),
+      );
+    }
+    this.webrtcConnection = null;
+  }
+
+  /** Tear down a WebSocket connection (if any), ignoring disconnect() failures. */
+  private cleanupWebSocket(): void {
+    if (!this.websocketConnection) return;
+    try {
+      this.websocketConnection.disconnect();
+    } catch (err) {
+      console.warn(
+        '[ConnectionFallback] Error closing WebSocket connection during cleanup:',
+        redactSensitive(err),
+      );
+    }
+    this.websocketConnection = null;
+  }
+
+  /**
+   * Promise-based delay used for exponential backoff.
+   */
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Send a message through the active connection (#985).
+   *
+   * Synchronous transports can still throw (e.g. data channel in CLOSED
+   * state). We catch, surface via onError, and never re-throw — the state
+   * machine must not crash on a single dropped message.
    */
   send(message: P2PMessage): void {
-    if (this.state.activeConnection === 'webrtc' && this.webrtcConnection) {
-      this.webrtcConnection.send(message);
-    } else if (this.state.activeConnection === 'websocket' && this.websocketConnection) {
-      this.websocketConnection.send(message);
-    } else {
-      console.warn('[ConnectionFallback] No active connection to send message');
+    try {
+      if (this.state.activeConnection === 'webrtc' && this.webrtcConnection) {
+        this.webrtcConnection.send(message);
+      } else if (this.state.activeConnection === 'websocket' && this.websocketConnection) {
+        this.websocketConnection.send(message);
+      } else {
+        console.warn('[ConnectionFallback] No active connection to send message');
+      }
+    } catch (error) {
+      this.recordSendError('send', error);
     }
   }
 
   /**
-   * Send game state through the active connection
+   * Send game state through the active connection (#985).
    */
   sendGameState(gameState: GameState, isFullSync: boolean = false): void {
-    if (this.state.activeConnection === 'webrtc' && this.webrtcConnection) {
-      this.webrtcConnection.sendGameState(gameState, isFullSync);
-    } else if (this.state.activeConnection === 'websocket' && this.websocketConnection) {
-      this.websocketConnection.sendGameState(gameState, isFullSync);
-    } else {
-      console.warn('[ConnectionFallback] No active connection to send game state');
+    try {
+      if (this.state.activeConnection === 'webrtc' && this.webrtcConnection) {
+        this.webrtcConnection.sendGameState(gameState, isFullSync);
+      } else if (this.state.activeConnection === 'websocket' && this.websocketConnection) {
+        this.websocketConnection.sendGameState(gameState, isFullSync);
+      } else {
+        console.warn('[ConnectionFallback] No active connection to send game state');
+      }
+    } catch (error) {
+      this.recordSendError('sendGameState', error);
     }
   }
 
   /**
-   * Send a player action through the active connection
+   * Send a player action through the active connection (#985).
    */
   sendPlayerAction(action: string, data: unknown): void {
-    if (this.state.activeConnection === 'webrtc' && this.webrtcConnection) {
-      this.webrtcConnection.sendPlayerAction(action, data);
-    } else if (this.state.activeConnection === 'websocket' && this.websocketConnection) {
-      this.websocketConnection.sendPlayerAction(action, data);
+    try {
+      if (this.state.activeConnection === 'webrtc' && this.webrtcConnection) {
+        this.webrtcConnection.sendPlayerAction(action, data);
+      } else if (this.state.activeConnection === 'websocket' && this.websocketConnection) {
+        this.websocketConnection.sendPlayerAction(action, data);
+      }
+    } catch (error) {
+      this.recordSendError('sendPlayerAction', error);
     }
   }
 
   /**
-   * Send a chat message through the active connection
+   * Send a chat message through the active connection (#985).
    */
   sendChat(text: string): void {
-    if (this.state.activeConnection === 'webrtc' && this.webrtcConnection) {
-      this.webrtcConnection.sendChat(text);
-    } else if (this.state.activeConnection === 'websocket' && this.websocketConnection) {
-      this.websocketConnection.sendChat(text);
+    try {
+      if (this.state.activeConnection === 'webrtc' && this.webrtcConnection) {
+        this.webrtcConnection.sendChat(text);
+      } else if (this.state.activeConnection === 'websocket' && this.websocketConnection) {
+        this.websocketConnection.sendChat(text);
+      }
+    } catch (error) {
+      this.recordSendError('sendChat', error);
     }
   }
 
   /**
-   * Send an emote through the active connection
+   * Send an emote through the active connection (#985).
    */
   sendEmote(emote: string): void {
-    if (this.state.activeConnection === 'webrtc' && this.webrtcConnection) {
-      this.webrtcConnection.sendEmote(emote);
-    } else if (this.state.activeConnection === 'websocket' && this.websocketConnection) {
-      this.websocketConnection.sendEmote(emote);
+    try {
+      if (this.state.activeConnection === 'webrtc' && this.webrtcConnection) {
+        this.webrtcConnection.sendEmote(emote);
+      } else if (this.state.activeConnection === 'websocket' && this.websocketConnection) {
+        this.websocketConnection.sendEmote(emote);
+      }
+    } catch (error) {
+      this.recordSendError('sendEmote', error);
     }
+  }
+
+  /**
+   * Centralised handler for transport throws during `send*` calls.
+   * Always reports a typed {@link ConnectionError} to the host; never throws.
+   */
+  private recordSendError(method: string, error: unknown): void {
+    // #982: redact — transport errors can carry player/session metadata.
+    console.error(
+      `[ConnectionFallback] ${method} failed:`,
+      redactSensitive(error),
+    );
+    this.recordError(
+      new ConnectionError(
+        ConnectionErrorCode.SEND_FAILED,
+        `${method} failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        error instanceof Error ? error : undefined,
+      ),
+    );
   }
 
   /**
@@ -433,12 +780,21 @@ export class ConnectionFallbackManager {
    * Check if connected
    */
   isConnected(): boolean {
-    if (this.state.activeConnection === 'webrtc') {
-      return this.webrtcConnection?.isConnected() ?? false;
-    } else if (this.state.activeConnection === 'websocket') {
-      return this.websocketConnection?.isConnected() ?? false;
+    try {
+      if (this.state.activeConnection === 'webrtc') {
+        return this.webrtcConnection?.isConnected() ?? false;
+      } else if (this.state.activeConnection === 'websocket') {
+        return this.websocketConnection?.isConnected() ?? false;
+      }
+      return false;
+    } catch (error) {
+      // isConnected is a status check — never let it crash callers.
+      console.warn(
+        '[ConnectionFallback] isConnected() threw:',
+        redactSensitive(error),
+      );
+      return false;
     }
-    return false;
   }
 
   /**
@@ -456,34 +812,42 @@ export class ConnectionFallbackManager {
   }
 
   /**
-   * Force fallback to WebSocket
+   * Force fallback to WebSocket (#985).
+   *
+   * Throws a typed {@link ConnectionError} if the fallback fails — unlike
+   * the auto-fallback path, the caller asked explicitly.
    */
   async forceFallback(): Promise<void> {
     if (this.state.activeConnection === 'websocket') {
       return;
     }
 
-    await this.attemptFallback();
+    try {
+      // Reset fallbackAttempted so attemptFallback actually runs.
+      this.state.fallbackAttempted = false;
+      this.cleanupWebRTC();
+      await this.connectWebSocket();
+    } catch (error) {
+      const wrapped =
+        error instanceof ConnectionError
+          ? error
+          : new ConnectionError(
+              ConnectionErrorCode.WEBSOCKET_FAILED,
+              `forceFallback failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+              error instanceof Error ? error : undefined,
+            );
+      this.recordError(wrapped);
+      throw wrapped;
+    }
   }
 
   /**
    * Disconnect and clean up
    */
   disconnect(): void {
-    if (this.fallbackTimer) {
-      clearTimeout(this.fallbackTimer);
-      this.fallbackTimer = null;
-    }
-
-    if (this.webrtcConnection) {
-      this.webrtcConnection.close();
-      this.webrtcConnection = null;
-    }
-
-    if (this.websocketConnection) {
-      this.websocketConnection.disconnect();
-      this.websocketConnection = null;
-    }
+    this.clearFallbackTimer();
+    this.cleanupWebRTC();
+    this.cleanupWebSocket();
 
     this.state.activeConnection = 'none';
     this.state.webrtcState = null;


### PR DESCRIPTION
## Problem

`connection-fallback.ts`'s async methods (`connectWebRTC`, `connectWebSocket`, `connectWithFallback`, `attemptFallback`, `forceFallback`, `initialize`) throw opaque `Error`s and never propagate failures through the existing `onError` event callback. Unhandled rejections can crash the connection state machine, and callers cannot distinguish ICE failure from WebSocket failure or timeout.

Refs: #985, [`QUICK_WINS_GAPS.md:25-35`](../blob/main/QUICK_WINS_GAPS.md#L25-L35).

## Changes

**`src/lib/connection-fallback.ts`** (+509 / -145)

1. **Typed errors.** New `ConnectionError` class + `ConnectionErrorCode` enum covering the failure modes called out in the issue plus a few structural extras:
   - `ICE_FAILED`, `WEBRTC_FAILED`, `WEBRTC_UNAVAILABLE`
   - `WEBSOCKET_FAILED`, `WEBSOCKET_UNAVAILABLE`
   - `TIMEOUT`, `NO_CONNECTION_METHOD`, `BOTH_FAILED`
   - `RETRY_EXHAUSTED`, `SEND_FAILED`
   - `instanceof ConnectionError` survives transpilation (prototype reset).
2. **Try/catch on every async method.** `initialize` wraps the whole flow plus an outer safety net that converts unexpected throws into `ConnectionError`. `connectWithFallback` refactored into a single-shot race with central `settleResolve`/`settleReject` helpers — guarantees exactly one settle, no leaked timers, no unhandled rejections.
3. **Retry + exponential backoff.** `connectWebRTC` retries transient failures (`maxRetries` option, default 0 to preserve old behaviour) with `retryBaseDelayMs * 2^attempt` and bubbles `RETRY_EXHAUSTED` when the budget runs out. Each attempt cleans up the partial WebRTC connection so retries start fresh.
4. **Errors surfaced to UI.** New private `recordError()` centralises `lastError` + state notification + `onError` callback. Every failure path (initialize, connectWithFallback, connectWebSocket, attemptFallback, forceFallback, send*) routes through it.
5. **Graceful degradation.** `send` / `sendGameState` / `sendPlayerAction` / `sendChat` / `sendEmote` now wrap transport calls in try/catch and route failures through `recordSendError` → `ConnectionError(SEND_FAILED)`. `isConnected()` swallows transport throws. `cleanupWebRTC` / `cleanupWebSocket` swallow `close()` failures so `disconnect()` is robust.
6. **\#982 redaction preserved.** Every `console.{error,warn,info}` call continues to pass its argument through `redactSensitive()`. Tests verify session IDs never leak.

**`src/lib/__tests__/connection-fallback.test.ts`** (new, 938 lines)

50 tests across 11 `describe` blocks covering:
- ConnectionError / ConnectionErrorCode primitives + `instanceof`
- `initialize()` failure modes (no transport, no URL, prefer-WS routing, top-level safety net)
- `connectWebRTC` retry/backoff (default no-retry, `RETRY_EXHAUSTED`, mid-retry recovery, exponential delay timing, cause preservation, cleanup-between-attempts)
- `connectWebSocket` failures (unavailable mid-flow, `WEBSOCKET_FAILED`, non-Error payloads, teardown-on-fail)
- `connectWithFallback` orchestration (WebRTC-wins, fallback-on-fail, timer-driven fallback, `BOTH_FAILED`, no-fallback bubble, timer-clear, no-double-settle, no-unhandled-rejection)
- `forceFallback` (no-op on WS, `WEBSOCKET_FAILED`, WebRTC cleanup)
- `send*` graceful degradation (per-method throw → `SEND_FAILED`, no-connection warning)
- `isConnected` / `disconnect` / cleanup defensive paths
- **\#982 redaction preservation** for WebRTC / WebSocket / send paths
- State-machine `lastError` tracking + onError-receives-Error invariant
- Module exports (`createConnectionFallbackManager`, `isConnectionAvailable`)
- Degenerate-input branch coverage

WebRTC + WebSocket transports are jest-mocked so each failure mode is deterministic and fast (`retryBaseDelayMs: 1`).

## Testing

```bash
npx jest connection-fallback           # 50/50 pass, 1 suite
npx tsc --noEmit                       # 0 errors
./node_modules/.bin/eslint src/lib/connection-fallback.ts \
                            src/lib/__tests__/connection-fallback.test.ts   # 0 errors / 0 warnings
```

Full suite (`npx jest`) — 233 suites pass, no regressions.

## Acceptance Criteria

- [x] All async methods in `connection-fallback.ts` have try/catch
- [x] Errors are surfaced to UI via `onError` callback
- [x] Connection state machine handles all error cases gracefully
- [x] Connection error enum for distinct failure modes (ICE_FAILED, WEBRTC_FAILED, WEBSOCKET_FAILED + extras)
- [x] Retry logic with exponential backoff for transient failures

Closes #985