### PR TITLE
chore(security): resolve #1110 - enable GitHub Code Scanning (CodeQL)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,81 @@
+# CodeQL Static Application Security Testing (SAST)
+# Triggers: PR (main/develop), push (main/develop), weekly schedule, manual.
+# Scans the TypeScript codebase and the GitHub Actions workflow files themselves.
+# Resolves #1110.
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main, develop]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.mdx'
+      - 'docs/**'
+      - '**/docs/**'
+      - 'LICENSE'
+      - '.editorconfig'
+  pull_request:
+    branches: [main, develop]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.mdx'
+      - 'docs/**'
+      - '**/docs/**'
+      - 'LICENSE'
+      - '.editorconfig'
+  schedule:
+    # Weekly: Mondays at 04:27 UTC (offset to avoid GitHub-side top-of-hour load).
+    - cron: '27 4 * * 1'
+  workflow_dispatch:
+
+# Minimal least-privilege scope required by the CodeQL Action.
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Skip Dependabot PRs so dependency-bump PRs are never blocked by CodeQL.
+    # Dependabot bumps are still covered by the weekly scheduled scan of main.
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        # javascript-typescript -> app code (URL importers, P2P, card parsing).
+        # actions              -> this and other workflow files.
+        language: [javascript-typescript, actions]
+    steps:
+      - name: Configure git
+        run: |
+          git config --global --add safe.directory '*'
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        if: matrix.language == 'javascript-typescript'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary

Resolves #1110.

Adds `.github/workflows/codeql.yml` to run **GitHub Code Scanning (CodeQL)** — the repo's first SAST workflow. None of the existing workflows (`ci.yml`, `release.yml`, `mobile-build.yml`, `video-derived-tests.yml`) perform static security analysis; ESLint only catches style/bugs, not vulnerability classes. This directly addresses the new untrusted-input surfaces flagged in the issue (deck URL importers #1000, P2P message handling, card-text regex parsing).

## What this adds

A single `analyze` job driven by a **language matrix** over `javascript-typescript` and `actions` (the latter scans the workflow files themselves), following the official `github/codeql-action` `init` → `autobuild` → `analyze` pattern.

### Triggers
- `pull_request` to `main` / `develop`
- `push` to `main` / `develop`
- **Weekly schedule** — `27 4 * * 1` (Mondays ~04:27 UTC, offset off the top of the hour)
- `workflow_dispatch` (manual)

### Languages / query suites
- `javascript-typescript` — app code (URL importers, P2P, card parsing)
- `actions` — `.github/workflows/**` (so CI config itself is scanned)

### Does NOT block Dependabot
- **`if: github.actor != 'dependabot[bot]'`** on the analyze job — Dependabot PRs skip the job (reported *skipped*, never *failed*).
- **`paths-ignore`** on `**/*.md`, `**/*.mdx`, `docs/**`, `LICENSE`, `.editorconfig` so doc-only changes don't trigger.
- Dependabot bumps are **still covered** by the weekly scheduled scan of `main`, so nothing goes uninspected.

### Conventions matched (per AGENTS.md + sibling workflows)
- `Configure git` first step (`git config --global --add safe.directory '*'`)
- `actions/checkout@v4`, `actions/setup-node@v4` (Node 22, `cache: 'npm'`)
- Top-level `permissions:` (least-privilege: `contents: read`, `actions: read`, `security-events: write`) — mirrors `release.yml`
- `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`
- `push`/`pull_request` on `[main, develop]`, `paths` filtering like `video-derived-tests.yml`

### Action pinning
Pinned to `github/codeql-action@v3` as specified in the issue. Note: `v4` is now the latest major and is a one-line bump if/when desired; `v3` remains fully supported (only `v1`/`v2` are deprecated).

## Branch-protection note (for the maintainer)
When enabling this as a **required** check on `main`, the job name to require is `Analyze (javascript-typescript)` (and optionally `Analyze (actions)`). Because Dependabot PRs intentionally *skip* the job, GitHub reports it as `skipped` rather than `failed`, so it will not block those PRs. If stricter enforcement is ever wanted, the `if:` guard can be removed.

## CodeQL findings / triage — ✅ CLEAN BASELINE
The workflow ran on this PR (run [#28219865056](https://github.com/anchapin/planar-nexus/actions/runs/28219865056)):

| Language | Job | Result | Alerts |
| --- | --- | --- | --- |
| `javascript-typescript` | `Analyze (javascript-typescript)` | ✅ success | **0** |
| `actions` | `Analyze (actions)` | ✅ success | **0** |

Verified via the code-scanning API (`repos/.../code-scanning/alerts`): **0 open alerts and 0 alerts in any state**, with both `/language:javascript-typescript` and `/language:actions` analyses uploaded for `refs/pull/1136/merge`. **No findings to triage** — the baseline is green on merge with nothing left unaddressed, satisfying the issue's "no high-severity findings left unaddressed" criterion.

## Verification
- [x] YAML valid — `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/codeql.yml'))"` ✅
- [x] `yaml-lint` ✅
- [x] `github/codeql-action@v3`, `actions/checkout@v4`, `actions/setup-node@v4` tags verified to exist
- [x] Commit message passes repo `commitlint` (`chore` type — `ci` is not in this repo's allowed `type-enum`)

## Notes on deviations from the issue's literal recipe
- **Commit/PR type is `chore`, not `ci`**: this repo's `commitlint.config.js` restricts `type-enum` to `[feat, fix, docs, style, refactor, test, chore, revert]` and enforces `header-case: lower-case`. Using `ci(security):` would have failed the repo's own `commitlint` CI job. The subject is lower-cased accordingly (e.g. `codeql` not `CodeQL`).
- The PR title retains the issue's wording where possible while staying conventional.

Resolves #1110
