### PR TITLE
feat(ux): resolve #1106 — add a first-run onboarding tour for new players

### DIFF
--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * First-run onboarding tour (#1106).
+ *
+ * Simulates a brand-new visitor by clearing the `planar-nexus:onboarded` flag
+ * via addInitScript (runs before any app code), then steps through the tour,
+ * and finally verifies completion.
+ *
+ * The tour's step title lives in `#onboarding-tour-title` (a div, exposed to AT
+ * via the dialog's `aria-labelledby`), so we assert on that id rather than a
+ * heading role — the dashboard hero also renders a "Welcome to Planar Nexus"
+ * string that would otherwise collide.
+ *
+ * The webServer (npm run dev on :9002) is started by playwright.config.ts.
+ */
+
+const ONBOARDED_KEY = "planar-nexus:onboarded";
+const DIALOG = 'div[role="dialog"][aria-labelledby="onboarding-tour-title"]';
+const TITLE = "#onboarding-tour-title";
+
+/** Strip the onboarding flag before the app mounts so the tour auto-starts. */
+async function forceFreshVisitor(page: import("@playwright/test").Page) {
+  await page.addInitScript((key) => {
+    try {
+      window.localStorage.removeItem(key);
+    } catch {
+      /* ignore */
+    }
+  }, ONBOARDED_KEY);
+}
+
+/** Assert the tour is showing a given step title. */
+async function expectTourTitle(
+  page: import("@playwright/test").Page,
+  title: string,
+) {
+  await expect(page.locator(TITLE)).toHaveText(title);
+}
+
+test.describe("Onboarding tour", () => {
+  test.beforeEach(async ({ page }) => {
+    await forceFreshVisitor(page);
+    await page.goto("/dashboard");
+  });
+
+  test("auto-starts on first launch and can be completed", async ({ page }) => {
+    // The tour appears shortly after first load.
+    await expect(page.locator(DIALOG)).toBeVisible({ timeout: 10000 });
+    await expectTourTitle(page, "Welcome to Planar Nexus");
+
+    // Each step exposes a primary "Next" / final "Get started" button.
+    const next = page.locator('[data-tour-primary]');
+
+    // Step through the whole tour (8 steps total).
+    for (let i = 0; i < 8; i++) {
+      await expect(next).toBeVisible();
+      await next.click();
+    }
+
+    // Final click landed on "Get started" and dismissed the dialog.
+    await expect(page.locator(DIALOG)).toBeHidden();
+
+    // Completion persisted the onboarding flag.
+    const seen = await page.evaluate((key) => {
+      try {
+        return window.localStorage.getItem(key);
+      } catch {
+        return null;
+      }
+    }, ONBOARDED_KEY);
+    expect(seen).toBe("true");
+  });
+
+  test("advances with the Enter key", async ({ page }) => {
+    await expect(page.locator(DIALOG)).toBeVisible({ timeout: 10000 });
+    await expectTourTitle(page, "Welcome to Planar Nexus");
+
+    // Primary button receives focus on open; Enter then advances the step.
+    const next = page.locator('[data-tour-primary]');
+    await next.focus();
+    await page.keyboard.press("Enter");
+
+    await expectTourTitle(page, "Build Your Deck");
+  });
+
+  test("Escape dismisses the tour and marks it seen", async ({ page }) => {
+    await expect(page.locator(DIALOG)).toBeVisible({ timeout: 10000 });
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator(DIALOG)).toBeHidden();
+
+    const seen = await page.evaluate((key) => {
+      try {
+        return window.localStorage.getItem(key);
+      } catch {
+        return null;
+      }
+    }, ONBOARDED_KEY);
+    expect(seen).toBe("true");
+  });
+
+  test("is not shown once the onboarding flag is set", async ({ page }) => {
+    // Pre-seed the flag before the app loads.
+    await page.addInitScript((key) => {
+      try {
+        window.localStorage.setItem(key, "true");
+      } catch {
+        /* ignore */
+      }
+    }, ONBOARDED_KEY);
+    await page.goto("/dashboard");
+
+    // Tour must NOT appear.
+    await expect(page.locator(DIALOG)).toBeHidden({ timeout: 5000 });
+  });
+
+  test("can be restarted from Settings", async ({ page }) => {
+    // Complete it once so we are in the "seen" state.
+    await expect(page.locator(DIALOG)).toBeVisible({ timeout: 10000 });
+    const next = page.locator('[data-tour-primary]');
+    for (let i = 0; i < 8; i++) {
+      await expect(next).toBeVisible();
+      await next.click();
+    }
+    await expect(page.locator(DIALOG)).toBeHidden();
+
+    // Restart from Settings.
+    await page.goto("/settings");
+    await page.getByRole("button", { name: /Restart tour/i }).click();
+
+    // The tour reappears at the welcome step.
+    await expect(page.locator(DIALOG)).toBeVisible({ timeout: 10000 });
+    await expectTourTitle(page, "Welcome to Planar Nexus");
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,10 @@ import { defineConfig } from '@playwright/test';
  * This configuration sets up E2E testing for the Planar Nexus application.
  * Tests run against a local dev server on port 9002.
  */
+
+// Dev-server origin (also used as the base URL for every test).
+const E2E_ORIGIN = process.env.BASE_URL || 'http://localhost:9002';
+
 export default defineConfig({
   // Directory containing E2E tests
   testDir: './e2e',
@@ -43,8 +47,23 @@ export default defineConfig({
   // Shared settings for all the projects below
   use: {
     // Base URL for all tests
-    baseURL: process.env.BASE_URL || 'http://localhost:9002',
-    
+    baseURL: E2E_ORIGIN,
+
+    // Hide the first-run onboarding tour (#1106) for every test by default.
+    // The tour auto-starts when `planar-nexus:onboarded` is absent, and its
+    // modal backdrop would intercept pointer events across the whole suite.
+    // `e2e/onboarding.spec.ts` opts back in by clearing this key per page
+    // via `forceFreshVisitor()` (addInitScript runs after storageState).
+    storageState: {
+      cookies: [],
+      origins: [
+        {
+          origin: E2E_ORIGIN,
+          localStorage: [{ name: 'planar-nexus:onboarded', value: 'true' }],
+        },
+      ],
+    },
+
     // Collect trace when retrying the failed test
     trace: 'on-first-retry',
     

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -4,6 +4,7 @@ import { Sidebar, SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
 import { AppSidebar } from '@/components/app-sidebar';
 import { AppFooter } from '@/components/app-footer';
 import { IndexedDBMigration } from '@/components/indexeddb-migration';
+import { OnboardingTour } from '@/components/onboarding-tour';
 import { usePathname } from 'next/navigation';
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
@@ -13,6 +14,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <SidebarProvider>
       <IndexedDBMigration />
+      <OnboardingTour />
       <Sidebar collapsible="icon">
         <AppSidebar />
       </Sidebar>

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -35,6 +35,8 @@ import {
   isCustomImagesEnabled,
   validateImageDirectory,
 } from "@/lib/card-image-resolver";
+import { restartOnboardingTour } from "@/components/onboarding-tour";
+import { RotateCcw } from "lucide-react";
 
 export default function SettingsPage() {
   return (
@@ -57,6 +59,23 @@ export default function SettingsPage() {
           <CardContent>
             <Button asChild>
               <a href="/database-management">Manage Database</a>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="mb-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Help &amp; Onboarding</CardTitle>
+            <CardDescription>
+              Replay the first-run tour that highlights the key sections of the app
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button onClick={() => restartOnboardingTour()}>
+              <RotateCcw className="mr-2 h-4 w-4" aria-hidden="true" />
+              Restart tour
             </Button>
           </CardContent>
         </Card>

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -20,20 +20,20 @@ export function AppSidebar() {
 
   const menuItems = [
     { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
-    { href: '/deck-builder', label: 'Deck Builder', icon: Library },
+    { href: '/deck-builder', label: 'Deck Builder', icon: Library, tourId: 'deck-builder' },
     { href: '/card-studio', label: 'Card Studio', icon: Palette },
-    { href: '/collection', label: 'Collection', icon: Package },
+    { href: '/collection', label: 'Collection', icon: Package, tourId: 'collection' },
     { href: '/draft-assistant', label: 'Draft Assistant', icon: Gem },
-    { href: '/deck-coach', label: 'AI Deck Coach', icon: Bot },
+    { href: '/deck-coach', label: 'AI Deck Coach', icon: Bot, tourId: 'deck-coach' },
     { href: '/coach-report', label: 'Coach Report', icon: GraduationCap },
     { href: '/meta', label: 'Meta Analysis', icon: TrendingUp },
     { href: '/game-analysis', label: 'Game Analysis', icon: BarChart3 },
     { href: '/saved-games', label: 'Saved Games', icon: Save },
-    { href: '/single-player', label: 'Single Player', icon: Swords },
-    { href: '/multiplayer', label: 'Multiplayer', icon: Users },
+    { href: '/single-player', label: 'Single Player', icon: Swords, tourId: 'single-player' },
+    { href: '/multiplayer', label: 'Multiplayer', icon: Users, tourId: 'multiplayer' },
     { href: '/game-board', label: 'Game Board Demo', icon: Eye },
     { href: '/card-interactions-demo', label: 'Card Interactions', icon: MousePointer },
-    { href: '/settings', label: 'Settings', icon: Settings },
+    { href: '/settings', label: 'Settings', icon: Settings, tourId: 'settings' },
   ];
 
   return (
@@ -57,7 +57,7 @@ export function AppSidebar() {
                 isActive={pathname === item.href}
                 tooltip={{ children: item.label }}
               >
-                <Link href={item.href}>
+                <Link href={item.href} data-tour={item.tourId}>
                   <item.icon />
                   <span>{item.label}</span>
                 </Link>

--- a/src/components/onboarding-tour.tsx
+++ b/src/components/onboarding-tour.tsx
@@ -1,0 +1,514 @@
+"use client";
+
+/**
+ * OnboardingTour — app-wide first-run tour (#1106).
+ *
+ * Extends the per-tutorial pattern from `game-tutorial.tsx` to the whole app.
+ * - Auto-starts on first launch when the `planar-nexus:onboarded` flag is absent.
+ * - Dismissible (Skip / Escape / overlay click) and re-triggerable from Settings.
+ * - Each step targets an element by a stable `data-tour="..."` attribute.
+ * - Keyboard-navigable (Tab cycles within the callout, Enter advances, Escape cancels)
+ *   and announced to screen readers (role="dialog" + aria-live announcer).
+ * - Reuses existing UI primitives (Card, Button) rather than a tour dependency.
+ * - Respects `prefers-reduced-motion` (#1103).
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export const ONBOARDING_STORAGE_KEY = "planar-nexus:onboarded";
+/** Custom event dispatched to re-trigger the tour from anywhere (e.g. Settings). */
+export const START_TOUR_EVENT = "planar-nexus:start-tour";
+
+export interface OnboardingStep {
+  id: string;
+  title: string;
+  description: string;
+  /** CSS selector for the highlighted element, e.g. "[data-tour='decks']". */
+  target?: string;
+  side?: "top" | "bottom" | "left" | "right" | "center";
+}
+
+const ONBOARDING_STEPS: OnboardingStep[] = [
+  {
+    id: "welcome",
+    title: "Welcome to Planar Nexus",
+    description:
+      "Take a 30-second tour of the essentials. You can skip anytime and restart it later from Settings.",
+    side: "center",
+  },
+  {
+    id: "decks",
+    title: "Build Your Deck",
+    description:
+      "The Deck Builder is where you craft and tune decks from a vast card library. Start here after importing or creating a deck.",
+    target: "[data-tour='deck-builder']",
+    side: "right",
+  },
+  {
+    id: "collection",
+    title: "Your Collection",
+    description:
+      "Browse and manage every card you own. Filter, sort, and track what's available across formats.",
+    target: "[data-tour='collection']",
+    side: "right",
+  },
+  {
+    id: "coach",
+    title: "AI Deck Coach",
+    description:
+      "Get instant analysis and improvement suggestions for your decks from the built-in AI coach.",
+    target: "[data-tour='deck-coach']",
+    side: "right",
+  },
+  {
+    id: "play",
+    title: "Play Against the AI",
+    description:
+      "Jump into Single Player to test your deck. Pick an AI opponent difficulty and start a match.",
+    target: "[data-tour='single-player']",
+    side: "right",
+  },
+  {
+    id: "multiplayer",
+    title: "Multiplayer",
+    description:
+      "Challenge friends in bring-your-own-code multiplayer. Share a game code to start a match.",
+    target: "[data-tour='multiplayer']",
+    side: "right",
+  },
+  {
+    id: "settings",
+    title: "Settings",
+    description:
+      "Configure card images, sound, auto-save, and privacy. You can restart this tour from here anytime.",
+    target: "[data-tour='settings']",
+    side: "right",
+  },
+  {
+    id: "done",
+    title: "You're All Set",
+    description:
+      "That's the tour! Build a deck, then jump into Single Player. Need a refresher? Restart the tour from Settings.",
+    side: "center",
+  },
+];
+
+/* ----------------------------- storage helpers ---------------------------- */
+
+export function isOnboarded(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(ONBOARDING_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function markOnboarded(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(ONBOARDING_STORAGE_KEY, "true");
+  } catch {
+    /* localStorage may be unavailable (private mode); tour still works in-session. */
+  }
+}
+
+/** Re-trigger the tour from anywhere. The mounted <OnboardingTour /> listens. */
+export function restartOnboardingTour(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(START_TOUR_EVENT));
+}
+
+/* ------------------------------- primitives ------------------------------- */
+
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReduced(mq.matches);
+    update();
+    mq.addEventListener?.("change", update);
+    return () => mq.removeEventListener?.("change", update);
+  }, []);
+  return reduced;
+}
+
+/** Focusable element selector used by the lightweight focus trap. */
+const FOCUSABLE =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+/* ------------------------------- component -------------------------------- */
+
+export function OnboardingTour() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [index, setIndex] = useState(0);
+  const [hydrated, setHydrated] = useState(false);
+  const [targetRect, setTargetRect] = useState<DOMRect | null>(null);
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const prevFocusRef = useRef<HTMLElement | null>(null);
+  const reduceMotion = usePrefersReducedMotion();
+
+  const steps = ONBOARDING_STEPS;
+  const step = steps[index];
+  const isFirst = index === 0;
+  const isLast = index === steps.length - 1;
+
+  /* ---- auto-start on first run (after hydration to avoid SSR mismatch) ---- */
+  useEffect(() => {
+    setHydrated(true);
+    if (typeof window === "undefined") return;
+    if (!isOnboarded()) {
+      const t = window.setTimeout(() => setIsOpen(true), 600);
+      return () => window.clearTimeout(t);
+    }
+  }, []);
+
+  /* ---- listen for restart requests (e.g. from Settings) ---- */
+  useEffect(() => {
+    const handler = () => {
+      setIndex(0);
+      setIsOpen(true);
+    };
+    window.addEventListener(START_TOUR_EVENT, handler);
+    return () => window.removeEventListener(START_TOUR_EVENT, handler);
+  }, []);
+
+  /* ---- track the highlighted element's position ---- */
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const update = () => {
+      if (!step.target || step.side === "center") {
+        setTargetRect(null);
+        return;
+      }
+      const el = document.querySelector<HTMLElement>(step.target);
+      if (!el) {
+        setTargetRect(null);
+        return;
+      }
+      el.scrollIntoView({
+        behavior: reduceMotion ? "auto" : "smooth",
+        block: "center",
+        inline: "center",
+      });
+      setTargetRect(el.getBoundingClientRect());
+    };
+
+    update();
+    // Re-measure shortly after in case layout is still settling.
+    const retry = window.setTimeout(update, 320);
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      window.clearTimeout(retry);
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [isOpen, index, step, reduceMotion]);
+
+  /* ---- focus management: focus the callout, restore focus on close ---- */
+  const focusCallout = useCallback(() => {
+    const node = dialogRef.current;
+    if (!node) return;
+    const primary = node.querySelector<HTMLElement>("[data-tour-primary]");
+    (primary ?? node).focus();
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    prevFocusRef.current =
+      (document.activeElement as HTMLElement) || prevFocusRef.current;
+    const t = window.setTimeout(focusCallout, reduceMotion ? 0 : 80);
+    return () => window.clearTimeout(t);
+  }, [isOpen, index, reduceMotion, focusCallout]);
+
+  /* ---- navigation ---- */
+  const close = useCallback(() => {
+    setIsOpen(false);
+    markOnboarded();
+    window.requestAnimationFrame(() => {
+      prevFocusRef.current?.focus?.();
+      prevFocusRef.current = null;
+    });
+  }, []);
+
+  const next = useCallback(() => {
+    if (isLast) {
+      close();
+      return;
+    }
+    setIndex((i) => i + 1);
+  }, [isLast, close]);
+
+  const prev = useCallback(() => {
+    setIndex((i) => Math.max(0, i - 1));
+  }, []);
+
+  /* ---- keyboard: Escape cancels; Tab is trapped within the callout ---- */
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        close();
+        return;
+      }
+      if (e.key === "ArrowRight" && !isLast) {
+        e.preventDefault();
+        next();
+        return;
+      }
+      if (e.key === "ArrowLeft" && !isFirst) {
+        e.preventDefault();
+        prev();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const node = dialogRef.current;
+      if (!node) return;
+      const items = Array.from(
+        node.querySelectorAll<HTMLElement>(FOCUSABLE),
+      ).filter((el) => !el.hasAttribute("disabled"));
+      if (items.length === 0) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement as HTMLElement;
+
+      if (e.shiftKey) {
+        if (active === first || !node.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    },
+    [close, next, prev, isFirst, isLast],
+  );
+
+  /* ---- render guards ---- */
+  // Nothing to render until hydrated (avoids SSR/CSR markup mismatch).
+  if (!hydrated) return null;
+
+  return (
+    <>
+      {/* SR-only live region: announces each step as it changes. */}
+      <div aria-live="polite" aria-atomic="true" className="sr-only">
+        {isOpen
+          ? `Step ${index + 1} of ${steps.length}: ${step.title}. ${step.description}`
+          : ""}
+      </div>
+
+      {!isOpen ? null : (
+        <>
+          {/* Dimming overlay (click to dismiss). Pointer events only; SR hides it. */}
+          <div
+            className="fixed inset-0 z-50 bg-black/40"
+            onClick={close}
+            aria-hidden="true"
+          />
+
+          {/* Highlight ring around the target element. */}
+          {targetRect && (
+            <div
+              className={cn(
+                "fixed z-50 pointer-events-none rounded-lg border-2 border-primary shadow-[0_0_24px_rgba(99,102,241,0.45)]",
+                reduceMotion ? "" : "transition-all duration-200",
+              )}
+              style={{
+                top: targetRect.top - 4,
+                left: targetRect.left - 4,
+                width: targetRect.width + 8,
+                height: targetRect.height + 8,
+              }}
+              aria-hidden="true"
+            />
+          )}
+
+          {/* Callout (popover-styled card). */}
+          <div
+            ref={dialogRef}
+            role="dialog"
+            aria-modal="false"
+            aria-labelledby="onboarding-tour-title"
+            aria-describedby="onboarding-tour-desc"
+            tabIndex={-1}
+            onKeyDown={onKeyDown}
+            style={getPopupStyle(step.side, targetRect)}
+            className={cn(
+              "z-50 w-[min(380px,calc(100vw-2rem))] outline-none",
+              reduceMotion ? "" : "transition-all duration-200",
+            )}
+          >
+            <Card className="border-primary/30 shadow-xl">
+              <CardHeader className="pb-2">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="flex h-6 w-6 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground"
+                      aria-hidden="true"
+                    >
+                      {index + 1}
+                    </span>
+                    <CardTitle
+                      id="onboarding-tour-title"
+                      className="text-base leading-tight"
+                    >
+                      {step.title}
+                    </CardTitle>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 shrink-0"
+                    onClick={close}
+                    aria-label="Close tour"
+                  >
+                    <X className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </div>
+                <CardDescription>
+                  Step {index + 1} of {steps.length}
+                </CardDescription>
+              </CardHeader>
+
+              <CardContent className="space-y-3">
+                <p
+                  id="onboarding-tour-desc"
+                  className="text-sm text-foreground"
+                >
+                  {step.description}
+                </p>
+
+                {/* Progress dots */}
+                <div
+                  className="flex items-center justify-center gap-1.5"
+                  aria-hidden="true"
+                >
+                  {steps.map((_, idx) => (
+                    <span
+                      key={idx}
+                      className={cn(
+                        "h-2 w-2 rounded-full",
+                        idx === index
+                          ? "bg-primary"
+                          : idx < index
+                            ? "bg-primary/50"
+                            : "bg-muted",
+                      )}
+                    />
+                  ))}
+                </div>
+
+                {/* Navigation buttons */}
+                <div className="flex items-center justify-between pt-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={prev}
+                    disabled={isFirst}
+                    className="h-8 text-xs"
+                  >
+                    <ChevronLeft className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
+                    Back
+                  </Button>
+
+                  <div className="flex items-center gap-2">
+                    {!isLast && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={close}
+                        className="h-8 text-xs"
+                      >
+                        Skip tour
+                      </Button>
+                    )}
+                    <Button
+                      size="sm"
+                      onClick={next}
+                      data-tour-primary
+                      className="h-8 gap-1 text-xs"
+                    >
+                      {isLast ? "Get started" : "Next"}
+                      {!isLast && (
+                        <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
+/* --------------------------- positioning helper --------------------------- */
+
+function getPopupStyle(
+  side: OnboardingStep["side"],
+  rect: DOMRect | null,
+): React.CSSProperties {
+  if (!rect || side === "center") {
+    return {
+      position: "fixed",
+      top: "50%",
+      left: "50%",
+      transform: "translate(-50%, -50%)",
+    };
+  }
+
+  const padding = 12;
+  const width = 380;
+  const height = 200;
+  let top = 0;
+  let left = 0;
+
+  switch (side) {
+    case "top":
+      top = rect.top - height - padding;
+      left = rect.left + rect.width / 2 - width / 2;
+      break;
+    case "bottom":
+      top = rect.bottom + padding;
+      left = rect.left + rect.width / 2 - width / 2;
+      break;
+    case "left":
+      top = rect.top + rect.height / 2 - height / 2;
+      left = rect.left - width - padding;
+      break;
+    case "right":
+    default:
+      top = rect.top + rect.height / 2 - height / 2;
+      left = rect.right + padding;
+      break;
+  }
+
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  // Clamp into the viewport.
+  top = Math.max(padding, Math.min(top, vh - height - padding));
+  left = Math.max(padding, Math.min(left, vw - width - padding));
+
+  return { position: "fixed", top, left };
+}


### PR DESCRIPTION
## Summary

Adds an app-wide first-run onboarding tour so new players get oriented on first launch. Extends the per-tutorial pattern from `game-tutorial.tsx` to the whole app (it was in-game only).

Resolves #1106.

## What changed

- **New `src/components/onboarding-tour.tsx`** — the tour driver. Reuses existing `Card`/`Button` primitives (no tour library). Auto-starts on first launch, dismissible, and re-triggerable.
- **`src/components/app-sidebar.tsx`** — added stable `data-tour="..."` anchors to the highlighted nav items (Deck Builder, Collection, AI Deck Coach, Single Player, Multiplayer, Settings) instead of brittle CSS selectors.
- **`src/app/(app)/layout.tsx`** — mounts `<OnboardingTour />` once for the whole app shell.
- **`src/app/(app)/settings/page.tsx`** — adds a "Help & Onboarding" card with a **Restart tour** button.
- **New `e2e/onboarding.spec.ts`** — Playwright spec simulating fresh `localStorage`, stepping through the tour, and verifying completion/restart.

## Tour steps (8)
Welcome → Deck Builder → Collection → AI Deck Coach → Single Player (Play) → Multiplayer → Settings → You're All Set.

## Persistence
Uses a `planar-nexus:onboarded` localStorage flag, consistent with the precedent in `game-tutorial.tsx` (`planar-nexus-game-tutorial-completed`). Helpers `isOnboarded()`/`restartOnboardingTour()` are exported for reuse.

## Accessibility
- Callout is a `role="dialog"` with `aria-labelledby`/`aria-describedby`; an `aria-live="polite"` SR-only region announces each step.
- **Focus management**: focus moves to the callout's primary button on open and is restored to the trigger on dismiss.
- **Keyboard**: `Enter` advances, `Escape` cancels, `←/→` step back/forward, and `Tab` is trapped within the callout.
- Elements targeted by stable `data-tour` attributes.

## Reduced motion (#1103)
Detects `prefers-reduced-motion`: skips the smooth scroll-into-view and the highlight/callout transitions when reduced motion is preferred.

## Acceptance criteria
- [x] Tour auto-starts on first launch (fresh localStorage), dismissible, and re-triggerable from Settings
- [x] Steps highlight the key app sections (Deck Builder, Collection, Coach, Play/Single Player, Multiplayer, Settings)
- [x] Keyboard-navigable (Tab/Enter/Escape) and announced to screen readers
- [x] Playwright spec simulating fresh localStorage + completing the tour

## Verification (ran locally)
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (1 pre-existing `useState` warning in settings page, unrelated to this change)
- `npm test` (jest) — **236 suites / 4508 tests passed**
- `npx playwright test e2e/onboarding.spec.ts` (chromium) — **5/5 passed** ✅ (ran locally, headed browsers not required)
- `npx playwright test e2e/basic-navigation.spec.ts` (chromium) — **6/6 passed** (confirms sidebar nav unaffected)

## Notes / deviations
- The issue proposed an `onboarding/` directory; I used a single `src/components/onboarding-tour.tsx` to match the precedent of the flat `game-tutorial.tsx` layout and keep the diff focused.
- `CardTitle` is a `<div>` in this repo (exposed to AT via the dialog's `aria-labelledby`), so the e2e asserts step titles via the unique `#onboarding-tour-title` id rather than a heading role.