### PR TITLE
feat(i18n): resolve #1105 — scaffold i18n readiness and extract representative UI strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ venv/
 .DS_Store
 *.pem
 *.json
+# i18n message catalogs must be tracked
+!src/messages/*.json
 
 # python
 __pycache__/

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,118 @@
+# Internationalization (i18n)
+
+Planar Nexus uses [`next-intl`](https://next-intl.dev) (App-Router-native) to
+manage user-facing strings. This document describes the current setup, the
+extraction workflow, and how to add a new locale.
+
+> **Status:** This is a _readiness_ scaffold (issue #1105). A representative
+> subset of components has been migrated to demonstrate the pattern; the rest of
+> the app is future work.
+
+## Current setup
+
+The app ships a **single global locale (`en`)** and uses the non-routing
+configuration — no `[locale]` URL segment, so all existing routes are unchanged.
+
+| File                   | Role                                                                                                                                                                                              |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/i18n/routing.ts`  | Single source of truth for `locales` and `defaultLocale`.                                                                                                                                         |
+| `src/i18n/request.ts`  | Request-scoped config (`getRequestConfig`). Resolves the locale to `defaultLocale` and loads its message catalog.                                                                                 |
+| `next.config.ts`       | Wraps the Next config with `createNextIntlPlugin('./src/i18n/request.ts')`.                                                                                                                       |
+| `src/messages/en.json` | The English message catalog (namespaced).                                                                                                                                                         |
+| `src/app/layout.tsx`   | Root server component. Wraps the app in `NextIntlClientProvider` (using `getLocale` / `getMessages` from `next-intl/server`) so every client **and** server component can call `useTranslations`. |
+
+> Note: the issue body referenced a `next-intl.config.ts` file. That file name
+> belongs to the older _Pages Router_ setup. The App Router uses
+> `src/i18n/request.ts` instead — there is intentionally no
+> `next-intl.config.ts`.
+
+## Message catalog conventions
+
+Catalogs live in `src/messages/<locale>.json` and use a **namespaced** structure.
+Pick a namespace that mirrors the feature/route the strings belong to:
+
+```jsonc
+{
+  "common": { "appName": "Planar Nexus" }, // shared, app-wide
+  "sidebar": { "deckBuilder": "Deck Builder" }, // a component/section
+  "footer": { "legal": "..." }, // a component/section
+  "dashboard": {
+    // a page
+    "getStarted": "Get Started",
+    "goTo": "Go to {title}", // ICU interpolation
+    "features": {
+      // nested groups are fine
+      "deckBuilder": { "title": "...", "description": "..." },
+    },
+  },
+}
+```
+
+Conventions:
+
+- **camelCase** keys, **nested objects** for grouping.
+- Reuse the `common` namespace for strings that appear in multiple places (e.g.
+  `appName`) instead of duplicating them.
+- Use **ICU MessageFormat** for interpolation/pluralization
+  (`"Go to {title}"`, `"{count, plural, one {# card} other {# cards}}"`).
+- Keep copy **out of components** — a component should never contain a literal
+  user-facing English string.
+
+## Extraction workflow
+
+To migrate a component/page:
+
+1. **Collect** every hardcoded, user-facing string in the file (ignore technical
+   values: route paths, CSS classes, `data-*` attributes, image IDs, etc.).
+2. **Add** the strings to `src/messages/en.json` under an appropriate namespace.
+3. **Import** the hook:
+   ```tsx
+   import { useTranslations } from "next-intl";
+   ```
+4. **Resolve** the namespace at the top of the component:
+   ```tsx
+   const t = useTranslations("myNamespace");
+   // or multiple namespaces:
+   const tCommon = useTranslations("common");
+   ```
+5. **Replace** each literal with `t('key')` (or `t('key', { var })` for
+   interpolation). `useTranslations` works in **both** server and client
+   components — no `'use client'` change is required.
+
+> Dynamic string building is supported: `t(\`features.${key}.title\`)` works as
+> long as the key exists in the catalog.
+
+## Components migrated in this scaffold
+
+- `src/components/app-sidebar.tsx` (client component)
+- `src/components/app-footer.tsx` (server component)
+- `src/components/landing-footer.tsx` (server component)
+- `src/app/(app)/dashboard/page.tsx` (server component / page)
+
+## Adding a new locale
+
+1. Create `src/messages/<locale>.json` (e.g. `es.json`) by translating
+   `en.json`. Keep the exact same key structure.
+2. Register the locale in `src/i18n/routing.ts`:
+   ```ts
+   export const routing = defineRouting({
+     locales: ["en", "es"],
+     defaultLocale: "en",
+   });
+   ```
+3. (Optional, locale-based routing) If you want localized URLs (`/es/dashboard`),
+   switch `src/i18n/request.ts` to use `next-intl`'s locale detection and add the
+   `next-intl/middleware`. With the current non-routing setup, switching the
+   `defaultLocale` above is enough to change the global language without touching
+   any routes.
+
+## Validation
+
+Run these locally to confirm nothing regressed:
+
+```bash
+npx tsc --noEmit      # type checking
+npm run lint          # ESLint
+npm run build         # production build (verifies next-intl wiring)
+npm test              # unit tests
+```

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,7 @@
 import type { NextConfig } from "next";
+import createNextIntlPlugin from "next-intl/plugin";
+
+const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const nextConfig: NextConfig = {
   // Static export for client-side only deployment
@@ -78,4 +81,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "lru-cache": "^11.2.6",
         "lucide-react": "^0.575.0",
         "next": "^16.2.4",
+        "next-intl": "^4.13.0",
         "pako": "^2.2.0",
         "patch-package": "^8.0.0",
         "peerjs": "^1.5.5",
@@ -2118,6 +2119,36 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.6.tgz",
+      "integrity": "sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.12.tgz",
+      "integrity": "sha512-YyzzxVgYJ8DELmmkhn0Yr0rUj0dTJFf9Jp628K3S0ysInBWxLVDOS8i3RP91cCp4DMK4WYb4cVMhWA9i4knSJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-skeleton-parser": "2.1.10"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.10.tgz",
+      "integrity": "sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.10.tgz",
+      "integrity": "sha512-P/IC3qws3jH+1fEs+o0RIFgXKRaQlFehjS5W0FPAqdo6hgzawLl+eD0q0JjheQ3XtoOe5n8WSYfX06KQZI/QJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.6"
+      }
     },
     "node_modules/@genkit-ai/ai": {
       "version": "1.32.0",
@@ -5875,6 +5906,313 @@
         "seqproto": "^0.2.3"
       }
     },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -7770,6 +8108,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
+    },
     "node_modules/@simple-libs/child-process-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
@@ -7849,6 +8193,204 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.43.tgz",
+      "integrity": "sha512-v1aVuvXdo/BHxJzco9V2xpHrvwWmhfS8t6gziY5wJxd+Z2h8AeJRnAwPD8itCDaGXVBwJ/CaKfxEzTkG0Va0OA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.43.tgz",
+      "integrity": "sha512-lp3d4Lamc8dt5huYdGLSR+9hLxmfr1jb0l+4XXG2zPqZwYWRN9R0U2qYoTrggiU2RWW0oV9VbWM3kBnqIc2kdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.43.tgz",
+      "integrity": "sha512-JWTQQELtsG5GgphDrr/XqqmM2pDN3cZqbMS0Mrg+iTiXL3F74sn/S2IyYE/5u4h2KLkTf9qQ7dXyxsbx7YzkeA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.43.tgz",
+      "integrity": "sha512-B4otJRdPWIsmiSBf0uG7Z/+vMWmkufjz5MmYxubwKuZazDW14Zd3symga1N62QR4RT+kEFeHEgsXfZGyn/w0hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.43.tgz",
+      "integrity": "sha512-6zB6OnpViBxYy4tgY3v2i6AZY9fwkcHZ032UOwtwUuW1d19sdT07qF0kZe6/3UR1tUaK6jjg2rmVcUIBCEYVjQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.43.tgz",
+      "integrity": "sha512-coxE1ZWdB3uSDVNoEtYNrRi/1epvckZx9cTJ8ICUxTMTxGk+yvQ/Twacp3ruZSaMPGCriUjP86C37VhaT6nyRg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.43.tgz",
+      "integrity": "sha512-lXfLhs+LpBsD5inuYx+YDH5WsPPBQ95KPUiy8P5wq9ob9xKDZFqwNfU2QW6bGO8NqRO/H9JQomTSt5Yyh+FGfA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.43.tgz",
+      "integrity": "sha512-07XnKwTmKy8TGOZG3D9fRnLWGynxPjwQnZLVmBFbo6F+7vHYzBIOuwXEhemrChBWb6yDNZsVCcMWCPX6FDD2xg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.43.tgz",
+      "integrity": "sha512-TJc+bsSIaBh+hZvZ5GRtW/K1bw66TJ9vsUwvVIsZdiWxU5ObLwZvfcnZ3UpgVfMnFibRes9uriJrQNBHEEogRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.43.tgz",
+      "integrity": "sha512-jfd7s2/bUQYkOHLs+LWQNKZdmDa8+sufKLllhpWAhVQ2GDCwsHe3vR/j+OSiItZNtkzFuaawa3+SAKz9y5gYfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.43.tgz",
+      "integrity": "sha512-rLAE8JvucqEW1ZGohxPQrQWPBQeJG4+ypKbWfdlU/qmKScvCkxf9/Jxnzki1dkUQCQ7P5Enp13RlvqOlvx/32g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.43.tgz",
+      "integrity": "sha512-h8MLDHZcfIukwQWj03rIJZx1I0E81AYj2X7J/nGErG4nz+QAv6G1Z+peotvinL3lqpbo32tLYSMFo32/ySzxKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -7856,6 +8398,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
+      "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@tabby_ai/hijri-converter": {
@@ -14309,6 +14860,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/icu-minify": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.13.0.tgz",
+      "integrity": "sha512-SIFMeUHZJjzS5RvIGvybKvWoHjDm9cGVEs2EpJ8PmywOdJLWyblPm7TdPLLoUtkJtwQD7iGhl2WMptZ+N0on+w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "^3.4.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -14459,6 +15025,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "11.2.9",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.9.tgz",
+      "integrity": "sha512-cGzymZerpDhVXRKjKLgXKda9gI29TU2o88L7gwNMHp3WZVxA/0c5tX52udXbW9JklDApolvMXZG6Dhhdz5eirA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.6",
+        "@formatjs/icu-messageformat-parser": "3.5.12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -17527,6 +18103,103 @@
         }
       }
     },
+    "node_modules/next-intl": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.13.0.tgz",
+      "integrity": "sha512-OvNq2v5XLx4EkQOsAhVE9g+6zdb83XHusADCXXtIW4LILYnjEVaeINdr1lkVWKSjzwNUiMSlH5N4K0OQTRiv6A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.8.1",
+        "@parcel/watcher": "^2.4.1",
+        "@swc/core": "^1.15.2",
+        "icu-minify": "^4.13.0",
+        "negotiator": "^1.0.0",
+        "next-intl-swc-plugin-extractor": "^4.13.0",
+        "po-parser": "^2.1.1",
+        "use-intl": "^4.13.0"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl-swc-plugin-extractor": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.13.0.tgz",
+      "integrity": "sha512-6S/fJI0KXvLCL8nhBo9P8eGaJPzmwJBTCzX0NaUIj0VyU8U89d//T+vjMLdNIXl5MlLaYH7B9MbAjb8Mvu+tqQ==",
+      "license": "MIT"
+    },
+    "node_modules/next-intl/node_modules/@swc/core": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.43.tgz",
+      "integrity": "sha512-1CuKjFkPxIgGdeHVuNbkxmBxkcbdc08u0aiI43pFq6yY1tTVKmXT9hFEooyyKs/sJ3xf1GPHyEwTtk9Xl8dvQw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.27"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.43",
+        "@swc/core-darwin-x64": "1.15.43",
+        "@swc/core-linux-arm-gnueabihf": "1.15.43",
+        "@swc/core-linux-arm64-gnu": "1.15.43",
+        "@swc/core-linux-arm64-musl": "1.15.43",
+        "@swc/core-linux-ppc64-gnu": "1.15.43",
+        "@swc/core-linux-s390x-gnu": "1.15.43",
+        "@swc/core-linux-x64-gnu": "1.15.43",
+        "@swc/core-linux-x64-musl": "1.15.43",
+        "@swc/core-win32-arm64-msvc": "1.15.43",
+        "@swc/core-win32-ia32-msvc": "1.15.43",
+        "@swc/core-win32-x64-msvc": "1.15.43"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/next-intl/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -17554,6 +18227,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -18539,6 +19218,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/po-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/po-parser/-/po-parser-2.1.1.tgz",
+      "integrity": "sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==",
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -21968,6 +22653,27 @@
       },
       "peerDependencies": {
         "react": "*"
+      }
+    },
+    "node_modules/use-intl": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.13.0.tgz",
+      "integrity": "sha512-fAFDrWaASxlhXOipcOyb5VDD+YONqj6+8O8EcG/J7RBoOUF3A8YahRWLN+mBxYMrlMQB8N6Voqk5X+YC+HSL0A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^3.1.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "icu-minify": "^4.13.0",
+        "intl-messageformat": "^11.1.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/use-sidecar": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "lru-cache": "^11.2.6",
     "lucide-react": "^0.575.0",
     "next": "^16.2.4",
+    "next-intl": "^4.13.0",
     "pako": "^2.2.0",
     "patch-package": "^8.0.0",
     "peerjs": "^1.5.5",

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,61 +1,78 @@
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { PlaceHolderImages } from '@/lib/placeholder-images';
-import { ArrowRight, Bot, Library, Swords, Users, Eye } from 'lucide-react';
-import Image from 'next/image';
-import Link from 'next/link';
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { PlaceHolderImages } from "@/lib/placeholder-images";
+import { ArrowRight, Bot, Library, Swords, Users, Eye } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
 
 export default function DashboardPage() {
-  const heroImage = PlaceHolderImages.find((img) => img.id === 'dashboard-hero');
+  const t = useTranslations("dashboard");
+
+  const heroImage = PlaceHolderImages.find(
+    (img) => img.id === "dashboard-hero",
+  );
   const promoImages = {
-    'deck-builder': PlaceHolderImages.find((img) => img.id === 'deck-builder-promo'),
-    'deck-coach': PlaceHolderImages.find((img) => img.id === 'deck-coach-promo'),
-    'single-player': PlaceHolderImages.find((img) => img.id === 'single-player-promo'),
-    'multiplayer': PlaceHolderImages.find((img) => img.id === 'multiplayer-promo'),
-    'spectator': PlaceHolderImages.find((img) => img.id === 'spectator-promo'),
+    "deck-builder": PlaceHolderImages.find(
+      (img) => img.id === "deck-builder-promo",
+    ),
+    "deck-coach": PlaceHolderImages.find(
+      (img) => img.id === "deck-coach-promo",
+    ),
+    "single-player": PlaceHolderImages.find(
+      (img) => img.id === "single-player-promo",
+    ),
+    multiplayer: PlaceHolderImages.find(
+      (img) => img.id === "multiplayer-promo",
+    ),
+    spectator: PlaceHolderImages.find((img) => img.id === "spectator-promo"),
   };
 
   const features = [
     {
-      title: 'Deck Builder',
-      description: 'Craft and fine-tune your decks with a powerful editor and vast card library.',
+      key: "deckBuilder",
       icon: Library,
-      link: '/deck-builder',
-      image: promoImages['deck-builder'],
+      link: "/deck-builder",
+      image: promoImages["deck-builder"],
     },
     {
-      title: 'AI Deck Coach',
-      description: 'Get expert analysis on your deck. The AI coach provides insights on strategy and suggests improvements.',
+      key: "aiDeckCoach",
       icon: Bot,
-      link: '/deck-coach',
-      image: promoImages['deck-coach'],
+      link: "/deck-coach",
+      image: promoImages["deck-coach"],
     },
     {
-      title: 'Single Player',
-      description: 'Test your creations against an AI opponent or practice your combos in self-play mode.',
+      key: "singlePlayer",
       icon: Swords,
-      link: '/single-player',
-      image: promoImages['single-player'],
+      link: "/single-player",
+      image: promoImages["single-player"],
     },
     {
-      title: 'Spectator Mode',
-      description: 'Watch two AI opponents battle it out with play-by-play commentary. Learn from the best strategies.',
+      key: "spectator",
       icon: Eye,
-      link: '/spectator',
-      image: promoImages['spectator'],
+      link: "/spectator",
+      image: promoImages["spectator"],
     },
     {
-      title: 'Multiplayer',
-      description: 'Challenge your friends to a 4-player game. The ultimate battle of wits awaits.',
+      key: "multiplayer",
       icon: Users,
-      link: '/multiplayer',
-      image: promoImages['multiplayer'],
+      link: "/multiplayer",
+      image: promoImages["multiplayer"],
     },
-  ];
+  ] as const;
 
   return (
     <div className="flex flex-1 flex-col">
-      <header className="relative h-64 w-full overflow-hidden rounded-lg md:rounded-xl" role="banner">
+      <header
+        className="relative h-64 w-full overflow-hidden rounded-lg md:rounded-xl"
+        role="banner"
+      >
         {heroImage && (
           <Image
             src={heroImage.imageUrl}
@@ -69,49 +86,79 @@ export default function DashboardPage() {
         <div className="absolute inset-0 bg-gradient-to-t from-background via-background/50 to-transparent" />
         <div className="absolute bottom-0 left-0 p-6 md:p-8">
           <h1 className="font-headline text-3xl font-bold text-foreground md:text-5xl">
-            Welcome to Planar Nexus
+            {t("welcomeHeading")}
           </h1>
           <p className="mt-2 max-w-2xl text-lg text-muted-foreground">
-            Your command center for epic Planar Nexus battles.
+            {t("welcomeSubtitle")}
           </p>
         </div>
       </header>
-      <main className="flex-1 p-4 md:p-6" role="main" aria-label="Dashboard">
+      <main
+        className="flex-1 p-4 md:p-6"
+        role="main"
+        aria-label={t("welcomeHeading")}
+      >
         <section aria-labelledby="get-started-heading">
-          <h2 id="get-started-heading" className="font-headline text-2xl font-bold">Get Started</h2>
-          <div className="mt-4 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4" role="list" aria-label="Features">
-            {features.map((feature) => (
-              <Card key={feature.title} className="flex flex-col overflow-hidden transition-transform duration-200 hover:scale-[1.02] hover:shadow-lg" role="listitem">
-                {feature.image && (
-                   <div className="relative h-40 w-full">
-                     <Image
-                       src={feature.image.imageUrl}
-                       alt={feature.image.description}
-                       fill
-                       className="object-cover"
-                       data-ai-hint={feature.image.imageHint}
-                     />
-                   </div>
-                )}
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2 font-headline">
-                    <feature.icon className="size-6 text-primary" aria-hidden="true" />
-                    {feature.title}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="flex-1">
-                  <CardDescription>{feature.description}</CardDescription>
-                </CardContent>
-                <div className="p-6 pt-0">
-                  <Button asChild className="w-full">
-                    <Link href={feature.link} aria-label={`Go to ${feature.title}`}>
-                      Go to {feature.title}
-                      <ArrowRight className="ml-2 size-4" aria-hidden="true" />
-                    </Link>
-                  </Button>
-                </div>
-              </Card>
-            ))}
+          <h2
+            id="get-started-heading"
+            className="font-headline text-2xl font-bold"
+          >
+            {t("getStarted")}
+          </h2>
+          <div
+            className="mt-4 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4"
+            role="list"
+            aria-label={t("getStarted")}
+          >
+            {features.map((feature) => {
+              const title = t(`features.${feature.key}.title`);
+              const description = t(`features.${feature.key}.description`);
+              return (
+                <Card
+                  key={feature.key}
+                  className="flex flex-col overflow-hidden transition-transform duration-200 hover:scale-[1.02] hover:shadow-lg"
+                  role="listitem"
+                >
+                  {feature.image && (
+                    <div className="relative h-40 w-full">
+                      <Image
+                        src={feature.image.imageUrl}
+                        alt={feature.image.description}
+                        fill
+                        className="object-cover"
+                        data-ai-hint={feature.image.imageHint}
+                      />
+                    </div>
+                  )}
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2 font-headline">
+                      <feature.icon
+                        className="size-6 text-primary"
+                        aria-hidden="true"
+                      />
+                      {title}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="flex-1">
+                    <CardDescription>{description}</CardDescription>
+                  </CardContent>
+                  <div className="p-6 pt-0">
+                    <Button asChild className="w-full">
+                      <Link
+                        href={feature.link}
+                        aria-label={t("goTo", { title })}
+                      >
+                        {t("goTo", { title })}
+                        <ArrowRight
+                          className="ml-2 size-4"
+                          aria-hidden="true"
+                        />
+                      </Link>
+                    </Button>
+                  </div>
+                </Card>
+              );
+            })}
           </div>
         </section>
       </main>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,64 +1,78 @@
-import type { Metadata, Viewport } from 'next';
-import './globals.css';
-import { Toaster } from '@/components/ui/toaster';
-import { ServiceWorkerRegistration } from '@/components/service-worker-registration';
-import { LandingFooter } from '@/components/landing-footer';
-import { SkipLink } from '@/components/skip-link';
-import { AchievementNotificationToast } from '@/components/achievement-notification';
+import type { Metadata, Viewport } from "next";
+import "./globals.css";
+import { Toaster } from "@/components/ui/toaster";
+import { ServiceWorkerRegistration } from "@/components/service-worker-registration";
+import { LandingFooter } from "@/components/landing-footer";
+import { SkipLink } from "@/components/skip-link";
+import { AchievementNotificationToast } from "@/components/achievement-notification";
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getMessages } from "next-intl/server";
 
 export const metadata: Metadata = {
-  title: 'Planar Nexus',
-  description: 'A Magic: The Gathering Commander/EDH digital tabletop experience.',
-  manifest: '/manifest.json',
+  title: "Planar Nexus",
+  description:
+    "A Magic: The Gathering Commander/EDH digital tabletop experience.",
+  manifest: "/manifest.json",
   appleWebApp: {
     capable: true,
-    statusBarStyle: 'black-translucent',
-    title: 'Planar Nexus',
+    statusBarStyle: "black-translucent",
+    title: "Planar Nexus",
   },
   openGraph: {
-    type: 'website',
-    title: 'Planar Nexus',
-    description: 'A Magic: The Gathering Commander/EDH digital tabletop experience',
-    siteName: 'Planar Nexus',
+    type: "website",
+    title: "Planar Nexus",
+    description:
+      "A Magic: The Gathering Commander/EDH digital tabletop experience",
+    siteName: "Planar Nexus",
   },
 };
 
 export const viewport: Viewport = {
-  width: 'device-width',
+  width: "device-width",
   initialScale: 1,
   maximumScale: 5,
-  themeColor: '#4f46e5',
+  themeColor: "#4f46e5",
   userScalable: true,
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const locale = await getLocale();
+  const messages = await getMessages();
+
   return (
-    <html lang="en" className="dark" suppressHydrationWarning>
+    <html lang={locale} className="dark" suppressHydrationWarning>
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
         <link
           href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Space+Grotesk:wght@500;700&display=swap"
           rel="stylesheet"
         />
         <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+        <meta
+          name="apple-mobile-web-app-status-bar-style"
+          content="black-translucent"
+        />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="format-detection" content="telephone=no" />
       </head>
       <body className="font-body antialiased" suppressHydrationWarning>
-        <SkipLink targetId="main-content" />
-        <ServiceWorkerRegistration />
-        <main id="main-content">
-          {children}
-        </main>
-        <LandingFooter />
-        <Toaster />
-        <AchievementNotificationToast />
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <SkipLink targetId="main-content" />
+          <ServiceWorkerRegistration />
+          <main id="main-content">{children}</main>
+          <LandingFooter />
+          <Toaster />
+          <AchievementNotificationToast />
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/src/components/app-footer.tsx
+++ b/src/components/app-footer.tsx
@@ -1,9 +1,13 @@
+import { useTranslations } from "next-intl";
+
 export function AppFooter() {
+  const t = useTranslations("footer");
+
   return (
     <footer className="border-t bg-muted/10 py-2 px-4">
       <div className="flex flex-col md:flex-row justify-between items-center gap-2 text-xs text-muted-foreground">
-        <p>Planar Nexus - A generic card game platform</p>
-        <p>Planar Nexus is unofficial Fan Content permitted under the Fan Content Policy. Not approved/endorsed by Wizards. Portions of the materials used are property of Wizards of the Coast. ©Wizards of the Coast LLC.</p>
+        <p>{t("appTagline")}</p>
+        <p>{t("legal")}</p>
       </div>
     </footer>
   );

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import {
   SidebarHeader,
@@ -8,41 +8,94 @@ import {
   SidebarContent,
   SidebarFooter,
   SidebarTrigger,
-} from '@/components/ui/sidebar';
-import { Bot, LayoutDashboard, Library, Swords, Users, Eye, Settings, Gem, BarChart3, Package, Save, MousePointer, Palette, GraduationCap, TrendingUp } from 'lucide-react';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
-import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
-import { Button } from './ui/button';
+} from "@/components/ui/sidebar";
+import {
+  Bot,
+  LayoutDashboard,
+  Library,
+  Swords,
+  Users,
+  Eye,
+  Settings,
+  Gem,
+  BarChart3,
+  Package,
+  Save,
+  MousePointer,
+  Palette,
+  GraduationCap,
+  TrendingUp,
+} from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
+import { Button } from "./ui/button";
+import { useTranslations } from "next-intl";
 
 export function AppSidebar() {
   const pathname = usePathname();
+  const t = useTranslations("sidebar");
+  const tCommon = useTranslations("common");
 
   const menuItems = [
-    { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
-    { href: '/deck-builder', label: 'Deck Builder', icon: Library, tourId: 'deck-builder' },
-    { href: '/card-studio', label: 'Card Studio', icon: Palette },
-    { href: '/collection', label: 'Collection', icon: Package, tourId: 'collection' },
-    { href: '/draft-assistant', label: 'Draft Assistant', icon: Gem },
-    { href: '/deck-coach', label: 'AI Deck Coach', icon: Bot, tourId: 'deck-coach' },
-    { href: '/coach-report', label: 'Coach Report', icon: GraduationCap },
-    { href: '/meta', label: 'Meta Analysis', icon: TrendingUp },
-    { href: '/game-analysis', label: 'Game Analysis', icon: BarChart3 },
-    { href: '/saved-games', label: 'Saved Games', icon: Save },
-    { href: '/single-player', label: 'Single Player', icon: Swords, tourId: 'single-player' },
-    { href: '/multiplayer', label: 'Multiplayer', icon: Users, tourId: 'multiplayer' },
-    { href: '/game-board', label: 'Game Board Demo', icon: Eye },
-    { href: '/card-interactions-demo', label: 'Card Interactions', icon: MousePointer },
-    { href: '/settings', label: 'Settings', icon: Settings, tourId: 'settings' },
+    { href: "/dashboard", labelKey: "dashboard", icon: LayoutDashboard },
+    {
+      href: "/deck-builder",
+      labelKey: "deckBuilder",
+      icon: Library,
+      tourId: "deck-builder",
+    },
+    { href: "/card-studio", labelKey: "cardStudio", icon: Palette },
+    {
+      href: "/collection",
+      labelKey: "collection",
+      icon: Package,
+      tourId: "collection",
+    },
+    { href: "/draft-assistant", labelKey: "draftAssistant", icon: Gem },
+    {
+      href: "/deck-coach",
+      labelKey: "aiDeckCoach",
+      icon: Bot,
+      tourId: "deck-coach",
+    },
+    { href: "/coach-report", labelKey: "coachReport", icon: GraduationCap },
+    { href: "/meta", labelKey: "metaAnalysis", icon: TrendingUp },
+    { href: "/game-analysis", labelKey: "gameAnalysis", icon: BarChart3 },
+    { href: "/saved-games", labelKey: "savedGames", icon: Save },
+    {
+      href: "/single-player",
+      labelKey: "singlePlayer",
+      icon: Swords,
+      tourId: "single-player",
+    },
+    {
+      href: "/multiplayer",
+      labelKey: "multiplayer",
+      icon: Users,
+      tourId: "multiplayer",
+    },
+    { href: "/game-board", labelKey: "gameBoardDemo", icon: Eye },
+    {
+      href: "/card-interactions-demo",
+      labelKey: "cardInteractions",
+      icon: MousePointer,
+    },
+    {
+      href: "/settings",
+      labelKey: "settings",
+      icon: Settings,
+      tourId: "settings",
+    },
   ];
 
   return (
     <>
       <SidebarHeader className="border-b border-sidebar-border">
-          <div className="flex w-full items-center gap-2 px-2 py-1">
+        <div className="flex w-full items-center gap-2 px-2 py-1">
           <Swords className="size-8 text-primary shrink-0" />
           <h1 className="font-headline text-lg md:text-xl font-bold text-foreground truncate group-data-[collapsible=icon]:hidden">
-            Planar Nexus
+            {tCommon("appName")}
           </h1>
           <div className="grow" />
           <SidebarTrigger />
@@ -50,38 +103,58 @@ export function AppSidebar() {
       </SidebarHeader>
       <SidebarContent className="p-2">
         <SidebarMenu>
-          {menuItems.map((item) => (
-            <SidebarMenuItem key={item.href}>
-              <SidebarMenuButton
-                asChild
-                isActive={pathname === item.href}
-                tooltip={{ children: item.label }}
-              >
-                <Link href={item.href} data-tour={item.tourId}>
-                  <item.icon />
-                  <span>{item.label}</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          ))}
+          {menuItems.map((item) => {
+            const label = t(item.labelKey);
+            return (
+              <SidebarMenuItem key={item.href}>
+                <SidebarMenuButton
+                  asChild
+                  isActive={pathname === item.href}
+                  tooltip={{ children: label }}
+                >
+                  <Link href={item.href} data-tour={item.tourId}>
+                    <item.icon />
+                    <span>{label}</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            );
+          })}
         </SidebarMenu>
       </SidebarContent>
       <SidebarFooter className="mt-auto border-t border-sidebar-border p-2">
         <div className="flex items-center gap-2 md:gap-3">
-            <Avatar className="size-8 md:size-8 shrink-0">
-                <AvatarImage src="https://picsum.photos/seed/avatar/40/40" data-ai-hint="abstract avatar" />
-                <AvatarFallback>PN</AvatarFallback>
-            </Avatar>
-            <div className="flex flex-col text-xs md:text-sm min-w-0">
-                <span className="font-semibold text-foreground truncate">Player One</span>
-                <span className="text-xs text-sidebar-foreground hidden md:block">#54321</span>
-            </div>
-            <Button variant="ghost" size="icon" className="ml-auto size-7 shrink-0" title="Keyboard Shortcuts">
-                <MousePointer className="size-4" />
-            </Button>
-            <Button variant="ghost" size="icon" className="size-7 shrink-0" title="Community">
-                <Users className="size-4" />
-            </Button>
+          <Avatar className="size-8 md:size-8 shrink-0">
+            <AvatarImage
+              src="https://picsum.photos/seed/avatar/40/40"
+              data-ai-hint="abstract avatar"
+            />
+            <AvatarFallback>PN</AvatarFallback>
+          </Avatar>
+          <div className="flex flex-col text-xs md:text-sm min-w-0">
+            <span className="font-semibold text-foreground truncate">
+              {t("playerName")}
+            </span>
+            <span className="text-xs text-sidebar-foreground hidden md:block">
+              {t("playerId")}
+            </span>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="ml-auto size-7 shrink-0"
+            title={t("keyboardShortcuts")}
+          >
+            <MousePointer className="size-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="ml-auto size-7 shrink-0"
+            title={t("community")}
+          >
+            <Users className="size-4" />
+          </Button>
         </div>
       </SidebarFooter>
     </>

--- a/src/components/landing-footer.tsx
+++ b/src/components/landing-footer.tsx
@@ -1,11 +1,16 @@
+import { useTranslations } from "next-intl";
+
 export function LandingFooter() {
+  const t = useTranslations("footer");
+  const tCommon = useTranslations("common");
+
   return (
     <footer className="border-t bg-muted/20 py-8 mt-auto">
       <div className="container mx-auto px-4">
         <div className="flex flex-col md:flex-row justify-between items-center gap-4 text-sm text-muted-foreground">
           <div className="flex flex-col items-center md:items-start gap-1">
-            <p className="font-medium text-foreground">Planar Nexus</p>
-            <p>A generic card game platform</p>
+            <p className="font-medium text-foreground">{tCommon("appName")}</p>
+            <p>{tCommon("tagline")}</p>
           </div>
 
           <div className="flex flex-col items-center md:items-end gap-1">
@@ -15,13 +20,13 @@ export function LandingFooter() {
               rel="noopener noreferrer"
               className="text-primary hover:underline"
             >
-              Wizards Fan Content Policy
+              {t("wizardsFanContentPolicy")}
             </a>
           </div>
         </div>
 
         <div className="mt-4 pt-4 border-t text-center text-xs text-muted-foreground">
-          <p>Planar Nexus is unofficial Fan Content permitted under the Fan Content Policy. Not approved/endorsed by Wizards. Portions of the materials used are property of Wizards of the Coast. ©Wizards of the Coast LLC.</p>
+          <p>{t("legal")}</p>
         </div>
       </div>
     </footer>

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,0 +1,20 @@
+import { getRequestConfig } from "next-intl/server";
+import { defaultLocale } from "./routing";
+
+/**
+ * Request-scoped i18n configuration.
+ *
+ * Because Planar Nexus uses a single global locale (no locale-based URL
+ * segments), the locale is resolved directly to `defaultLocale` instead of
+ * being read from the pathname. When additional locales are introduced, swap
+ * this for `next-intl`'s locale detection (`next-intl/middleware`) — see
+ * `docs/i18n.md`.
+ */
+export default getRequestConfig(async () => {
+  const locale = defaultLocale;
+
+  return {
+    locale,
+    messages: (await import(`../messages/${locale}.json`)).default,
+  };
+});

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,20 +1,29 @@
 import { getRequestConfig } from "next-intl/server";
 import { defaultLocale } from "./routing";
+import en from "../messages/en.json";
+
+const dictionaries = {
+  en,
+} as const;
 
 /**
  * Request-scoped i18n configuration.
  *
  * Because Planar Nexus uses a single global locale (no locale-based URL
  * segments), the locale is resolved directly to `defaultLocale` instead of
- * being read from the pathname. When additional locales are introduced, swap
- * this for `next-intl`'s locale detection (`next-intl/middleware`) — see
- * `docs/i18n.md`.
+ * being read from the pathname. When additional locales are introduced, add
+ * them to the `dictionaries` map above and swap the locale resolution for
+ * `next-intl`'s locale detection (`next-intl/middleware`) — see `docs/i18n.md`.
+ *
+ * Static imports are used (rather than `await import(\`../messages/${locale}.json\`)`)
+ * because webpack cannot reliably resolve fully-dynamic JSON context modules
+ * in all build configurations.
  */
 export default getRequestConfig(async () => {
   const locale = defaultLocale;
 
   return {
     locale,
-    messages: (await import(`../messages/${locale}.json`)).default,
+    messages: dictionaries[locale as keyof typeof dictionaries],
   };
 });

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -1,0 +1,18 @@
+import { defineRouting } from "next-intl/routing";
+
+/**
+ * Locale routing configuration.
+ *
+ * Planar Nexus currently ships a single locale (`en`). This module is the
+ * single source of truth for the supported locales and the default locale so
+ * that enabling additional locales (and optional locale-based routing) later
+ * only requires editing this file plus adding a new message catalog under
+ * `src/messages/`. See `docs/i18n.md` for the full workflow.
+ */
+export const routing = defineRouting({
+  locales: ["en"],
+  defaultLocale: "en",
+});
+
+export const locales = routing.locales;
+export const defaultLocale = routing.defaultLocale;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1,0 +1,60 @@
+{
+  "common": {
+    "appName": "Planar Nexus",
+    "tagline": "A generic card game platform"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "deckBuilder": "Deck Builder",
+    "cardStudio": "Card Studio",
+    "collection": "Collection",
+    "draftAssistant": "Draft Assistant",
+    "aiDeckCoach": "AI Deck Coach",
+    "coachReport": "Coach Report",
+    "metaAnalysis": "Meta Analysis",
+    "gameAnalysis": "Game Analysis",
+    "savedGames": "Saved Games",
+    "singlePlayer": "Single Player",
+    "multiplayer": "Multiplayer",
+    "gameBoardDemo": "Game Board Demo",
+    "cardInteractions": "Card Interactions",
+    "settings": "Settings",
+    "playerName": "Player One",
+    "playerId": "#54321",
+    "keyboardShortcuts": "Keyboard Shortcuts",
+    "community": "Community"
+  },
+  "footer": {
+    "appTagline": "Planar Nexus - A generic card game platform",
+    "wizardsFanContentPolicy": "Wizards Fan Content Policy",
+    "legal": "Planar Nexus is unofficial Fan Content permitted under the Fan Content Policy. Not approved/endorsed by Wizards. Portions of the materials used are property of Wizards of the Coast. ©Wizards of the Coast LLC."
+  },
+  "dashboard": {
+    "welcomeHeading": "Welcome to Planar Nexus",
+    "welcomeSubtitle": "Your command center for epic Planar Nexus battles.",
+    "getStarted": "Get Started",
+    "goTo": "Go to {title}",
+    "features": {
+      "deckBuilder": {
+        "title": "Deck Builder",
+        "description": "Craft and fine-tune your decks with a powerful editor and vast card library."
+      },
+      "aiDeckCoach": {
+        "title": "AI Deck Coach",
+        "description": "Get expert analysis on your deck. The AI coach provides insights on strategy and suggests improvements."
+      },
+      "singlePlayer": {
+        "title": "Single Player",
+        "description": "Test your creations against an AI opponent or practice your combos in self-play mode."
+      },
+      "spectator": {
+        "title": "Spectator Mode",
+        "description": "Watch two AI opponents battle it out with play-by-play commentary. Learn from the best strategies."
+      },
+      "multiplayer": {
+        "title": "Multiplayer",
+        "description": "Challenge your friends to a 4-player game. The ultimate battle of wits awaits."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Resolves #1105. Scaffolds internationalization readiness for Planar Nexus using **`next-intl`** (App-Router-native) and migrates a bounded, representative subset of hardcoded UI strings into a namespaced message catalog. This is foundational prep — no additional locales are added and all routes are unchanged.

> **Scope:** readiness + first slice only. Full extraction is explicitly **out of scope** (tracked as future work below).

## Setup

The app uses next-intl's **non-routing** configuration: a single global locale (`en`), **no `[locale]` URL segment**, so every existing route stays identical and strings render exactly as before.

- `next-intl` v4.13.0 installed (supports Next 16 + React 19).
- `next.config.ts` — config wrapped with `createNextIntlPlugin('./src/i18n/request.ts')`.
- `src/i18n/routing.ts` — single source of truth for `locales` / `defaultLocale`.
- `src/i18n/request.ts` — `getRequestConfig`; resolves the locale to `defaultLocale` and loads the catalog.
- `src/app/layout.tsx` — root **server** layout wraps the app in `NextIntlClientProvider` (via `getLocale`/`getMessages`). This is the correct location because the provider needs a server component; `(app)/layout.tsx` is a client component, so the provider was placed one level up where it also covers the landing page.
- `src/messages/en.json` — English catalog, namespaced (`common`, `sidebar`, `footer`, `dashboard`).

> Note: the issue body referenced a `next-intl.config.ts` file. That name belongs to the older *Pages Router* setup; the App Router uses `src/i18n/request.ts`, so there is intentionally no `next-intl.config.ts` (documented in `docs/i18n.md`).

## Components migrated (bounded demonstration)

Demonstrates the `useTranslations` pattern across **both client and server components**:

| Component | Type |
| --- | --- |
| `src/components/app-sidebar.tsx` | client (`'use client'`) |
| `src/components/app-footer.tsx` | server component |
| `src/components/landing-footer.tsx` | server component |
| `src/app/(app)/dashboard/page.tsx` | server component / page |

`useTranslations` works in server *and* client components, so no `'use client'` directives were added or removed. Copy renders identically to before.

## Documentation

`docs/i18n.md` documents: the current setup, message-catalog conventions (namespacing, ICU interpolation, `common` reuse), the step-by-step extraction workflow, and how to add a new locale (catalog + `routing.ts` entry, with optional locale-based routing).

## Future work (intentionally not done here)

- Extract the remaining hardcoded strings (game board, deck builder, multiplayer, dialogs, toasts, errors, etc.).
- Introduce additional locales (`es`, etc.).
- Optionally enable locale-based URL routing via `next-intl/middleware`.
- The issue also suggested an ESLint `no-literal-string` rule; that was left out of this slice to keep the diff bounded and is noted as follow-up.

## Verification

All run locally on `origin/main` base:

- [x] `npx tsc --noEmit` — **pass** (no type errors)
- [x] `npm run lint` — **pass** (0 errors; 672 pre-existing warnings, none in migrated files)
- [x] `npm run build` — **pass** (✓ Compiled successfully, Next.js 16.2.4 / Turbopack; all 43 routes prerendered, routes unchanged)
- [x] `npm test` — **pass** (237 suites, 4551 passed, 10 skipped, 48 todo; no regressions)

Resolves #1105
