### PR TITLE
fix: implement infect and toxic keyword combat damage (closes #972)

### DIFF
--- a/src/lib/game-state/__tests__/combat.test.ts
+++ b/src/lib/game-state/__tests__/combat.test.ts
@@ -2758,3 +2758,287 @@ describe("Combat System - Deathtouch and Indestructible (#669)", () => {
     });
   });
 });
+
+// ============================================================
+// Infect and Toxic keyword combat damage (Issue #972)
+// CR 702.93 (Infect): damage to creatures is dealt as -1/-1 counters;
+//   damage to players is dealt as poison counters (no life loss).
+// CR 702.94 (Toxic): a creature with toxic N that deals combat damage
+//   to a player causes that player to get N poison counters IN ADDITION
+//   to the normal damage effects.
+// ============================================================
+describe("Combat System - Infect and Toxic (#972)", () => {
+  function getMinusOneCounters(
+    state: import("../types").GameState,
+    cardId: CardInstanceId,
+  ): number {
+    return (
+      state.cards.get(cardId)?.counters.find((c) => c.type === "-1/-1")
+        ?.count ?? 0
+    );
+  }
+
+  it("infect attacker deals -1/-1 counters (not marked damage) to a blocker (CR 702.93b)", () => {
+    // 3/3 infect attacker vs 0/5 blocker: 3 infect damage → 3 -1/-1 counters.
+    // Blocker effective toughness drops to 2, so it survives with counters and
+    // NO damage marked on it.
+    const { state, aliceId, bobId } = setupGameWithCreatures(
+      [{ name: "Infect Attacker", power: 3, toughness: 3, keywords: ["Infect"] }],
+      [{ name: "Blocker", power: 0, toughness: 5 }],
+    );
+
+    const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
+    const blockerId = state.zones.get(`${bobId}-battlefield`)!.cardIds[0];
+
+    state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+    const atk = declareAttackers(state, [
+      { cardId: attackerId, defenderId: bobId },
+    ]);
+    atk.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+    const blk = declareBlockers(
+      atk.state,
+      new Map([[attackerId, [blockerId]]]),
+    );
+
+    const result = resolveCombatDamage(blk.state);
+    expect(result.success).toBe(true);
+
+    // Blocker received 3 -1/-1 counters, NOT 3 marked damage.
+    expect(getMinusOneCounters(result.state, blockerId)).toBe(3);
+    const blockerCard = result.state.cards.get(blockerId)!;
+    expect(blockerCard.damage).toBe(0);
+
+    // Effective toughness 5 - 3 = 2 > 0, so the blocker survives.
+    const bobGraveyard = result.state.zones.get(`${bobId}-graveyard`)!;
+    expect(bobGraveyard.cardIds).not.toContain(blockerId);
+  });
+
+  it("infect attacker destroys a blocker when -1/-1 counters reduce toughness to 0 (SBA 704.5g)", () => {
+    // 2/2 infect attacker vs 0/2 blocker: 2 infect damage → 2 -1/-1 counters.
+    // Effective toughness 2 - 2 = 0, so SBA destroys it.
+    const { state, aliceId, bobId } = setupGameWithCreatures(
+      [{ name: "Infect Attacker", power: 2, toughness: 2, keywords: ["Infect"] }],
+      [{ name: "Blocker", power: 0, toughness: 2 }],
+    );
+
+    const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
+    const blockerId = state.zones.get(`${bobId}-battlefield`)!.cardIds[0];
+
+    state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+    const atk = declareAttackers(state, [
+      { cardId: attackerId, defenderId: bobId },
+    ]);
+    atk.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+    const blk = declareBlockers(
+      atk.state,
+      new Map([[attackerId, [blockerId]]]),
+    );
+
+    const result = resolveCombatDamage(blk.state);
+    expect(result.success).toBe(true);
+
+    const bobGraveyard = result.state.zones.get(`${bobId}-graveyard`)!;
+    expect(bobGraveyard.cardIds).toContain(blockerId);
+  });
+
+  it("infect attacker unblocked deals poison counters to player (no life loss) (CR 702.93c)", () => {
+    // 3/3 infect attacker unblocked → 3 poison counters, life unchanged.
+    const { state, aliceId, bobId } = setupGameWithCreatures(
+      [{ name: "Infect Attacker", power: 3, toughness: 3, keywords: ["Infect"] }],
+      [],
+    );
+
+    const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
+
+    state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+    const atk = declareAttackers(state, [
+      { cardId: attackerId, defenderId: bobId },
+    ]);
+
+    const result = resolveCombatDamage(atk.state);
+    expect(result.success).toBe(true);
+
+    const bob = result.state.players.get(bobId)!;
+    expect(bob.poisonCounters).toBe(3);
+    expect(bob.life).toBe(20); // no life loss with infect
+  });
+
+  it("toxic attacker unblocked deals normal damage plus toxic poison (CR 702.94)", () => {
+    // 2/2 toxic 1 attacker unblocked → 2 life loss AND 1 poison counter.
+    const { state, aliceId, bobId } = setupGameWithCreatures(
+      [{ name: "Toxic Attacker", power: 2, toughness: 2, keywords: ["Toxic 1"] }],
+      [],
+    );
+
+    const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
+
+    state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+    const atk = declareAttackers(state, [
+      { cardId: attackerId, defenderId: bobId },
+    ]);
+
+    const result = resolveCombatDamage(atk.state);
+    expect(result.success).toBe(true);
+
+    const bob = result.state.players.get(bobId)!;
+    expect(bob.life).toBe(18); // 20 - 2
+    expect(bob.poisonCounters).toBe(1);
+  });
+
+  it("toxic N attacker unblocked adds N poison counters", () => {
+    // 1/1 toxic 3 attacker unblocked → 1 life loss AND 3 poison counters.
+    const { state, aliceId, bobId } = setupGameWithCreatures(
+      [{ name: "Toxic Three", power: 1, toughness: 1, keywords: ["Toxic 3"] }],
+      [],
+    );
+
+    const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
+
+    state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+    const atk = declareAttackers(state, [
+      { cardId: attackerId, defenderId: bobId },
+    ]);
+
+    const result = resolveCombatDamage(atk.state);
+    expect(result.success).toBe(true);
+
+    const bob = result.state.players.get(bobId)!;
+    expect(bob.life).toBe(19); // 20 - 1
+    expect(bob.poisonCounters).toBe(3);
+  });
+
+  it("infect + deathtouch attacker destroys a blocker with a single point (CR 702.2b + 702.93b)", () => {
+    // 1/1 infect + deathtouch attacker vs 0/5 blocker: 1 infect damage →
+    // 1 -1/-1 counter, and because the source has deathtouch any nonzero
+    // infect damage is lethal, so the blocker is destroyed.
+    const { state, aliceId, bobId } = setupGameWithCreatures(
+      [
+        {
+          name: "Infect Deathtoucher",
+          power: 1,
+          toughness: 1,
+          keywords: ["Infect", "Deathtouch"],
+        },
+      ],
+      [{ name: "Blocker", power: 0, toughness: 5 }],
+    );
+
+    const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
+    const blockerId = state.zones.get(`${bobId}-battlefield`)!.cardIds[0];
+
+    state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+    const atk = declareAttackers(state, [
+      { cardId: attackerId, defenderId: bobId },
+    ]);
+    atk.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+    const blk = declareBlockers(
+      atk.state,
+      new Map([[attackerId, [blockerId]]]),
+    );
+
+    const result = resolveCombatDamage(blk.state);
+    expect(result.success).toBe(true);
+
+    // Blocker is destroyed (deathtouch lethality) despite only 1 damage.
+    // Note: counters are cleared when a card moves to the graveyard
+    // (moveCardToZone resets counters), so we assert destruction here;
+    // the infect -1/-1 counter behaviour is verified in the surviving-
+    // blocker test above.
+    const bobGraveyard = result.state.zones.get(`${bobId}-graveyard`)!;
+    expect(bobGraveyard.cardIds).toContain(blockerId);
+  });
+
+  it("non-infect attacker marks normal damage and adds no -1/-1 counters", () => {
+    // 3/3 regular attacker vs 0/5 blocker: 3 marked damage, no -1/-1 counters.
+    const { state, aliceId, bobId } = setupGameWithCreatures(
+      [{ name: "Vanilla Attacker", power: 3, toughness: 3 }],
+      [{ name: "Blocker", power: 0, toughness: 5 }],
+    );
+
+    const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
+    const blockerId = state.zones.get(`${bobId}-battlefield`)!.cardIds[0];
+
+    state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+    const atk = declareAttackers(state, [
+      { cardId: attackerId, defenderId: bobId },
+    ]);
+    atk.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+    const blk = declareBlockers(
+      atk.state,
+      new Map([[attackerId, [blockerId]]]),
+    );
+
+    const result = resolveCombatDamage(blk.state);
+    expect(result.success).toBe(true);
+
+    const blockerCard = result.state.cards.get(blockerId)!;
+    expect(blockerCard.damage).toBe(3);
+    expect(getMinusOneCounters(result.state, blockerId)).toBe(0);
+  });
+
+  it("toxic attacker with trample adds toxic poison on excess damage to player", () => {
+    // 5/5 toxic 1 trampler vs 0/1 blocker: 1 to blocker (lethal), 4 tramples
+    // to player → 4 life loss AND 1 toxic poison counter.
+    const { state, aliceId, bobId } = setupGameWithCreatures(
+      [
+        {
+          name: "Toxic Trampler",
+          power: 5,
+          toughness: 5,
+          keywords: ["Toxic 1", "Trample"],
+        },
+      ],
+      [{ name: "Blocker", power: 0, toughness: 1 }],
+    );
+
+    const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
+    const blockerId = state.zones.get(`${bobId}-battlefield`)!.cardIds[0];
+
+    state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+    const atk = declareAttackers(state, [
+      { cardId: attackerId, defenderId: bobId },
+    ]);
+    atk.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+    const blk = declareBlockers(
+      atk.state,
+      new Map([[attackerId, [blockerId]]]),
+    );
+
+    const result = resolveCombatDamage(blk.state);
+    expect(result.success).toBe(true);
+
+    const bob = result.state.players.get(bobId)!;
+    expect(bob.life).toBe(16); // 20 - 4 trample
+    expect(bob.poisonCounters).toBe(1);
+  });
+
+  it("infect blocker deals -1/-1 counters to the attacker (CR 702.93b)", () => {
+    // 0/3 attacker (0 power) blocked by a 2/2 infect blocker: the blocker
+    // deals 2 infect damage to the attacker → 2 -1/-1 counters on attacker.
+    const { state, aliceId, bobId } = setupGameWithCreatures(
+      [{ name: "Attacker", power: 0, toughness: 3 }],
+      [{ name: "Infect Blocker", power: 2, toughness: 2, keywords: ["Infect"] }],
+    );
+
+    const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
+    const blockerId = state.zones.get(`${bobId}-battlefield`)!.cardIds[0];
+
+    state.turn.currentPhase = Phase.DECLARE_ATTACKERS;
+    const atk = declareAttackers(state, [
+      { cardId: attackerId, defenderId: bobId },
+    ]);
+    atk.state.turn.currentPhase = Phase.DECLARE_BLOCKERS;
+    const blk = declareBlockers(
+      atk.state,
+      new Map([[attackerId, [blockerId]]]),
+    );
+
+    const result = resolveCombatDamage(blk.state);
+    expect(result.success).toBe(true);
+
+    // Attacker received 2 -1/-1 counters and no marked damage.
+    expect(getMinusOneCounters(result.state, attackerId)).toBe(2);
+    const attackerCard = result.state.cards.get(attackerId)!;
+    expect(attackerCard.damage).toBe(0);
+  });
+});

--- a/src/lib/game-state/combat.ts
+++ b/src/lib/game-state/combat.ts
@@ -7,7 +7,7 @@
 
 import type { GameState, CardInstanceId, PlayerId } from "./types";
 import { Phase, isOnBattlefield } from "./types";
-import { isCreature, getPower, getToughness } from "./card-instance";
+import { isCreature, getPower, getToughness, addCounters } from "./card-instance";
 import { dealDamageToCard } from "./keyword-actions";
 import { checkStateBasedActions } from "./state-based-actions";
 import { dealCommanderDamage, isCommander } from "./commander-damage";
@@ -828,6 +828,9 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
       );
 
       const attackerHasDeathtouch = hasDeathtouch(attackerCard);
+      // CR 702.93 (Infect): damage to creatures from a source with infect
+      // is dealt as -1/-1 counters instead of marked damage.
+      const attackerHasInfect = hasInfect(attackerCard);
 
       // Deal damage from attacker to blockers
       for (const blocker of sortedBlockers) {
@@ -863,39 +866,64 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
           damage = Math.min(remainingDamage, blockerToughness);
         }
 
-        // Apply damage to blocker
-        const damageResult = dealDamageToCard(
-          updatedState,
-          blocker.cardId,
-          damage,
-          true,
-          attacker.cardId,
-        );
-        updatedState = damageResult.state;
-
-        // Check for lifelink on blocker
-        if (blockerHasLifelink) {
-          const blockerController = updatedState.players.get(
-            blockerCard.controllerId,
-          );
-          if (blockerController) {
-            updatedState = {
-              ...updatedState,
-              players: new Map(updatedState.players).set(
-                blockerCard.controllerId!,
-                {
-                  ...blockerController,
-                  life: blockerController.life + damage,
-                },
-              ),
+        if (attackerHasInfect) {
+          // CR 702.93b: Infect damage to a creature is dealt as -1/-1
+          // counters; it is NOT marked as damage on the creature.
+          const blockerWithCounters = addCounters(blockerCard, "-1/-1", damage);
+          let finalBlocker = blockerWithCounters;
+          // CR 702.2b + 702.93b: A source with both infect and deathtouch
+          // still counts as a deathtouch source — any nonzero infect damage
+          // is lethal, so mark lethal damage to trigger SBA destruction.
+          if (attackerHasDeathtouch && damage > 0) {
+            const lethalDamage = getToughness(blockerWithCounters);
+            finalBlocker = {
+              ...blockerWithCounters,
+              damage: Math.max(blockerWithCounters.damage, lethalDamage),
             };
           }
+          updatedState = {
+            ...updatedState,
+            cards: new Map(updatedState.cards).set(blocker.cardId, finalBlocker),
+            lastModifiedAt: Date.now(),
+          };
+          damageEvents.push(
+            `${attackerCard.cardData.name} deals ${damage} infect damage (${damage} -1/-1 counters) to ${blockerCard.cardData.name}`,
+          );
+        } else {
+          // Apply damage to blocker
+          const damageResult = dealDamageToCard(
+            updatedState,
+            blocker.cardId,
+            damage,
+            true,
+            attacker.cardId,
+          );
+          updatedState = damageResult.state;
+
+          // Check for lifelink on blocker
+          if (blockerHasLifelink) {
+            const blockerController = updatedState.players.get(
+              blockerCard.controllerId,
+            );
+            if (blockerController) {
+              updatedState = {
+                ...updatedState,
+                players: new Map(updatedState.players).set(
+                  blockerCard.controllerId!,
+                  {
+                    ...blockerController,
+                    life: blockerController.life + damage,
+                  },
+                ),
+              };
+            }
+          }
+          damageEvents.push(
+            `${attackerCard.cardData.name} deals ${damage} to ${blockerCard.cardData.name}`,
+          );
         }
 
         remainingDamage -= damage;
-        damageEvents.push(
-          `${attackerCard.cardData.name} deals ${damage} to ${blockerCard.cardData.name}`,
-        );
       }
 
       // Handle trample excess damage
@@ -924,18 +952,31 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
               `${attackerCard.cardData.name} tramples ${remainingDamage} poison to ${defender.name}`,
             );
           } else {
+            let updatedDefender = {
+              ...defender,
+              life: Math.max(0, defender.life - remainingDamage),
+            };
+            // CR 702.94 (Toxic): any combat damage to a player from a toxic
+            // source adds toxic-level poison counters in addition to life loss.
+            const toxicLevel = getToxicLevel(attackerCard);
+            if (toxicLevel > 0) {
+              updatedDefender = {
+                ...updatedDefender,
+                poisonCounters:
+                  updatedDefender.poisonCounters + toxicLevel,
+              };
+            }
             updatedState = {
               ...updatedState,
               players: new Map(updatedState.players).set(
                 attacker.defenderId as PlayerId,
-                {
-                  ...defender,
-                  life: Math.max(0, defender.life - remainingDamage),
-                },
+                updatedDefender,
               ),
             };
             damageEvents.push(
-              `${attackerCard.cardData.name} tramples ${remainingDamage} to ${defender.name}`,
+              toxicLevel > 0
+                ? `${attackerCard.cardData.name} tramples ${remainingDamage} to ${defender.name} and ${toxicLevel} toxic poison`
+                : `${attackerCard.cardData.name} tramples ${remainingDamage} to ${defender.name}`,
             );
           }
         }
@@ -993,18 +1034,53 @@ export function resolveCombatDamage(state: GameState): CombatActionResult {
         const blockerPower = getEffectivePower(blockerCard, layerSystem);
         if (blockerPower <= 0) continue;
 
-        // Apply damage from blocker to attacker
-        const damageResult = dealDamageToCard(
-          updatedState,
-          attacker.cardId,
-          blockerPower,
-          true,
-          blocker.cardId,
-        );
-        updatedState = damageResult.state;
-        damageEvents.push(
-          `${blockerCard.cardData.name} deals ${blockerPower} to ${attackerCard.cardData.name}`,
-        );
+        // CR 702.93 (Infect): a blocker with infect deals damage to the
+        // attacker as -1/-1 counters instead of marked damage.
+        const blockerHasInfect = hasInfect(blockerCard);
+        if (blockerHasInfect) {
+          const currentAttacker = updatedState.cards.get(attacker.cardId);
+          if (currentAttacker) {
+            const attackerWithCounters = addCounters(
+              currentAttacker,
+              "-1/-1",
+              blockerPower,
+            );
+            let finalAttacker = attackerWithCounters;
+            // CR 702.2b + 702.93b: infect + deathtouch is lethal.
+            const blockerHasDeathtouch = hasDeathtouch(blockerCard);
+            if (blockerHasDeathtouch && blockerPower > 0) {
+              const lethalDamage = getToughness(attackerWithCounters);
+              finalAttacker = {
+                ...attackerWithCounters,
+                damage: Math.max(attackerWithCounters.damage, lethalDamage),
+              };
+            }
+            updatedState = {
+              ...updatedState,
+              cards: new Map(updatedState.cards).set(
+                attacker.cardId,
+                finalAttacker,
+              ),
+              lastModifiedAt: Date.now(),
+            };
+            damageEvents.push(
+              `${blockerCard.cardData.name} deals ${blockerPower} infect damage (${blockerPower} -1/-1 counters) to ${attackerCard.cardData.name}`,
+            );
+          }
+        } else {
+          // Apply damage from blocker to attacker
+          const damageResult = dealDamageToCard(
+            updatedState,
+            attacker.cardId,
+            blockerPower,
+            true,
+            blocker.cardId,
+          );
+          updatedState = damageResult.state;
+          damageEvents.push(
+            `${blockerCard.cardData.name} deals ${blockerPower} to ${attackerCard.cardData.name}`,
+          );
+        }
       }
     }
   }

--- a/src/lib/game-state/state-based-actions.ts
+++ b/src/lib/game-state/state-based-actions.ts
@@ -168,8 +168,17 @@ export function checkStateBasedActions(
 
       // SBA 704.5g: A creature with toughness 0 or less is destroyed
       if (isCreature(card)) {
-        const toughness = getToughness(card);
-        if (toughness <= 0) {
+        // Account for P/T counters (CR 613.8c). Infect damage manifests as
+        // -1/-1 counters (CR 702.93b), so a creature can reach 0 toughness
+        // via counters without any marked damage. The net counter bonus
+        // (matching Layer 7c) is applied here so such creatures are destroyed.
+        const plusOneCounters =
+          card.counters?.find((c) => c.type === "+1/+1")?.count ?? 0;
+        const minusOneCounters =
+          card.counters?.find((c) => c.type === "-1/-1")?.count ?? 0;
+        const effectiveToughness =
+          getToughness(card) + plusOneCounters - minusOneCounters;
+        if (effectiveToughness <= 0) {
           if (!cardsToDestroy.includes(card.id)) {
             cardsToDestroy.push(card.id);
           }


### PR DESCRIPTION
## Problem
Issue #972: `hasInfect` and `getToxicLevel` existed in `evergreen-keywords.ts`, and `combat.ts` already handled infect/toxic for damage to **players** (unblocked attackers, trample excess). However, when a creature with infect dealt combat damage to another **creature**, the damage was applied as regular marked damage instead of -1/-1 counters per CR 702.93b. Toxic on trample-excess damage to a player was also missing.

## Changes
**`src/lib/game-state/combat.ts`**
- **Infect → creatures (CR 702.93b):** In `resolveCombatDamage`, when an attacker with infect deals damage to a blocker, the damage is now converted to `-1/-1` counters (via `addCounters`) instead of being marked as damage. Mirrored for the blocker→attacker direction (a blocker with infect adds -1/-1 counters to the attacker).
- **Infect + deathtouch (CR 702.2b + 702.93b):** A source with both infect and deathtouch still counts as a deathtouch source, so any nonzero infect damage is lethal — lethal damage is marked to trigger SBA destruction (consistent with the existing deathtouch handling in `dealDamageToCard`).
- **Toxic + trample (CR 702.94):** Trample excess damage to a player from a toxic source now adds the toxic-level poison counters in addition to the life loss (previously only the unblocked path added toxic poison).
- The non-infect damage path is unchanged.

**`src/lib/game-state/state-based-actions.ts`**
- **SBA 704.5g (toughness ≤ 0):** Now accounts for +1/+1 and -1/-1 counter net bonus (matching Layer 7c, CR 613.8c) so a creature whose toughness reaches 0 via infect -1/-1 counters is destroyed. Previously `getToughness` ignored counters, so infect could never kill a creature through counters alone.

## Testing
New `describe("Combat System - Infect and Toxic (#972)")` block in `combat.test.ts` with 9 tests covering:
- Infect attacker adds -1/-1 counters (not marked damage) to a surviving blocker; no damage marked.
- Infect attacker destroys a blocker when -1/-1 counters reduce effective toughness to 0 (SBA 704.5g).
- Infect attacker unblocked → poison counters to player, no life loss (CR 702.93c).
- Toxic 1 attacker unblocked → normal damage + 1 poison (CR 702.94).
- Toxic 3 attacker unblocked → adds N=3 poison counters.
- Infect + deathtouch → single point destroys a blocker (CR 702.2b + 702.93b).
- Non-infect attacker → normal marked damage, no -1/-1 counters (regression guard).
- Toxic + trample excess → life loss + toxic poison to player.
- Infect blocker → -1/-1 counters on the attacker (blocker→attacker direction).

## Verification
- `npx jest combat evergreen-keywords keyword-enforcement` → 232 suites, 4415 passed (10 skipped, 48 todo).
- `npx jest game-state/` → 98 suites, 1934 passed (full module, no regressions from the SBA change).
- `npx jest state-based` → 52 passed.
- `npx tsc --noEmit` → no errors.

Closes #972