### PR TITLE
fix(a11y): resolve #1101 — add aria-labels to icon-only buttons across interactive components

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -1,0 +1,61 @@
+# Accessibility (a11y) Conventions
+
+This document captures the conventions used across Planar Nexus to keep the UI
+accessible. It is the reference for issue #1101 and future a11y work.
+
+## Icon-only buttons
+
+Any `<Button>` whose only visible content is an icon (no text label) **must**
+expose a programmatically determinable accessible name, per
+[WCAG 2.1 SC 4.1.2 (Name, Role, Value)](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html).
+
+### Rule
+
+- Add an `aria-label` to every `<Button size="icon">` (or any button whose
+  children are only icons). The shadcn `Button` forwards all extra props to the
+  underlying `<button>`, so `aria-label` passes through automatically.
+- Prefer `aria-label` over `title`. A `title` attribute renders a tooltip but is
+  **not** a reliable accessible name across browsers/screen readers. If a
+  tooltip is also desired, keep `title` alongside `aria-label`.
+- Labels must be **action-oriented and descriptive** (e.g. `"Add card"`,
+  `"Decrease life"`, `"Open chat"`), never generic (`"button"`, `"icon"`).
+- When a button's action depends on state, make the label dynamic
+  (e.g. `aria-label={isHidden ? "Show spectators" : "Hide spectators"}`).
+- Where the component already uses the i18n `t()` helper, pass the translated
+  string: `aria-label={t("openChat")}`.
+
+### Examples
+
+```tsx
+// Good — icon-only button with an accessible name
+<Button variant="outline" size="icon" onClick={onAdd} aria-label="Increase quantity">
+  <Plus className="h-4 w-4" />
+</Button>
+
+// Good — dynamic label reflecting toggle state
+<Button variant="ghost" size="icon" onClick={onToggleVisibility}
+  aria-label={isHidden ? "Show spectators" : "Hide spectators"}>
+  {isHidden ? <EyeOff /> : <Eye />}
+</Button>
+
+// Good — tooltip kept, accessible name explicit
+<Button variant="ghost" size="icon" onClick={onOpenSettings}
+  aria-label={t("settings")} title={t("settings")}>
+  <Settings />
+</Button>
+```
+
+### Testing
+
+Component tests assert accessible names using Testing Library's role queries,
+which resolve the accessible name the same way a screen reader does:
+
+```tsx
+expect(
+  screen.getByRole("button", { name: "Increase quantity" }),
+).toBeInTheDocument();
+```
+
+See `src/components/__tests__/icon-button-a11y.test.tsx` for representative
+coverage of the icon-only buttons in `SpectatorView`, `LifeAdjustment`, and
+`CounterAdjustment`.

--- a/src/components/__tests__/icon-button-a11y.test.tsx
+++ b/src/components/__tests__/icon-button-a11y.test.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { SpectatorView } from "../spectator-view";
+import {
+  LifeAdjustment,
+  CounterAdjustment,
+  type JudgePlayerState,
+} from "../judge-tools";
+import type { Spectator, SpectatorPermissions } from "@/lib/spectator";
+
+// jsdom polyfills required by Radix primitives used by Card (ResizeObserver).
+class RO {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (typeof globalThis.ResizeObserver === "undefined") {
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = RO;
+}
+
+const basePlayer: JudgePlayerState = {
+  id: "p1",
+  name: "Alice",
+  life: 20,
+  poisonCounters: 0,
+  energyCounters: 2,
+  isActive: true,
+};
+
+const fullPermissions: SpectatorPermissions = {
+  canChat: true,
+  canSeeHands: true,
+  canSeeTimers: true,
+  isHidden: false,
+};
+
+const spectators: Spectator[] = [{ id: "s1", name: "Bob", joinedAt: 0 }];
+
+describe("SpectatorView — icon-only buttons expose accessible names (#1101)", () => {
+  it("announces the chat, visibility, and settings buttons by name", () => {
+    render(
+      <SpectatorView
+        spectators={spectators}
+        permissions={fullPermissions}
+        onOpenChat={jest.fn()}
+        onToggleVisibility={jest.fn()}
+        onOpenSettings={jest.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Open chat" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Hide spectators" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Spectator settings" }),
+    ).toBeInTheDocument();
+  });
+
+  it("flips the visibility button label when spectators are hidden", () => {
+    render(
+      <SpectatorView
+        spectators={spectators}
+        permissions={{ ...fullPermissions, isHidden: true }}
+        onToggleVisibility={jest.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Show spectators" }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("LifeAdjustment / CounterAdjustment — icon-only buttons expose accessible names (#1101)", () => {
+  it("announces life increase/decrease buttons by name", () => {
+    render(<LifeAdjustment player={basePlayer} onAdjust={jest.fn()} />);
+    expect(
+      screen.getByRole("button", { name: "Decrease life" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Increase life" }),
+    ).toBeInTheDocument();
+  });
+
+  it("announces counter increase/decrease buttons by name", () => {
+    const { rerender } = render(
+      <CounterAdjustment
+        player={basePlayer}
+        counterType="poison"
+        onAdjust={jest.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Decrease poison counter" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Increase poison counter" }),
+    ).toBeInTheDocument();
+
+    rerender(
+      <CounterAdjustment
+        player={basePlayer}
+        counterType="energy"
+        onAdjust={jest.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Increase energy counter" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/ai-coach/chat-panel.tsx
+++ b/src/components/ai-coach/chat-panel.tsx
@@ -1,14 +1,25 @@
-'use client';
+"use client";
 
-import { useRef, useEffect, useState } from 'react';
-import { useGameChat } from '@/hooks/use-game-chat';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import { PlaceholderComponent, StubDebugBanner } from '@/components/ui/placeholder';
-import { Bot, User, Send, Loader2, History, Database, Sparkles } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { ComponentErrorBoundary } from '@/components/error-boundaries';
+import { useRef, useEffect, useState } from "react";
+import { useGameChat } from "@/hooks/use-game-chat";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  PlaceholderComponent,
+  StubDebugBanner,
+} from "@/components/ui/placeholder";
+import {
+  Bot,
+  User,
+  Send,
+  Loader2,
+  History,
+  Database,
+  Sparkles,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { ComponentErrorBoundary } from "@/components/error-boundaries";
 
 interface AICoachChatPanelProps {
   currentPlayerId: string;
@@ -21,16 +32,12 @@ export function AICoachChatPanel({
   currentPlayerName,
   className,
 }: AICoachChatPanelProps) {
-  const {
-    messages,
-    status,
-    sendMessage,
-  } = useGameChat({
+  const { messages, status, sendMessage } = useGameChat({
     currentPlayerId,
     currentPlayerName,
   });
 
-  const [input, setInput] = useState('');
+  const [input, setInput] = useState("");
   const [dismissed, setDismissed] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -41,33 +48,33 @@ export function AICoachChatPanel({
     }
   }, [messages, status]);
 
-  const isThinking = status === 'submitted' || status === 'streaming';
-  const isLoading = status === 'submitted' || status === 'streaming';
+  const isThinking = status === "submitted" || status === "streaming";
+  const isLoading = status === "submitted" || status === "streaming";
 
   // Graceful degradation: when the conversational AI backend is unavailable the
   // chat surfaces a friendly "Coming Soon" placeholder instead of a raw error
   // or a stuck "thinking" state (Issue #1009).
-  const isBackendUnavailable = status === 'error' && !dismissed;
+  const isBackendUnavailable = status === "error" && !dismissed;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (input.trim() && !isLoading) {
       sendMessage(input);
-      setInput('');
+      setInput("");
     }
   };
 
   // Helper to extract text content from AI SDK v6 message
   const getMessageContent = (message: any): string => {
-    if (!message.content) return '';
-    if (typeof message.content === 'string') return message.content;
+    if (!message.content) return "";
+    if (typeof message.content === "string") return message.content;
     if (Array.isArray(message.content)) {
       return message.content
-        .filter((part: any) => part.type === 'text')
+        .filter((part: any) => part.type === "text")
         .map((part: any) => part.text)
-        .join('');
+        .join("");
     }
-    return '';
+    return "";
   };
 
   return (
@@ -78,134 +85,154 @@ export function AICoachChatPanel({
       resetLabel="Restart Coach"
       className={className}
     >
-      <div className={cn('flex flex-col h-[500px] border rounded-lg bg-card shadow-sm overflow-hidden', className)}>
+      <div
+        className={cn(
+          "flex flex-col h-[500px] border rounded-lg bg-card shadow-sm overflow-hidden",
+          className,
+        )}
+      >
         <div className="flex items-center gap-2 p-3 border-b bg-muted/20">
-        <Bot className="w-5 h-5 text-primary" />
-        <h3 className="font-semibold text-sm">AI Coach</h3>
-        <div className="ml-auto flex items-center gap-2">
-          {isLoading && <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />}
-          <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
-            {status === 'ready' ? 'Ready' : status}
-          </span>
+          <Bot className="w-5 h-5 text-primary" />
+          <h3 className="font-semibold text-sm">AI Coach</h3>
+          <div className="ml-auto flex items-center gap-2">
+            {isLoading && (
+              <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
+            )}
+            <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
+              {status === "ready" ? "Ready" : status}
+            </span>
+          </div>
         </div>
-      </div>
 
-      {/* Debug-mode banner clarifying this is a stub surface (Issue #1009) */}
-      <StubDebugBanner label="Conversational AI Coach" />
+        {/* Debug-mode banner clarifying this is a stub surface (Issue #1009) */}
+        <StubDebugBanner label="Conversational AI Coach" />
 
-      <ScrollArea className="flex-1 p-4">
-        <div ref={scrollRef} className="space-y-4">
-          {isBackendUnavailable && (
-            <PlaceholderComponent
-              stubId="ai-coach-conversational"
-              icon={Sparkles}
-              title="Conversational Coach — Coming Soon"
-              description="The conversational AI coach is still being wired up. Your deck analysis and heuristic coaching are available right now while we finish this feature."
-              action={
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setDismissed(true)}
-                >
-                  Dismiss
-                </Button>
-              }
-            />
-          )}
+        <ScrollArea className="flex-1 p-4">
+          <div ref={scrollRef} className="space-y-4">
+            {isBackendUnavailable && (
+              <PlaceholderComponent
+                stubId="ai-coach-conversational"
+                icon={Sparkles}
+                title="Conversational Coach — Coming Soon"
+                description="The conversational AI coach is still being wired up. Your deck analysis and heuristic coaching are available right now while we finish this feature."
+                action={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setDismissed(true)}
+                  >
+                    Dismiss
+                  </Button>
+                }
+              />
+            )}
 
-          {messages.length === 0 && !isBackendUnavailable && (
-            <div className="text-center py-8 text-muted-foreground">
-              <Bot className="w-12 h-12 mx-auto mb-3 opacity-20" />
-              <p className="text-sm">Ask me anything about your deck, game history, or card rules!</p>
-            </div>
-          )}
+            {messages.length === 0 && !isBackendUnavailable && (
+              <div className="text-center py-8 text-muted-foreground">
+                <Bot className="w-12 h-12 mx-auto mb-3 opacity-20" />
+                <p className="text-sm">
+                  Ask me anything about your deck, game history, or card rules!
+                </p>
+              </div>
+            )}
 
-          {messages.map((message: any) => {
-            const isAI = message.role === 'assistant';
-            const content = getMessageContent(message);
-            return (
-              <div
-                key={message.id}
-                className={cn(
-                  'flex gap-3 text-sm',
-                  isAI ? 'justify-start' : 'justify-end'
-                )}
-              >
-                {isAI && (
-                  <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
-                    <Bot className="w-4 h-4 text-primary" />
-                  </div>
-                )}
-                
+            {messages.map((message: any) => {
+              const isAI = message.role === "assistant";
+              const content = getMessageContent(message);
+              return (
                 <div
+                  key={message.id}
                   className={cn(
-                    'max-w-[85%] rounded-2xl px-4 py-2 shadow-sm',
-                    isAI 
-                      ? 'bg-muted rounded-tl-none' 
-                      : 'bg-primary text-primary-foreground rounded-tr-none'
+                    "flex gap-3 text-sm",
+                    isAI ? "justify-start" : "justify-end",
                   )}
                 >
-                  <div className="whitespace-pre-wrap leading-relaxed">
-                    {content}
-                  </div>
-                  
-                  {/* Handle tool calls/invocations if present in message */}
-                  {message.toolInvocations && message.toolInvocations.length > 0 && (
-                    <div className="mt-2 space-y-2 border-t pt-2 border-border/50">
-                      {message.toolInvocations.map((tool: any) => (
-                        <div key={tool.toolCallId} className="flex items-center gap-2 text-[10px] text-muted-foreground font-mono">
-                          {tool.toolName === 'searchCards' ? <Database className="w-3 h-3" /> : <History className="w-3 h-3" />}
-                          <span>EXECUTING: {tool.toolName}</span>
-                          {'result' in tool && <span className="text-green-500">✓ DONE</span>}
+                  {isAI && (
+                    <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+                      <Bot className="w-4 h-4 text-primary" />
+                    </div>
+                  )}
+
+                  <div
+                    className={cn(
+                      "max-w-[85%] rounded-2xl px-4 py-2 shadow-sm",
+                      isAI
+                        ? "bg-muted rounded-tl-none"
+                        : "bg-primary text-primary-foreground rounded-tr-none",
+                    )}
+                  >
+                    <div className="whitespace-pre-wrap leading-relaxed">
+                      {content}
+                    </div>
+
+                    {/* Handle tool calls/invocations if present in message */}
+                    {message.toolInvocations &&
+                      message.toolInvocations.length > 0 && (
+                        <div className="mt-2 space-y-2 border-t pt-2 border-border/50">
+                          {message.toolInvocations.map((tool: any) => (
+                            <div
+                              key={tool.toolCallId}
+                              className="flex items-center gap-2 text-[10px] text-muted-foreground font-mono"
+                            >
+                              {tool.toolName === "searchCards" ? (
+                                <Database className="w-3 h-3" />
+                              ) : (
+                                <History className="w-3 h-3" />
+                              )}
+                              <span>EXECUTING: {tool.toolName}</span>
+                              {"result" in tool && (
+                                <span className="text-green-500">✓ DONE</span>
+                              )}
+                            </div>
+                          ))}
                         </div>
-                      ))}
+                      )}
+                  </div>
+
+                  {!isAI && (
+                    <div className="w-8 h-8 rounded-full bg-primary flex items-center justify-center shrink-0">
+                      <User className="w-4 h-4 text-primary-foreground" />
                     </div>
                   )}
                 </div>
+              );
+            })}
 
-                {!isAI && (
-                  <div className="w-8 h-8 rounded-full bg-primary flex items-center justify-center shrink-0">
-                    <User className="w-4 h-4 text-primary-foreground" />
-                  </div>
-                )}
+            {isThinking && (
+              <div className="flex gap-3 animate-in fade-in slide-in-from-bottom-2 duration-300">
+                <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+                  <Bot className="w-4 h-4 text-primary" />
+                </div>
+                <div className="bg-muted rounded-2xl rounded-tl-none px-4 py-2 flex gap-1 items-center h-9">
+                  <span className="w-1 h-1 bg-muted-foreground rounded-full animate-bounce [animation-delay:-0.3s]"></span>
+                  <span className="w-1 h-1 bg-muted-foreground rounded-full animate-bounce [animation-delay:-0.15s]"></span>
+                  <span className="w-1 h-1 bg-muted-foreground rounded-full animate-bounce"></span>
+                </div>
               </div>
-            );
-          })}
-          
-          {isThinking && (
-            <div className="flex gap-3 animate-in fade-in slide-in-from-bottom-2 duration-300">
-              <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
-                <Bot className="w-4 h-4 text-primary" />
-              </div>
-              <div className="bg-muted rounded-2xl rounded-tl-none px-4 py-2 flex gap-1 items-center h-9">
-                <span className="w-1 h-1 bg-muted-foreground rounded-full animate-bounce [animation-delay:-0.3s]"></span>
-                <span className="w-1 h-1 bg-muted-foreground rounded-full animate-bounce [animation-delay:-0.15s]"></span>
-                <span className="w-1 h-1 bg-muted-foreground rounded-full animate-bounce"></span>
-              </div>
-            </div>
-          )}
-        </div>
-      </ScrollArea>
+            )}
+          </div>
+        </ScrollArea>
 
-      <form onSubmit={handleSubmit} className="p-3 border-t bg-muted/5">
-        <div className="flex gap-2">
-          <Input
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            placeholder="How can I improve my win rate?"
-            className="flex-1 h-10 shadow-none border-none focus-visible:ring-1"
-            disabled={isLoading}
-          />
-          <Button 
-            type="submit" 
-            size="icon" 
-            disabled={isLoading || !input.trim()}
-            className="h-10 w-10 shrink-0"
-          >
-            <Send className="w-4 h-4" />
-          </Button>
-        </div>
-      </form>
+        <form onSubmit={handleSubmit} className="p-3 border-t bg-muted/5">
+          <div className="flex gap-2">
+            <Input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="How can I improve my win rate?"
+              className="flex-1 h-10 shadow-none border-none focus-visible:ring-1"
+              disabled={isLoading}
+            />
+            <Button
+              type="submit"
+              size="icon"
+              aria-label="Send message"
+              disabled={isLoading || !input.trim()}
+              className="h-10 w-10 shrink-0"
+            >
+              <Send className="w-4 h-4" />
+            </Button>
+          </div>
+        </form>
       </div>
     </ComponentErrorBoundary>
   );

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -143,6 +143,7 @@ export function AppSidebar() {
             variant="ghost"
             size="icon"
             className="ml-auto size-7 shrink-0"
+            aria-label={t("keyboardShortcuts")}
             title={t("keyboardShortcuts")}
           >
             <MousePointer className="size-4" />
@@ -151,6 +152,7 @@ export function AppSidebar() {
             variant="ghost"
             size="icon"
             className="ml-auto size-7 shrink-0"
+            aria-label={t("community")}
             title={t("community")}
           >
             <Users className="size-4" />

--- a/src/components/collection-tracker.tsx
+++ b/src/components/collection-tracker.tsx
@@ -1,13 +1,19 @@
-'use client';
+"use client";
 
-import * as React from 'react';
-import { useCollection, CollectionCard } from '@/hooks/use-collection';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import { VirtualCardList } from '@/components/virtual-card-list';
+import * as React from "react";
+import { useCollection, CollectionCard } from "@/hooks/use-collection";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { VirtualCardList } from "@/components/virtual-card-list";
 import {
   Dialog,
   DialogContent,
@@ -16,7 +22,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from '@/components/ui/dialog';
+} from "@/components/ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -24,7 +30,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+} from "@/components/ui/dropdown-menu";
 import {
   Plus,
   Minus,
@@ -37,8 +43,8 @@ import {
   CheckCircle,
   FolderOpen,
   ArrowUpDown,
-} from 'lucide-react';
-import { cn } from '@/lib/utils';
+} from "lucide-react";
+import { cn } from "@/lib/utils";
 
 interface CollectionTrackerProps {
   className?: string;
@@ -58,12 +64,15 @@ export function CollectionTracker({ className }: CollectionTrackerProps) {
     getCollectionStats,
   } = useCollection();
 
-  const [searchQuery, setSearchQuery] = React.useState('');
-  const [sortBy, setSortBy] = React.useState<'name' | 'quantity' | 'added'>('name');
-  const [sortOrder, setSortOrder] = React.useState<'asc' | 'desc'>('asc');
-  const [showNewCollectionDialog, setShowNewCollectionDialog] = React.useState(false);
-  const [newCollectionName, setNewCollectionName] = React.useState('');
-  const [importText, setImportText] = React.useState('');
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const [sortBy, setSortBy] = React.useState<"name" | "quantity" | "added">(
+    "name",
+  );
+  const [sortOrder, setSortOrder] = React.useState<"asc" | "desc">("asc");
+  const [showNewCollectionDialog, setShowNewCollectionDialog] =
+    React.useState(false);
+  const [newCollectionName, setNewCollectionName] = React.useState("");
+  const [importText, setImportText] = React.useState("");
   const [showImportDialog, setShowImportDialog] = React.useState(false);
 
   const stats = getCollectionStats();
@@ -82,17 +91,18 @@ export function CollectionTracker({ className }: CollectionTrackerProps) {
     cards.sort((a, b) => {
       let comparison = 0;
       switch (sortBy) {
-        case 'name':
+        case "name":
           comparison = a.card.name.localeCompare(b.card.name);
           break;
-        case 'quantity':
+        case "quantity":
           comparison = a.quantity - b.quantity;
           break;
-        case 'added':
-          comparison = new Date(a.addedAt).getTime() - new Date(b.addedAt).getTime();
+        case "added":
+          comparison =
+            new Date(a.addedAt).getTime() - new Date(b.addedAt).getTime();
           break;
       }
-      return sortOrder === 'asc' ? comparison : -comparison;
+      return sortOrder === "asc" ? comparison : -comparison;
     });
 
     return cards;
@@ -101,7 +111,7 @@ export function CollectionTracker({ className }: CollectionTrackerProps) {
   const handleCreateCollection = () => {
     if (newCollectionName.trim()) {
       createCollection(newCollectionName.trim());
-      setNewCollectionName('');
+      setNewCollectionName("");
       setShowNewCollectionDialog(false);
     }
   };
@@ -109,33 +119,33 @@ export function CollectionTracker({ className }: CollectionTrackerProps) {
   const handleImport = () => {
     if (importText.trim()) {
       importFromCSV(importText);
-      setImportText('');
+      setImportText("");
       setShowImportDialog(false);
     }
   };
 
   const handleExport = () => {
     const csv = exportToCSV();
-    const blob = new Blob([csv], { type: 'text/csv' });
+    const blob = new Blob([csv], { type: "text/csv" });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
+    const a = document.createElement("a");
     a.href = url;
-    a.download = `${activeCollection.name.replace(/\s+/g, '-').toLowerCase()}.csv`;
+    a.download = `${activeCollection.name.replace(/\s+/g, "-").toLowerCase()}.csv`;
     a.click();
     URL.revokeObjectURL(url);
   };
 
-  const toggleSort = (field: 'name' | 'quantity' | 'added') => {
+  const toggleSort = (field: "name" | "quantity" | "added") => {
     if (sortBy === field) {
-      setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+      setSortOrder(sortOrder === "asc" ? "desc" : "asc");
     } else {
       setSortBy(field);
-      setSortOrder('asc');
+      setSortOrder("asc");
     }
   };
 
   return (
-    <div className={cn('flex flex-col h-full', className)}>
+    <div className={cn("flex flex-col h-full", className)}>
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b">
         <div className="flex items-center gap-2">
@@ -154,7 +164,8 @@ export function CollectionTracker({ className }: CollectionTrackerProps) {
               <DialogHeader>
                 <DialogTitle>Import Collection</DialogTitle>
                 <DialogDescription>
-                  Paste your card list in CSV format (quantity,card name) or simple format (quantity card name)
+                  Paste your card list in CSV format (quantity,card name) or
+                  simple format (quantity card name)
                 </DialogDescription>
               </DialogHeader>
               <div className="py-4">
@@ -166,7 +177,10 @@ export function CollectionTracker({ className }: CollectionTrackerProps) {
                 />
               </div>
               <DialogFooter>
-                <Button variant="outline" onClick={() => setShowImportDialog(false)}>
+                <Button
+                  variant="outline"
+                  onClick={() => setShowImportDialog(false)}
+                >
                   Cancel
                 </Button>
                 <Button onClick={handleImport}>Import</Button>
@@ -183,7 +197,9 @@ export function CollectionTracker({ className }: CollectionTrackerProps) {
       {/* Stats Overview */}
       <div className="grid grid-cols-4 gap-2 p-4 border-b bg-muted/30">
         <div className="text-center">
-          <div className="text-2xl font-bold text-primary">{stats.totalCards}</div>
+          <div className="text-2xl font-bold text-primary">
+            {stats.totalCards}
+          </div>
           <div className="text-xs text-muted-foreground">Total Cards</div>
         </div>
         <div className="text-center">
@@ -191,11 +207,15 @@ export function CollectionTracker({ className }: CollectionTrackerProps) {
           <div className="text-xs text-muted-foreground">Unique</div>
         </div>
         <div className="text-center">
-          <div className="text-2xl font-bold text-green-500">{stats.playableCards}</div>
+          <div className="text-2xl font-bold text-green-500">
+            {stats.playableCards}
+          </div>
           <div className="text-xs text-muted-foreground">Playsets</div>
         </div>
         <div className="text-center">
-          <div className="text-2xl font-bold text-amber-500">{stats.tradeableCards}</div>
+          <div className="text-2xl font-bold text-amber-500">
+            {stats.tradeableCards}
+          </div>
           <div className="text-xs text-muted-foreground">Tradeable</div>
         </div>
       </div>
@@ -216,7 +236,7 @@ export function CollectionTracker({ className }: CollectionTrackerProps) {
               <DropdownMenuItem
                 key={c.id}
                 onClick={() => setActiveCollectionId(c.id)}
-                className={cn(c.id === activeCollectionId && 'bg-primary/10')}
+                className={cn(c.id === activeCollectionId && "bg-primary/10")}
               >
                 {c.name} ({c.cards.length} cards)
               </DropdownMenuItem>
@@ -245,31 +265,31 @@ export function CollectionTracker({ className }: CollectionTrackerProps) {
       <div className="flex items-center gap-2 px-4 py-2 border-b bg-muted/20">
         <span className="text-xs text-muted-foreground">Sort by:</span>
         <Button
-          variant={sortBy === 'name' ? 'secondary' : 'ghost'}
+          variant={sortBy === "name" ? "secondary" : "ghost"}
           size="sm"
-          onClick={() => toggleSort('name')}
+          onClick={() => toggleSort("name")}
           className="h-7"
         >
           Name
-          {sortBy === 'name' && <ArrowUpDown className="h-3 w-3 ml-1" />}
+          {sortBy === "name" && <ArrowUpDown className="h-3 w-3 ml-1" />}
         </Button>
         <Button
-          variant={sortBy === 'quantity' ? 'secondary' : 'ghost'}
+          variant={sortBy === "quantity" ? "secondary" : "ghost"}
           size="sm"
-          onClick={() => toggleSort('quantity')}
+          onClick={() => toggleSort("quantity")}
           className="h-7"
         >
           Quantity
-          {sortBy === 'quantity' && <ArrowUpDown className="h-3 w-3 ml-1" />}
+          {sortBy === "quantity" && <ArrowUpDown className="h-3 w-3 ml-1" />}
         </Button>
         <Button
-          variant={sortBy === 'added' ? 'secondary' : 'ghost'}
+          variant={sortBy === "added" ? "secondary" : "ghost"}
           size="sm"
-          onClick={() => toggleSort('added')}
+          onClick={() => toggleSort("added")}
           className="h-7"
         >
           Added
-          {sortBy === 'added' && <ArrowUpDown className="h-3 w-3 ml-1" />}
+          {sortBy === "added" && <ArrowUpDown className="h-3 w-3 ml-1" />}
         </Button>
       </div>
 
@@ -277,7 +297,9 @@ export function CollectionTracker({ className }: CollectionTrackerProps) {
       <div className="flex-1 min-h-0">
         {filteredCards.length === 0 ? (
           <div className="h-full flex items-center justify-center p-4 text-center text-muted-foreground">
-            {searchQuery ? 'No cards match your search' : 'Your collection is empty. Import cards to get started.'}
+            {searchQuery
+              ? "No cards match your search"
+              : "Your collection is empty. Import cards to get started."}
           </div>
         ) : (
           <VirtualCardList
@@ -296,20 +318,28 @@ export function CollectionTracker({ className }: CollectionTrackerProps) {
       </div>
 
       {/* New Collection Dialog */}
-      <Dialog open={showNewCollectionDialog} onOpenChange={setShowNewCollectionDialog}>
+      <Dialog
+        open={showNewCollectionDialog}
+        onOpenChange={setShowNewCollectionDialog}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Create New Collection</DialogTitle>
-            <DialogDescription>Enter a name for your new collection</DialogDescription>
+            <DialogDescription>
+              Enter a name for your new collection
+            </DialogDescription>
           </DialogHeader>
           <Input
             value={newCollectionName}
             onChange={(e) => setNewCollectionName(e.target.value)}
             placeholder="Collection name"
-            onKeyDown={(e) => e.key === 'Enter' && handleCreateCollection()}
+            onKeyDown={(e) => e.key === "Enter" && handleCreateCollection()}
           />
           <DialogFooter>
-            <Button variant="outline" onClick={() => setShowNewCollectionDialog(false)}>
+            <Button
+              variant="outline"
+              onClick={() => setShowNewCollectionDialog(false)}
+            >
               Cancel
             </Button>
             <Button onClick={handleCreateCollection}>Create</Button>
@@ -326,7 +356,11 @@ interface CollectionCardItemProps {
   onRemove: () => void;
 }
 
-function CollectionCardItem({ card, onAdd, onRemove }: CollectionCardItemProps) {
+function CollectionCardItem({
+  card,
+  onAdd,
+  onRemove,
+}: CollectionCardItemProps) {
   const isPlayable = card.quantity >= 4;
   const isTradeable = card.quantity > 4;
 
@@ -357,11 +391,25 @@ function CollectionCardItem({ card, onAdd, onRemove }: CollectionCardItemProps) 
         </div>
       </div>
       <div className="flex items-center gap-2">
-        <Button variant="outline" size="icon" className="h-8 w-8" onClick={onRemove}>
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8"
+          onClick={onRemove}
+          aria-label="Decrease quantity"
+        >
           <Minus className="h-4 w-4" />
         </Button>
-        <span className="w-8 text-center font-mono font-bold">{card.quantity}</span>
-        <Button variant="outline" size="icon" className="h-8 w-8" onClick={onAdd}>
+        <span className="w-8 text-center font-mono font-bold">
+          {card.quantity}
+        </span>
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8"
+          onClick={onAdd}
+          aria-label="Increase quantity"
+        >
           <Plus className="h-4 w-4" />
         </Button>
       </div>
@@ -379,15 +427,19 @@ export function DeckComparison({ deckCards, className }: DeckComparisonProps) {
   const { compareDeckWithCollection } = useCollection();
   const comparison = compareDeckWithCollection(deckCards);
 
-  const missingCount = comparison.filter((c) => c.status === 'missing').length;
-  const insufficientCount = comparison.filter((c) => c.status === 'insufficient').length;
-  const okCount = comparison.filter((c) => c.status === 'ok').length;
+  const missingCount = comparison.filter((c) => c.status === "missing").length;
+  const insufficientCount = comparison.filter(
+    (c) => c.status === "insufficient",
+  ).length;
+  const okCount = comparison.filter((c) => c.status === "ok").length;
 
   return (
     <Card className={className}>
       <CardHeader>
         <CardTitle className="text-lg">Deck vs Collection</CardTitle>
-        <CardDescription>Compare your deck list with your collection</CardDescription>
+        <CardDescription>
+          Compare your deck list with your collection
+        </CardDescription>
       </CardHeader>
       <CardContent>
         <div className="grid grid-cols-3 gap-4 mb-4">
@@ -396,11 +448,15 @@ export function DeckComparison({ deckCards, className }: DeckComparisonProps) {
             <div className="text-xs text-muted-foreground">Complete</div>
           </div>
           <div className="text-center">
-            <div className="text-2xl font-bold text-amber-500">{insufficientCount}</div>
+            <div className="text-2xl font-bold text-amber-500">
+              {insufficientCount}
+            </div>
             <div className="text-xs text-muted-foreground">Partial</div>
           </div>
           <div className="text-center">
-            <div className="text-2xl font-bold text-red-500">{missingCount}</div>
+            <div className="text-2xl font-bold text-red-500">
+              {missingCount}
+            </div>
             <div className="text-xs text-muted-foreground">Missing</div>
           </div>
         </div>
@@ -410,10 +466,10 @@ export function DeckComparison({ deckCards, className }: DeckComparisonProps) {
               <div
                 key={card.name}
                 className={cn(
-                  'flex items-center justify-between p-2 rounded text-sm',
-                  card.status === 'ok' && 'bg-green-500/10',
-                  card.status === 'insufficient' && 'bg-amber-500/10',
-                  card.status === 'missing' && 'bg-red-500/10'
+                  "flex items-center justify-between p-2 rounded text-sm",
+                  card.status === "ok" && "bg-green-500/10",
+                  card.status === "insufficient" && "bg-amber-500/10",
+                  card.status === "missing" && "bg-red-500/10",
                 )}
               >
                 <span>{card.name}</span>
@@ -421,9 +477,15 @@ export function DeckComparison({ deckCards, className }: DeckComparisonProps) {
                   <span className="font-mono">
                     {card.collectionQuantity}/{card.deckQuantity}
                   </span>
-                  {card.status === 'missing' && <AlertCircle className="h-4 w-4 text-red-500" />}
-                  {card.status === 'insufficient' && <AlertCircle className="h-4 w-4 text-amber-500" />}
-                  {card.status === 'ok' && <CheckCircle className="h-4 w-4 text-green-500" />}
+                  {card.status === "missing" && (
+                    <AlertCircle className="h-4 w-4 text-red-500" />
+                  )}
+                  {card.status === "insufficient" && (
+                    <AlertCircle className="h-4 w-4 text-amber-500" />
+                  )}
+                  {card.status === "ok" && (
+                    <CheckCircle className="h-4 w-4 text-green-500" />
+                  )}
                 </div>
               </div>
             ))}
@@ -443,7 +505,9 @@ export function TradeList({ className }: { className?: string }) {
     <Card className={className}>
       <CardHeader>
         <CardTitle className="text-lg">Trade List</CardTitle>
-        <CardDescription>Cards you have extras of (more than 4)</CardDescription>
+        <CardDescription>
+          Cards you have extras of (more than 4)
+        </CardDescription>
       </CardHeader>
       <CardContent>
         {tradeList.length === 0 ? (

--- a/src/components/custom-card-editor.tsx
+++ b/src/components/custom-card-editor.tsx
@@ -684,6 +684,7 @@ export function CustomCardEditor({
                           })
                         }
                         disabled={readOnly}
+                        aria-label="Clear artwork URL"
                       >
                         <X className="w-4 h-4" />
                       </Button>

--- a/src/components/draft-pool-view.tsx
+++ b/src/components/draft-pool-view.tsx
@@ -73,7 +73,7 @@ export function DraftPoolView({
 
     // Sort by name
     return Array.from(groups.entries()).sort((a, b) =>
-      a[0].localeCompare(b[0])
+      a[0].localeCompare(b[0]),
     );
   }, [pool]);
 
@@ -87,7 +87,8 @@ export function DraftPoolView({
     // Count by color
     const colorCounts: Record<string, number> = {};
     for (const card of pool) {
-      const color = card.colors.length > 0 ? card.colors.join(",") : "Colorless";
+      const color =
+        card.colors.length > 0 ? card.colors.join(",") : "Colorless";
       colorCounts[color] = (colorCounts[color] || 0) + 1;
     }
 
@@ -105,7 +106,7 @@ export function DraftPoolView({
     <Card
       className={cn(
         "flex flex-col h-full border-l-4 border-l-primary",
-        className
+        className,
       )}
     >
       {/* Header */}
@@ -115,26 +116,23 @@ export function DraftPoolView({
             <Package className="h-5 w-5" />
             Draft Pool
           </CardTitle>
-          <Badge variant="secondary">
-            {stats.totalCards} cards
-          </Badge>
+          <Badge variant="secondary">{stats.totalCards} cards</Badge>
         </div>
 
         {/* Progress toward deck */}
         <div className="mt-2 space-y-1">
           <div className="flex items-center justify-between text-sm">
             <span className="text-muted-foreground">Progress</span>
-            <span className={cn(
-              "font-medium",
-              stats.isDeckReady && "text-green-500"
-            )}>
+            <span
+              className={cn(
+                "font-medium",
+                stats.isDeckReady && "text-green-500",
+              )}
+            >
               {stats.totalCards} / {MINIMUM_DECK_SIZE}
             </span>
           </div>
-          <Progress
-            value={stats.progress}
-            className="h-2"
-          />
+          <Progress value={stats.progress} className="h-2" />
         </div>
       </CardHeader>
 
@@ -151,9 +149,7 @@ export function DraftPoolView({
                   card={cards[0]}
                   quantity={cards.length}
                   onRemove={
-                    onRemoveCard
-                      ? () => onRemoveCard(cards[0].id)
-                      : undefined
+                    onRemoveCard ? () => onRemoveCard(cards[0].id) : undefined
                   }
                 />
               ))}
@@ -230,7 +226,10 @@ function PoolCardRow({ card, quantity, onRemove }: PoolCardRowProps) {
 
       {/* Quantity */}
       {quantity > 1 && (
-        <Badge variant="secondary" className="h-5 w-5 p-0 flex items-center justify-center">
+        <Badge
+          variant="secondary"
+          className="h-5 w-5 p-0 flex items-center justify-center"
+        >
           {quantity}
         </Badge>
       )}
@@ -242,6 +241,7 @@ function PoolCardRow({ card, quantity, onRemove }: PoolCardRowProps) {
           size="icon"
           className="h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity"
           onClick={onRemove}
+          aria-label="Remove card"
         >
           <Trash2 className="h-3 w-3" />
         </Button>

--- a/src/components/game-tutorial.tsx
+++ b/src/components/game-tutorial.tsx
@@ -311,6 +311,7 @@ export function GameTutorial({
                 size="icon"
                 className="h-6 w-6"
                 onClick={handleSkip}
+                aria-label="Skip tutorial"
               >
                 <X className="h-3 w-3" />
               </Button>

--- a/src/components/judge-tools.tsx
+++ b/src/components/judge-tools.tsx
@@ -1,22 +1,28 @@
-'use client';
+"use client";
 
-import { useState, useCallback } from 'react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { 
-  Gavel, 
-  Users, 
-  Shield, 
-  Heart, 
-  Skull, 
-  RotateCcw, 
-  AlertTriangle, 
-  Eye, 
+import { useState, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Gavel,
+  Users,
+  Shield,
+  Heart,
+  Skull,
+  RotateCcw,
+  AlertTriangle,
+  Eye,
   Settings,
   Plus,
   Minus,
@@ -24,15 +30,19 @@ import {
   X,
   Pause,
   Play,
-  Zap
-} from 'lucide-react';
-import { cn } from '@/lib/utils';
+  Zap,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
 
 // Judge role types
-export type JudgeRole = 'judge' | 'head-judge' | 'spectator-privileged';
+export type JudgeRole = "judge" | "head-judge" | "spectator-privileged";
 
 // Warning/Penalty types
-export type PenaltyType = 'warning' | 'game-loss' | 'match-loss' | 'disqualification';
+export type PenaltyType =
+  | "warning"
+  | "game-loss"
+  | "match-loss"
+  | "disqualification";
 
 export interface Warning {
   id: string;
@@ -79,7 +89,7 @@ export interface JudgeToolsConfig {
 // Default judge configuration
 export const DEFAULT_JUDGE_CONFIG: JudgeToolsConfig = {
   enabled: false,
-  role: 'judge',
+  role: "judge",
   canModifyLife: true,
   canModifyCounters: true,
   canUndoActions: true,
@@ -95,25 +105,23 @@ interface PenaltyBadgeProps {
 export function PenaltyBadge({ type }: PenaltyBadgeProps) {
   const getConfig = () => {
     switch (type) {
-      case 'warning':
-        return { color: 'bg-yellow-500', label: 'Warning' };
-      case 'game-loss':
-        return { color: 'bg-orange-500', label: 'Game Loss' };
-      case 'match-loss':
-        return { color: 'bg-red-500', label: 'Match Loss' };
-      case 'disqualification':
-        return { color: 'bg-purple-500', label: 'DQ' };
+      case "warning":
+        return { color: "bg-yellow-500", label: "Warning" };
+      case "game-loss":
+        return { color: "bg-orange-500", label: "Game Loss" };
+      case "match-loss":
+        return { color: "bg-red-500", label: "Match Loss" };
+      case "disqualification":
+        return { color: "bg-purple-500", label: "DQ" };
       default:
-        return { color: 'bg-gray-500', label: type };
+        return { color: "bg-gray-500", label: type };
     }
   };
 
   const config = getConfig();
 
   return (
-    <Badge className={cn('text-white', config.color)}>
-      {config.label}
-    </Badge>
+    <Badge className={cn("text-white", config.color)}>{config.label}</Badge>
   );
 }
 
@@ -124,8 +132,14 @@ interface WarningLogProps {
   className?: string;
 }
 
-export function WarningLog({ warnings, onDismiss, className }: WarningLogProps) {
-  const sortedWarnings = [...warnings].sort((a, b) => b.timestamp - a.timestamp);
+export function WarningLog({
+  warnings,
+  onDismiss,
+  className,
+}: WarningLogProps) {
+  const sortedWarnings = [...warnings].sort(
+    (a, b) => b.timestamp - a.timestamp,
+  );
 
   return (
     <Card className={className}>
@@ -134,9 +148,7 @@ export function WarningLog({ warnings, onDismiss, className }: WarningLogProps) 
           <AlertTriangle className="w-5 h-5 text-yellow-500" />
           Warning Log
         </CardTitle>
-        <CardDescription>
-          Track issued warnings and penalties
-        </CardDescription>
+        <CardDescription>Track issued warnings and penalties</CardDescription>
       </CardHeader>
       <CardContent>
         {sortedWarnings.length === 0 ? (
@@ -152,7 +164,9 @@ export function WarningLog({ warnings, onDismiss, className }: WarningLogProps) 
               >
                 <div className="flex-1">
                   <div className="flex items-center gap-2">
-                    <span className="font-medium text-sm">{warning.playerName}</span>
+                    <span className="font-medium text-sm">
+                      {warning.playerName}
+                    </span>
                     <PenaltyBadge type={warning.type} />
                   </div>
                   <p className="text-xs text-muted-foreground mt-1">
@@ -184,7 +198,11 @@ interface LifeAdjustmentProps {
   disabled?: boolean;
 }
 
-export function LifeAdjustment({ player, onAdjust, disabled }: LifeAdjustmentProps) {
+export function LifeAdjustment({
+  player,
+  onAdjust,
+  disabled,
+}: LifeAdjustmentProps) {
   return (
     <div className="flex items-center gap-2">
       <Button
@@ -193,14 +211,21 @@ export function LifeAdjustment({ player, onAdjust, disabled }: LifeAdjustmentPro
         onClick={() => onAdjust(player.id, -1)}
         disabled={disabled || player.life <= 0}
         className="h-8 w-8"
+        aria-label="Decrease life"
       >
         <Minus className="w-3 h-3" />
       </Button>
       <div className="flex items-center gap-1 min-w-[60px] justify-center">
-        <Heart className={cn(
-          'w-4 h-4',
-          player.life > 10 ? 'text-green-500' : player.life > 5 ? 'text-yellow-500' : 'text-red-500'
-        )} />
+        <Heart
+          className={cn(
+            "w-4 h-4",
+            player.life > 10
+              ? "text-green-500"
+              : player.life > 5
+                ? "text-yellow-500"
+                : "text-red-500",
+          )}
+        />
         <span className="font-bold text-lg w-8 text-center">{player.life}</span>
       </div>
       <Button
@@ -209,6 +234,7 @@ export function LifeAdjustment({ player, onAdjust, disabled }: LifeAdjustmentPro
         onClick={() => onAdjust(player.id, 1)}
         disabled={disabled}
         className="h-8 w-8"
+        aria-label="Increase life"
       >
         <Plus className="w-3 h-3" />
       </Button>
@@ -223,7 +249,8 @@ export function LifeAdjustment({ player, onAdjust, disabled }: LifeAdjustmentPro
             disabled={disabled || (player.life + amount <= 0 && amount < 0)}
             className="h-7 text-xs"
           >
-            {amount > 0 ? '+' : ''}{amount}
+            {amount > 0 ? "+" : ""}
+            {amount}
           </Button>
         ))}
       </div>
@@ -234,14 +261,29 @@ export function LifeAdjustment({ player, onAdjust, disabled }: LifeAdjustmentPro
 // Counter adjustment component
 interface CounterAdjustmentProps {
   player: JudgePlayerState;
-  counterType: 'poison' | 'energy';
-  onAdjust: (playerId: string, counterType: 'poison' | 'energy', amount: number) => void;
+  counterType: "poison" | "energy";
+  onAdjust: (
+    playerId: string,
+    counterType: "poison" | "energy",
+    amount: number,
+  ) => void;
   disabled?: boolean;
 }
 
-export function CounterAdjustment({ player, counterType, onAdjust, disabled }: CounterAdjustmentProps) {
-  const value = counterType === 'poison' ? player.poisonCounters : player.energyCounters;
-  const icon = counterType === 'poison' ? <Skull className="w-4 h-4 text-purple-500" /> : <Zap className="w-4 h-4 text-yellow-500" />;
+export function CounterAdjustment({
+  player,
+  counterType,
+  onAdjust,
+  disabled,
+}: CounterAdjustmentProps) {
+  const value =
+    counterType === "poison" ? player.poisonCounters : player.energyCounters;
+  const icon =
+    counterType === "poison" ? (
+      <Skull className="w-4 h-4 text-purple-500" />
+    ) : (
+      <Zap className="w-4 h-4 text-yellow-500" />
+    );
 
   return (
     <div className="flex items-center gap-2">
@@ -251,6 +293,7 @@ export function CounterAdjustment({ player, counterType, onAdjust, disabled }: C
         onClick={() => onAdjust(player.id, counterType, -1)}
         disabled={disabled || value <= 0}
         className="h-8 w-8"
+        aria-label={`Decrease ${counterType} counter`}
       >
         <Minus className="w-3 h-3" />
       </Button>
@@ -264,6 +307,7 @@ export function CounterAdjustment({ player, counterType, onAdjust, disabled }: C
         onClick={() => onAdjust(player.id, counterType, 1)}
         disabled={disabled}
         className="h-8 w-8"
+        aria-label={`Increase ${counterType} counter`}
       >
         <Plus className="w-3 h-3" />
       </Button>
@@ -277,7 +321,10 @@ interface GameStateInspectorProps {
   className?: string;
 }
 
-export function GameStateInspector({ gameState, className }: GameStateInspectorProps) {
+export function GameStateInspector({
+  gameState,
+  className,
+}: GameStateInspectorProps) {
   return (
     <Card className={className}>
       <CardHeader>
@@ -306,31 +353,43 @@ export function GameStateInspector({ gameState, className }: GameStateInspectorP
         {/* Active/Priority players */}
         <div className="flex gap-2">
           <Badge variant="outline" className="bg-green-500/10">
-            Active: {gameState.players.find(p => p.id === gameState.activePlayerId)?.name || 'N/A'}
+            Active:{" "}
+            {gameState.players.find((p) => p.id === gameState.activePlayerId)
+              ?.name || "N/A"}
           </Badge>
           <Badge variant="outline" className="bg-blue-500/10">
-            Priority: {gameState.players.find(p => p.id === gameState.priorityPlayerId)?.name || 'N/A'}
+            Priority:{" "}
+            {gameState.players.find((p) => p.id === gameState.priorityPlayerId)
+              ?.name || "N/A"}
           </Badge>
         </div>
 
         {/* Player states */}
         <div className="space-y-2">
-          <Label className="text-xs text-muted-foreground">Player States:</Label>
+          <Label className="text-xs text-muted-foreground">
+            Player States:
+          </Label>
           {gameState.players.map((player) => (
             <div
               key={player.id}
               className={cn(
-                'flex items-center justify-between p-2 rounded text-sm',
-                player.isActive && 'bg-green-500/10 border border-green-500/30'
+                "flex items-center justify-between p-2 rounded text-sm",
+                player.isActive && "bg-green-500/10 border border-green-500/30",
               )}
             >
               <span className="font-medium">{player.name}</span>
               <div className="flex items-center gap-3">
                 <div className="flex items-center gap-1">
-                  <Heart className={cn(
-                    'w-3 h-3',
-                    player.life > 10 ? 'text-green-500' : player.life > 5 ? 'text-yellow-500' : 'text-red-500'
-                  )} />
+                  <Heart
+                    className={cn(
+                      "w-3 h-3",
+                      player.life > 10
+                        ? "text-green-500"
+                        : player.life > 5
+                          ? "text-yellow-500"
+                          : "text-red-500",
+                    )}
+                  />
                   <span>{player.life}</span>
                 </div>
                 {player.poisonCounters > 0 && (
@@ -358,17 +417,24 @@ interface IssuePenaltyProps {
   className?: string;
 }
 
-export function IssuePenalty({ players, currentRound, judgeName: _judgeName, onIssuePenalty, disabled, className }: IssuePenaltyProps) {
-  const [selectedPlayer, setSelectedPlayer] = useState('');
-  const [penaltyType, setPenaltyType] = useState<PenaltyType>('warning');
-  const [reason, setReason] = useState('');
+export function IssuePenalty({
+  players,
+  currentRound,
+  judgeName: _judgeName,
+  onIssuePenalty,
+  disabled,
+  className,
+}: IssuePenaltyProps) {
+  const [selectedPlayer, setSelectedPlayer] = useState("");
+  const [penaltyType, setPenaltyType] = useState<PenaltyType>("warning");
+  const [reason, setReason] = useState("");
 
   const handleSubmit = () => {
     if (selectedPlayer && reason) {
       onIssuePenalty(selectedPlayer, penaltyType, reason);
-      setSelectedPlayer('');
-      setPenaltyType('warning');
-      setReason('');
+      setSelectedPlayer("");
+      setPenaltyType("warning");
+      setReason("");
     }
   };
 
@@ -401,10 +467,17 @@ export function IssuePenalty({ players, currentRound, judgeName: _judgeName, onI
         <div className="space-y-2">
           <Label>Penalty Type</Label>
           <div className="flex flex-wrap gap-2">
-            {(['warning', 'game-loss', 'match-loss', 'disqualification'] as PenaltyType[]).map((type) => (
+            {(
+              [
+                "warning",
+                "game-loss",
+                "match-loss",
+                "disqualification",
+              ] as PenaltyType[]
+            ).map((type) => (
               <Button
                 key={type}
-                variant={penaltyType === type ? 'default' : 'outline'}
+                variant={penaltyType === type ? "default" : "outline"}
                 size="sm"
                 onClick={() => setPenaltyType(type)}
                 disabled={disabled}
@@ -445,7 +518,11 @@ interface JudgePanelProps {
   warnings: Warning[];
   onConfigChange: (config: JudgeToolsConfig) => void;
   onLifeAdjust: (playerId: string, amount: number) => void;
-  onCounterAdjust: (playerId: string, counterType: 'poison' | 'energy', amount: number) => void;
+  onCounterAdjust: (
+    playerId: string,
+    counterType: "poison" | "energy",
+    amount: number,
+  ) => void;
   onUndoAction: () => void;
   onPauseGame: () => void;
   onResumeGame: () => void;
@@ -468,7 +545,7 @@ export function JudgePanel({
   onIssuePenalty,
   onDismissWarning,
   isGamePaused = false,
-  className
+  className,
 }: JudgePanelProps) {
   if (!config.enabled) {
     return (
@@ -494,10 +571,18 @@ export function JudgePanel({
   return (
     <Tabs defaultValue="control" className={className}>
       <TabsList className="w-full">
-        <TabsTrigger value="control" className="flex-1">Control</TabsTrigger>
-        <TabsTrigger value="inspect" className="flex-1">Inspect</TabsTrigger>
-        <TabsTrigger value="penalties" className="flex-1">Penalties</TabsTrigger>
-        <TabsTrigger value="settings" className="flex-1">Settings</TabsTrigger>
+        <TabsTrigger value="control" className="flex-1">
+          Control
+        </TabsTrigger>
+        <TabsTrigger value="inspect" className="flex-1">
+          Inspect
+        </TabsTrigger>
+        <TabsTrigger value="penalties" className="flex-1">
+          Penalties
+        </TabsTrigger>
+        <TabsTrigger value="settings" className="flex-1">
+          Settings
+        </TabsTrigger>
       </TabsList>
 
       {/* Control Tab */}
@@ -509,7 +594,9 @@ export function JudgePanel({
                 <Users className="w-5 h-5" />
                 Player Controls
               </span>
-              <Badge variant="outline">{gameState.players.length} Players</Badge>
+              <Badge variant="outline">
+                {gameState.players.length} Players
+              </Badge>
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
@@ -517,9 +604,11 @@ export function JudgePanel({
               <div key={player.id} className="space-y-2">
                 <div className="flex items-center justify-between">
                   <span className="font-medium">{player.name}</span>
-                  {player.isActive && <Badge className="bg-green-500">Active</Badge>}
+                  {player.isActive && (
+                    <Badge className="bg-green-500">Active</Badge>
+                  )}
                 </div>
-                
+
                 {config.canModifyLife && (
                   <LifeAdjustment
                     player={player}
@@ -527,7 +616,7 @@ export function JudgePanel({
                     disabled={!config.enabled}
                   />
                 )}
-                
+
                 {config.canModifyCounters && (
                   <div className="flex items-center gap-4">
                     <CounterAdjustment
@@ -559,7 +648,7 @@ export function JudgePanel({
           )}
           {config.canPauseGame && (
             <Button
-              variant={isGamePaused ? 'default' : 'outline'}
+              variant={isGamePaused ? "default" : "outline"}
               onClick={isGamePaused ? onResumeGame : onPauseGame}
               className="flex-1"
             >
@@ -588,18 +677,15 @@ export function JudgePanel({
       <TabsContent value="penalties" className="space-y-4">
         {config.canIssuePenalties && (
           <IssuePenalty
-            players={gameState.players.map(p => ({ id: p.id, name: p.name }))}
+            players={gameState.players.map((p) => ({ id: p.id, name: p.name }))}
             currentRound={gameState.turn}
             judgeName="Judge"
             onIssuePenalty={onIssuePenalty}
             disabled={!config.enabled}
           />
         )}
-        
-        <WarningLog
-          warnings={warnings}
-          onDismiss={onDismissWarning}
-        />
+
+        <WarningLog warnings={warnings} onDismiss={onDismissWarning} />
       </TabsContent>
 
       {/* Settings Tab */}
@@ -616,21 +702,29 @@ export function JudgePanel({
               <Label>Enable Judge Tools</Label>
               <Switch
                 checked={config.enabled}
-                onCheckedChange={(checked) => onConfigChange({ ...config, enabled: checked })}
+                onCheckedChange={(checked) =>
+                  onConfigChange({ ...config, enabled: checked })
+                }
               />
             </div>
 
             <div className="space-y-2">
               <Label>Judge Role</Label>
               <div className="flex gap-2">
-                {(['spectator-privileged', 'judge', 'head-judge'] as JudgeRole[]).map((role) => (
+                {(
+                  ["spectator-privileged", "judge", "head-judge"] as JudgeRole[]
+                ).map((role) => (
                   <Button
                     key={role}
-                    variant={config.role === role ? 'default' : 'outline'}
+                    variant={config.role === role ? "default" : "outline"}
                     size="sm"
                     onClick={() => onConfigChange({ ...config, role })}
                   >
-                    {role === 'spectator-privileged' ? 'Spectator' : role === 'judge' ? 'Judge' : 'Head Judge'}
+                    {role === "spectator-privileged"
+                      ? "Spectator"
+                      : role === "judge"
+                        ? "Judge"
+                        : "Head Judge"}
                   </Button>
                 ))}
               </div>
@@ -643,35 +737,45 @@ export function JudgePanel({
                   <span className="text-sm">Modify Life Totals</span>
                   <Switch
                     checked={config.canModifyLife}
-                    onCheckedChange={(checked) => onConfigChange({ ...config, canModifyLife: checked })}
+                    onCheckedChange={(checked) =>
+                      onConfigChange({ ...config, canModifyLife: checked })
+                    }
                   />
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm">Modify Counters</span>
                   <Switch
                     checked={config.canModifyCounters}
-                    onCheckedChange={(checked) => onConfigChange({ ...config, canModifyCounters: checked })}
+                    onCheckedChange={(checked) =>
+                      onConfigChange({ ...config, canModifyCounters: checked })
+                    }
                   />
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm">Undo Actions</span>
                   <Switch
                     checked={config.canUndoActions}
-                    onCheckedChange={(checked) => onConfigChange({ ...config, canUndoActions: checked })}
+                    onCheckedChange={(checked) =>
+                      onConfigChange({ ...config, canUndoActions: checked })
+                    }
                   />
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm">Issue Penalties</span>
                   <Switch
                     checked={config.canIssuePenalties}
-                    onCheckedChange={(checked) => onConfigChange({ ...config, canIssuePenalties: checked })}
+                    onCheckedChange={(checked) =>
+                      onConfigChange({ ...config, canIssuePenalties: checked })
+                    }
                   />
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm">Pause Game</span>
                   <Switch
                     checked={config.canPauseGame}
-                    onCheckedChange={(checked) => onConfigChange({ ...config, canPauseGame: checked })}
+                    onCheckedChange={(checked) =>
+                      onConfigChange({ ...config, canPauseGame: checked })
+                    }
                   />
                 </div>
               </div>
@@ -698,7 +802,12 @@ interface UseJudgeToolsReturn {
   config: JudgeToolsConfig;
   warnings: Warning[];
   setConfig: (config: JudgeToolsConfig) => void;
-  addWarning: (playerId: string, type: PenaltyType, reason: string, round: number) => void;
+  addWarning: (
+    playerId: string,
+    type: PenaltyType,
+    reason: string,
+    round: number,
+  ) => void;
   dismissWarning: (warningId: string) => void;
   clearWarnings: () => void;
 }
@@ -707,19 +816,22 @@ export function useJudgeTools(): UseJudgeToolsReturn {
   const [config, setConfig] = useState<JudgeToolsConfig>(DEFAULT_JUDGE_CONFIG);
   const [warnings, setWarnings] = useState<Warning[]>([]);
 
-  const addWarning = useCallback((playerId: string, type: PenaltyType, reason: string, round: number) => {
-    const warning: Warning = {
-      id: `warning-${Date.now()}`,
-      playerId,
-      playerName: `Player ${playerId}`, // Would be resolved from game state
-      type,
-      reason,
-      round,
-      timestamp: Date.now(),
-      issuedBy: 'Judge',
-    };
-    setWarnings((prev) => [...prev, warning]);
-  }, []);
+  const addWarning = useCallback(
+    (playerId: string, type: PenaltyType, reason: string, round: number) => {
+      const warning: Warning = {
+        id: `warning-${Date.now()}`,
+        playerId,
+        playerName: `Player ${playerId}`, // Would be resolved from game state
+        type,
+        reason,
+        round,
+        timestamp: Date.now(),
+        issuedBy: "Judge",
+      };
+      setWarnings((prev) => [...prev, warning]);
+    },
+    [],
+  );
 
   const dismissWarning = useCallback((warningId: string) => {
     setWarnings((prev) => prev.filter((w) => w.id !== warningId));

--- a/src/components/meta/sideboard/SideboardPlanEditor.tsx
+++ b/src/components/meta/sideboard/SideboardPlanEditor.tsx
@@ -1,17 +1,35 @@
 "use client";
 
-import React, { useState, useEffect } from 'react';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import React, { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
-import { X, Plus, Save } from 'lucide-react';
-import { SavedSideboardPlan, saveSideboardPlan, updateSideboardPlan, validateSideboardPlan } from '@/lib/sideboard-plans';
-import { SideboardCard } from '@/lib/anti-meta';
-import { MagicFormat } from '@/lib/meta';
+import { X, Plus, Save } from "lucide-react";
+import {
+  SavedSideboardPlan,
+  saveSideboardPlan,
+  updateSideboardPlan,
+  validateSideboardPlan,
+} from "@/lib/sideboard-plans";
+import { SideboardCard } from "@/lib/anti-meta";
+import { MagicFormat } from "@/lib/meta";
 
 interface SideboardPlanEditorProps {
   open: boolean;
@@ -32,28 +50,36 @@ interface SideboardPlanEditorProps {
 /**
  * Dialog for creating and editing sideboard plans
  */
-export function SideboardPlanEditor({ 
-  open, 
-  onOpenChange, 
+export function SideboardPlanEditor({
+  open,
+  onOpenChange,
   initialPlan,
   defaultValues,
-  onSave 
+  onSave,
 }: SideboardPlanEditorProps) {
-  const [name, setName] = useState('');
-  const [format, setFormat] = useState<MagicFormat>('standard');
-  const [archetypeId, setArchetypeId] = useState('');
-  const [archetypeName, setArchetypeName] = useState('');
-  const [opponentArchetypeId, setOpponentArchetypeId] = useState('');
-  const [opponentArchetypeName, setOpponentArchetypeName] = useState('');
+  const [name, setName] = useState("");
+  const [format, setFormat] = useState<MagicFormat>("standard");
+  const [archetypeId, setArchetypeId] = useState("");
+  const [archetypeName, setArchetypeName] = useState("");
+  const [opponentArchetypeId, setOpponentArchetypeId] = useState("");
+  const [opponentArchetypeName, setOpponentArchetypeName] = useState("");
   const [inCards, setInCards] = useState<SideboardCard[]>([]);
   const [outCards, setOutCards] = useState<SideboardCard[]>([]);
-  const [notes, setNotes] = useState('');
+  const [notes, setNotes] = useState("");
   const [errors, setErrors] = useState<string[]>([]);
   const [isSaving, setIsSaving] = useState(false);
 
   // New card input state
-  const [newInCard, setNewInCard] = useState({ name: '', count: 1, reason: '' });
-  const [newOutCard, setNewOutCard] = useState({ name: '', count: 1, reason: '' });
+  const [newInCard, setNewInCard] = useState({
+    name: "",
+    count: 1,
+    reason: "",
+  });
+  const [newOutCard, setNewOutCard] = useState({
+    name: "",
+    count: 1,
+    reason: "",
+  });
 
   // Load initial data
   useEffect(() => {
@@ -68,55 +94,58 @@ export function SideboardPlanEditor({
       setOutCards(initialPlan.outCards);
       setNotes(initialPlan.notes);
     } else if (defaultValues) {
-      setName('');
-      setFormat(defaultValues.format || 'standard');
-      setArchetypeId(defaultValues.archetypeId || '');
-      setArchetypeName(defaultValues.archetypeName || '');
-      setOpponentArchetypeId(defaultValues.opponentArchetypeId || '');
-      setOpponentArchetypeName(defaultValues.opponentArchetypeName || '');
+      setName("");
+      setFormat(defaultValues.format || "standard");
+      setArchetypeId(defaultValues.archetypeId || "");
+      setArchetypeName(defaultValues.archetypeName || "");
+      setOpponentArchetypeId(defaultValues.opponentArchetypeId || "");
+      setOpponentArchetypeName(defaultValues.opponentArchetypeName || "");
       setInCards(defaultValues.inCards || []);
       setOutCards(defaultValues.outCards || []);
-      setNotes('');
+      setNotes("");
     } else {
       // Reset form
-      setName('');
-      setFormat('standard');
-      setArchetypeId('');
-      setArchetypeName('');
-      setOpponentArchetypeId('');
-      setOpponentArchetypeName('');
+      setName("");
+      setFormat("standard");
+      setArchetypeId("");
+      setArchetypeName("");
+      setOpponentArchetypeId("");
+      setOpponentArchetypeName("");
       setInCards([]);
       setOutCards([]);
-      setNotes('');
+      setNotes("");
     }
     setErrors([]);
   }, [initialPlan, defaultValues, open]);
 
   // Simple archetype list for the dropdown
   const archetypeOptions = [
-    { id: 'std-aggro-red', name: 'Red Aggro' },
-    { id: 'std-aggro-white', name: 'White Aggro' },
-    { id: 'std-control-blue', name: 'Blue Control' },
-    { id: 'std-midrange-black', name: 'Black Midrange' },
-    { id: 'std-combo-temur', name: 'Temur Combo' },
-    { id: 'std-tempo-blue-red', name: 'Izzet Tempo' },
-    { id: 'std-midrange-green', name: 'Green Midrange' },
-    { id: 'mod-burn', name: 'Burn' },
-    { id: 'mod-jund', name: 'Jund' },
-    { id: 'mod-uw-control', name: 'UW Control' },
-    { id: 'cmdr-aggro', name: 'Commander Aggro' },
-    { id: 'cmdr-control', name: 'Commander Control' },
-    { id: 'cmdr-midrange', name: 'Commander Midrange' },
+    { id: "std-aggro-red", name: "Red Aggro" },
+    { id: "std-aggro-white", name: "White Aggro" },
+    { id: "std-control-blue", name: "Blue Control" },
+    { id: "std-midrange-black", name: "Black Midrange" },
+    { id: "std-combo-temur", name: "Temur Combo" },
+    { id: "std-tempo-blue-red", name: "Izzet Tempo" },
+    { id: "std-midrange-green", name: "Green Midrange" },
+    { id: "mod-burn", name: "Burn" },
+    { id: "mod-jund", name: "Jund" },
+    { id: "mod-uw-control", name: "UW Control" },
+    { id: "cmdr-aggro", name: "Commander Aggro" },
+    { id: "cmdr-control", name: "Commander Control" },
+    { id: "cmdr-midrange", name: "Commander Midrange" },
   ];
 
   const handleAddInCard = () => {
     if (!newInCard.name.trim()) return;
-    setInCards([...inCards, { 
-      cardName: newInCard.name.trim(), 
-      count: newInCard.count, 
-      reason: newInCard.reason 
-    }]);
-    setNewInCard({ name: '', count: 1, reason: '' });
+    setInCards([
+      ...inCards,
+      {
+        cardName: newInCard.name.trim(),
+        count: newInCard.count,
+        reason: newInCard.reason,
+      },
+    ]);
+    setNewInCard({ name: "", count: 1, reason: "" });
   };
 
   const handleRemoveInCard = (index: number) => {
@@ -125,12 +154,15 @@ export function SideboardPlanEditor({
 
   const handleAddOutCard = () => {
     if (!newOutCard.name.trim()) return;
-    setOutCards([...outCards, { 
-      cardName: newOutCard.name.trim(), 
-      count: newOutCard.count, 
-      reason: newOutCard.reason 
-    }]);
-    setNewOutCard({ name: '', count: 1, reason: '' });
+    setOutCards([
+      ...outCards,
+      {
+        cardName: newOutCard.name.trim(),
+        count: newOutCard.count,
+        reason: newOutCard.reason,
+      },
+    ]);
+    setNewOutCard({ name: "", count: 1, reason: "" });
   };
 
   const handleRemoveOutCard = (index: number) => {
@@ -139,7 +171,7 @@ export function SideboardPlanEditor({
 
   const handleArchetypeChange = (value: string) => {
     setArchetypeId(value);
-    const archetype = archetypeOptions.find(a => a.id === value);
+    const archetype = archetypeOptions.find((a) => a.id === value);
     if (archetype) {
       setArchetypeName(archetype.name);
     }
@@ -147,7 +179,7 @@ export function SideboardPlanEditor({
 
   const handleOpponentArchetypeChange = (value: string) => {
     setOpponentArchetypeId(value);
-    const archetype = archetypeOptions.find(a => a.id === value);
+    const archetype = archetypeOptions.find((a) => a.id === value);
     if (archetype) {
       setOpponentArchetypeName(archetype.name);
     }
@@ -175,18 +207,20 @@ export function SideboardPlanEditor({
     setIsSaving(true);
     try {
       let savedPlan: SavedSideboardPlan;
-      
+
       if (initialPlan) {
-        savedPlan = updateSideboardPlan(initialPlan.id, planData) || planData as SavedSideboardPlan;
+        savedPlan =
+          updateSideboardPlan(initialPlan.id, planData) ||
+          (planData as SavedSideboardPlan);
       } else {
         savedPlan = saveSideboardPlan(planData);
       }
-      
+
       onSave?.(savedPlan);
       onOpenChange(false);
     } catch (error) {
-      console.error('Failed to save sideboard plan:', error);
-      setErrors(['Failed to save plan. Please try again.']);
+      console.error("Failed to save sideboard plan:", error);
+      setErrors(["Failed to save plan. Please try again."]);
     } finally {
       setIsSaving(false);
     }
@@ -196,11 +230,13 @@ export function SideboardPlanEditor({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>{initialPlan ? 'Edit Sideboard Plan' : 'Create Sideboard Plan'}</DialogTitle>
+          <DialogTitle>
+            {initialPlan ? "Edit Sideboard Plan" : "Create Sideboard Plan"}
+          </DialogTitle>
           <DialogDescription>
-            {initialPlan 
-              ? 'Update your custom sideboard plan' 
-              : 'Create a custom sideboard plan for your matchups'}
+            {initialPlan
+              ? "Update your custom sideboard plan"
+              : "Create a custom sideboard plan for your matchups"}
           </DialogDescription>
         </DialogHeader>
 
@@ -230,7 +266,10 @@ export function SideboardPlanEditor({
           {/* Format */}
           <div className="space-y-2">
             <Label>Format</Label>
-            <Select value={format} onValueChange={(v) => setFormat(v as MagicFormat)}>
+            <Select
+              value={format}
+              onValueChange={(v) => setFormat(v as MagicFormat)}
+            >
               <SelectTrigger>
                 <SelectValue />
               </SelectTrigger>
@@ -264,7 +303,10 @@ export function SideboardPlanEditor({
 
             <div className="space-y-2">
               <Label>Opponent Archetype</Label>
-              <Select value={opponentArchetypeId} onValueChange={handleOpponentArchetypeChange}>
+              <Select
+                value={opponentArchetypeId}
+                onValueChange={handleOpponentArchetypeChange}
+              >
                 <SelectTrigger>
                   <SelectValue placeholder="Select opponent" />
                 </SelectTrigger>
@@ -281,12 +323,16 @@ export function SideboardPlanEditor({
 
           {/* In Cards */}
           <div className="space-y-2">
-            <Label>Cards to Bring In ({inCards.reduce((sum, c) => sum + c.count, 0)})</Label>
+            <Label>
+              Cards to Bring In ({inCards.reduce((sum, c) => sum + c.count, 0)})
+            </Label>
             <div className="flex gap-2">
               <Input
                 placeholder="Card name"
                 value={newInCard.name}
-                onChange={(e) => setNewInCard({ ...newInCard, name: e.target.value })}
+                onChange={(e) =>
+                  setNewInCard({ ...newInCard, name: e.target.value })
+                }
                 className="flex-1"
               />
               <Input
@@ -294,22 +340,38 @@ export function SideboardPlanEditor({
                 min={1}
                 max={4}
                 value={newInCard.count}
-                onChange={(e) => setNewInCard({ ...newInCard, count: parseInt(e.target.value) || 1 })}
+                onChange={(e) =>
+                  setNewInCard({
+                    ...newInCard,
+                    count: parseInt(e.target.value) || 1,
+                  })
+                }
                 className="w-20"
               />
-              <Button type="button" variant="outline" size="icon" onClick={handleAddInCard}>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={handleAddInCard}
+                aria-label="Add card to side in"
+              >
                 <Plus className="h-4 w-4" />
               </Button>
             </div>
             <div className="flex flex-wrap gap-2 mt-2">
               {inCards.map((card, index) => (
-                <Badge key={index} variant="outline" className="bg-green-50 pl-2 pr-1 py-1">
+                <Badge
+                  key={index}
+                  variant="outline"
+                  className="bg-green-50 pl-2 pr-1 py-1"
+                >
                   {card.cardName} x{card.count}
                   <Button
                     variant="ghost"
                     size="icon"
                     className="h-4 w-4 ml-1 text-muted-foreground hover:text-red-500"
                     onClick={() => handleRemoveInCard(index)}
+                    aria-label="Remove card from side in"
                   >
                     <X className="h-3 w-3" />
                   </Button>
@@ -320,12 +382,17 @@ export function SideboardPlanEditor({
 
           {/* Out Cards */}
           <div className="space-y-2">
-            <Label>Cards to Take Out ({outCards.reduce((sum, c) => sum + c.count, 0)})</Label>
+            <Label>
+              Cards to Take Out ({outCards.reduce((sum, c) => sum + c.count, 0)}
+              )
+            </Label>
             <div className="flex gap-2">
               <Input
                 placeholder="Card name"
                 value={newOutCard.name}
-                onChange={(e) => setNewOutCard({ ...newOutCard, name: e.target.value })}
+                onChange={(e) =>
+                  setNewOutCard({ ...newOutCard, name: e.target.value })
+                }
                 className="flex-1"
               />
               <Input
@@ -333,22 +400,38 @@ export function SideboardPlanEditor({
                 min={1}
                 max={4}
                 value={newOutCard.count}
-                onChange={(e) => setNewOutCard({ ...newOutCard, count: parseInt(e.target.value) || 1 })}
+                onChange={(e) =>
+                  setNewOutCard({
+                    ...newOutCard,
+                    count: parseInt(e.target.value) || 1,
+                  })
+                }
                 className="w-20"
               />
-              <Button type="button" variant="outline" size="icon" onClick={handleAddOutCard}>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={handleAddOutCard}
+                aria-label="Add card to side out"
+              >
                 <Plus className="h-4 w-4" />
               </Button>
             </div>
             <div className="flex flex-wrap gap-2 mt-2">
               {outCards.map((card, index) => (
-                <Badge key={index} variant="outline" className="bg-red-50 pl-2 pr-1 py-1">
+                <Badge
+                  key={index}
+                  variant="outline"
+                  className="bg-red-50 pl-2 pr-1 py-1"
+                >
                   {card.cardName} x{card.count}
                   <Button
                     variant="ghost"
                     size="icon"
                     className="h-4 w-4 ml-1 text-muted-foreground hover:text-red-500"
                     onClick={() => handleRemoveOutCard(index)}
+                    aria-label="Remove card from side out"
                   >
                     <X className="h-3 w-3" />
                   </Button>
@@ -376,7 +459,7 @@ export function SideboardPlanEditor({
           </Button>
           <Button onClick={handleSave} disabled={isSaving}>
             <Save className="h-4 w-4 mr-2" />
-            {isSaving ? 'Saving...' : 'Save Plan'}
+            {isSaving ? "Saving..." : "Save Plan"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/qr-code-display.tsx
+++ b/src/components/qr-code-display.tsx
@@ -1,12 +1,12 @@
-'use client';
+"use client";
 
-import { useEffect, useRef, useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { QrCode, Copy, Check } from 'lucide-react';
-import QRCode from 'qrcode';
+import { useEffect, useRef, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { QrCode, Copy, Check } from "lucide-react";
+import QRCode from "qrcode";
 
 /**
  * QR Code Display Component
@@ -27,10 +27,10 @@ interface QRCodeDisplayProps {
 export function QRCodeDisplay({
   qrCode,
   gameCode,
-  gameName = 'Planar Nexus Game',
+  gameName = "Planar Nexus Game",
   onCopy,
   size = 200,
-  connectionInfo
+  connectionInfo,
 }: QRCodeDisplayProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [copied, setCopied] = useState(false);
@@ -50,16 +50,16 @@ export function QRCodeDisplay({
           width: size,
           margin: 2,
           color: {
-            dark: '#000000',
-            light: '#ffffff',
+            dark: "#000000",
+            light: "#ffffff",
           },
-          errorCorrectionLevel: 'M',
+          errorCorrectionLevel: "M",
         });
 
         setError(null);
       } catch (err) {
-        console.error('Error generating QR code:', err);
-        setError('Failed to generate QR code');
+        console.error("Error generating QR code:", err);
+        setError("Failed to generate QR code");
       }
     };
 
@@ -70,7 +70,7 @@ export function QRCodeDisplay({
     navigator.clipboard.writeText(gameCode);
     setCopied(true);
     onCopy?.();
-    
+
     setTimeout(() => setCopied(false), 2000);
   };
 
@@ -126,6 +126,7 @@ export function QRCodeDisplay({
               variant="outline"
               size="icon"
               onClick={handleCopy}
+              aria-label="Copy game code"
               title="Copy code"
             >
               {copied ? (
@@ -163,7 +164,7 @@ export function QRCodeScanner({ onScan, onError }: QRCodeScannerProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [hasCamera, setHasCamera] = useState<boolean | null>(null);
   const [scanning, setScanning] = useState(false);
-  const [manualCode, setManualCode] = useState('');
+  const [manualCode, setManualCode] = useState("");
   const [showManual, setShowManual] = useState(false);
 
   // Check for camera availability
@@ -171,34 +172,34 @@ export function QRCodeScanner({ onScan, onError }: QRCodeScannerProps) {
     async function checkCamera() {
       try {
         const devices = await navigator.mediaDevices.enumerateDevices();
-        const cameras = devices.filter(d => d.kind === 'videoinput');
+        const cameras = devices.filter((d) => d.kind === "videoinput");
         setHasCamera(cameras.length > 0);
       } catch (err) {
-        console.error('Error checking camera:', err);
+        console.error("Error checking camera:", err);
         setHasCamera(false);
       }
     }
-    
+
     checkCamera();
   }, []);
 
   const startScanning = async () => {
     if (!videoRef.current) return;
-    
+
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ 
-        video: { facingMode: 'environment' } 
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: "environment" },
       });
-      
+
       videoRef.current.srcObject = stream;
       await videoRef.current.play();
       setScanning(true);
-      
+
       // Note: Full QR scanning would require additional library like jsQR
       // For now, this shows camera preview
     } catch (err) {
-      console.error('Error starting camera:', err);
-      onError?.(err instanceof Error ? err : new Error('Camera error'));
+      console.error("Error starting camera:", err);
+      onError?.(err instanceof Error ? err : new Error("Camera error"));
       setShowManual(true);
     }
   };
@@ -206,7 +207,7 @@ export function QRCodeScanner({ onScan, onError }: QRCodeScannerProps) {
   const stopScanning = () => {
     if (videoRef.current?.srcObject) {
       const stream = videoRef.current.srcObject as MediaStream;
-      stream.getTracks().forEach(track => track.stop());
+      stream.getTracks().forEach((track) => track.stop());
     }
     setScanning(false);
   };
@@ -229,13 +230,13 @@ export function QRCodeScanner({ onScan, onError }: QRCodeScannerProps) {
       <CardContent className="space-y-4">
         {/* Camera Preview */}
         <div className="relative aspect-square bg-black rounded-lg overflow-hidden">
-          <video 
+          <video
             ref={videoRef}
             className="w-full h-full object-cover"
             playsInline
             muted
           />
-          
+
           {!scanning && (
             <div className="absolute inset-0 flex items-center justify-center bg-black/50">
               <Button onClick={startScanning} variant="secondary">
@@ -244,11 +245,11 @@ export function QRCodeScanner({ onScan, onError }: QRCodeScannerProps) {
               </Button>
             </div>
           )}
-          
+
           {scanning && (
             <div className="absolute bottom-4 left-4 right-4">
-              <Button 
-                onClick={stopScanning} 
+              <Button
+                onClick={stopScanning}
                 variant="destructive"
                 className="w-full"
               >
@@ -260,12 +261,12 @@ export function QRCodeScanner({ onScan, onError }: QRCodeScannerProps) {
 
         {/* Manual Entry Toggle */}
         <div className="text-center">
-          <Button 
-            variant="link" 
+          <Button
+            variant="link"
             onClick={() => setShowManual(!showManual)}
             className="text-sm"
           >
-            {showManual ? 'Hide' : 'Enter code manually'}
+            {showManual ? "Hide" : "Enter code manually"}
           </Button>
         </div>
 

--- a/src/components/spectator-view.tsx
+++ b/src/components/spectator-view.tsx
@@ -1,13 +1,20 @@
-'use client';
+"use client";
 
-import { useState, useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Separator } from '@/components/ui/separator';
-import { Eye, EyeOff, Users, MessageCircle, Settings, Crown } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import type { Spectator, SpectatorPermissions } from '@/lib/spectator';
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import {
+  Eye,
+  EyeOff,
+  Users,
+  MessageCircle,
+  Settings,
+  Crown,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { Spectator, SpectatorPermissions } from "@/lib/spectator";
 
 interface SpectatorViewProps {
   spectators: Spectator[];
@@ -28,13 +35,14 @@ export function SpectatorView({
   onOpenSettings,
   className,
 }: SpectatorViewProps) {
-  const [visibleSpectators, setVisibleSpectators] = useState<Spectator[]>(spectators);
+  const [visibleSpectators, setVisibleSpectators] =
+    useState<Spectator[]>(spectators);
 
   useEffect(() => {
     // Filter hidden spectators based on permissions
     if (permissions.isHidden) {
       setVisibleSpectators(
-        spectators.filter((s) => !s.isHidden || s.id === currentSpectatorId)
+        spectators.filter((s) => !s.isHidden || s.id === currentSpectatorId),
       );
     } else {
       setVisibleSpectators(spectators);
@@ -54,18 +62,35 @@ export function SpectatorView({
           </CardTitle>
           <div className="flex items-center gap-1">
             {permissions.canChat && (
-              <Button variant="ghost" size="icon" onClick={onOpenChat}>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onOpenChat}
+                aria-label="Open chat"
+              >
                 <MessageCircle className="w-4 h-4" />
               </Button>
             )}
-            <Button variant="ghost" size="icon" onClick={onToggleVisibility}>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onToggleVisibility}
+              aria-label={
+                permissions.isHidden ? "Show spectators" : "Hide spectators"
+              }
+            >
               {permissions.isHidden ? (
                 <EyeOff className="w-4 h-4" />
               ) : (
                 <Eye className="w-4 h-4" />
               )}
             </Button>
-            <Button variant="ghost" size="icon" onClick={onOpenSettings}>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onOpenSettings}
+              aria-label="Spectator settings"
+            >
               <Settings className="w-4 h-4" />
             </Button>
           </div>
@@ -83,8 +108,8 @@ export function SpectatorView({
               <div
                 key={spectator.id}
                 className={cn(
-                  'flex items-center justify-between p-2 rounded-md',
-                  spectator.id === currentSpectatorId && 'bg-primary/10'
+                  "flex items-center justify-between p-2 rounded-md",
+                  spectator.id === currentSpectatorId && "bg-primary/10",
                 )}
               >
                 <div className="flex items-center gap-2">
@@ -132,8 +157,8 @@ export function SpectatorBanner({
   return (
     <div
       className={cn(
-        'flex items-center justify-between px-4 py-2 bg-muted/50 border-b',
-        className
+        "flex items-center justify-between px-4 py-2 bg-muted/50 border-b",
+        className,
       )}
     >
       <div className="flex items-center gap-4">
@@ -142,14 +167,15 @@ export function SpectatorBanner({
           Spectating
         </Badge>
         <span className="text-sm text-muted-foreground">
-          {playerCount} player{playerCount !== 1 ? 's' : ''} in game
+          {playerCount} player{playerCount !== 1 ? "s" : ""} in game
         </span>
         {spectatorCount > 0 && (
           <>
             <Separator orientation="vertical" className="h-4" />
             <span className="text-sm text-muted-foreground">
               <Eye className="w-3 h-3 inline mr-1" />
-              {spectatorCount} spectator{spectatorCount !== 1 ? 's' : ''} watching
+              {spectatorCount} spectator{spectatorCount !== 1 ? "s" : ""}{" "}
+              watching
             </span>
           </>
         )}
@@ -162,8 +188,14 @@ export function SpectatorBanner({
 }
 
 // Join as spectator form
-export function JoinSpectatorForm({ onJoin, className }: { onJoin: (name: string, isHidden: boolean) => void; className?: string }) {
-  const [name, setName] = useState('');
+export function JoinSpectatorForm({
+  onJoin,
+  className,
+}: {
+  onJoin: (name: string, isHidden: boolean) => void;
+  className?: string;
+}) {
+  const [name, setName] = useState("");
   const [isHidden, setIsHidden] = useState(false);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -174,7 +206,7 @@ export function JoinSpectatorForm({ onJoin, className }: { onJoin: (name: string
   };
 
   return (
-    <form onSubmit={handleSubmit} className={cn('space-y-4', className)}>
+    <form onSubmit={handleSubmit} className={cn("space-y-4", className)}>
       <div className="space-y-2">
         <label htmlFor="spectator-name" className="text-sm font-medium">
           Spectator Name
@@ -198,7 +230,10 @@ export function JoinSpectatorForm({ onJoin, className }: { onJoin: (name: string
           onChange={(e) => setIsHidden(e.target.checked)}
           className="rounded"
         />
-        <label htmlFor="spectator-hidden" className="text-sm text-muted-foreground">
+        <label
+          htmlFor="spectator-hidden"
+          className="text-sm text-muted-foreground"
+        >
           Join as hidden spectator
         </label>
       </div>

--- a/src/components/team-assignment.tsx
+++ b/src/components/team-assignment.tsx
@@ -1,15 +1,21 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
-import { Separator } from '@/components/ui/separator';
-import { Users, Shuffle, Check, X, Edit2 } from 'lucide-react';
-import { Team, TeamId, Player, TeamSettings } from '@/lib/multiplayer-types';
+import { useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Separator } from "@/components/ui/separator";
+import { Users, Shuffle, Check, X, Edit2 } from "lucide-react";
+import { Team, TeamId, Player, TeamSettings } from "@/lib/multiplayer-types";
 
 interface TeamAssignmentProps {
   teams: Team[];
@@ -35,10 +41,10 @@ export function TeamAssignment({
   isHost,
 }: TeamAssignmentProps) {
   const [editingTeam, setEditingTeam] = useState<TeamId | null>(null);
-  const [teamNameInput, setTeamNameInput] = useState('');
+  const [teamNameInput, setTeamNameInput] = useState("");
 
   // Get unassigned players
-  const unassignedPlayers = players.filter(p => !p.teamId);
+  const unassignedPlayers = players.filter((p) => !p.teamId);
 
   // Handle team name edit
   const handleStartEdit = (team: Team) => {
@@ -51,12 +57,12 @@ export function TeamAssignment({
       onUpdateTeamName(teamId, teamNameInput.trim());
     }
     setEditingTeam(null);
-    setTeamNameInput('');
+    setTeamNameInput("");
   };
 
   const handleCancelEdit = () => {
     setEditingTeam(null);
-    setTeamNameInput('');
+    setTeamNameInput("");
   };
 
   // Handle drag and drop for team assignment
@@ -97,39 +103,57 @@ export function TeamAssignment({
             <h4 className="text-sm font-medium">Team Settings</h4>
             <div className="grid grid-cols-2 gap-4">
               <div className="flex items-center justify-between">
-                <Label htmlFor="shared-life" className="text-sm">Shared Life</Label>
+                <Label htmlFor="shared-life" className="text-sm">
+                  Shared Life
+                </Label>
                 <Switch
                   id="shared-life"
                   checked={teamSettings.sharedLife}
-                  onCheckedChange={(checked) => onUpdateTeamSettings({ sharedLife: checked })}
+                  onCheckedChange={(checked) =>
+                    onUpdateTeamSettings({ sharedLife: checked })
+                  }
                 />
               </div>
               <div className="flex items-center justify-between">
-                <Label htmlFor="shared-blockers" className="text-sm">Shared Blockers</Label>
+                <Label htmlFor="shared-blockers" className="text-sm">
+                  Shared Blockers
+                </Label>
                 <Switch
                   id="shared-blockers"
                   checked={teamSettings.sharedBlockers}
-                  onCheckedChange={(checked) => onUpdateTeamSettings({ sharedBlockers: checked })}
+                  onCheckedChange={(checked) =>
+                    onUpdateTeamSettings({ sharedBlockers: checked })
+                  }
                 />
               </div>
               <div className="flex items-center justify-between">
-                <Label htmlFor="team-chat" className="text-sm">Team Chat</Label>
+                <Label htmlFor="team-chat" className="text-sm">
+                  Team Chat
+                </Label>
                 <Switch
                   id="team-chat"
                   checked={teamSettings.teamChat}
-                  onCheckedChange={(checked) => onUpdateTeamSettings({ teamChat: checked })}
+                  onCheckedChange={(checked) =>
+                    onUpdateTeamSettings({ teamChat: checked })
+                  }
                 />
               </div>
               {teamSettings.sharedLife && (
                 <div className="flex items-center gap-2">
-                  <Label htmlFor="starting-life" className="text-sm">Starting Life</Label>
+                  <Label htmlFor="starting-life" className="text-sm">
+                    Starting Life
+                  </Label>
                   <Input
                     id="starting-life"
                     type="number"
                     min={1}
                     max={100}
                     value={teamSettings.startingLifePerTeam}
-                    onChange={(e) => onUpdateTeamSettings({ startingLifePerTeam: parseInt(e.target.value) || 30 })}
+                    onChange={(e) =>
+                      onUpdateTeamSettings({
+                        startingLifePerTeam: parseInt(e.target.value) || 30,
+                      })
+                    }
                     className="w-20 h-8"
                   />
                 </div>
@@ -141,7 +165,7 @@ export function TeamAssignment({
         {/* Teams Display */}
         <div className="grid grid-cols-2 gap-4">
           {teams.map((team) => {
-            const teamPlayers = players.filter(p => p.teamId === team.id);
+            const teamPlayers = players.filter((p) => p.teamId === team.id);
             const isEditing = editingTeam === team.id;
 
             return (
@@ -152,7 +176,7 @@ export function TeamAssignment({
                 onDragOver={(e) => e.preventDefault()}
                 onDrop={(e) => {
                   e.preventDefault();
-                  const playerId = e.dataTransfer.getData('playerId');
+                  const playerId = e.dataTransfer.getData("playerId");
                   if (playerId) {
                     handlePlayerDrop(playerId, team.id);
                   }
@@ -173,6 +197,7 @@ export function TeamAssignment({
                         variant="ghost"
                         onClick={() => handleSaveEdit(team.id)}
                         className="h-8 w-8"
+                        aria-label="Save team name"
                       >
                         <Check className="w-4 h-4 text-green-500" />
                       </Button>
@@ -181,6 +206,7 @@ export function TeamAssignment({
                         variant="ghost"
                         onClick={handleCancelEdit}
                         className="h-8 w-8"
+                        aria-label="Cancel edit"
                       >
                         <X className="w-4 h-4 text-red-500" />
                       </Button>
@@ -205,6 +231,7 @@ export function TeamAssignment({
                           variant="ghost"
                           onClick={() => handleStartEdit(team)}
                           className="h-8 w-8"
+                          aria-label="Edit team"
                         >
                           <Edit2 className="w-4 h-4" />
                         </Button>
@@ -225,24 +252,35 @@ export function TeamAssignment({
                         key={player.id}
                         draggable={isHost}
                         onDragStart={(e) => {
-                          e.dataTransfer.setData('playerId', player.id);
+                          e.dataTransfer.setData("playerId", player.id);
                         }}
                         className={`flex items-center justify-between p-2 rounded-md ${
-                          isHost ? 'cursor-move bg-muted/50' : 'bg-muted/30'
+                          isHost ? "cursor-move bg-muted/50" : "bg-muted/30"
                         }`}
                         style={{ borderLeft: `3px solid ${team.color}` }}
                       >
                         <div className="flex items-center gap-2">
                           <span className="font-medium">{player.name}</span>
-                          {player.status === 'host' && (
-                            <Badge variant="outline" className="text-xs">Host</Badge>
+                          {player.status === "host" && (
+                            <Badge variant="outline" className="text-xs">
+                              Host
+                            </Badge>
                           )}
                         </div>
                         <Badge
-                          variant={player.status === 'ready' || player.status === 'host' ? 'default' : 'secondary'}
+                          variant={
+                            player.status === "ready" ||
+                            player.status === "host"
+                              ? "default"
+                              : "secondary"
+                          }
                           className="text-xs"
                         >
-                          {player.status === 'ready' ? 'Ready' : player.status === 'host' ? 'Host' : 'Not Ready'}
+                          {player.status === "ready"
+                            ? "Ready"
+                            : player.status === "host"
+                              ? "Host"
+                              : "Not Ready"}
                         </Badge>
                       </div>
                     ))
@@ -253,7 +291,11 @@ export function TeamAssignment({
                 {teamSettings?.sharedLife && (
                   <div className="mt-3 pt-3 border-t">
                     <div className="text-sm text-muted-foreground">
-                      Shared Life: <span className="font-bold text-foreground">{team.sharedLifeTotal || teamSettings.startingLifePerTeam}</span>
+                      Shared Life:{" "}
+                      <span className="font-bold text-foreground">
+                        {team.sharedLifeTotal ||
+                          teamSettings.startingLifePerTeam}
+                      </span>
                     </div>
                   </div>
                 )}
@@ -274,18 +316,26 @@ export function TeamAssignment({
                     key={player.id}
                     draggable={isHost}
                     onDragStart={(e) => {
-                      e.dataTransfer.setData('playerId', player.id);
+                      e.dataTransfer.setData("playerId", player.id);
                     }}
                     className={`flex items-center gap-2 p-2 rounded-md border ${
-                      isHost ? 'cursor-move' : ''
+                      isHost ? "cursor-move" : ""
                     }`}
                   >
                     <span className="font-medium">{player.name}</span>
                     <Badge
-                      variant={player.status === 'ready' || player.status === 'host' ? 'default' : 'secondary'}
+                      variant={
+                        player.status === "ready" || player.status === "host"
+                          ? "default"
+                          : "secondary"
+                      }
                       className="text-xs"
                     >
-                      {player.status === 'ready' ? 'Ready' : player.status === 'host' ? 'Host' : 'Not Ready'}
+                      {player.status === "ready"
+                        ? "Ready"
+                        : player.status === "host"
+                          ? "Host"
+                          : "Not Ready"}
                     </Badge>
                   </div>
                 ))}
@@ -305,14 +355,14 @@ export function TeamAssignment({
             ) : (
               <>
                 <X className="w-5 h-5 text-red-500" />
-                <span className="text-sm text-red-600">Teams must be balanced</span>
+                <span className="text-sm text-red-600">
+                  Teams must be balanced
+                </span>
               </>
             )}
           </div>
           {teamSettings?.sharedLife && (
-            <Badge variant="outline">
-              Two-Headed Giant Mode
-            </Badge>
+            <Badge variant="outline">Two-Headed Giant Mode</Badge>
           )}
         </div>
       </CardContent>


### PR DESCRIPTION
## Summary

Resolves #1101 — adds accessible names to every icon-only `<Button size="icon">` across the interactive components so screen readers announce each button's purpose instead of a generic "button" (WCAG 2.1 SC 4.1.2 — Name, Role, Value).

## Problem

Many `<Button size="icon">` elements contained only an icon with no visible text and no `aria-label`, so assistive technology users could not determine their action. A few used a `title=` attribute, which renders a tooltip but is **not** a reliable accessible name.

## Approach

The shadcn `Button` (`src/components/ui/button.tsx`) already spreads `...props` onto the underlying `<button>`, so `aria-label` passes through with no base-component change needed. I audited the whole `src/components/**` tree (35 `size="icon"` buttons total) and added a descriptive, action-oriented `aria-label` to every one that lacked an accessible name. For buttons that previously relied on `title=`, the `aria-label` was added (and `title` retained where it provides a useful tooltip).

### Files changed (11 components + 1 test + 1 doc)

| Component | Buttons labeled | Labels |
| --- | --- | --- |
| `src/components/spectator-view.tsx` | 3 | Open chat, Show/Hide spectators (dynamic), Spectator settings |
| `src/components/judge-tools.tsx` | 4 | Decrease/Increase life, Decrease/Increase `${counterType}` counter |
| `src/components/meta/sideboard/SideboardPlanEditor.tsx` | 4 | Add/remove card to side in / side out |
| `src/components/team-assignment.tsx` | 3 | Save team name, Cancel edit, Edit team |
| `src/components/collection-tracker.tsx` | 2 | Decrease/Increase quantity |
| `src/components/app-sidebar.tsx` | 2 | `aria-label={t("keyboardShortcuts")}` / `aria-label={t("community")}` (i18n preserved) |
| `src/components/ai-coach/chat-panel.tsx` | 1 | Send message |
| `src/components/qr-code-display.tsx` | 1 | Copy game code |
| `src/components/custom-card-editor.tsx` | 1 | Clear artwork URL |
| `src/components/draft-pool-view.tsx` | 1 | Remove card |
| `src/components/game-tutorial.tsx` | 1 | Skip tutorial |

**23 icon-only buttons labeled.** After the change, all 35 `size="icon"` buttons in `src/components/**` expose an accessible name (verified by a repo-wide scan).

### Label conventions
- Action-oriented and descriptive (`"Add card"`, `"Decrease life"`), never generic.
- Dynamic where state-dependent (`isHidden ? "Show spectators" : "Hide spectators"`).
- i18n preserved where the component already uses the `t()` helper (`app-sidebar.tsx`).

## Tests

New `src/components/__tests__/icon-button-a11y.test.tsx` asserts the accessible names of representative icon-only buttons using Testing Library role queries (which resolve the accessible name the same way a screen reader does):

```tsx
expect(screen.getByRole("button", { name: "Increase life" })).toBeInTheDocument();
```

Covers `SpectatorView` (incl. dynamic toggle label), `LifeAdjustment`, and `CounterAdjustment` (poison + energy). 4 new tests, all passing.

## Verification
- [x] `npm run typecheck` (`tsc --noEmit`) — no errors
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 66/66 component tests pass (incl. 4 new)
- [x] No visible UI change (labels are AT-only)
- [x] No button behavior or styling changed

## Documentation
Added `docs/ACCESSIBILITY.md` documenting the icon-only button a11y convention for future contributors.

Resolves #1101
