### PR TITLE
feat(a11y): resolve #1103 — honor prefers-reduced-motion in game animations

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -128,6 +128,24 @@ global.navigator = {
   },
 };
 
+// matchMedia — jsdom does not implement it. Provide a permissive default that
+// reports no preference; individual tests can override via Object.defineProperty
+// or jest.spyOn(window, "matchMedia") to emulate prefers-reduced-motion, etc.
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  const noop = () => {};
+  const mediaQueryList = {
+    matches: false,
+    media: "",
+    onchange: null,
+    addListener: noop, // legacy
+    removeListener: noop, // legacy
+    addEventListener: noop,
+    removeEventListener: noop,
+    dispatchEvent: noop,
+  };
+  window.matchMedia = (query) => ({ ...mediaQueryList, media: String(query) });
+}
+
 // ============================================================================
 // Test Data Seeding Utilities
 // ============================================================================

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -88,14 +88,25 @@
     @apply outline-none ring-2 ring-ring ring-offset-2 ring-offset-background;
   }
 
-  /* Accessibility: Reduced motion */
+  /* Accessibility: Reduced motion (#1103)
+     Global safety net that catches CSS-driven motion (keyframes, transitions,
+     smooth scroll, parallax) regardless of whether a component reads the JS
+     hook. JS/canvas-driven animations are gated per-component via the
+     `usePrefersReducedMotion` hook in src/hooks/use-prefers-reduced-motion.ts.
+     Essential transitions (e.g. dialog open/close, focus rings) are kept
+     effectively instant rather than removed, so functionality is preserved. */
   @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto !important;
+    }
+
     *,
     *::before,
     *::after {
       animation-duration: 0.01ms !important;
       animation-iteration-count: 1 !important;
       transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
     }
   }
 

--- a/src/components/__tests__/damage-indicator.test.tsx
+++ b/src/components/__tests__/damage-indicator.test.tsx
@@ -1,0 +1,80 @@
+import { render } from "@testing-library/react";
+import { DamageIndicator, type DamageEvent } from "../damage-indicator";
+
+/**
+ * Sets the global `window.matchMedia` implementation so the
+ * `usePrefersReducedMotion` hook reports the requested preference. The hook
+ * subscribes via `addEventListener`, so the stub records listeners and the
+ * initial `.matches` value drives the first effect.
+ */
+function setReducedMotion(matches: boolean) {
+  const listeners: Array<(event: { matches: boolean }) => void> = [];
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: jest.fn().mockImplementation(() => ({
+      matches,
+      media: "(prefers-reduced-motion: reduce)",
+      onchange: null,
+      addEventListener: (_type: string, cb: (event: { matches: boolean }) => void) =>
+        listeners.push(cb),
+      removeEventListener: (_type: string, cb: (event: { matches: boolean }) => void) => {
+        const i = listeners.indexOf(cb);
+        if (i >= 0) listeners.splice(i, 1);
+      },
+      addListener: (cb: (event: { matches: boolean }) => void) => listeners.push(cb),
+      removeListener: (cb: (event: { matches: boolean }) => void) => {
+        const i = listeners.indexOf(cb);
+        if (i >= 0) listeners.splice(i, 1);
+      },
+      dispatchEvent: () => true,
+    })),
+  });
+}
+
+const event: DamageEvent = {
+  id: "dmg-1",
+  amount: 5,
+  type: "combat",
+  targetId: "t1",
+  sourceName: "Goblin",
+  timestamp: 0,
+};
+
+describe("DamageIndicator — prefers-reduced-motion (#1103)", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("renders the floating transition when motion is allowed", () => {
+    setReducedMotion(false);
+    const { container } = render(
+      <DamageIndicator event={event} onComplete={() => {}} />,
+    );
+
+    const indicator = container.firstElementChild as HTMLElement;
+    expect(indicator.className).toContain("transition-all");
+    expect(indicator.className).toContain("duration-500");
+  });
+
+  it("omits the floating transition and completes without motion when reduced", () => {
+    setReducedMotion(true);
+    const onComplete = jest.fn();
+    const { container } = render(
+      <DamageIndicator event={event} onComplete={onComplete} />,
+    );
+
+    const indicator = container.firstElementChild as HTMLElement;
+    // #1103: no transition / float classes under reduced motion.
+    expect(indicator.className).not.toContain("transition-all");
+    expect(indicator.className).not.toContain("duration-500");
+
+    // onComplete still fires so the parent can retire the event.
+    jest.advanceTimersByTime(1500);
+    expect(onComplete).toHaveBeenCalledWith("dmg-1");
+  });
+});

--- a/src/components/achievement-notification.tsx
+++ b/src/components/achievement-notification.tsx
@@ -36,6 +36,7 @@ import {
   GitCompare
 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { usePrefersReducedMotion } from '@/hooks/use-prefers-reduced-motion';
 
 /**
  * Icon mapping for achievements
@@ -75,6 +76,11 @@ function getIconComponent(iconName: string) {
  */
 export function AchievementNotificationToast() {
   const { toast } = useToast();
+  // #1103: when the user prefers reduced motion, the entrance/exit animations
+  // are dampened by the global CSS rule and we keep the toast on screen a bit
+  // longer so the unlock is still readable without the celebratory motion.
+  const reduceMotion = usePrefersReducedMotion();
+  const toastDuration = reduceMotion ? 7000 : 5000;
 
   useEffect(() => {
     // Subscribe to achievement notifications
@@ -104,7 +110,7 @@ export function AchievementNotificationToast() {
               </span>
             </div>
           ),
-          duration: 5000,
+          duration: toastDuration,
         });
       }
     );
@@ -112,7 +118,7 @@ export function AchievementNotificationToast() {
     return () => {
       unsubscribe();
     };
-  }, [toast]);
+  }, [toast, toastDuration]);
 
   return null;
 }
@@ -123,6 +129,9 @@ export function AchievementNotificationToast() {
  */
 export function useAchievementToast() {
   const { toast } = useToast();
+  // #1103: mirror the reduced-motion accommodation of the auto toast above.
+  const reduceMotion = usePrefersReducedMotion();
+  const toastDuration = reduceMotion ? 7000 : 5000;
 
   const showAchievementToast = (notification: AchievementNotification) => {
     const Icon = getIconComponent(notification.achievement.icon);
@@ -148,7 +157,7 @@ export function useAchievementToast() {
           </span>
         </div>
       ),
-      duration: 5000,
+      duration: toastDuration,
     });
   };
 

--- a/src/components/card-sleeve.tsx
+++ b/src/components/card-sleeve.tsx
@@ -9,6 +9,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Upload, Check, Palette, Image, RotateCcw, Eye, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { usePrefersReducedMotion } from '@/hooks/use-prefers-reduced-motion';
 
 // Sleeve patterns
 export type SleevePattern = 'gradient' | 'stripes' | 'dots' | 'diamond' | 'swirl' | 'solid';
@@ -117,6 +118,8 @@ interface SleeveSelectorProps {
 }
 
 export function SleeveSelector({ selectedSleeve, onSelect, className }: SleeveSelectorProps) {
+  // #1103: skip the hover scale transform when the user prefers reduced motion.
+  const reduceMotion = usePrefersReducedMotion();
   return (
     <div className={cn('grid grid-cols-3 sm:grid-cols-4 gap-2', className)}>
       {DEFAULT_SLEEVES.map((sleeve) => (
@@ -124,9 +127,10 @@ export function SleeveSelector({ selectedSleeve, onSelect, className }: SleeveSe
           key={sleeve.type}
           onClick={() => onSelect(sleeve)}
           className={cn(
-            'relative aspect-[3/4] rounded-md overflow-hidden border-2 transition-all hover:scale-105',
-            selectedSleeve.type === sleeve.type 
-              ? 'border-primary ring-2 ring-primary/50' 
+            'relative aspect-[3/4] rounded-md overflow-hidden border-2 transition-all',
+            !reduceMotion && 'hover:scale-105',
+            selectedSleeve.type === sleeve.type
+              ? 'border-primary ring-2 ring-primary/50'
               : 'border-border hover:border-primary/50'
           )}
           title={sleeve.name}
@@ -159,6 +163,8 @@ interface PlaymatSelectorProps {
 }
 
 export function PlaymatSelector({ selectedPlaymat, onSelect, className }: PlaymatSelectorProps) {
+  // #1103: skip the hover scale transform when the user prefers reduced motion.
+  const reduceMotion = usePrefersReducedMotion();
   return (
     <div className={cn('grid grid-cols-2 sm:grid-cols-3 gap-2', className)}>
       {DEFAULT_PLAYMATS.map((playmat) => (
@@ -166,9 +172,10 @@ export function PlaymatSelector({ selectedPlaymat, onSelect, className }: Playma
           key={playmat.type}
           onClick={() => onSelect(playmat)}
           className={cn(
-            'relative aspect-video rounded-md overflow-hidden border-2 transition-all hover:scale-105',
-            selectedPlaymat.type === playmat.type 
-              ? 'border-primary ring-2 ring-primary/50' 
+            'relative aspect-video rounded-md overflow-hidden border-2 transition-all',
+            !reduceMotion && 'hover:scale-105',
+            selectedPlaymat.type === playmat.type
+              ? 'border-primary ring-2 ring-primary/50'
               : 'border-border hover:border-primary/50'
           )}
           title={playmat.name}

--- a/src/components/combat-animations.tsx
+++ b/src/components/combat-animations.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { cn } from '@/lib/utils';
+import { usePrefersReducedMotion } from '@/hooks/use-prefers-reduced-motion';
 
 /**
  * Combat Animation System
@@ -61,8 +62,22 @@ export function AttackAnimation({ action, onComplete, className }: CombatAnimati
   const [phase, setPhase] = useState<AnimationPhase>('idle');
   const [trailPositions, setTrailPositions] = useState<{ x: number; y: number }[]>([]);
   const animationRef = useRef<number | undefined>(undefined);
+  // #1103: skip the multi-phase motion sequence under reduced motion — show the
+  // final state immediately and complete without trails / impact particles.
+  const reduceMotion = usePrefersReducedMotion();
 
   useEffect(() => {
+    if (reduceMotion) {
+      // #1103: show the attack indicator statically (peak state, no transforms —
+      // see getAnimationStyle) for a short dwell so the event is communicated
+      // without motion, then complete.
+      setPhase('strike');
+      const completeTimer = setTimeout(() => {
+        onComplete?.(action.id);
+      }, 300);
+      return () => clearTimeout(completeTimer);
+    }
+
     // Windup phase - prepare to attack
     const windupTimer = setTimeout(() => setPhase('windup'), 50);
     
@@ -106,11 +121,16 @@ export function AttackAnimation({ action, onComplete, className }: CombatAnimati
         clearInterval(animationRef.current);
       }
     };
-  }, [action.id, onComplete]);
+  }, [action.id, onComplete, reduceMotion]);
 
-  const getAnimationStyle = () => {
+  const getAnimationStyle = (): React.CSSProperties => {
+    // #1103: no transforms / filter animation under reduced motion.
+    if (reduceMotion) {
+      return phase === 'fadeout' ? { opacity: 0 } : { opacity: 1 };
+    }
+
     const baseStyle = { opacity: 1 };
-    
+
     switch (phase) {
       case 'windup':
         return { ...baseStyle, transform: 'translateX(-30px) scale(1.1)', filter: 'brightness(1.2)' };
@@ -149,37 +169,38 @@ export function AttackAnimation({ action, onComplete, className }: CombatAnimati
         className
       )}
     >
-      {/* Trail effect */}
-      {phase === 'strike' && trailPositions.map((pos, idx) => (
+      {/* Trail effect — decorative, skipped under reduced motion (#1103) */}
+      {!reduceMotion && phase === 'strike' && trailPositions.map((pos, idx) => (
         <div
           key={idx}
           className="absolute w-8 h-8 bg-red-500/30 rounded-full blur-sm"
-          style={{ 
-            left: pos.x, 
+          style={{
+            left: pos.x,
             top: pos.y,
             opacity: 0.5 - (idx * 0.1)
           }}
         />
       ))}
-      
+
       {/* Main attack indicator */}
       <div
         className={cn(
           'flex items-center gap-2 bg-gradient-to-r from-red-600 to-red-500',
           'border-2 border-red-400 rounded-lg px-4 py-2 shadow-lg shadow-red-500/50',
-          'transition-all duration-150 ease-out'
+          // #1103: drop the transition when motion is reduced.
+          !reduceMotion && 'transition-all duration-150 ease-out'
         )}
         style={getAnimationStyle()}
       >
-        <span className="text-2xl animate-pulse">{getIcon()}</span>
+        <span className={cn('text-2xl', !reduceMotion && 'animate-pulse')}>{getIcon()}</span>
         <div className="flex flex-col">
           <span className="font-bold text-white text-sm">{action.sourceName}</span>
           <span className="text-red-200 text-xs">attacking!</span>
         </div>
       </div>
-      
-      {/* Impact particles */}
-      {phase === 'impact' && (
+
+      {/* Impact particles — decorative, skipped under reduced motion (#1103) */}
+      {!reduceMotion && phase === 'impact' && (
         <div className="absolute left-full top-1/2 -translate-y-1/2">
           {Array.from({ length: 8 }).map((_, i) => (
             <div
@@ -201,8 +222,22 @@ export function AttackAnimation({ action, onComplete, className }: CombatAnimati
 // Block animation with shield effect
 export function BlockAnimation({ action, onComplete, className }: CombatAnimationProps) {
   const [phase, setPhase] = useState<'idle' | 'raise' | 'block' | 'hold' | 'lower' | 'complete'>('idle');
+  // #1103: under reduced motion, skip the raise/block/hold/lower sequence and
+  // present the static block indicator, completing on the next tick.
+  const reduceMotion = usePrefersReducedMotion();
 
   useEffect(() => {
+    if (reduceMotion) {
+      // #1103: show the block indicator statically (peak state, no transforms —
+      // see getAnimationStyle) for a short dwell so the event is communicated
+      // without motion, then complete.
+      setPhase('block');
+      const completeTimer = setTimeout(() => {
+        onComplete?.(action.id);
+      }, 300);
+      return () => clearTimeout(completeTimer);
+    }
+
     const raiseTimer = setTimeout(() => setPhase('raise'), 50);
     const blockTimer = setTimeout(() => setPhase('block'), 200);
     const holdTimer = setTimeout(() => setPhase('hold'), 400);
@@ -219,9 +254,14 @@ export function BlockAnimation({ action, onComplete, className }: CombatAnimatio
       clearTimeout(lowerTimer);
       clearTimeout(completeTimer);
     };
-  }, [action.id, onComplete]);
+  }, [action.id, onComplete, reduceMotion]);
 
-  const getAnimationStyle = () => {
+  const getAnimationStyle = (): React.CSSProperties => {
+    // #1103: no transforms / opacity ramp under reduced motion.
+    if (reduceMotion) {
+      return { transform: 'scale(1)', opacity: 1 };
+    }
+
     switch (phase) {
       case 'raise':
         return { transform: 'scale(0.8) translateY(20px)', opacity: 0.7 };
@@ -245,21 +285,22 @@ export function BlockAnimation({ action, onComplete, className }: CombatAnimatio
         className
       )}
     >
-      {/* Shield glow effect */}
+      {/* Shield glow effect — pulse is decorative, skipped under reduced motion (#1103) */}
       <div
         className={cn(
           'absolute inset-0 bg-blue-500/30 rounded-full blur-xl',
-          phase === 'block' && 'animate-pulse'
+          !reduceMotion && phase === 'block' && 'animate-pulse'
         )}
         style={{ transform: 'scale(2)' }}
       />
-      
+
       {/* Main block indicator */}
       <div
         className={cn(
           'flex items-center gap-2 bg-gradient-to-r from-blue-600 to-blue-500',
           'border-2 border-blue-400 rounded-lg px-4 py-2 shadow-lg shadow-blue-500/50',
-          'transition-all duration-200 ease-out'
+          // #1103: drop the transition when motion is reduced.
+          !reduceMotion && 'transition-all duration-200 ease-out'
         )}
         style={getAnimationStyle()}
       >
@@ -269,9 +310,9 @@ export function BlockAnimation({ action, onComplete, className }: CombatAnimatio
           <span className="text-blue-200 text-xs">blocking</span>
         </div>
       </div>
-      
-      {/* Shield particles */}
-      {phase === 'block' && (
+
+      {/* Shield particles — decorative, skipped under reduced motion (#1103) */}
+      {!reduceMotion && phase === 'block' && (
         <div className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-full">
           {Array.from({ length: 6 }).map((_, i) => (
             <div
@@ -294,37 +335,51 @@ export function BlockAnimation({ action, onComplete, className }: CombatAnimatio
 export function DamageAnimation({ action, onComplete, className }: CombatAnimationProps) {
   const [phase, setPhase] = useState<'idle' | 'appear' | 'float' | 'fade' | 'complete'>('idle');
   const [displayAmount, setDisplayAmount] = useState(0);
+  // #1103: under reduced motion, skip the count-up + bounce/float/fade — show
+  // the full damage value statically, dwell briefly so it's readable, complete.
+  const reduceMotion = usePrefersReducedMotion();
 
   useEffect(() => {
-    if (action.amount) {
-      // Animate the damage number counting up
-      const steps = 10;
-      const increment = action.amount / steps;
-      let current = 0;
-      
-      const countInterval = setInterval(() => {
-        current += increment;
-        setDisplayAmount(Math.min(Math.round(current), action.amount || 0));
-      }, 30);
-      
-      const appearTimer = setTimeout(() => setPhase('appear'), 50);
-      const floatTimer = setTimeout(() => setPhase('float'), 300);
-      const fadeTimer = setTimeout(() => setPhase('fade'), 1200);
-      const completeTimer = setTimeout(() => {
-        setPhase('complete');
-        clearInterval(countInterval);
-        onComplete?.(action.id);
-      }, 1500);
-
-      return () => {
-        clearInterval(countInterval);
-        clearTimeout(appearTimer);
-        clearTimeout(floatTimer);
-        clearTimeout(fadeTimer);
-        clearTimeout(completeTimer);
-      };
+    if (!action.amount) {
+      return;
     }
-  }, [action.id, action.amount, onComplete]);
+
+    if (reduceMotion) {
+      setDisplayAmount(action.amount);
+      setPhase('appear');
+      const completeTimer = setTimeout(() => {
+        onComplete?.(action.id);
+      }, 800);
+      return () => clearTimeout(completeTimer);
+    }
+
+    // Animate the damage number counting up
+    const steps = 10;
+    const increment = action.amount / steps;
+    let current = 0;
+
+    const countInterval = setInterval(() => {
+      current += increment;
+      setDisplayAmount(Math.min(Math.round(current), action.amount || 0));
+    }, 30);
+
+    const appearTimer = setTimeout(() => setPhase('appear'), 50);
+    const floatTimer = setTimeout(() => setPhase('float'), 300);
+    const fadeTimer = setTimeout(() => setPhase('fade'), 1200);
+    const completeTimer = setTimeout(() => {
+      setPhase('complete');
+      clearInterval(countInterval);
+      onComplete?.(action.id);
+    }, 1500);
+
+    return () => {
+      clearInterval(countInterval);
+      clearTimeout(appearTimer);
+      clearTimeout(floatTimer);
+      clearTimeout(fadeTimer);
+      clearTimeout(completeTimer);
+    };
+  }, [action.id, action.amount, onComplete, reduceMotion]);
 
   const getDamageColor = () => {
     switch (action.type) {
@@ -351,17 +406,20 @@ export function DamageAnimation({ action, onComplete, className }: CombatAnimati
       {/* Damage number */}
       <div
         className={cn(
-          'flex flex-col items-center transition-all duration-300',
-          phase === 'appear' && 'animate-bounce',
-          phase === 'float' && '-translate-y-8',
-          phase === 'fade' && 'opacity-0 -translate-y-16'
+          'flex flex-col items-center',
+          // #1103: motion classes only when motion is allowed.
+          !reduceMotion && 'transition-all duration-300',
+          !reduceMotion && phase === 'appear' && 'animate-bounce',
+          !reduceMotion && phase === 'float' && '-translate-y-8',
+          !reduceMotion && phase === 'fade' && 'opacity-0 -translate-y-16'
         )}
       >
         <span
           className={cn(
             'text-5xl font-bold drop-shadow-lg',
             getDamageColor(),
-            'animate-pulse'
+            // #1103: drop the pulse animation under reduced motion.
+            !reduceMotion && 'animate-pulse'
           )}
           style={{
             textShadow: '0 0 10px currentColor, 0 0 20px currentColor',
@@ -369,16 +427,16 @@ export function DamageAnimation({ action, onComplete, className }: CombatAnimati
         >
           -{displayAmount}
         </span>
-        
+
         {action.targetName && (
           <span className="text-sm text-muted-foreground mt-1">
             {action.targetName}
           </span>
         )}
       </div>
-      
-      {/* Impact effect */}
-      {phase === 'appear' && (
+
+      {/* Impact effect — decorative, skipped under reduced motion (#1103) */}
+      {!reduceMotion && phase === 'appear' && (
         <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
           <div className="w-16 h-16 bg-red-500/50 rounded-full animate-ping" />
         </div>
@@ -538,6 +596,8 @@ export function CombatCard({
 }: CombatCardProps) {
   const [isAnimating, setIsAnimating] = useState(false);
   const [showImpact, setShowImpact] = useState(false);
+  // #1103: gate the bounce / pulse / scale micro-animations on the card.
+  const reduceMotion = usePrefersReducedMotion();
 
   useEffect(() => {
     if (isAttacking || isBlocking) {
@@ -566,20 +626,23 @@ export function CombatCard({
     <div
       className={cn(
         'relative w-16 h-24 bg-gradient-to-br from-primary/20 to-primary/5 border-2 rounded-lg',
-        'flex flex-col items-center justify-between p-1 cursor-pointer transition-all duration-200',
+        'flex flex-col items-center justify-between p-1 cursor-pointer',
+        // #1103: keep the tap rotate (state, not motion) but drop the transition
+        // and decorative bounce/pulse/scale when motion is reduced.
+        !reduceMotion && 'transition-all duration-200',
         isTapped && 'rotate-90',
         getBorderColor(),
         (isAttacking || isBlocking) && 'shadow-lg',
         hasDealtDamage && 'opacity-60',
-        isAnimating && 'animate-bounce',
-        showImpact && 'animate-pulse scale-110',
+        !reduceMotion && isAnimating && 'animate-bounce',
+        !reduceMotion && showImpact && 'animate-pulse scale-110',
         className
       )}
       onClick={onTap}
     >
       {/* Card name */}
       <span className="text-[8px] font-medium truncate w-full text-center">{cardName}</span>
-      
+
       {/* Power/Toughness */}
       <div className="flex items-center justify-center gap-1">
         <span className={cn(
@@ -591,7 +654,7 @@ export function CombatCard({
         <span className="text-xs text-muted-foreground">/</span>
         <span className="text-xs font-bold">{toughness}</span>
       </div>
-      
+
       {/* Ability indicators */}
       <div className="absolute bottom-0.5 left-0.5 flex gap-0.5">
         {hasFirstStrike && <span className="text-[8px]" title="First Strike">⚡</span>}
@@ -599,10 +662,13 @@ export function CombatCard({
         {hasDeathtouch && <span className="text-[8px]" title="Deathtouch">💀</span>}
         {hasTrample && <span className="text-[8px]" title="Trample">🐘</span>}
       </div>
-      
-      {/* Attack indicator */}
+
+      {/* Attack indicator — pulse is decorative, skipped under reduced motion (#1103) */}
       {isAttacking && (
-        <div className="absolute -top-2 -right-2 w-5 h-5 bg-red-500 rounded-full flex items-center justify-center text-white text-xs shadow-lg animate-pulse">
+        <div className={cn(
+          'absolute -top-2 -right-2 w-5 h-5 bg-red-500 rounded-full flex items-center justify-center text-white text-xs shadow-lg',
+          !reduceMotion && 'animate-pulse'
+        )}>
           ⚔️
         </div>
       )}
@@ -633,6 +699,9 @@ interface CombatPhaseIndicatorProps {
 export function CombatPhaseIndicator({ phase, className }: CombatPhaseIndicatorProps) {
   const [isVisible, setIsVisible] = useState(true);
   const [isAnimating, setIsAnimating] = useState(false);
+  // #1103: phase banner is functional (announces the combat step), so it stays
+  // visible; only the decorative bounce / flash are suppressed under reduced motion.
+  const reduceMotion = usePrefersReducedMotion();
 
   useEffect(() => {
     setIsAnimating(true);
@@ -678,18 +747,19 @@ export function CombatPhaseIndicator({ phase, className }: CombatPhaseIndicatorP
           'bg-gradient-to-r border-2 border-white/30 rounded-lg px-6 py-3 shadow-2xl',
           'flex items-center gap-3',
           color,
-          isAnimating && 'animate-bounce'
+          // #1103: skip the decorative bounce under reduced motion.
+          !reduceMotion && isAnimating && 'animate-bounce'
         )}
         style={{
-          animation: isAnimating ? 'bounce 0.5s ease-out' : undefined,
+          animation: !reduceMotion && isAnimating ? 'bounce 0.5s ease-out' : undefined,
         }}
       >
         <span className="text-3xl">{icon}</span>
         <span className="font-bold text-white text-lg">{text}</span>
       </div>
-      
-      {/* Background flash effect */}
-      {isAnimating && (
+
+      {/* Background flash effect — decorative, skipped under reduced motion (#1103) */}
+      {!reduceMotion && isAnimating && (
         <div className="absolute inset-0 -z-10 bg-white/20 rounded-lg animate-ping" />
       )}
     </div>

--- a/src/components/damage-indicator.tsx
+++ b/src/components/damage-indicator.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import { cn } from '@/lib/utils';
+import { usePrefersReducedMotion } from '@/hooks/use-prefers-reduced-motion';
 
 export type DamageType = 'combat' | 'noncombat' | 'poison' | 'life' | 'heal';
 
@@ -23,14 +24,18 @@ interface DamageIndicatorProps {
 export function DamageIndicator({ event, onComplete, className }: DamageIndicatorProps) {
   const [isVisible, setIsVisible] = useState(true);
   const [offset, setOffset] = useState(0);
+  // #1103: skip the floating-up motion when the user prefers reduced motion;
+  // show the value in place and dismiss without translation.
+  const reduceMotion = usePrefersReducedMotion();
 
   useEffect(() => {
-    // Animate the damage number floating up
+    // Animate the damage number floating up (skipped under reduced motion).
     const animationTimer = setTimeout(() => {
-      setOffset(-60);
+      setOffset(reduceMotion ? 0 : -60);
     }, 50);
 
-    // Fade out after animation
+    // Fade out after animation. Under reduced motion we still let the value
+    // linger briefly so it remains readable, just without the float.
     const fadeTimer = setTimeout(() => {
       setIsVisible(false);
       onComplete?.(event.id);
@@ -40,7 +45,7 @@ export function DamageIndicator({ event, onComplete, className }: DamageIndicato
       clearTimeout(animationTimer);
       clearTimeout(fadeTimer);
     };
-  }, [event.id, onComplete]);
+  }, [event.id, onComplete, reduceMotion]);
 
   const getColor = () => {
     switch (event.type) {
@@ -82,7 +87,8 @@ export function DamageIndicator({ event, onComplete, className }: DamageIndicato
     <div
       className={cn(
         'absolute left-1/2 -translate-x-1/2 pointer-events-none select-none',
-        'transition-all duration-500 ease-out',
+        // #1103: keep the transition only when motion is allowed.
+        !reduceMotion && 'transition-all duration-500 ease-out',
         getColor(),
         className
       )}

--- a/src/components/emote-picker.tsx
+++ b/src/components/emote-picker.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Smile, ThumbsUp, Heart, Zap, Skull, Clock, HelpCircle, Laugh, Angry, PartyPopper } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { usePrefersReducedMotion } from '@/hooks/use-prefers-reduced-motion';
 
 export type EmoteType = 
   | 'thumbsup' 
@@ -53,6 +54,11 @@ interface EmotePickerProps {
 
 export function EmotePicker({ onSelectEmote, disabled, className }: EmotePickerProps) {
   const [open, setOpen] = useState(false);
+  // #1103: popover open/close is essential UI, so it stays functional. When the
+  // user prefers reduced motion we explicitly drop the entrance/exit transition
+  // on the popover panel (the global CSS rule is the broader safety net, this
+  // is the per-component gate).
+  const reduceMotion = usePrefersReducedMotion();
 
   const handleEmoteSelect = (emote: EmoteType) => {
     onSelectEmote(emote);
@@ -73,7 +79,12 @@ export function EmotePicker({ onSelectEmote, disabled, className }: EmotePickerP
           <Smile className="w-4 h-4" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-2" align="start" role="listbox" aria-label="Select an emote">
+      <PopoverContent
+        className={cn('w-auto p-2', reduceMotion && 'transition-none')}
+        align="start"
+        role="listbox"
+        aria-label="Select an emote"
+      >
         <div className="grid grid-cols-5 gap-1" role="listbox">
           {EMOTES.map((emote) => (
             <Button

--- a/src/components/onboarding-tour.tsx
+++ b/src/components/onboarding-tour.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/card";
 import { ChevronLeft, ChevronRight, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
 
 export const ONBOARDING_STORAGE_KEY = "planar-nexus:onboarded";
 /** Custom event dispatched to re-trigger the tour from anywhere (e.g. Settings). */
@@ -131,18 +132,9 @@ export function restartOnboardingTour(): void {
 
 /* ------------------------------- primitives ------------------------------- */
 
-function usePrefersReducedMotion(): boolean {
-  const [reduced, setReduced] = useState(false);
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return;
-    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const update = () => setReduced(mq.matches);
-    update();
-    mq.addEventListener?.("change", update);
-    return () => mq.removeEventListener?.("change", update);
-  }, []);
-  return reduced;
-}
+// Reduced-motion awareness comes from the shared `@/hooks/use-prefers-reduced-motion`
+// hook (see issue #1103) so every animation component honors the OS preference
+// from a single source of truth.
 
 /** Focusable element selector used by the lightweight focus trap. */
 const FOCUSABLE =

--- a/src/components/pack-passing-animation.tsx
+++ b/src/components/pack-passing-animation.tsx
@@ -9,6 +9,7 @@
 
 import { cn } from "@/lib/utils";
 import { Package, ArrowLeft, ArrowRight } from "lucide-react";
+import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
 
 interface PackPassingAnimationProps {
   /** Is pack currently passing */
@@ -32,15 +33,23 @@ export function PackPassingAnimation({
   children,
   duration = 500,
 }: PackPassingAnimationProps) {
+  // #1103: under reduced motion, snap to the end state instantly — no slide,
+  // no opacity ramp, no scale. The "passing" state is still communicated
+  // (opacity stays lower so the handoff is legible) but without motion.
+  const reduceMotion = usePrefersReducedMotion();
+  const motionEnabled = !reduceMotion;
+
   return (
     <div
       className={cn(
-        "transition-all ease-in-out",
-        isPassing && direction === 'to-ai' && "-translate-x-8 opacity-50 scale-95",
-        isPassing && direction === 'to-user' && "translate-x-8 opacity-50 scale-95"
+        motionEnabled && "transition-all ease-in-out",
+        motionEnabled && isPassing && direction === 'to-ai' && "-translate-x-8 opacity-50 scale-95",
+        motionEnabled && isPassing && direction === 'to-user' && "translate-x-8 opacity-50 scale-95",
+        // Reduced-motion fallback: dim only, no transform / no slide.
+        !motionEnabled && isPassing && "opacity-50"
       )}
       style={{
-        transitionDuration: isPassing ? `${duration}ms` : '0ms',
+        transitionDuration: motionEnabled && isPassing ? `${duration}ms` : '0ms',
       }}
     >
       {children}

--- a/src/hooks/__tests__/use-prefers-reduced-motion.test.ts
+++ b/src/hooks/__tests__/use-prefers-reduced-motion.test.ts
@@ -1,0 +1,104 @@
+import { renderHook, act } from "@testing-library/react";
+import { usePrefersReducedMotion } from "../use-prefers-reduced-motion";
+
+/**
+ * Minimal MediaQueryList stub used to drive the hook under jsdom. The global
+ * matchMedia mock installed in jest.setup.js returns a fresh stub for every
+ * call; these helpers swap the implementation per test.
+ */
+type Listener = (event: { matches: boolean }) => void;
+
+interface MqlStub {
+  readonly matches: boolean;
+  media: string;
+  onchange: null;
+  addEventListener: (type: string, cb: Listener) => void;
+  removeEventListener: (type: string, cb: Listener) => void;
+  addListener: (cb: Listener) => void;
+  removeListener: (cb: Listener) => void;
+  dispatchEvent: () => boolean;
+}
+
+function installMatchMedia(matches: boolean): {
+  mql: MqlStub;
+  emit: (next: boolean) => void;
+} {
+  const listeners: Listener[] = [];
+  let current = matches;
+  const mql: MqlStub = {
+    // `matches` is a live view of `current` — the hook reads `mql.matches`
+    // inside its listener, so it must reflect the latest emitted value.
+    get matches() {
+      return current;
+    },
+    media: "(prefers-reduced-motion: reduce)",
+    onchange: null,
+    addEventListener: (_type, cb) => listeners.push(cb),
+    removeEventListener: (_type, cb) => {
+      const i = listeners.indexOf(cb);
+      if (i >= 0) listeners.splice(i, 1);
+    },
+    addListener: (cb) => listeners.push(cb),
+    removeListener: (cb) => {
+      const i = listeners.indexOf(cb);
+      if (i >= 0) listeners.splice(i, 1);
+    },
+    dispatchEvent: () => true,
+  };
+
+  const matchMediaSpy = jest.fn().mockImplementation(() => mql);
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: matchMediaSpy,
+  });
+
+  return {
+    mql,
+    emit: (next: boolean) => {
+      current = next;
+      // matchMedia listeners receive a MediaQueryListEvent-like object.
+      listeners.forEach((cb) => cb({ matches: current }));
+    },
+  };
+}
+
+describe("usePrefersReducedMotion", () => {
+  it("reports false when the OS preference is not set", () => {
+    installMatchMedia(false);
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+  });
+
+  it("reports true when the OS preference is 'reduce'", () => {
+    installMatchMedia(true);
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(true);
+  });
+
+  it("reacts to media-query changes at runtime", () => {
+    const { emit } = installMatchMedia(false);
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+
+    act(() => emit(true));
+    expect(result.current).toBe(true);
+
+    act(() => emit(false));
+    expect(result.current).toBe(false);
+  });
+
+  it("returns false (SSR-safe default) when matchMedia is unavailable", () => {
+    // Simulate an environment without matchMedia (SSR / older browser).
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    const { result, unmount } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+    // Should not throw on unmount either.
+    expect(() => unmount()).not.toThrow();
+  });
+});

--- a/src/hooks/use-prefers-reduced-motion.ts
+++ b/src/hooks/use-prefers-reduced-motion.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Media query used by the OS / browser to signal that the user has asked the
+ * system to minimize the amount of non-essential motion.
+ */
+export const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+/**
+ * Reactively tracks the user's `prefers-reduced-motion` OS / browser setting.
+ *
+ * - SSR-safe: returns `false` on the server and during the first client render
+ *   so markup matches the server-rendered output, then re-syncs in an effect.
+ * - Reactive: subscribes to media-query changes and re-renders when the user
+ *   toggles the preference (or changes device) at runtime.
+ * - Defensive: falls back gracefully on environments without `matchMedia`
+ *   (older browsers, jsdom without a polyfill).
+ *
+ * @returns `true` when the user prefers reduced motion, `false` otherwise.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mql = window.matchMedia(REDUCED_MOTION_QUERY);
+    const update = () => setReduced(mql.matches);
+
+    // Sync immediately so the first paint after mount reflects the real value.
+    update();
+
+    if (typeof mql.addEventListener === "function") {
+      mql.addEventListener("change", update);
+      return () => mql.removeEventListener("change", update);
+    }
+
+    // Safari < 14 legacy fallback.
+    if (typeof (mql as MediaQueryList).addListener === "function") {
+      const legacyListener = (event: MediaQueryListEvent) => setReduced(event.matches);
+      mql.addListener(legacyListener);
+      return () => mql.removeListener(legacyListener);
+    }
+  }, []);
+
+  return reduced;
+}


### PR DESCRIPTION
## Summary

Resolves #1103. Game animations now honor the user's OS-level `prefers-reduced-motion: reduce` setting. A shared reactive hook gates JS/canvas-driven motion, and the existing global CSS media query is strengthened as a safety net for all CSS-driven motion.

## Changes

### New shared hook
- **`src/hooks/use-prefers-reduced-motion.ts`** — SSR-safe, reactive `usePrefersReducedMotion()` built on `matchMedia("(prefers-reduced-motion: reduce)")` with a `change` listener (and a legacy `addListener` fallback for old Safari). Returns `false` on the server / first render, then syncs.
- Refactored `src/components/onboarding-tour.tsx` to consume the shared hook instead of its private duplicate (single source of truth).

### Per-component honoring (motion gated, functionality preserved)
- **`combat-animations.tsx`** — `AttackAnimation`, `BlockAnimation`, `DamageAnimation`, `CombatCard`, `CombatPhaseIndicator`: under reduced motion, decorative motion (multi-phase transforms, trails, impact particles, `animate-bounce`/`animate-pulse`/`animate-ping`, count-up) is suppressed. Event-communicating indicators still appear statically for a brief dwell then complete, so the lifecycle (`onComplete`) and game state are unchanged.
- **`damage-indicator.tsx`** — skips the floating-up offset/transition; value shows in place and still retires via `onComplete`.
- **`pack-passing-animation.tsx`** — snaps to the dimmed end state instantly (no slide/scale), passing state still legible.
- **`achievement-notification.tsx`** — toast entrance/exit is dampened by the global CSS rule; duration is extended (5s → 7s) under reduced motion so unlocks remain readable without the celebratory motion.
- **`card-sleeve.tsx`** — `hover:scale-105` transforms on the sleeve/playmat selectors are gated off.
- **`emote-picker.tsx`** — popover open/close stays functional (essential UI); its transition is explicitly dropped under reduced motion.

### Global CSS safety net
- **`src/app/globals.css`** — broadened the existing `@media (prefers-reduced-motion: reduce)` block to also force `scroll-behavior: auto` (incl. on `html`) and added a clarifying comment. Catches any CSS keyframes/transitions/parallax not gated per-component. Functional transitions (dialog open/close, focus rings) are made instant, not removed.

### Tests
- **`src/hooks/__tests__/use-prefers-reduced-motion.test.ts`** — covers reduced vs not, runtime media-query reactivity, and the SSR-safe `matchMedia`-unavailable path.
- **`src/components/__tests__/damage-indicator.test.tsx`** — asserts the floating transition is present when motion is allowed and absent (and `onComplete` still fires) under reduced motion.
- **`jest.setup.js`** — added a permissive default `window.matchMedia` mock so the hook works in any jsdom test (overridable per-test).

## Acceptance criteria
- [x] `usePrefersReducedMotion` hook added and used in combat-animations, pack-passing, damage-indicator, achievement-notification (also card-sleeve, emote-picker, onboarding-tour)
- [x] With OS reduced-motion ON, no large-area motion / parallax from the listed components
- [x] Global `@media (prefers-reduced-motion: reduce)` safety net in `globals.css`
- [x] Unit tests cover the hook (reduced vs not, reactive) and a component reduced-motion branch
- [x] Functionality preserved — only motion is reduced; state/lifecycle unchanged

## Verification
- `jest` — new + related suites pass (6/6 new; 65 passed / 4 skipped in related suites, 0 failures)
- `eslint` — 0 errors on touched files (full repo: 0 errors, only pre-existing warnings)
- `tsc --noEmit` — 0 errors in any touched file. 9 pre-existing `Cannot find module 'next-intl'` errors remain on `origin/main` (introduced by the i18n scaffold in #1105); they are environmental (dependency not present in the shared install) and unrelated to this change.

## Notes / deviations
- The in-issue optional **Settings toggle** that overrides the OS preference was intentionally **not** added: it would require a new settings surface + persistence + wiring into every consumer and a UI for it, which is a meaningfully larger scope than this audit-and-honor ticket. The OS-level preference is now fully honored everywhere via the hook + CSS. A follow-up issue is recommended if an in-app override is still desired.
- No Playwright e2e with emulated reduced-motion was added (the issue listed it as a criterion); the behavior is covered by the hook + component unit tests instead. Happy to add an e2e if the maintainers want that specific gate.

Resolves #1103