### PR TITLE
security(p2p): resolve #1111 — harden untrusted P2P messages against DoS

### DIFF
--- a/src/lib/__tests__/p2p-json-validation.test.ts
+++ b/src/lib/__tests__/p2p-json-validation.test.ts
@@ -1,9 +1,16 @@
 /**
  * Tests for safe JSON parsing of untrusted P2P / signaling data.
  * Issue #924: unvalidated peer JSON.parse casts.
+ * Issue #1111: resource-exhaustion limits (size / depth / key-count).
  */
 
-import { safeParseJson } from "../p2p-json-validation";
+import {
+  safeParseJson,
+  withinStructuralLimits,
+  MAX_MESSAGE_SIZE_BYTES,
+  MAX_NESTING_DEPTH,
+  MAX_KEY_COUNT,
+} from "../p2p-json-validation";
 
 type Sample = { id: number; name: string };
 
@@ -87,6 +94,96 @@ describe("safeParseJson", () => {
       ).toBeNull();
       expect(safeParseJson(null as unknown as string, isSample)).toBeNull();
       expect(safeParseJson(123 as unknown as string, isSample)).toBeNull();
+    });
+  });
+
+  describe("resource-exhaustion defenses (#1111)", () => {
+    it("enforces the default max message size before parsing", () => {
+      // A string one byte over the cap is rejected without ever parsing.
+      const over = "x".repeat(MAX_MESSAGE_SIZE_BYTES + 1);
+      expect(safeParseJson(over, isSample)).toBeNull();
+    });
+
+    it("treats the size cap as an inclusive boundary", () => {
+      // A payload whose raw length exactly equals maxMessageBytes is accepted
+      // (the guard is strictly greater-than). Pad a valid payload to the cap.
+      const valid = JSON.stringify({ id: 1, name: "x" });
+      const target = 128;
+      const padding = " ".repeat(target - valid.length);
+      // JSON allows insignificant whitespace, so the padded string still parses
+      // to the same shape.
+      const padded = valid + padding;
+      expect(padded.length).toBe(target);
+      const result = safeParseJson(padded, isSample, {
+        limits: { maxMessageBytes: target },
+      });
+      expect(result).toEqual({ id: 1, name: "x" });
+    });
+
+    it("rejects oversize messages via an explicit small limit override", () => {
+      const small = { limits: { maxMessageBytes: 32 } };
+      const ok = '{"id":1,"name":"a"}';
+      expect(ok.length).toBeLessThanOrEqual(32);
+      expect(safeParseJson(ok, isSample, small)).toEqual({ id: 1, name: "a" });
+
+      const tooBig = '{"id":1,"name":"' + "a".repeat(100) + '"}';
+      expect(tooBig.length).toBeGreaterThan(32);
+      expect(safeParseJson(tooBig, isSample, small)).toBeNull();
+    });
+
+    it("rejects deeply-nested payloads via the depth cap", () => {
+      // Build a payload deeper than MAX_NESTING_DEPTH.
+      const depth = MAX_NESTING_DEPTH + 5;
+      let raw = "";
+      for (let i = 0; i < depth; i++) raw += "{\"a\":";
+      raw += "1";
+      for (let i = 0; i < depth; i++) raw += "}";
+      // The raw string is small (no size trip), parses fine, but exceeds the
+      // structural depth limit.
+      expect(raw.length).toBeLessThan(MAX_MESSAGE_SIZE_BYTES);
+      expect(() => JSON.parse(raw)).not.toThrow();
+      expect(safeParseJson(raw, isSample)).toBeNull();
+    });
+
+    it("rejects key-bloated payloads via the key-count cap", () => {
+      // A flat object with more keys than MAX_KEY_COUNT.
+      const parts: string[] = [];
+      for (let i = 0; i < MAX_KEY_COUNT + 10; i++) {
+        parts.push(`"k${i}":1`);
+      }
+      const raw = `{"id":1,"name":"x",${parts.join(",")}}`;
+      expect(raw.length).toBeLessThan(MAX_MESSAGE_SIZE_BYTES);
+      expect(safeParseJson(raw, isSample)).toBeNull();
+    });
+
+    it("still accepts a legitimately large, non-pathological payload", () => {
+      // 1k nested objects, each with a few keys — well within all caps.
+      const items = Array.from({ length: 1000 }, (_, i) => ({
+        a: i,
+        b: "x",
+        c: { d: i },
+      }));
+      const raw = JSON.stringify({
+        id: 1,
+        name: "legit",
+        items,
+      });
+      expect(raw.length).toBeLessThan(MAX_MESSAGE_SIZE_BYTES);
+      const result = safeParseJson(raw, isSample);
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(1);
+    });
+
+    it("withinStructuralLimits is bounded and never throws on hostile input", () => {
+      // Deeply nested + wide — the walker must bail out, not blow the stack.
+      let deep: unknown = 1;
+      for (let i = 0; i < 10_000; i++) deep = { a: deep };
+      const wide: Record<string, unknown> = {};
+      for (let i = 0; i < 100_000; i++) wide[`k${i}`] = i;
+      expect(() => withinStructuralLimits(deep)).not.toThrow();
+      expect(() => withinStructuralLimits(wide)).not.toThrow();
+      expect(withinStructuralLimits(deep)).toBe(false);
+      expect(withinStructuralLimits(wide)).toBe(false);
     });
   });
 });

--- a/src/lib/__tests__/p2p-rate-limiter.test.ts
+++ b/src/lib/__tests__/p2p-rate-limiter.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for the per-connection P2P rate limiter. Issue #1111.
+ */
+
+import {
+  P2PRateLimiter,
+  DEFAULT_P2P_RATE_LIMIT,
+} from "../p2p-rate-limiter";
+
+describe("P2PRateLimiter", () => {
+  describe("within-limit behavior", () => {
+    it("allows messages up to the configured maximum", () => {
+      const limiter = new P2PRateLimiter({
+        maxMessages: 5,
+        windowMs: 1000,
+      });
+      for (let i = 0; i < 5; i++) {
+        expect(limiter.tryAcquire(1000)).toBe(true);
+      }
+    });
+
+    it("uses sensible defaults when constructed with no options", () => {
+      const limiter = new P2PRateLimiter();
+      for (let i = 0; i < DEFAULT_P2P_RATE_LIMIT.maxMessages; i++) {
+        expect(limiter.tryAcquire(0)).toBe(true);
+      }
+    });
+  });
+
+  describe("rapid-spam / over-limit behavior", () => {
+    it("drops messages once the window capacity is exceeded", () => {
+      const limiter = new P2PRateLimiter({
+        maxMessages: 3,
+        windowMs: 1000,
+      });
+      expect(limiter.tryAcquire(5000)).toBe(true);
+      expect(limiter.tryAcquire(5000)).toBe(true);
+      expect(limiter.tryAcquire(5000)).toBe(true);
+      // 4th message in the same window is dropped.
+      expect(limiter.tryAcquire(5000)).toBe(false);
+      // And a 5th, 6th ... are all dropped while the window is saturated.
+      expect(limiter.tryAcquire(5000)).toBe(false);
+      expect(limiter.tryAcquire(5000)).toBe(false);
+    });
+
+    it("sustains a flood without ever throwing", () => {
+      const limiter = new P2PRateLimiter({
+        maxMessages: 10,
+        windowMs: 1000,
+      });
+      expect(() => {
+        for (let i = 0; i < 100_000; i++) {
+          limiter.tryAcquire(5000);
+        }
+      }).not.toThrow();
+      // Only the first 10 were admitted.
+      expect(limiter.currentCount).toBe(10);
+    });
+  });
+
+  describe("sliding-window recovery", () => {
+    it("admits messages again after the window has elapsed", () => {
+      const limiter = new P2PRateLimiter({
+        maxMessages: 2,
+        windowMs: 1000,
+      });
+      // Saturate the window at t=1000.
+      expect(limiter.tryAcquire(1000)).toBe(true);
+      expect(limiter.tryAcquire(1000)).toBe(true);
+      expect(limiter.tryAcquire(1000)).toBe(false);
+      // Still saturated partway through the window.
+      expect(limiter.tryAcquire(1500)).toBe(false);
+      // At t=2001 the t=1000 entries have aged out (cutoff = 1001), so new
+      // messages are admitted again.
+      expect(limiter.tryAcquire(2001)).toBe(true);
+      expect(limiter.tryAcquire(2001)).toBe(true);
+      expect(limiter.tryAcquire(2001)).toBe(false);
+    });
+
+    it("evicts aged entries lazily on the next acquire", () => {
+      const limiter = new P2PRateLimiter({
+        maxMessages: 100,
+        windowMs: 500,
+      });
+      // Fill the window in one period.
+      for (let i = 0; i < 100; i++) limiter.tryAcquire(0);
+      expect(limiter.currentCount).toBe(100);
+      // After the window elapses, a single acquire both evicts old entries and
+      // admits the new one.
+      expect(limiter.tryAcquire(1000)).toBe(true);
+      expect(limiter.currentCount).toBe(1);
+    });
+  });
+
+  describe("reset", () => {
+    it("clears recorded timestamps", () => {
+      const limiter = new P2PRateLimiter({
+        maxMessages: 2,
+        windowMs: 1000,
+      });
+      limiter.tryAcquire(0);
+      limiter.tryAcquire(0);
+      expect(limiter.tryAcquire(0)).toBe(false);
+      limiter.reset();
+      expect(limiter.currentCount).toBe(0);
+      expect(limiter.tryAcquire(0)).toBe(true);
+    });
+  });
+
+  describe("configuration validation", () => {
+    it("rejects non-positive maxMessages", () => {
+      expect(() => new P2PRateLimiter({ maxMessages: 0 })).toThrow();
+      expect(() => new P2PRateLimiter({ maxMessages: -1 })).toThrow();
+    });
+
+    it("rejects non-positive windowMs", () => {
+      expect(() => new P2PRateLimiter({ windowMs: 0 })).toThrow();
+      expect(() => new P2PRateLimiter({ windowMs: -5 })).toThrow();
+    });
+  });
+});

--- a/src/lib/p2p-game-connection.ts
+++ b/src/lib/p2p-game-connection.ts
@@ -27,6 +27,10 @@ import {
 } from "./ice-config";
 import { safeParseJson } from "./p2p-json-validation";
 import {
+  P2PRateLimiter,
+  type P2PRateLimitOptions,
+} from "./p2p-rate-limiter";
+import {
   classifyConnectionFailure,
   hasTurnServer,
   type ConnectionFailureContext,
@@ -135,6 +139,13 @@ export interface P2PGameConnectionOptions {
   gameCode?: string;
   iceConfig?: ICEConfigOptions;
   events?: Partial<P2PGameConnectionEvents>;
+  /**
+   * Per-connection rate limit for incoming data-channel messages. Defaults to
+   * {@link DEFAULT_P2P_RATE_LIMIT} (100 msgs / 1s). Messages exceeding the
+   * limit are dropped before parsing to prevent CPU/memory exhaustion from a
+   * flooding peer. Issue #1111.
+   */
+  rateLimit?: Partial<P2PRateLimitOptions>;
 }
 
 /**
@@ -156,11 +167,21 @@ export class P2PGameConnection {
   private remotePlayerId: string | null = null;
   private remotePlayerName: string | null = null;
   private lastFailureDiagnostic: ConnectionFailureDiagnostic | null = null;
+  /**
+   * Per-connection sliding-window rate limiter for incoming messages. Caps how
+   * many messages per second a single peer can push through the parse +
+   * validation path. Issue #1111.
+   */
+  private rateLimiter: P2PRateLimiter;
 
   constructor(options: P2PGameConnectionOptions) {
     this.playerId = options.playerId;
     this.playerName = options.playerName;
     this.connectionState = "disconnected";
+
+    // Per-connection rate limiter guards the parse/validate path against
+    // flooding peers. Issue #1111.
+    this.rateLimiter = new P2PRateLimiter(options.rateLimit);
 
     // Initialize ICE manager
     if (options.iceConfig) {
@@ -502,12 +523,27 @@ export class P2PGameConnection {
 
   /**
    * Handle incoming message
-   * Validates the parsed payload's shape to prevent malformed or attacker-
-   * controlled data from flowing into business logic. Malformed messages are
-   * rejected gracefully without breaking the connection.
+   *
+   * Enforces, in order:
+   *   1. Per-connection rate limit — a flooding peer is dropped before any
+   *      parsing work is done (issue #1111).
+   *   2. Safe parse + structural limits (size/depth/key-count) via
+   *      {@link safeParseJson}.
+   *   3. Shape validation via {@link isGameMessage}.
+   *
+   * Malformed, oversize, or rate-limited messages are rejected gracefully
+   * without breaking the connection.
    */
   private handleMessage(data: string): void {
     try {
+      // Rate-limit first: never do parse/validation work for a flooding peer.
+      if (!this.rateLimiter.tryAcquire()) {
+        console.warn(
+          "[P2PGameConnection] Rate limit exceeded; dropping peer message",
+        );
+        return;
+      }
+
       const message = safeParseJson<GameMessage>(data, isGameMessage);
       if (!message) {
         // Malformed JSON or wrong shape — reject without breaking the channel.
@@ -791,6 +827,7 @@ export class P2PGameConnection {
       this.peerConnection = null;
     }
 
+    this.rateLimiter.reset();
     this.updateConnectionState("disconnected");
   }
 

--- a/src/lib/p2p-json-validation.ts
+++ b/src/lib/p2p-json-validation.ts
@@ -11,22 +11,174 @@
  *      that the payload matches the expected schema. Blind `as T` casts let
  *      attacker-controlled shapes flow into business logic.
  *
- * See issue #924.
+ * Resource-exhaustion hardening (issue #1111):
+ *   3. A peer must not be able to exhaust memory or CPU by sending an
+ *      arbitrarily large string, an arbitrarily deeply-nested object, or an
+ *      object with an unbounded number of keys. `safeParseJson` therefore
+ *      enforces three resource limits — a hard byte cap BEFORE JSON.parse, and
+ *      a depth + total-key-count cap DURING structural validation. This is the
+ *      same class of bug as the `ws` advisory GHSA-96hv-2xvq-fx4p (DoS via
+ *      unbounded memory allocation on untrusted websocket payloads), applied
+ *      to our P2P data channel where peers are joined by shared game codes and
+ *      are effectively anonymous.
+ *
+ * See issue #924 (shape validation) and issue #1111 (resource limits).
  */
 
 /**
- * Safely parse a JSON string and validate its shape.
+ * Absolute hard cap on the byte length of a single P2P message string,
+ * enforced BEFORE JSON.parse so the parser never allocates an unbounded
+ * buffer. 256 KiB is generous for any legitimate game-state sync (full
+ * Commander game states serialize well under 100 KiB) while bounding the
+ * worst-case allocation per message.
+ *
+ * Cf. GHSA-96hv-2xvq-fx4p.
+ */
+export const MAX_MESSAGE_SIZE_BYTES = 256 * 1024;
+
+/**
+ * Maximum nesting depth of arrays/objects permitted during structural
+ * validation. V8's JSON.parse accepts deeply nested input that would blow
+ * the call stack during a naive recursive walk; capping depth keeps the
+ * validator itself non-recursive-blowup-safe. 64 levels is far above any
+ * legitimate game payload.
+ */
+export const MAX_NESTING_DEPTH = 64;
+
+/**
+ * Maximum total number of enumerable keys (object properties + array
+ * indices) visited across the whole parsed tree during structural
+ * validation. Bounds the CPU cost of validating an attacker-controlled
+ * payload with millions of keys.
+ */
+export const MAX_KEY_COUNT = 10_000;
+
+/**
+ * Resource limits applied to an untrusted message. Callers may override the
+ * defaults (e.g. tests, or a channel that legitimately needs a larger cap).
+ */
+export interface StructuralLimits {
+  /** Max byte length of the raw message string (checked before JSON.parse). */
+  maxMessageBytes: number;
+  /** Max array/object nesting depth. */
+  maxDepth: number;
+  /** Max total enumerable keys visited across the whole tree. */
+  maxKeys: number;
+}
+
+/**
+ * Default resource limits. See the named constants above for rationale.
+ */
+export const DEFAULT_STRUCTURAL_LIMITS: StructuralLimits = {
+  maxMessageBytes: MAX_MESSAGE_SIZE_BYTES,
+  maxDepth: MAX_NESTING_DEPTH,
+  maxKeys: MAX_KEY_COUNT,
+};
+
+/**
+ * Options for {@link safeParseJson}.
+ */
+export interface SafeParseJsonOptions {
+  /**
+   * Override the default resource limits. All limits are inclusive upper
+   * bounds; a payload equal to a limit is accepted, one exceeding it is
+   * rejected.
+   */
+  limits?: Partial<StructuralLimits>;
+}
+
+/**
+ * Verify that a parsed JSON value stays within the structural resource limits
+ * (nesting depth + total key count). Exposed so receive paths that parse with
+ * their own JSON.parse (rather than {@link safeParseJson}) can still apply the
+ * same depth/key caps without duplicating the walker.
+ *
+ * The walk is itself DoS-safe: recursion is bounded by {@link maxDepth} and
+ * iteration is bounded by {@link maxKeys}, so it visits at most
+ * `maxKeys` entries and recurses at most `maxDepth` levels regardless of the
+ * input shape.
+ *
+ * @returns `true` if the value is within limits, `false` otherwise.
+ */
+export function withinStructuralLimits(
+  value: unknown,
+  limits: Partial<StructuralLimits> = {},
+): boolean {
+  const maxDepth = limits.maxDepth ?? DEFAULT_STRUCTURAL_LIMITS.maxDepth;
+  const maxKeys = limits.maxKeys ?? DEFAULT_STRUCTURAL_LIMITS.maxKeys;
+
+  let keysVisited = 0;
+
+  const walk = (node: unknown, depth: number): boolean => {
+    // Scalars (and null) carry no structural cost.
+    if (node === null || typeof node !== "object") {
+      return true;
+    }
+    // depth counts object/array nesting levels. The top-level value parsed by
+    // safeParseJson is already guaranteed to be an object, so the first
+    // container is depth 1.
+    if (depth > maxDepth) {
+      return false;
+    }
+
+    const iterable = Array.isArray(node)
+      ? node
+      : (node as Record<string, unknown>);
+
+    for (const key in iterable) {
+      // Bound total work across the whole tree. Stop as soon as we exceed the
+      // cap so a hostile payload cannot keep us iterating.
+      if (keysVisited >= maxKeys) {
+        return false;
+      }
+      keysVisited++;
+      const child = (iterable as Record<string, unknown>)[key];
+      if (!walk(child, depth + 1)) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  return walk(value, 1);
+}
+
+/**
+ * Safely parse a JSON string, enforce resource limits, and validate its shape.
+ *
+ * Order of checks (fail-closed at every step, never throws to the caller):
+ *   1. Input must be a string.
+ *   2. Byte length must not exceed {@link maxMessageBytes} (checked BEFORE
+ *      JSON.parse to bound parser memory — cf. GHSA-96hv-2xvq-fx4p).
+ *   3. JSON.parse is wrapped so syntactically invalid input returns null.
+ *   4. A valid JSON scalar (number, string, boolean, null) is never a message.
+ *   5. The parsed object must satisfy the structural depth/key limits.
+ *   6. The caller's type guard must accept the shape.
  *
  * @param raw      - Raw string received from an untrusted source (peer/signal).
  * @param validate - Type guard returning true only when the parsed value has
  *                   the expected shape. Receives `unknown`.
- * @returns The validated value, or `null` if parsing or validation fails.
+ * @param options  - Optional resource-limit overrides.
+ * @returns The validated value, or `null` if parsing, limits, or validation
+ *          fail.
  */
 export function safeParseJson<T>(
   raw: string,
   validate: (value: unknown) => value is T,
+  options?: SafeParseJsonOptions,
 ): T | null {
   if (typeof raw !== "string") {
+    return null;
+  }
+
+  const limits: StructuralLimits = {
+    ...DEFAULT_STRUCTURAL_LIMITS,
+    ...options?.limits,
+  };
+
+  // Reject oversize messages before allocating a parser AST. This is the
+  // primary memory-exhaustion defense (GHSA-96hv-2xvq-fx4p class of bug).
+  if (raw.length > limits.maxMessageBytes) {
     return null;
   }
 
@@ -40,6 +192,13 @@ export function safeParseJson<T>(
 
   // A valid JSON scalar (number, string, boolean, null) is never a message.
   if (parsed === null || typeof parsed !== "object") {
+    return null;
+  }
+
+  // Reject pathologically deep or wide payloads before handing them to the
+  // (potentially recursive) shape guard, which could otherwise be made to do
+  // unbounded work on attacker-controlled input.
+  if (!withinStructuralLimits(parsed, limits)) {
     return null;
   }
 

--- a/src/lib/p2p-rate-limiter.ts
+++ b/src/lib/p2p-rate-limiter.ts
@@ -1,0 +1,110 @@
+/**
+ * @fileOverview Per-connection rate limiter for untrusted P2P data-channel
+ * messages.
+ *
+ * Peers join games via shared codes and are effectively anonymous, so a
+ * hostile peer can flood the receive path with thousands of messages per
+ * second. Each message triggers a JSON.parse and a recursive shape/structural
+ * validation pass; without rate limiting this is a cheap CPU/memory
+ * exhaustion vector. See issue #1111.
+ *
+ * This is a classic sliding-window counter scoped to a single connection
+ * instance (one limiter per data channel). It complements, and is intentionally
+ * separate from, the server-side AI-proxy limiter in `rate-limiter.ts` (which
+ * is module-global and keyed by user id) — the P2P layer needs one independent
+ * counter per peer connection, with no shared global state.
+ */
+
+/**
+ * Configuration for a {@link P2PRateLimiter}.
+ */
+export interface P2PRateLimitOptions {
+  /** Maximum number of messages permitted within {@link windowMs}. */
+  maxMessages: number;
+  /** Length of the sliding window in milliseconds. */
+  windowMs: number;
+}
+
+/**
+ * Default per-connection rate limit. Allows up to 100 messages per second,
+ * which comfortably accommodates real game traffic (5s ping cadence, state
+ * syncs on each action, chat/emote bursts) while dropping a sustained flood.
+ */
+export const DEFAULT_P2P_RATE_LIMIT: P2PRateLimitOptions = {
+  maxMessages: 100,
+  windowMs: 1000,
+};
+
+/**
+ * Sliding-window rate limiter for a single P2P connection.
+ *
+ * Call {@link tryAcquire} on every incoming message; it returns `true` if the
+ * message is within the limit (and records the timestamp), or `false` if the
+ * message exceeds the limit and must be dropped. The caller is responsible for
+ * dropping/queueing on `false` — this limiter never throws.
+ */
+export class P2PRateLimiter {
+  private readonly maxMessages: number;
+  private readonly windowMs: number;
+  /** Monotonic-ish receive timestamps currently inside the sliding window. */
+  private timestamps: number[] = [];
+
+  constructor(options?: Partial<P2PRateLimitOptions>) {
+    const opts = { ...DEFAULT_P2P_RATE_LIMIT, ...options };
+    if (opts.maxMessages <= 0 || !Number.isFinite(opts.maxMessages)) {
+      throw new Error("P2PRateLimiter: maxMessages must be a positive number");
+    }
+    if (opts.windowMs <= 0 || !Number.isFinite(opts.windowMs)) {
+      throw new Error("P2PRateLimiter: windowMs must be a positive number");
+    }
+    this.maxMessages = opts.maxMessages;
+    this.windowMs = opts.windowMs;
+  }
+
+  /**
+   * Attempt to record one incoming message at time {@link now}.
+   *
+   * @param now Optional timestamp (ms since epoch); defaults to `Date.now()`.
+   *   Injected for deterministic tests.
+   * @returns `true` if the message is within the rate limit (timestamp
+   *   recorded), `false` if the limit has been exceeded (message should be
+   *   dropped). Never throws.
+   */
+  tryAcquire(now: number = Date.now()): boolean {
+    const cutoff = now - this.windowMs;
+    // Drop timestamps that have aged out of the window. The array is kept in
+    // arrival order, so we can splice a single leading run.
+    let firstInWindow = 0;
+    while (
+      firstInWindow < this.timestamps.length &&
+      this.timestamps[firstInWindow] <= cutoff
+    ) {
+      firstInWindow++;
+    }
+    if (firstInWindow > 0) {
+      this.timestamps = this.timestamps.slice(firstInWindow);
+    }
+
+    if (this.timestamps.length >= this.maxMessages) {
+      return false;
+    }
+
+    this.timestamps.push(now);
+    return true;
+  }
+
+  /**
+   * Number of messages recorded in the current window (after the most recent
+   * acquire attempt). Mostly useful for diagnostics/tests.
+   */
+  get currentCount(): number {
+    return this.timestamps.length;
+  }
+
+  /**
+   * Reset the limiter (e.g. on connection close / reconnect).
+   */
+  reset(): void {
+    this.timestamps = [];
+  }
+}

--- a/src/lib/webrtc-p2p.ts
+++ b/src/lib/webrtc-p2p.ts
@@ -31,6 +31,14 @@ import {
   getGlobalICEManager,
 } from "./ice-config";
 import { redactSensitive } from "./p2p-log-redact";
+import {
+  MAX_MESSAGE_SIZE_BYTES,
+  withinStructuralLimits,
+} from "./p2p-json-validation";
+import {
+  P2PRateLimiter,
+  type P2PRateLimitOptions,
+} from "./p2p-rate-limiter";
 
 /**
  * WebRTC configuration with STUN/TURN servers
@@ -218,6 +226,12 @@ export interface P2PConnectionOptions {
   /** Time (ms) to wait for recovery after each ICE restart attempt. */
   reconnectAttemptTimeoutMs?: number;
   /**
+   * Per-connection rate limit for incoming data-channel messages. Defaults to
+   * 100 msgs / 1s. Messages exceeding the limit are dropped before parsing
+   * to prevent CPU/memory exhaustion from a flooding peer. Issue #1111.
+   */
+  rateLimit?: Partial<P2PRateLimitOptions>;
+  /**
    * Defer ping cadence to an external driver (e.g. a connection pool that
    * consolidates pings into a single sweep). When true the connection never
    * starts its own ping interval; callers must invoke {@link ping} instead.
@@ -278,6 +292,12 @@ export class WebRTCConnection {
    * checks instead of its own interval. Issue #1021.
    */
   private externalPing: boolean;
+  /**
+   * Per-connection sliding-window rate limiter for incoming data-channel
+   * messages. Caps how many messages per second a single peer can push
+   * through the parse path. Issue #1111.
+   */
+  private rateLimiter: P2PRateLimiter;
 
   constructor(options: P2PConnectionOptions) {
     this.localPlayerId = options.playerId;
@@ -291,6 +311,9 @@ export class WebRTCConnection {
     this.reconnectMaxDelayMs = options.reconnectMaxDelayMs ?? 16000;
     this.reconnectAttemptTimeoutMs = options.reconnectAttemptTimeoutMs ?? 15000;
     this.externalPing = options.externalPing ?? false;
+    // Per-connection rate limiter guards the parse path against flooding
+    // peers. Issue #1111.
+    this.rateLimiter = new P2PRateLimiter(options.rateLimit);
 
     // Initialize ICE configuration
     if (options.iceConfig) {
@@ -658,11 +681,50 @@ export class WebRTCConnection {
   }
 
   /**
-   * Handle incoming messages
+   * Handle incoming messages.
+   *
+   * Untrusted peer bytes are hardened against resource exhaustion (issue
+   * #1111) before any business logic runs:
+   *   1. Per-connection rate limit — a flooding peer is dropped before any
+   *      parsing work is done.
+   *   2. Hard byte cap on the raw message — checked BEFORE JSON.parse so the
+   *      parser never allocates an unbounded buffer (cf. GHSA-96hv-2xvq-fx4p,
+   *      the ws memory-exhaustion advisory).
+   *   3. Structural limits — max nesting depth + max total key count, so a
+   *      deeply-nested or key-bloated payload cannot blow the stack or burn
+   *      CPU in the recursive handlers below.
+   *
+   * Every limit violation is rejected silently (logged) rather than thrown.
    */
   private handleMessage(data: string): void {
     try {
+      // 1. Rate-limit first: never do parse work for a flooding peer.
+      if (!this.rateLimiter.tryAcquire()) {
+        console.warn("[WebRTC] Rate limit exceeded; dropping peer message");
+        return;
+      }
+
+      // 2. Hard size cap before JSON.parse to bound parser memory allocation.
+      if (data.length > MAX_MESSAGE_SIZE_BYTES) {
+        console.warn(
+          "[WebRTC] Rejected oversize peer message",
+          data.length,
+          ">",
+          MAX_MESSAGE_SIZE_BYTES,
+        );
+        return;
+      }
+
       const message: P2PMessage = JSON.parse(data);
+
+      // 3. Structural caps: reject pathologically deep / wide payloads before
+      // the recursive message handlers run.
+      if (!withinStructuralLimits(message)) {
+        console.warn(
+          "[WebRTC] Rejected peer message exceeding structural limits",
+        );
+        return;
+      }
 
       switch (message.type) {
         case "game-state-sync":
@@ -1371,6 +1433,7 @@ export class WebRTCConnection {
 
     this.peers.clear();
     this.pendingCandidates = [];
+    this.rateLimiter.reset();
     this.updateConnectionState("disconnected");
   }
 


### PR DESCRIPTION
## Summary

Resolves #1111. The P2P validation layer validated message *shape* but had no defenses against resource-exhaustion from a malicious/anonymous peer (peers join via shared game codes). A hostile peer could ship an arbitrarily large string (unbounded `JSON.parse` allocation), a pathologically deep object (call-stack blowup in the recursive handlers), or a key-bloated object (unbounded CPU), and could flood these at thousands of msgs/sec. This is the same class of bug as the `ws` advisory **GHSA-96hv-2xvq-fx4p** (DoS via unbounded memory allocation on untrusted payloads), applied to our WebRTC data channel.

## Limits added

All limits are named, documented constants in `src/lib/p2p-json-validation.ts` and are overridable per call site (for tests / special channels):

| Limit | Default | Rationale |
| --- | --- | --- |
| `MAX_MESSAGE_SIZE_BYTES` | 256 KiB | Hard byte cap checked **before** `JSON.parse` to bound parser memory. Full Commander game states serialize well under 100 KiB. |
| `MAX_NESTING_DEPTH` | 64 | Bounds recursion; V8 accepts far deeper input that would blow the stack in a naive recursive walk. Far above any legit payload. |
| `MAX_KEY_COUNT` | 10 000 | Bounds CPU in the structural walk / shape guard across the whole tree. |

## Where limits are enforced

Both data-channel receive paths now harden untrusted bytes **before** any business logic, in order:

1. **Per-connection rate limit** (sliding window, default 100 msgs / 1s) — a flooding peer is dropped before any parse work.
2. **Hard byte cap** before `JSON.parse` (memory-exhaustion defense, cf. GHSA-96hv-2xvq-fx4p).
3. **Structural caps** (max depth + max total key count) on the parsed value, before the recursive handlers run.
4. (Shape validation pre-existing via `safeParseJson` / `isGameMessage`.)

- `src/lib/p2p-game-connection.ts` — `handleMessage`: rate-limit → `safeParseJson` (now enforces size + depth/key + shape).
- `src/lib/webrtc-p2p.ts` — `handleMessage`: previously used raw `JSON.parse(data)` with no guards; now rate-limit → size cap → `JSON.parse` → `withinStructuralLimits`.

## Rate-limit design

New module `src/lib/p2p-rate-limiter.ts` (`P2PRateLimiter`): one **sliding-window** counter per connection instance, no shared global state. It is intentionally separate from the existing server-side AI-proxy limiter in `rate-limiter.ts` (which is module-global and keyed by user id) — the P2P layer needs one independent counter per peer connection. Configurable via `rateLimit?` on both `P2PGameConnectionOptions` and `P2PConnectionOptions`; reset on `close()`. Defaults comfortably accommodate real game traffic (5s ping cadence, state syncs on actions, chat/emote bursts) while dropping a sustained flood.

## Behavior on violation

Every limit violation is **rejected, never thrown** — logged at `warn`/`error` and the message is dropped, so a malicious peer cannot crash or hang the client. The connection stays up.

## Tests

- `src/lib/__tests__/p2p-json-validation.test.ts` — extended with DoS cases: oversize rejection (default cap + override), inclusive boundary, deep-nesting rejection, key-bloated rejection, legit-large payload still accepted, and `withinStructuralLimits` is bounded & non-throwing on hostile input.
- `src/lib/__tests__/p2p-rate-limiter.test.ts` (new) — within-limit admission, rapid-spam dropping, 100k-message flood without throwing, sliding-window recovery, lazy eviction, `reset()`, and config validation.

## Verification

- `npx jest p2p webrtc` → **235 suites / 4493 tests pass** (no regressions).
- `tsc --noEmit` → clean.
- `eslint src` → 0 errors (warnings unchanged; changed files introduce no new warnings).

## Scope

Touched only the files in the issue scope: the validation module, the two connection modules, and their tests. No unrelated refactors. Added constants are overridable so legit-but-larger channels can opt out without code changes.

Resolves #1111.