### PR TITLE
fix(ux): resolve #1100 — finish removing native alert()/confirm() from production components

### DIFF
--- a/src/app/(app)/database-management/page.tsx
+++ b/src/app/(app)/database-management/page.tsx
@@ -28,6 +28,7 @@ import {
   importCardsFromFile,
 } from "@/lib/card-database";
 import { useToast } from "@/hooks/use-toast";
+import { useConfirmDialog } from "@/hooks/use-confirm-dialog";
 
 export default function DatabaseManagementPage() {
   const { toast } = useToast();
@@ -40,6 +41,7 @@ export default function DatabaseManagementPage() {
   const [importProgress, setImportProgress] = useState(0);
   const [isClearing, setIsClearing] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const { confirm, confirmDialog } = useConfirmDialog();
 
   useEffect(() => {
     loadStats();
@@ -108,11 +110,14 @@ export default function DatabaseManagementPage() {
   }
 
   async function handleClearDatabase() {
-    if (
-      !confirm(
+    const confirmed = await confirm({
+      title: "Clear card database?",
+      description:
         "Are you sure you want to clear the entire card database? This cannot be undone.",
-      )
-    ) {
+      confirmLabel: "Clear Database",
+      destructive: true,
+    });
+    if (!confirmed) {
       return;
     }
 
@@ -160,6 +165,7 @@ export default function DatabaseManagementPage() {
 
   return (
     <div className="space-y-6">
+      {confirmDialog}
       <div>
         <h1 className="text-3xl font-bold">Database Management</h1>
         <p className="text-muted-foreground">

--- a/src/app/(app)/game-history/page.tsx
+++ b/src/app/(app)/game-history/page.tsx
@@ -1,25 +1,40 @@
-'use client';
+"use client";
 
-import { useState, useEffect } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import { Trophy, Swords, History, TrendingUp, Activity, Trash2 } from 'lucide-react';
-import { 
-  getAllGameRecords, 
-  getPlayerStats, 
+import { useState, useEffect } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Trophy,
+  Swords,
+  History,
+  TrendingUp,
+  Activity,
+  Trash2,
+} from "lucide-react";
+import {
+  getAllGameRecords,
+  getPlayerStats,
   getRecentGames,
   clearGameHistory,
   type GameRecord,
-  type PlayerStats 
-} from '@/lib/game-history';
+  type PlayerStats,
+} from "@/lib/game-history";
+import { useConfirmDialog } from "@/hooks/use-confirm-dialog";
 
 export default function GameHistoryPage() {
   const [stats, setStats] = useState<PlayerStats | null>(null);
   const [recentGames, setRecentGames] = useState<GameRecord[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const { confirm, confirmDialog } = useConfirmDialog();
 
   useEffect(() => {
     loadStats();
@@ -31,37 +46,52 @@ export default function GameHistoryPage() {
     setIsLoading(false);
   }
 
-  function handleClearHistory() {
-    if (confirm('Are you sure you want to clear all game history? This cannot be undone.')) {
+  async function handleClearHistory() {
+    const confirmed = await confirm({
+      title: "Clear game history?",
+      description:
+        "Are you sure you want to clear all game history? This cannot be undone.",
+      confirmLabel: "Clear History",
+      destructive: true,
+    });
+    if (confirmed) {
       clearGameHistory();
       loadStats();
     }
   }
 
   function formatDate(timestamp: number): string {
-    return new Date(timestamp).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
+    return new Date(timestamp).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
     });
   }
 
   function getResultColor(result: string): string {
     switch (result) {
-      case 'win': return 'bg-green-500';
-      case 'loss': return 'bg-red-500';
-      case 'draw': return 'bg-gray-500';
-      default: return 'bg-gray-500';
+      case "win":
+        return "bg-green-500";
+      case "loss":
+        return "bg-red-500";
+      case "draw":
+        return "bg-gray-500";
+      default:
+        return "bg-gray-500";
     }
   }
 
   function getResultIcon(result: string): string {
     switch (result) {
-      case 'win': return '✓';
-      case 'loss': return '✗';
-      case 'draw': return '○';
-      default: return '?';
+      case "win":
+        return "✓";
+      case "loss":
+        return "✗";
+      case "draw":
+        return "○";
+      default:
+        return "?";
     }
   }
 
@@ -75,6 +105,7 @@ export default function GameHistoryPage() {
 
   return (
     <div className="space-y-6">
+      {confirmDialog}
       <div>
         <h1 className="text-3xl font-bold">Game History</h1>
         <p className="text-muted-foreground">
@@ -112,11 +143,15 @@ export default function GameHistoryPage() {
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Vs AI Win Rate</CardTitle>
+            <CardTitle className="text-sm font-medium">
+              Vs AI Win Rate
+            </CardTitle>
             <Swords className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{stats?.vsAiStats.winRate ?? 0}%</div>
+            <div className="text-2xl font-bold">
+              {stats?.vsAiStats.winRate ?? 0}%
+            </div>
             <p className="text-xs text-muted-foreground">
               {stats?.vsAiStats.wins ?? 0}W - {stats?.vsAiStats.losses ?? 0}L
             </p>
@@ -129,10 +164,10 @@ export default function GameHistoryPage() {
             <History className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{stats?.avgTurnsPerGame ?? 0}</div>
-            <p className="text-xs text-muted-foreground">
-              Per game average
-            </p>
+            <div className="text-2xl font-bold">
+              {stats?.avgTurnsPerGame ?? 0}
+            </div>
+            <p className="text-xs text-muted-foreground">Per game average</p>
           </CardContent>
         </Card>
       </div>
@@ -172,7 +207,9 @@ export default function GameHistoryPage() {
                 <div className="text-center py-8 text-muted-foreground">
                   <Trophy className="h-12 w-12 mx-auto mb-4 opacity-50" />
                   <p>No games played yet</p>
-                  <p className="text-sm">Start a single-player game to track your results!</p>
+                  <p className="text-sm">
+                    Start a single-player game to track your results!
+                  </p>
                 </div>
               ) : (
                 <ScrollArea className="h-[400px]">
@@ -191,20 +228,28 @@ export default function GameHistoryPage() {
                           </div>
                           <div>
                             <div className="font-medium">
-                              {game.mode === 'vs_ai' ? 'vs AI' : game.mode === 'self_play' ? 'Self Play' : 'Goldfish'}
+                              {game.mode === "vs_ai"
+                                ? "vs AI"
+                                : game.mode === "self_play"
+                                  ? "Self Play"
+                                  : "Goldfish"}
                               {game.difficulty && ` (${game.difficulty})`}
                             </div>
                             <div className="text-xs text-muted-foreground">
                               {game.playerDeck}
                               {game.opponentDeck && ` vs ${game.opponentDeck}`}
-                              {' • '}
+                              {" • "}
                               {formatDate(game.date)}
                             </div>
                           </div>
                         </div>
                         <div className="text-right">
                           <div className="text-sm font-medium">
-                            {game.result === 'win' ? 'Victory' : game.result === 'loss' ? 'Defeat' : 'Draw'}
+                            {game.result === "win"
+                              ? "Victory"
+                              : game.result === "loss"
+                                ? "Defeat"
+                                : "Draw"}
                           </div>
                           <div className="text-xs text-muted-foreground">
                             {game.turns} turns • {game.playerLifeAtEnd} life
@@ -230,26 +275,41 @@ export default function GameHistoryPage() {
                 <div>
                   <div className="flex items-center justify-between mb-2">
                     <span className="text-sm font-medium">Vs AI</span>
-                    <Badge variant={stats?.vsAiStats.winRate && stats.vsAiStats.winRate >= 50 ? 'default' : 'secondary'}>
+                    <Badge
+                      variant={
+                        stats?.vsAiStats.winRate &&
+                        stats.vsAiStats.winRate >= 50
+                          ? "default"
+                          : "secondary"
+                      }
+                    >
                       {stats?.vsAiStats.winRate ?? 0}% WR
                     </Badge>
                   </div>
                   <div className="text-xs text-muted-foreground">
-                    {stats?.vsAiStats.wins}W - {stats?.vsAiStats.losses}L - {stats?.vsAiStats.draws}D
-                    {' '}({stats?.vsAiStats.games} games)
+                    {stats?.vsAiStats.wins}W - {stats?.vsAiStats.losses}L -{" "}
+                    {stats?.vsAiStats.draws}D ({stats?.vsAiStats.games} games)
                   </div>
                 </div>
 
                 <div>
                   <div className="flex items-center justify-between mb-2">
                     <span className="text-sm font-medium">Self Play</span>
-                    <Badge variant={stats?.selfPlayStats.winRate && stats.selfPlayStats.winRate >= 50 ? 'default' : 'secondary'}>
+                    <Badge
+                      variant={
+                        stats?.selfPlayStats.winRate &&
+                        stats.selfPlayStats.winRate >= 50
+                          ? "default"
+                          : "secondary"
+                      }
+                    >
                       {stats?.selfPlayStats.winRate ?? 0}% WR
                     </Badge>
                   </div>
                   <div className="text-xs text-muted-foreground">
-                    {stats?.selfPlayStats.wins}W - {stats?.selfPlayStats.losses}L - {stats?.selfPlayStats.draws}D
-                    {' '}({stats?.selfPlayStats.games} games)
+                    {stats?.selfPlayStats.wins}W - {stats?.selfPlayStats.losses}
+                    L - {stats?.selfPlayStats.draws}D (
+                    {stats?.selfPlayStats.games} games)
                   </div>
                 </div>
               </CardContent>
@@ -262,20 +322,28 @@ export default function GameHistoryPage() {
                   <CardDescription>AI difficulty performance</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-3">
-                  {Object.entries(stats.difficultyStats).map(([difficulty, diffStats]) => (
-                    <div key={difficulty}>
-                      <div className="flex items-center justify-between mb-1">
-                        <span className="text-sm font-medium capitalize">{difficulty}</span>
-                        <Badge variant={diffStats.winRate >= 50 ? 'default' : 'secondary'}>
-                          {diffStats.winRate}% WR
-                        </Badge>
+                  {Object.entries(stats.difficultyStats).map(
+                    ([difficulty, diffStats]) => (
+                      <div key={difficulty}>
+                        <div className="flex items-center justify-between mb-1">
+                          <span className="text-sm font-medium capitalize">
+                            {difficulty}
+                          </span>
+                          <Badge
+                            variant={
+                              diffStats.winRate >= 50 ? "default" : "secondary"
+                            }
+                          >
+                            {diffStats.winRate}% WR
+                          </Badge>
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {diffStats.wins}W - {diffStats.losses}L -{" "}
+                          {diffStats.draws}D ({diffStats.games} games)
+                        </div>
                       </div>
-                      <div className="text-xs text-muted-foreground">
-                        {diffStats.wins}W - {diffStats.losses}L - {diffStats.draws}D
-                        {' '}({diffStats.games} games)
-                      </div>
-                    </div>
-                  ))}
+                    ),
+                  )}
                 </CardContent>
               </Card>
             )}

--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -42,6 +42,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { GameBoardErrorBoundary } from "@/components/error-boundaries";
 import type { PlayerCount, ZoneType } from "@/types/game";
 import { useToast } from "@/hooks/use-toast";
+import { useConfirmDialog } from "@/hooks/use-confirm-dialog";
 import type { ScryfallCard, SavedDeck } from "@/app/actions";
 import type { Permanent, HandCard } from "@/ai/game-state-evaluator";
 import { gameLogger } from "@/lib/logger";
@@ -859,6 +860,7 @@ function GameBoardContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { toast } = useToast();
+  const { confirm, confirmDialog } = useConfirmDialog();
   const isMobile = useIsMobile();
 
   const [gameState, setGameState] = useState<GameState | null>(null);
@@ -2118,7 +2120,13 @@ function GameBoardContent() {
   const handleConcede = useCallback(async () => {
     if (!gameState) return;
 
-    if (confirm("Are you sure you want to concede?")) {
+    const confirmed = await confirm({
+      title: "Concede game?",
+      description: "Are you sure you want to concede?",
+      confirmLabel: "Concede",
+      destructive: true,
+    });
+    if (confirmed) {
       const player = Array.from(gameState.players.values()).find(
         (p) => p.name === playerName,
       );
@@ -2138,7 +2146,7 @@ function GameBoardContent() {
         }, 2000);
       }
     }
-  }, [gameState, playerName, router, toast]);
+  }, [gameState, playerName, router, toast, confirm]);
 
   // Handle draw offer - Use engine function
   const handleOfferDraw = useCallback(async () => {
@@ -3813,6 +3821,7 @@ function GameBoardContent() {
 
       {/* Tutorial */}
       {isGameStarted && <GameTutorial />}
+      {confirmDialog}
     </div>
   );
 }

--- a/src/app/(app)/multiplayer/host/page.tsx
+++ b/src/app/(app)/multiplayer/host/page.tsx
@@ -3,48 +3,71 @@
  * Allows players to create and manage a game lobby
  */
 
-'use client';
+"use client";
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Copy, Check, Users, Play, X, Crown, Clock, Eye, Info } from 'lucide-react';
-import { useLobby } from '@/hooks/use-lobby';
-import { HostGameConfig, PlayerStatus } from '@/lib/multiplayer-types';
-import { FormatRulesDisplay } from '@/components/format-rules-display';
-import { DeckSelectorWithValidation } from '@/components/deck-selector-with-validation';
-import { TeamAssignment } from '@/components/team-assignment';
-import { SavedDeck } from '@/app/actions';
+import {
+  Copy,
+  Check,
+  Users,
+  Play,
+  X,
+  Crown,
+  Clock,
+  Eye,
+  Info,
+} from "lucide-react";
+import { useLobby } from "@/hooks/use-lobby";
+import { HostGameConfig, PlayerStatus } from "@/lib/multiplayer-types";
+import { FormatRulesDisplay } from "@/components/format-rules-display";
+import { DeckSelectorWithValidation } from "@/components/deck-selector-with-validation";
+import { TeamAssignment } from "@/components/team-assignment";
+import { SavedDeck } from "@/app/actions";
 import {
   createHostConnection,
   type ConnectionData,
   type DirectConnectionState,
-} from '@/lib/p2p-direct-connection';
-import { QRCodeDisplay } from '@/components/qr-code-display';
-import { P2PStatusBanner } from '@/components/p2p-status-banner';
+} from "@/lib/p2p-direct-connection";
+import { QRCodeDisplay } from "@/components/qr-code-display";
+import { P2PStatusBanner } from "@/components/p2p-status-banner";
+import { useConfirmDialog } from "@/hooks/use-confirm-dialog";
 
 export default function HostLobbyPage() {
-  const { 
-    lobby, 
-    isHost, 
-    isLoading, 
-    error, 
-    createLobby, 
-    updatePlayerStatus, 
-    updatePlayerDeck, 
-    canStartGame, 
-    canForceStart, 
-    startGame, 
-    forceStartGame, 
-    closeLobby, 
-    getGameCode, 
+  const {
+    lobby,
+    isHost,
+    isLoading,
+    error,
+    createLobby,
+    updatePlayerStatus,
+    updatePlayerDeck,
+    canStartGame,
+    canForceStart,
+    startGame,
+    forceStartGame,
+    closeLobby,
+    getGameCode,
     validateDeckForFormat,
     // Team management
     isTeamMode,
@@ -54,11 +77,20 @@ export default function HostLobbyPage() {
     updateTeamSettings,
     updateTeamName,
   } = useLobby();
+  const { confirm, confirmDialog } = useConfirmDialog();
 
   // Form state
-  const [gameName, setGameName] = useState('');
-  const [gameFormat, setGameFormat] = useState<'commander' | 'modern' | 'standard' | 'pioneer' | 'legacy' | 'vintage' | 'pauper'>('commander');
-  const [playerCount, setPlayerCount] = useState<'2' | '3' | '4'>('4');
+  const [gameName, setGameName] = useState("");
+  const [gameFormat, setGameFormat] = useState<
+    | "commander"
+    | "modern"
+    | "standard"
+    | "pioneer"
+    | "legacy"
+    | "vintage"
+    | "pauper"
+  >("commander");
+  const [playerCount, setPlayerCount] = useState<"2" | "3" | "4">("4");
   const [allowSpectators, setAllowSpectators] = useState(true);
   const [timerEnabled, setTimerEnabled] = useState(false);
   const [timerMinutes, setTimerMinutes] = useState(30);
@@ -68,8 +100,10 @@ export default function HostLobbyPage() {
   // UI state
   const [copied, setCopied] = useState(false);
   const [showCreateForm, setShowCreateForm] = useState(true);
-  const [p2pConnectionData, setP2pConnectionData] = useState<ConnectionData | null>(null);
-  const [p2pConnectionState, setP2pConnectionState] = useState<DirectConnectionState>('idle');
+  const [p2pConnectionData, setP2pConnectionData] =
+    useState<ConnectionData | null>(null);
+  const [p2pConnectionState, setP2pConnectionState] =
+    useState<DirectConnectionState>("idle");
   const [showP2pSetup, setShowP2pSetup] = useState(false);
 
   const gameCode = getGameCode();
@@ -99,7 +133,8 @@ export default function HostLobbyPage() {
     };
 
     // Get player name from localStorage or use default
-    const hostName = localStorage.getItem('planar_nexus_player_name') || 'Host Player';
+    const hostName =
+      localStorage.getItem("planar_nexus_player_name") || "Host Player";
 
     createLobby(config, hostName);
     setShowCreateForm(false);
@@ -121,7 +156,8 @@ export default function HostLobbyPage() {
   // Setup P2P connection with QR code
   const setupP2PConnection = async (hostName: string) => {
     try {
-      const playerId = localStorage.getItem('planar_nexus_player_id') || `host-${Date.now()}`;
+      const playerId =
+        localStorage.getItem("planar_nexus_player_id") || `host-${Date.now()}`;
 
       await createHostConnection({
         playerId,
@@ -130,34 +166,37 @@ export default function HostLobbyPage() {
         gameCode: getGameCode(),
         onQRCodeGenerated: (qrDataUrl, connectionData) => {
           setP2pConnectionData(connectionData);
-          setP2pConnectionState('waiting-for-answer');
+          setP2pConnectionState("waiting-for-answer");
           setShowP2pSetup(true);
         },
-        onICECandidate: () => {
-        },
+        onICECandidate: () => {},
       });
     } catch (error) {
-      console.error('[P2P Host] Failed to setup connection:', error);
+      console.error("[P2P Host] Failed to setup connection:", error);
     }
   };
 
   // Refresh P2P connection
   const refreshP2PConnection = async () => {
-    const hostName = localStorage.getItem('planar_nexus_player_name') || 'Host Player';
+    const hostName =
+      localStorage.getItem("planar_nexus_player_name") || "Host Player";
     setShowP2pSetup(false);
     setP2pConnectionData(null);
-    setP2pConnectionState('idle');
+    setP2pConnectionState("idle");
     await setupP2PConnection(hostName);
   };
 
   // Helper to get stored decks
   const getStoredDecks = () => {
-    const stored = localStorage.getItem('saved-decks');
+    const stored = localStorage.getItem("saved-decks");
     return stored ? JSON.parse(stored) : [];
   };
 
   // Handle deck selection with validation
-  const handleDeckSelect = (deck: SavedDeck, validation?: { isValid: boolean; errors: string[] }) => {
+  const handleDeckSelect = (
+    deck: SavedDeck,
+    validation?: { isValid: boolean; errors: string[] },
+  ) => {
     setSelectedDeck(deck);
     // Validation is handled by the deck selector component
     if (!validation) {
@@ -166,7 +205,7 @@ export default function HostLobbyPage() {
 
     // Update player deck in lobby
     if (lobby) {
-      const hostPlayer = lobby.players.find(p => p.id === lobby.hostId);
+      const hostPlayer = lobby.players.find((p) => p.id === lobby.hostId);
       if (hostPlayer) {
         updatePlayerDeck(lobby.hostId, deck.id, deck.name, deck);
       }
@@ -174,16 +213,17 @@ export default function HostLobbyPage() {
   };
 
   const handleCopyCode = () => {
-    navigator.clipboard.writeText(lobby?.gameCode || '');
+    navigator.clipboard.writeText(lobby?.gameCode || "");
     setCopied(true);
   };
 
   const handleReadyToggle = () => {
     if (!lobby) return;
 
-    const hostPlayer = lobby.players.find(p => p.id === lobby.hostId);
+    const hostPlayer = lobby.players.find((p) => p.id === lobby.hostId);
     if (hostPlayer) {
-      const newStatus: PlayerStatus = hostPlayer.status === 'ready' ? 'not-ready' : 'ready';
+      const newStatus: PlayerStatus =
+        hostPlayer.status === "ready" ? "not-ready" : "ready";
       updatePlayerStatus(lobby.hostId, newStatus);
     }
   };
@@ -192,40 +232,58 @@ export default function HostLobbyPage() {
     const success = startGame();
     if (success) {
       // Navigate to game board
-      window.location.href = '/game-board';
+      window.location.href = "/game-board";
     }
   };
 
-  const handleCloseLobby = () => {
-    if (confirm('Are you sure you want to close the lobby? This will disconnect all players.')) {
+  const handleCloseLobby = async () => {
+    const confirmed = await confirm({
+      title: "Close lobby?",
+      description:
+        "Are you sure you want to close the lobby? This will disconnect all players.",
+      confirmLabel: "Close Lobby",
+      destructive: true,
+    });
+    if (confirmed) {
       closeLobby();
-      window.location.href = '/multiplayer';
+      window.location.href = "/multiplayer";
     }
   };
 
-  const handleLeaveLobby = () => {
-    if (confirm('Are you sure you want to leave? The lobby will be closed for all players.')) {
+  const handleLeaveLobby = async () => {
+    const confirmed = await confirm({
+      title: "Leave lobby?",
+      description:
+        "Are you sure you want to leave? The lobby will be closed for all players.",
+      confirmLabel: "Leave",
+      destructive: true,
+    });
+    if (confirmed) {
       closeLobby();
-      window.location.href = '/multiplayer';
+      window.location.href = "/multiplayer";
     }
   };
 
   // Format display name
   const formatDisplayNames: Record<string, string> = {
-    commander: 'Commander',
-    modern: 'Modern',
-    standard: 'Standard',
-    pioneer: 'Pioneer',
-    legacy: 'Legacy',
-    vintage: 'Vintage',
-    pauper: 'Pauper',
+    commander: "Commander",
+    modern: "Modern",
+    standard: "Standard",
+    pioneer: "Pioneer",
+    legacy: "Legacy",
+    vintage: "Vintage",
+    pauper: "Pauper",
   };
 
   if (showCreateForm && !lobby) {
     return (
       <div className="flex-1 p-4 md:p-6 max-w-4xl mx-auto">
         <header className="mb-6">
-          <Button variant="ghost" onClick={() => window.location.href = '/multiplayer'} className="mb-4">
+          <Button
+            variant="ghost"
+            onClick={() => (window.location.href = "/multiplayer")}
+            className="mb-4"
+          >
             ← Back
           </Button>
           <h1 className="font-headline text-3xl font-bold">Host a Game</h1>
@@ -255,7 +313,12 @@ export default function HostLobbyPage() {
               {/* Game Format */}
               <div className="space-y-2">
                 <Label htmlFor="format">Format *</Label>
-                <Select value={gameFormat} onValueChange={(value: typeof gameFormat) => setGameFormat(value)}>
+                <Select
+                  value={gameFormat}
+                  onValueChange={(value: typeof gameFormat) =>
+                    setGameFormat(value)
+                  }
+                >
                   <SelectTrigger id="format">
                     <SelectValue />
                   </SelectTrigger>
@@ -274,7 +337,12 @@ export default function HostLobbyPage() {
               {/* Player Count */}
               <div className="space-y-2">
                 <Label htmlFor="players">Max Players</Label>
-                <Select value={playerCount} onValueChange={(value: typeof playerCount) => setPlayerCount(value)}>
+                <Select
+                  value={playerCount}
+                  onValueChange={(value: typeof playerCount) =>
+                    setPlayerCount(value)
+                  }
+                >
                   <SelectTrigger id="players">
                     <SelectValue />
                   </SelectTrigger>
@@ -310,7 +378,10 @@ export default function HostLobbyPage() {
                       Let others watch your game
                     </p>
                   </div>
-                  <Switch checked={allowSpectators} onCheckedChange={setAllowSpectators} />
+                  <Switch
+                    checked={allowSpectators}
+                    onCheckedChange={setAllowSpectators}
+                  />
                 </div>
 
                 <div className="flex items-center justify-between">
@@ -320,7 +391,10 @@ export default function HostLobbyPage() {
                       Add a turn timer for competitive play
                     </p>
                   </div>
-                  <Switch checked={timerEnabled} onCheckedChange={setTimerEnabled} />
+                  <Switch
+                    checked={timerEnabled}
+                    onCheckedChange={setTimerEnabled}
+                  />
                 </div>
 
                 {timerEnabled && (
@@ -332,7 +406,9 @@ export default function HostLobbyPage() {
                       min={1}
                       max={60}
                       value={timerMinutes}
-                      onChange={(e) => setTimerMinutes(parseInt(e.target.value) || 30)}
+                      onChange={(e) =>
+                        setTimerMinutes(parseInt(e.target.value) || 30)
+                      }
                     />
                   </div>
                 )}
@@ -350,7 +426,7 @@ export default function HostLobbyPage() {
                 className="w-full"
                 size="lg"
               >
-                {isLoading ? 'Creating...' : 'Create Lobby'}
+                {isLoading ? "Creating..." : "Create Lobby"}
               </Button>
             </CardContent>
           </Card>
@@ -365,6 +441,7 @@ export default function HostLobbyPage() {
 
     return (
       <div className="flex-1 p-4 md:p-6 max-w-5xl mx-auto">
+        {confirmDialog}
         <header className="mb-6">
           <Button variant="ghost" onClick={handleLeaveLobby} className="mb-4">
             ← Leave Lobby
@@ -373,7 +450,9 @@ export default function HostLobbyPage() {
             <div>
               <h1 className="font-headline text-3xl font-bold flex items-center gap-2">
                 {lobby.name}
-                <Badge variant="secondary">{formatDisplayNames[lobby.format]}</Badge>
+                <Badge variant="secondary">
+                  {formatDisplayNames[lobby.format]}
+                </Badge>
               </h1>
               <p className="text-muted-foreground mt-1">
                 Waiting for players to join...
@@ -393,7 +472,8 @@ export default function HostLobbyPage() {
                 <Users className="w-5 h-5" />
                 Invite Players
               </CardTitle>
-              <CardDescription>Share this code with your friends
+              <CardDescription>
+                Share this code with your friends
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -425,11 +505,15 @@ export default function HostLobbyPage() {
               <div className="space-y-2 text-sm">
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">Format:</span>
-                  <span className="font-medium">{formatDisplayNames[lobby.format]}</span>
+                  <span className="font-medium">
+                    {formatDisplayNames[lobby.format]}
+                  </span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">Players:</span>
-                  <span className="font-medium">{lobby.players.length} / {maxPlayers}</span>
+                  <span className="font-medium">
+                    {lobby.players.length} / {maxPlayers}
+                  </span>
                 </div>
                 {lobby.settings.timerEnabled && (
                   <div className="flex justify-between">
@@ -437,7 +521,9 @@ export default function HostLobbyPage() {
                       <Clock className="w-3 h-3" />
                       Timer:
                     </span>
-                    <span className="font-medium">{lobby.settings.timerMinutes} min turns</span>
+                    <span className="font-medium">
+                      {lobby.settings.timerMinutes} min turns
+                    </span>
                   </div>
                 )}
                 {lobby.settings.allowSpectators && (
@@ -454,7 +540,8 @@ export default function HostLobbyPage() {
               {playerSlots > 0 && (
                 <Alert>
                   <AlertDescription className="text-center">
-                    Waiting for {playerSlots} more player{playerSlots > 1 ? 's' : ''}...
+                    Waiting for {playerSlots} more player
+                    {playerSlots > 1 ? "s" : ""}...
                   </AlertDescription>
                 </Alert>
               )}
@@ -475,7 +562,11 @@ export default function HostLobbyPage() {
                 }}
               />
               <div className="mt-4 flex gap-3">
-                <Button onClick={refreshP2PConnection} variant="outline" className="flex-1">
+                <Button
+                  onClick={refreshP2PConnection}
+                  variant="outline"
+                  className="flex-1"
+                >
                   Generate New Connection Code
                 </Button>
                 <Button onClick={() => setShowP2pSetup(false)} variant="ghost">
@@ -488,7 +579,11 @@ export default function HostLobbyPage() {
           {/* Show P2P Setup Button */}
           {!showP2pSetup && (
             <div className="md:col-span-3">
-              <Button onClick={() => setShowP2pSetup(true)} variant="outline" className="w-full">
+              <Button
+                onClick={() => setShowP2pSetup(true)}
+                variant="outline"
+                className="w-full"
+              >
                 Show P2P Connection Code
               </Button>
             </div>
@@ -558,30 +653,42 @@ export default function HostLobbyPage() {
                         <div className="font-medium">
                           {player.name}
                           {player.id === lobby.hostId && (
-                            <Badge variant="outline" className="ml-2">Host</Badge>
+                            <Badge variant="outline" className="ml-2">
+                              Host
+                            </Badge>
                           )}
                         </div>
                         {player.deckName && (
                           <div className="text-sm text-muted-foreground">
                             Deck: {player.deckName}
-                            {player.deckFormat && player.deckFormat !== lobby.format && (
-                              <span className="text-yellow-600 ml-2">
-                                ({player.deckFormat} deck)
-                              </span>
-                            )}
+                            {player.deckFormat &&
+                              player.deckFormat !== lobby.format && (
+                                <span className="text-yellow-600 ml-2">
+                                  ({player.deckFormat} deck)
+                                </span>
+                              )}
                           </div>
                         )}
-                        {player.deckValidationErrors && player.deckValidationErrors.length > 0 && (
-                          <div className="text-xs text-red-500 mt-1">
-                            {player.deckValidationErrors[0]}
-                          </div>
-                        )}
+                        {player.deckValidationErrors &&
+                          player.deckValidationErrors.length > 0 && (
+                            <div className="text-xs text-red-500 mt-1">
+                              {player.deckValidationErrors[0]}
+                            </div>
+                          )}
                       </div>
                     </div>
                     <Badge
-                      variant={player.status === 'ready' || player.status === 'host' ? 'default' : 'secondary'}
+                      variant={
+                        player.status === "ready" || player.status === "host"
+                          ? "default"
+                          : "secondary"
+                      }
                     >
-                      {player.status === 'ready' ? 'Ready' : player.status === 'host' ? 'Host' : 'Not Ready'}
+                      {player.status === "ready"
+                        ? "Ready"
+                        : player.status === "host"
+                          ? "Host"
+                          : "Not Ready"}
                     </Badge>
                   </div>
                 ))}
@@ -629,11 +736,17 @@ export default function HostLobbyPage() {
                 ) : (
                   <Button
                     onClick={handleReadyToggle}
-                    variant={lobby.players.find(p => p.id === lobby.hostId)?.status === 'ready' ? 'outline' : 'default'}
+                    variant={
+                      lobby.players.find((p) => p.id === lobby.hostId)
+                        ?.status === "ready"
+                        ? "outline"
+                        : "default"
+                    }
                     className="flex-1"
                     size="lg"
                   >
-                    {lobby.players.find(p => p.id === lobby.hostId)?.status === 'ready' ? (
+                    {lobby.players.find((p) => p.id === lobby.hostId)
+                      ?.status === "ready" ? (
                       <>
                         <X className="w-4 h-4 mr-2" />
                         Not Ready
@@ -651,16 +764,17 @@ export default function HostLobbyPage() {
               {!canStartGame && !canForceStart && (
                 <p className="text-xs text-center text-muted-foreground mt-2">
                   {lobby.players.length < 2
-                    ? 'Need at least 2 players to start'
-                    : lobby.players.some(p => !p.deckId)
-                    ? 'All players must select a deck'
-                    : 'All players must have valid decks and be ready to start'}
+                    ? "Need at least 2 players to start"
+                    : lobby.players.some((p) => !p.deckId)
+                      ? "All players must select a deck"
+                      : "All players must have valid decks and be ready to start"}
                 </p>
               )}
 
               {canForceStart && !canStartGame && (
                 <p className="text-xs text-center text-amber-600 mt-2">
-                  Not all players are ready. Use "Force Start" to begin with ready players only.
+                  Not all players are ready. Use "Force Start" to begin with
+                  ready players only.
                 </p>
               )}
             </CardContent>

--- a/src/app/(app)/sideboards/page.tsx
+++ b/src/app/(app)/sideboards/page.tsx
@@ -1,20 +1,45 @@
 "use client";
 
-import React, { useState, useEffect } from 'react';
-import { SideboardPlanCard, SideboardPlanEditor } from '@/components/meta/sideboard';
-import { getAllSideboardPlans, deleteSideboardPlan, SavedSideboardPlan } from '@/lib/sideboard-plans';
-import { MagicFormat } from '@/lib/meta';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import React, { useState, useEffect } from "react";
+import {
+  SideboardPlanCard,
+  SideboardPlanEditor,
+} from "@/components/meta/sideboard";
+import {
+  getAllSideboardPlans,
+  deleteSideboardPlan,
+  SavedSideboardPlan,
+} from "@/lib/sideboard-plans";
+import { MagicFormat } from "@/lib/meta";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Plus, Trash2, Shield } from 'lucide-react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Plus, Trash2, Shield } from "lucide-react";
+import { useConfirmDialog } from "@/hooks/use-confirm-dialog";
 
 export default function SideboardsPage() {
   const [plans, setPlans] = useState<SavedSideboardPlan[]>([]);
-  const [formatFilter, setFormatFilter] = useState<string>('all');
+  const [formatFilter, setFormatFilter] = useState<string>("all");
   const [editorOpen, setEditorOpen] = useState(false);
-  const [editingPlan, setEditingPlan] = useState<SavedSideboardPlan | null>(null);
-  const [selectedPlan, setSelectedPlan] = useState<SavedSideboardPlan | null>(null);
+  const [editingPlan, setEditingPlan] = useState<SavedSideboardPlan | null>(
+    null,
+  );
+  const [selectedPlan, setSelectedPlan] = useState<SavedSideboardPlan | null>(
+    null,
+  );
+  const { confirm, confirmDialog } = useConfirmDialog();
 
   // Load plans on mount
   useEffect(() => {
@@ -23,17 +48,27 @@ export default function SideboardsPage() {
 
   const loadPlans = () => {
     const allPlans = getAllSideboardPlans();
-    setPlans(allPlans.sort((a, b) => 
-      new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
-    ));
+    setPlans(
+      allPlans.sort(
+        (a, b) =>
+          new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+      ),
+    );
   };
 
-  const filteredPlans = formatFilter === 'all' 
-    ? plans 
-    : plans.filter(plan => plan.format === formatFilter);
+  const filteredPlans =
+    formatFilter === "all"
+      ? plans
+      : plans.filter((plan) => plan.format === formatFilter);
 
-  const handleDelete = (plan: SavedSideboardPlan) => {
-    if (confirm(`Delete "${plan.name}"? This cannot be undone.`)) {
+  const handleDelete = async (plan: SavedSideboardPlan) => {
+    const confirmed = await confirm({
+      title: "Delete sideboard plan?",
+      description: `Delete "${plan.name}"? This cannot be undone.`,
+      confirmLabel: "Delete",
+      destructive: true,
+    });
+    if (confirmed) {
       deleteSideboardPlan(plan.id);
       loadPlans();
       if (selectedPlan?.id === plan.id) {
@@ -54,6 +89,7 @@ export default function SideboardsPage() {
 
   return (
     <div className="flex flex-1 flex-col">
+      {confirmDialog}
       <div className="container mx-auto py-6 px-4 max-w-6xl">
         {/* Header */}
         <div className="flex items-center justify-between mb-6">
@@ -63,7 +99,12 @@ export default function SideboardsPage() {
               Manage your custom sideboard configurations
             </p>
           </div>
-          <Button onClick={() => { setEditingPlan(null); setEditorOpen(true); }}>
+          <Button
+            onClick={() => {
+              setEditingPlan(null);
+              setEditorOpen(true);
+            }}
+          >
             <Plus className="h-4 w-4 mr-2" />
             New Plan
           </Button>
@@ -87,7 +128,7 @@ export default function SideboardsPage() {
             </Select>
           </div>
           <span className="text-sm text-muted-foreground">
-            {filteredPlans.length} plan{filteredPlans.length !== 1 ? 's' : ''}
+            {filteredPlans.length} plan{filteredPlans.length !== 1 ? "s" : ""}
           </span>
         </div>
 
@@ -112,11 +153,17 @@ export default function SideboardsPage() {
                 No Sideboard Plans Yet
               </CardTitle>
               <CardDescription>
-                Create custom sideboard plans or save recommendations from the meta page.
+                Create custom sideboard plans or save recommendations from the
+                meta page.
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <Button onClick={() => { setEditingPlan(null); setEditorOpen(true); }}>
+              <Button
+                onClick={() => {
+                  setEditingPlan(null);
+                  setEditorOpen(true);
+                }}
+              >
                 <Plus className="h-4 w-4 mr-2" />
                 Create Your First Plan
               </Button>

--- a/src/components/card-sleeve.tsx
+++ b/src/components/card-sleeve.tsx
@@ -1,33 +1,54 @@
-'use client';
+"use client";
 
-import { useState, useEffect, useCallback } from 'react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
-import { Upload, Check, Palette, Image, RotateCcw, Eye, Sparkles } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { usePrefersReducedMotion } from '@/hooks/use-prefers-reduced-motion';
+import { useState, useEffect, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Upload,
+  Check,
+  Palette,
+  Image,
+  RotateCcw,
+  Eye,
+  Sparkles,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
+import { toast } from "@/hooks/use-toast";
 
 // Sleeve patterns
-export type SleevePattern = 'gradient' | 'stripes' | 'dots' | 'diamond' | 'swirl' | 'solid';
+export type SleevePattern =
+  | "gradient"
+  | "stripes"
+  | "dots"
+  | "diamond"
+  | "swirl"
+  | "solid";
 
 // Default sleeve options
-export type SleeveType = 
-  | 'default' 
-  | 'blue' 
-  | 'red' 
-  | 'green' 
-  | 'black' 
-  | 'white' 
-  | 'purple' 
-  | 'orange'
-  | 'gold'
-  | 'silver'
-  | 'holographic'
-  | 'custom';
+export type SleeveType =
+  | "default"
+  | "blue"
+  | "red"
+  | "green"
+  | "black"
+  | "white"
+  | "purple"
+  | "orange"
+  | "gold"
+  | "silver"
+  | "holographic"
+  | "custom";
 
 export interface CardSleeve {
   type: SleeveType;
@@ -39,30 +60,96 @@ export interface CardSleeve {
 }
 
 export const DEFAULT_SLEEVES: CardSleeve[] = [
-  { type: 'default', name: 'Default', pattern: 'gradient', primaryColor: '#6366f1', secondaryColor: '#8b5cf6' },
-  { type: 'blue', name: 'Ocean Blue', pattern: 'gradient', primaryColor: '#3b82f6', secondaryColor: '#1d4ed8' },
-  { type: 'red', name: 'Ruby Red', pattern: 'gradient', primaryColor: '#ef4444', secondaryColor: '#dc2626' },
-  { type: 'green', name: 'Forest Green', pattern: 'gradient', primaryColor: '#22c55e', secondaryColor: '#16a34a' },
-  { type: 'black', name: 'Midnight', pattern: 'gradient', primaryColor: '#374151', secondaryColor: '#1f2937' },
-  { type: 'white', name: 'Snow White', pattern: 'gradient', primaryColor: '#f9fafb', secondaryColor: '#e5e7eb' },
-  { type: 'purple', name: 'Royal Purple', pattern: 'gradient', primaryColor: '#a855f7', secondaryColor: '#7c3aed' },
-  { type: 'orange', name: 'Sunset Orange', pattern: 'gradient', primaryColor: '#f97316', secondaryColor: '#ea580c' },
-  { type: 'gold', name: 'Golden', pattern: 'swirl', primaryColor: '#fbbf24', secondaryColor: '#d97706' },
-  { type: 'silver', name: 'Silver', pattern: 'diamond', primaryColor: '#9ca3af', secondaryColor: '#6b7280' },
-  { type: 'holographic', name: 'Holographic', pattern: 'swirl', primaryColor: '#ec4899', secondaryColor: '#8b5cf6' },
+  {
+    type: "default",
+    name: "Default",
+    pattern: "gradient",
+    primaryColor: "#6366f1",
+    secondaryColor: "#8b5cf6",
+  },
+  {
+    type: "blue",
+    name: "Ocean Blue",
+    pattern: "gradient",
+    primaryColor: "#3b82f6",
+    secondaryColor: "#1d4ed8",
+  },
+  {
+    type: "red",
+    name: "Ruby Red",
+    pattern: "gradient",
+    primaryColor: "#ef4444",
+    secondaryColor: "#dc2626",
+  },
+  {
+    type: "green",
+    name: "Forest Green",
+    pattern: "gradient",
+    primaryColor: "#22c55e",
+    secondaryColor: "#16a34a",
+  },
+  {
+    type: "black",
+    name: "Midnight",
+    pattern: "gradient",
+    primaryColor: "#374151",
+    secondaryColor: "#1f2937",
+  },
+  {
+    type: "white",
+    name: "Snow White",
+    pattern: "gradient",
+    primaryColor: "#f9fafb",
+    secondaryColor: "#e5e7eb",
+  },
+  {
+    type: "purple",
+    name: "Royal Purple",
+    pattern: "gradient",
+    primaryColor: "#a855f7",
+    secondaryColor: "#7c3aed",
+  },
+  {
+    type: "orange",
+    name: "Sunset Orange",
+    pattern: "gradient",
+    primaryColor: "#f97316",
+    secondaryColor: "#ea580c",
+  },
+  {
+    type: "gold",
+    name: "Golden",
+    pattern: "swirl",
+    primaryColor: "#fbbf24",
+    secondaryColor: "#d97706",
+  },
+  {
+    type: "silver",
+    name: "Silver",
+    pattern: "diamond",
+    primaryColor: "#9ca3af",
+    secondaryColor: "#6b7280",
+  },
+  {
+    type: "holographic",
+    name: "Holographic",
+    pattern: "swirl",
+    primaryColor: "#ec4899",
+    secondaryColor: "#8b5cf6",
+  },
 ];
 
 // Default playmat options
-export type PlaymatType = 
-  | 'default' 
-  | 'wood' 
-  | 'stone' 
-  | 'grass' 
-  | 'magic' 
-  | 'arena'
-  | 'space'
-  | 'ocean'
-  | 'custom';
+export type PlaymatType =
+  | "default"
+  | "wood"
+  | "stone"
+  | "grass"
+  | "magic"
+  | "arena"
+  | "space"
+  | "ocean"
+  | "custom";
 
 export interface Playmat {
   type: PlaymatType;
@@ -75,14 +162,68 @@ export interface Playmat {
 }
 
 export const DEFAULT_PLAYMATS: Playmat[] = [
-  { type: 'default', name: 'Classic', primaryColor: '#1f2937', borderColor: '#374151' },
-  { type: 'wood', name: 'Wooden Table', primaryColor: '#78350f', secondaryColor: '#451a03', borderColor: '#451a03', pattern: 'stripes' },
-  { type: 'stone', name: 'Stone Floor', primaryColor: '#4b5563', secondaryColor: '#374151', borderColor: '#1f2937', pattern: 'diamond' },
-  { type: 'grass', name: 'Forest Ground', primaryColor: '#166534', secondaryColor: '#14532d', borderColor: '#14532d', pattern: 'dots' },
-  { type: 'magic', name: 'Magic Arena', primaryColor: '#312e81', secondaryColor: '#1e1b4b', borderColor: '#1e1b4b', pattern: 'swirl' },
-  { type: 'arena', name: 'Colosseum', primaryColor: '#713f12', secondaryColor: '#451a03', borderColor: '#451a03', pattern: 'gradient' },
-  { type: 'space', name: 'Cosmic', primaryColor: '#0f172a', secondaryColor: '#1e1b4b', borderColor: '#312e81', pattern: 'swirl' },
-  { type: 'ocean', name: 'Ocean Depths', primaryColor: '#0c4a6e', secondaryColor: '#164e63', borderColor: '#155e75', pattern: 'gradient' },
+  {
+    type: "default",
+    name: "Classic",
+    primaryColor: "#1f2937",
+    borderColor: "#374151",
+  },
+  {
+    type: "wood",
+    name: "Wooden Table",
+    primaryColor: "#78350f",
+    secondaryColor: "#451a03",
+    borderColor: "#451a03",
+    pattern: "stripes",
+  },
+  {
+    type: "stone",
+    name: "Stone Floor",
+    primaryColor: "#4b5563",
+    secondaryColor: "#374151",
+    borderColor: "#1f2937",
+    pattern: "diamond",
+  },
+  {
+    type: "grass",
+    name: "Forest Ground",
+    primaryColor: "#166534",
+    secondaryColor: "#14532d",
+    borderColor: "#14532d",
+    pattern: "dots",
+  },
+  {
+    type: "magic",
+    name: "Magic Arena",
+    primaryColor: "#312e81",
+    secondaryColor: "#1e1b4b",
+    borderColor: "#1e1b4b",
+    pattern: "swirl",
+  },
+  {
+    type: "arena",
+    name: "Colosseum",
+    primaryColor: "#713f12",
+    secondaryColor: "#451a03",
+    borderColor: "#451a03",
+    pattern: "gradient",
+  },
+  {
+    type: "space",
+    name: "Cosmic",
+    primaryColor: "#0f172a",
+    secondaryColor: "#1e1b4b",
+    borderColor: "#312e81",
+    pattern: "swirl",
+  },
+  {
+    type: "ocean",
+    name: "Ocean Depths",
+    primaryColor: "#0c4a6e",
+    secondaryColor: "#164e63",
+    borderColor: "#155e75",
+    pattern: "gradient",
+  },
 ];
 
 // Customization settings interface
@@ -92,19 +233,23 @@ export interface CustomizationSettings {
 }
 
 // Generate pattern background
-function getPatternBackground(pattern: SleevePattern, primaryColor: string, secondaryColor: string): string {
+function getPatternBackground(
+  pattern: SleevePattern,
+  primaryColor: string,
+  secondaryColor: string,
+): string {
   switch (pattern) {
-    case 'gradient':
+    case "gradient":
       return `linear-gradient(135deg, ${primaryColor}, ${secondaryColor})`;
-    case 'stripes':
+    case "stripes":
       return `repeating-linear-gradient(45deg, ${primaryColor}, ${primaryColor} 10px, ${secondaryColor} 10px, ${secondaryColor} 20px)`;
-    case 'dots':
+    case "dots":
       return `radial-gradient(circle, ${secondaryColor} 2px, ${primaryColor} 2px)`;
-    case 'diamond':
+    case "diamond":
       return `linear-gradient(45deg, ${primaryColor} 25%, ${secondaryColor} 25%, ${secondaryColor} 50%, ${primaryColor} 50%, ${primaryColor} 75%, ${secondaryColor} 75%)`;
-    case 'swirl':
+    case "swirl":
       return `conic-gradient(from 0deg, ${primaryColor}, ${secondaryColor}, ${primaryColor})`;
-    case 'solid':
+    case "solid":
     default:
       return primaryColor;
   }
@@ -117,28 +262,36 @@ interface SleeveSelectorProps {
   className?: string;
 }
 
-export function SleeveSelector({ selectedSleeve, onSelect, className }: SleeveSelectorProps) {
+export function SleeveSelector({
+  selectedSleeve,
+  onSelect,
+  className,
+}: SleeveSelectorProps) {
   // #1103: skip the hover scale transform when the user prefers reduced motion.
   const reduceMotion = usePrefersReducedMotion();
   return (
-    <div className={cn('grid grid-cols-3 sm:grid-cols-4 gap-2', className)}>
+    <div className={cn("grid grid-cols-3 sm:grid-cols-4 gap-2", className)}>
       {DEFAULT_SLEEVES.map((sleeve) => (
         <button
           key={sleeve.type}
           onClick={() => onSelect(sleeve)}
           className={cn(
-            'relative aspect-[3/4] rounded-md overflow-hidden border-2 transition-all',
-            !reduceMotion && 'hover:scale-105',
+            "relative aspect-[3/4] rounded-md overflow-hidden border-2 transition-all",
+            !reduceMotion && "hover:scale-105",
             selectedSleeve.type === sleeve.type
-              ? 'border-primary ring-2 ring-primary/50'
-              : 'border-border hover:border-primary/50'
+              ? "border-primary ring-2 ring-primary/50"
+              : "border-border hover:border-primary/50",
           )}
           title={sleeve.name}
         >
           <div
             className="absolute inset-0"
             style={{
-              background: getPatternBackground(sleeve.pattern || 'gradient', sleeve.primaryColor!, sleeve.secondaryColor!),
+              background: getPatternBackground(
+                sleeve.pattern || "gradient",
+                sleeve.primaryColor!,
+                sleeve.secondaryColor!,
+              ),
             }}
           />
           {selectedSleeve.type === sleeve.type && (
@@ -162,29 +315,37 @@ interface PlaymatSelectorProps {
   className?: string;
 }
 
-export function PlaymatSelector({ selectedPlaymat, onSelect, className }: PlaymatSelectorProps) {
+export function PlaymatSelector({
+  selectedPlaymat,
+  onSelect,
+  className,
+}: PlaymatSelectorProps) {
   // #1103: skip the hover scale transform when the user prefers reduced motion.
   const reduceMotion = usePrefersReducedMotion();
   return (
-    <div className={cn('grid grid-cols-2 sm:grid-cols-3 gap-2', className)}>
+    <div className={cn("grid grid-cols-2 sm:grid-cols-3 gap-2", className)}>
       {DEFAULT_PLAYMATS.map((playmat) => (
         <button
           key={playmat.type}
           onClick={() => onSelect(playmat)}
           className={cn(
-            'relative aspect-video rounded-md overflow-hidden border-2 transition-all',
-            !reduceMotion && 'hover:scale-105',
+            "relative aspect-video rounded-md overflow-hidden border-2 transition-all",
+            !reduceMotion && "hover:scale-105",
             selectedPlaymat.type === playmat.type
-              ? 'border-primary ring-2 ring-primary/50'
-              : 'border-border hover:border-primary/50'
+              ? "border-primary ring-2 ring-primary/50"
+              : "border-border hover:border-primary/50",
           )}
           title={playmat.name}
         >
           <div
             className="absolute inset-0"
             style={{
-              background: playmat.pattern 
-                ? getPatternBackground(playmat.pattern, playmat.primaryColor!, playmat.secondaryColor || playmat.primaryColor!)
+              background: playmat.pattern
+                ? getPatternBackground(
+                    playmat.pattern,
+                    playmat.primaryColor!,
+                    playmat.secondaryColor || playmat.primaryColor!,
+                  )
                 : playmat.primaryColor,
               border: `4px solid ${playmat.borderColor}`,
             }}
@@ -207,39 +368,56 @@ export function PlaymatSelector({ selectedPlaymat, onSelect, className }: Playma
 interface SleevePreviewProps {
   sleeve: CardSleeve;
   className?: string;
-  size?: 'sm' | 'md' | 'lg';
+  size?: "sm" | "md" | "lg";
 }
 
-export function SleevePreview({ sleeve, className, size = 'md' }: SleevePreviewProps) {
+export function SleevePreview({
+  sleeve,
+  className,
+  size = "md",
+}: SleevePreviewProps) {
   const sizeClasses = {
-    sm: 'w-12 h-16',
-    md: 'w-16 h-24',
-    lg: 'w-24 h-36',
+    sm: "w-12 h-16",
+    md: "w-16 h-24",
+    lg: "w-24 h-36",
   };
 
   return (
     <div
       className={cn(
-        'rounded-md overflow-hidden shadow-lg relative',
+        "rounded-md overflow-hidden shadow-lg relative",
         sizeClasses[size],
-        className
+        className,
       )}
       style={{
-        background: sleeve.type === 'custom' && sleeve.customImage
-          ? `url(${sleeve.customImage}) center/cover`
-          : getPatternBackground(sleeve.pattern || 'gradient', sleeve.primaryColor!, sleeve.secondaryColor!),
+        background:
+          sleeve.type === "custom" && sleeve.customImage
+            ? `url(${sleeve.customImage}) center/cover`
+            : getPatternBackground(
+                sleeve.pattern || "gradient",
+                sleeve.primaryColor!,
+                sleeve.secondaryColor!,
+              ),
       }}
     >
       {/* Card back design */}
       <div className="w-full h-full flex items-center justify-center">
-        <div className={cn(
-          'border-2 border-white/30 rounded-sm flex items-center justify-center',
-          size === 'sm' ? 'w-8 h-12' : size === 'md' ? 'w-12 h-20' : 'w-18 h-28'
-        )}>
-          <Sparkles className={cn(
-            'text-white/50',
-            size === 'sm' ? 'w-4 h-4' : size === 'md' ? 'w-6 h-6' : 'w-8 h-8'
-          )} />
+        <div
+          className={cn(
+            "border-2 border-white/30 rounded-sm flex items-center justify-center",
+            size === "sm"
+              ? "w-8 h-12"
+              : size === "md"
+                ? "w-12 h-20"
+                : "w-18 h-28",
+          )}
+        >
+          <Sparkles
+            className={cn(
+              "text-white/50",
+              size === "sm" ? "w-4 h-4" : size === "md" ? "w-6 h-6" : "w-8 h-8",
+            )}
+          />
         </div>
       </div>
     </div>
@@ -256,15 +434,20 @@ export function PlaymatPreview({ playmat, className }: PlaymatPreviewProps) {
   return (
     <div
       className={cn(
-        'w-full aspect-video rounded-lg overflow-hidden shadow-lg relative',
-        className
+        "w-full aspect-video rounded-lg overflow-hidden shadow-lg relative",
+        className,
       )}
       style={{
-        background: playmat.type === 'custom' && playmat.backgroundImage
-          ? `url(${playmat.backgroundImage}) center/cover`
-          : playmat.pattern
-            ? getPatternBackground(playmat.pattern, playmat.primaryColor!, playmat.secondaryColor || playmat.primaryColor!)
-            : playmat.primaryColor,
+        background:
+          playmat.type === "custom" && playmat.backgroundImage
+            ? `url(${playmat.backgroundImage}) center/cover`
+            : playmat.pattern
+              ? getPatternBackground(
+                  playmat.pattern,
+                  playmat.primaryColor!,
+                  playmat.secondaryColor || playmat.primaryColor!,
+                )
+              : playmat.primaryColor,
         border: `8px solid ${playmat.borderColor}`,
       }}
     >
@@ -315,7 +498,9 @@ function PreviewDialog({ settings, trigger }: PreviewDialogProps) {
               <div className="flex-1">
                 <p className="font-medium">{settings.sleeve.name}</p>
                 <p className="text-sm text-muted-foreground">
-                  {settings.sleeve.type === 'custom' ? 'Custom upload' : 'Preset sleeve'}
+                  {settings.sleeve.type === "custom"
+                    ? "Custom upload"
+                    : "Preset sleeve"}
                 </p>
               </div>
             </div>
@@ -325,7 +510,9 @@ function PreviewDialog({ settings, trigger }: PreviewDialogProps) {
           <div className="space-y-2">
             <h4 className="text-sm font-medium">Playmat</h4>
             <PlaymatPreview playmat={settings.playmat} />
-            <p className="text-sm text-muted-foreground">{settings.playmat.name}</p>
+            <p className="text-sm text-muted-foreground">
+              {settings.playmat.name}
+            </p>
           </div>
         </div>
       </DialogContent>
@@ -341,14 +528,15 @@ interface CustomizationPanelProps {
   showPreview?: boolean;
 }
 
-export function CustomizationPanel({ 
-  settings, 
+export function CustomizationPanel({
+  settings,
   onSettingsChange,
   className,
   showPreview = true,
 }: CustomizationPanelProps) {
-  const [customSleeveName, setCustomSleeveName] = useState('');
-  const [pendingSettings, setPendingSettings] = useState<CustomizationSettings>(settings);
+  const [customSleeveName, setCustomSleeveName] = useState("");
+  const [pendingSettings, setPendingSettings] =
+    useState<CustomizationSettings>(settings);
 
   // Sync pending settings with actual settings
   useEffect(() => {
@@ -367,50 +555,60 @@ export function CustomizationPanel({
     onSettingsChange(newSettings);
   };
 
-  const handleImageUpload = useCallback((event: React.ChangeEvent<HTMLInputElement>, type: 'sleeve' | 'playmat') => {
-    const file = event.target.files?.[0];
-    if (file) {
-      // Check file size (limit to 5MB)
-      if (file.size > 5 * 1024 * 1024) {
-        alert('Image size must be less than 5MB');
-        return;
-      }
-
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        const imageData = reader.result as string;
-        if (type === 'sleeve') {
-          const newSettings = {
-            ...pendingSettings,
-            sleeve: {
-              type: 'custom' as SleeveType,
-              name: customSleeveName || 'Custom Sleeve',
-              customImage: imageData,
-              primaryColor: '#6366f1',
-              secondaryColor: '#8b5cf6',
-              pattern: 'gradient' as SleevePattern,
-            },
-          };
-          setPendingSettings(newSettings);
-          onSettingsChange(newSettings);
-        } else {
-          const newSettings = {
-            ...pendingSettings,
-            playmat: {
-              type: 'custom' as PlaymatType,
-              name: 'Custom Playmat',
-              backgroundImage: imageData,
-              primaryColor: '#1f2937',
-              borderColor: '#374151',
-            },
-          };
-          setPendingSettings(newSettings);
-          onSettingsChange(newSettings);
+  const handleImageUpload = useCallback(
+    (
+      event: React.ChangeEvent<HTMLInputElement>,
+      type: "sleeve" | "playmat",
+    ) => {
+      const file = event.target.files?.[0];
+      if (file) {
+        // Check file size (limit to 5MB)
+        if (file.size > 5 * 1024 * 1024) {
+          toast({
+            title: "Image too large",
+            description: "Image size must be less than 5MB.",
+            variant: "destructive",
+          });
+          return;
         }
-      };
-      reader.readAsDataURL(file);
-    }
-  }, [pendingSettings, onSettingsChange, customSleeveName]);
+
+        const reader = new FileReader();
+        reader.onloadend = () => {
+          const imageData = reader.result as string;
+          if (type === "sleeve") {
+            const newSettings = {
+              ...pendingSettings,
+              sleeve: {
+                type: "custom" as SleeveType,
+                name: customSleeveName || "Custom Sleeve",
+                customImage: imageData,
+                primaryColor: "#6366f1",
+                secondaryColor: "#8b5cf6",
+                pattern: "gradient" as SleevePattern,
+              },
+            };
+            setPendingSettings(newSettings);
+            onSettingsChange(newSettings);
+          } else {
+            const newSettings = {
+              ...pendingSettings,
+              playmat: {
+                type: "custom" as PlaymatType,
+                name: "Custom Playmat",
+                backgroundImage: imageData,
+                primaryColor: "#1f2937",
+                borderColor: "#374151",
+              },
+            };
+            setPendingSettings(newSettings);
+            onSettingsChange(newSettings);
+          }
+        };
+        reader.readAsDataURL(file);
+      }
+    },
+    [pendingSettings, onSettingsChange, customSleeveName],
+  );
 
   return (
     <Card className={className}>
@@ -420,24 +618,26 @@ export function CustomizationPanel({
             <Palette className="w-5 h-5" />
             Card Customization
           </CardTitle>
-          {showPreview && (
-            <PreviewDialog settings={pendingSettings} />
-          )}
+          {showPreview && <PreviewDialog settings={pendingSettings} />}
         </div>
       </CardHeader>
       <CardContent>
         <Tabs defaultValue="sleeves" className="w-full">
           <TabsList className="w-full">
-            <TabsTrigger value="sleeves" className="flex-1">Card Sleeves</TabsTrigger>
-            <TabsTrigger value="playmat" className="flex-1">Playmat</TabsTrigger>
+            <TabsTrigger value="sleeves" className="flex-1">
+              Card Sleeves
+            </TabsTrigger>
+            <TabsTrigger value="playmat" className="flex-1">
+              Playmat
+            </TabsTrigger>
           </TabsList>
-          
+
           <TabsContent value="sleeves" className="space-y-4">
             <SleeveSelector
               selectedSleeve={pendingSettings.sleeve}
               onSelect={handleSleeveSelect}
             />
-            
+
             <div className="border-t pt-4">
               <Label className="flex items-center gap-2 mb-2">
                 <Upload className="w-4 h-4" />
@@ -458,22 +658,24 @@ export function CustomizationPanel({
                     type="file"
                     accept="image/*"
                     className="hidden"
-                    onChange={(e) => handleImageUpload(e, 'sleeve')}
+                    onChange={(e) => handleImageUpload(e, "sleeve")}
                   />
                   <Button variant="outline" size="sm" asChild>
-                    <span><Image className="w-4 h-4 mr-1" /> Upload</span>
+                    <span>
+                      <Image className="w-4 h-4 mr-1" /> Upload
+                    </span>
                   </Button>
                 </Label>
               </div>
             </div>
           </TabsContent>
-          
+
           <TabsContent value="playmat" className="space-y-4">
             <PlaymatSelector
               selectedPlaymat={pendingSettings.playmat}
               onSelect={handlePlaymatSelect}
             />
-            
+
             <div className="border-t pt-4">
               <Label className="flex items-center gap-2 mb-2">
                 <Upload className="w-4 h-4" />
@@ -487,10 +689,12 @@ export function CustomizationPanel({
                   type="file"
                   accept="image/*"
                   className="hidden"
-                  onChange={(e) => handleImageUpload(e, 'playmat')}
+                  onChange={(e) => handleImageUpload(e, "playmat")}
                 />
                 <Button variant="outline" size="sm" asChild>
-                  <span><Image className="w-4 h-4 mr-1" /> Upload Image</span>
+                  <span>
+                    <Image className="w-4 h-4 mr-1" /> Upload Image
+                  </span>
                 </Button>
               </Label>
             </div>
@@ -517,8 +721,11 @@ const DEFAULT_SETTINGS: CustomizationSettings = {
   playmat: DEFAULT_PLAYMATS[0],
 };
 
-export function useCustomization({ storageKey = 'planar-nexus-customization' }: UseCustomizationOptions = {}): UseCustomizationReturn {
-  const [settings, setSettings] = useState<CustomizationSettings>(DEFAULT_SETTINGS);
+export function useCustomization({
+  storageKey = "planar-nexus-customization",
+}: UseCustomizationOptions = {}): UseCustomizationReturn {
+  const [settings, setSettings] =
+    useState<CustomizationSettings>(DEFAULT_SETTINGS);
 
   // Load settings from localStorage on mount
   useEffect(() => {
@@ -528,16 +735,19 @@ export function useCustomization({ storageKey = 'planar-nexus-customization' }: 
         const parsed = JSON.parse(stored);
         setSettings({ ...DEFAULT_SETTINGS, ...parsed });
       } catch (e) {
-        console.error('Failed to parse customization settings:', e);
+        console.error("Failed to parse customization settings:", e);
       }
     }
   }, [storageKey]);
 
   // Save settings to localStorage when changed
-  const updateSettings = useCallback((newSettings: CustomizationSettings) => {
-    setSettings(newSettings);
-    localStorage.setItem(storageKey, JSON.stringify(newSettings));
-  }, [storageKey]);
+  const updateSettings = useCallback(
+    (newSettings: CustomizationSettings) => {
+      setSettings(newSettings);
+      localStorage.setItem(storageKey, JSON.stringify(newSettings));
+    },
+    [storageKey],
+  );
 
   const resetToDefaults = useCallback(() => {
     setSettings(DEFAULT_SETTINGS);
@@ -560,7 +770,7 @@ export function CustomizationPage({ className }: CustomizationPageProps) {
   const { settings, updateSettings, resetToDefaults } = useCustomization();
 
   return (
-    <div className={cn('space-y-6', className)}>
+    <div className={cn("space-y-6", className)}>
       <div className="flex items-center justify-between">
         <h2 className="text-2xl font-bold">Customization</h2>
         <Button variant="outline" size="sm" onClick={resetToDefaults}>
@@ -568,7 +778,7 @@ export function CustomizationPage({ className }: CustomizationPageProps) {
           Reset to Defaults
         </Button>
       </div>
-      
+
       <CustomizationPanel
         settings={settings}
         onSettingsChange={updateSettings}

--- a/src/components/custom-card-editor.tsx
+++ b/src/components/custom-card-editor.tsx
@@ -1,32 +1,45 @@
-'use client';
+"use client";
 
-import { useState, useCallback, useEffect } from 'react';
-import { useToast } from '@/hooks/use-toast';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Badge } from '@/components/ui/badge';
-import { Slider } from '@/components/ui/slider';
-import { Switch } from '@/components/ui/switch';
-import { Separator } from '@/components/ui/separator';
-import { 
-  Palette, 
-  Type, 
-  Image as ImageIcon, 
-  Save, 
-  Copy, 
-  Download, 
+import { useState, useCallback, useEffect } from "react";
+import { useToast } from "@/hooks/use-toast";
+import { useConfirmDialog } from "@/hooks/use-confirm-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Badge } from "@/components/ui/badge";
+import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
+import { Separator } from "@/components/ui/separator";
+import {
+  Palette,
+  Type,
+  Image as ImageIcon,
+  Save,
+  Copy,
+  Download,
   Trash2,
   Plus,
   X,
   RotateCcw,
-  Upload
-} from 'lucide-react';
-import { cn } from '@/lib/utils';
+  Upload,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
 import {
   type CustomCardDefinition,
   type CardColor,
@@ -39,11 +52,11 @@ import {
   RARITY_COLORS,
   generateCustomCardId,
   validateCustomCard,
-} from '@/lib/custom-card';
+} from "@/lib/custom-card";
 
 /**
  * Custom Card Editor Component
- * 
+ *
  * WYSIWYG editor for creating and editing custom Magic: The Gathering cards
  * Part of the Custom Card Creation Studio (Issue #593)
  */
@@ -64,35 +77,42 @@ export interface CustomCardEditorProps {
 }
 
 const CARD_TYPES: { value: CustomCardType; label: string; icon: string }[] = [
-  { value: 'creature', label: 'Creature', icon: '🦄' },
-  { value: 'instant', label: 'Instant', icon: '⚡' },
-  { value: 'sorcery', label: 'Sorcery', icon: '🔮' },
-  { value: 'artifact', label: 'Artifact', icon: '⚙️' },
-  { value: 'enchantment', label: 'Enchantment', icon: '✨' },
-  { value: 'planeswalker', label: 'Planeswalker', icon: '🧙' },
-  { value: 'land', label: 'Land', icon: '🏔️' },
+  { value: "creature", label: "Creature", icon: "🦄" },
+  { value: "instant", label: "Instant", icon: "⚡" },
+  { value: "sorcery", label: "Sorcery", icon: "🔮" },
+  { value: "artifact", label: "Artifact", icon: "⚙️" },
+  { value: "enchantment", label: "Enchantment", icon: "✨" },
+  { value: "planeswalker", label: "Planeswalker", icon: "🧙" },
+  { value: "land", label: "Land", icon: "🏔️" },
 ];
 
 const FRAME_STYLES: { value: CardFrameStyle; label: string }[] = [
-  { value: 'modern', label: 'Modern' },
-  { value: 'old', label: 'Old School' },
-  { value: 'future', label: 'Future' },
-  { value: 'classic', label: 'Classic' },
-  { value: 'mirrodin', label: 'Mirrodin' },
-  { value: 'innistrad', label: 'Innistrad' },
-  { value: 'zendikar', label: 'Zendikar' },
-  { value: 'Ixalan', label: 'Ixalan' },
-  { value: 'Strixhaven', label: 'Strixhaven' },
+  { value: "modern", label: "Modern" },
+  { value: "old", label: "Old School" },
+  { value: "future", label: "Future" },
+  { value: "classic", label: "Classic" },
+  { value: "mirrodin", label: "Mirrodin" },
+  { value: "innistrad", label: "Innistrad" },
+  { value: "zendikar", label: "Zendikar" },
+  { value: "Ixalan", label: "Ixalan" },
+  { value: "Strixhaven", label: "Strixhaven" },
 ];
 
 const RARITIES: { value: CardRarity; label: string }[] = [
-  { value: 'common', label: 'Common' },
-  { value: 'uncommon', label: 'Uncommon' },
-  { value: 'rare', label: 'Rare' },
-  { value: 'mythic', label: 'Mythic Rare' },
+  { value: "common", label: "Common" },
+  { value: "uncommon", label: "Uncommon" },
+  { value: "rare", label: "Rare" },
+  { value: "mythic", label: "Mythic Rare" },
 ];
 
-const COLOR_OPTIONS: CardColor[] = ['white', 'blue', 'black', 'red', 'green', 'colorless'];
+const COLOR_OPTIONS: CardColor[] = [
+  "white",
+  "blue",
+  "black",
+  "red",
+  "green",
+  "colorless",
+];
 
 export function CustomCardEditor({
   initialCard,
@@ -103,7 +123,8 @@ export function CustomCardEditor({
   readOnly = false,
 }: CustomCardEditorProps) {
   const { toast } = useToast();
-  
+  const { confirm, confirmDialog } = useConfirmDialog();
+
   // Initialize card state
   const [card, setCard] = useState<CustomCardDefinition>(() => {
     if (initialCard) {
@@ -136,29 +157,32 @@ export function CustomCardEditor({
     setIsModified(false);
     setErrors([]);
     toast({
-      title: 'Card Reset',
-      description: 'Card has been reset to its original state.',
+      title: "Card Reset",
+      description: "Card has been reset to its original state.",
     });
   }, [initialCard, toast]);
 
   // Update a specific field
-  const updateField = useCallback(<K extends keyof CustomCardDefinition>(
-    field: K,
-    value: CustomCardDefinition[K]
-  ) => {
-    setCard(prev => ({
-      ...prev,
-      [field]: value,
-      updatedAt: Date.now(),
-    }));
-    setIsModified(true);
-  }, []);
+  const updateField = useCallback(
+    <K extends keyof CustomCardDefinition>(
+      field: K,
+      value: CustomCardDefinition[K],
+    ) => {
+      setCard((prev) => ({
+        ...prev,
+        [field]: value,
+        updatedAt: Date.now(),
+      }));
+      setIsModified(true);
+    },
+    [],
+  );
 
   // Toggle a card type
   const toggleCardType = useCallback((type: CustomCardType) => {
-    setCard(prev => {
+    setCard((prev) => {
       const types = prev.cardTypes.includes(type)
-        ? prev.cardTypes.filter(t => t !== type)
+        ? prev.cardTypes.filter((t) => t !== type)
         : [...prev.cardTypes, type];
       return { ...prev, cardTypes: types, updatedAt: Date.now() };
     });
@@ -167,9 +191,9 @@ export function CustomCardEditor({
 
   // Toggle a color
   const toggleColor = useCallback((color: CardColor) => {
-    setCard(prev => {
+    setCard((prev) => {
       const colors = prev.colors.includes(color)
-        ? prev.colors.filter(c => c !== color)
+        ? prev.colors.filter((c) => c !== color)
         : [...prev.colors, color];
       return { ...prev, colors, updatedAt: Date.now() };
     });
@@ -182,19 +206,19 @@ export function CustomCardEditor({
     if (validationErrors.length > 0) {
       setErrors(validationErrors);
       toast({
-        variant: 'destructive',
-        title: 'Validation Failed',
-        description: validationErrors.join(', '),
+        variant: "destructive",
+        title: "Validation Failed",
+        description: validationErrors.join(", "),
       });
       return;
     }
-    
+
     onSave?.(card);
     setIsModified(false);
     setErrors([]);
     toast({
-      title: 'Card Saved',
-      description: 'Your custom card has been saved.',
+      title: "Card Saved",
+      description: "Your custom card has been saved.",
     });
   }, [card, onSave, toast]);
 
@@ -202,35 +226,41 @@ export function CustomCardEditor({
   const handleDelete = useCallback(() => {
     onDelete?.(card.id);
     toast({
-      title: 'Card Deleted',
-      description: 'Your custom card has been deleted.',
+      title: "Card Deleted",
+      description: "Your custom card has been deleted.",
     });
   }, [card.id, onDelete, toast]);
 
   // Handle export as JSON
   const handleExport = useCallback(() => {
     const json = JSON.stringify(card, null, 2);
-    const blob = new Blob([json], { type: 'application/json' });
+    const blob = new Blob([json], { type: "application/json" });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
+    const a = document.createElement("a");
     a.href = url;
-    a.download = `${card.name || 'custom-card'}.json`;
+    a.download = `${card.name || "custom-card"}.json`;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
-    
+
     onExport?.(card);
     toast({
-      title: 'Card Exported',
-      description: 'Card has been exported as JSON.',
+      title: "Card Exported",
+      description: "Card has been exported as JSON.",
     });
   }, [card, onExport, toast]);
 
   // Handle new card
-  const handleCreateNew = useCallback(() => {
+  const handleCreateNew = useCallback(async () => {
     if (isModified) {
-      if (!confirm('You have unsaved changes. Create a new card anyway?')) {
+      const confirmed = await confirm({
+        title: "Unsaved changes",
+        description: "You have unsaved changes. Create a new card anyway?",
+        confirmLabel: "Create New",
+        destructive: true,
+      });
+      if (!confirmed) {
         return;
       }
     }
@@ -243,32 +273,33 @@ export function CustomCardEditor({
     } as CustomCardDefinition);
     setIsModified(false);
     setErrors([]);
-  }, [isModified, onCreateNew]);
+  }, [isModified, onCreateNew, confirm]);
 
   // Update type line based on card types
   useEffect(() => {
     if (card.cardTypes.length > 0) {
       const typeLabels: Record<CustomCardType, string> = {
-        creature: 'Creature',
-        instant: 'Instant',
-        sorcery: 'Sorcery',
-        artifact: 'Artifact',
-        enchantment: 'Enchantment',
-        planeswalker: 'Planeswalker',
-        land: 'Land',
-        legendary: 'Legendary',
-        token: 'Token',
+        creature: "Creature",
+        instant: "Instant",
+        sorcery: "Sorcery",
+        artifact: "Artifact",
+        enchantment: "Enchantment",
+        planeswalker: "Planeswalker",
+        land: "Land",
+        legendary: "Legendary",
+        token: "Token",
       };
-      
-      const mainType = card.cardTypes.map(t => typeLabels[t]).join(' — ');
-      if (!card.typeLine.includes('—')) {
-        updateField('typeLine', mainType);
+
+      const mainType = card.cardTypes.map((t) => typeLabels[t]).join(" — ");
+      if (!card.typeLine.includes("—")) {
+        updateField("typeLine", mainType);
       }
     }
   }, [card.cardTypes]);
 
   return (
     <div className="flex flex-col lg:flex-row gap-6">
+      {confirmDialog}
       {/* Editor Panel */}
       <div className="flex-1 space-y-4">
         {/* Header Actions */}
@@ -282,11 +313,21 @@ export function CustomCardEditor({
             )}
           </div>
           <div className="flex items-center gap-2">
-            <Button variant="outline" size="sm" onClick={handleReset} disabled={readOnly}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleReset}
+              disabled={readOnly}
+            >
               <RotateCcw className="w-4 h-4 mr-2" />
               Reset
             </Button>
-            <Button variant="outline" size="sm" onClick={handleCreateNew} disabled={readOnly}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleCreateNew}
+              disabled={readOnly}
+            >
               <Plus className="w-4 h-4 mr-2" />
               New
             </Button>
@@ -305,7 +346,9 @@ export function CustomCardEditor({
         {errors.length > 0 && (
           <Card className="border-destructive">
             <CardHeader className="py-2">
-              <CardTitle className="text-destructive text-sm">Validation Errors</CardTitle>
+              <CardTitle className="text-destructive text-sm">
+                Validation Errors
+              </CardTitle>
             </CardHeader>
             <CardContent>
               <ul className="list-disc list-inside text-sm text-destructive">
@@ -334,9 +377,7 @@ export function CustomCardEditor({
                   <Type className="w-4 h-4" />
                   Basic Information
                 </CardTitle>
-                <CardDescription>
-                  Core card properties
-                </CardDescription>
+                <CardDescription>Core card properties</CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="grid gap-2">
@@ -344,7 +385,7 @@ export function CustomCardEditor({
                   <Input
                     id="cardName"
                     value={card.name}
-                    onChange={(e) => updateField('name', e.target.value)}
+                    onChange={(e) => updateField("name", e.target.value)}
                     placeholder="Enter card name"
                     disabled={readOnly}
                   />
@@ -355,7 +396,7 @@ export function CustomCardEditor({
                   <Input
                     id="manaCost"
                     value={card.manaCost}
-                    onChange={(e) => updateField('manaCost', e.target.value)}
+                    onChange={(e) => updateField("manaCost", e.target.value)}
                     placeholder="{1}{W}{U} or 2UU"
                     disabled={readOnly}
                   />
@@ -369,7 +410,7 @@ export function CustomCardEditor({
                   <Input
                     id="typeLine"
                     value={card.typeLine}
-                    onChange={(e) => updateField('typeLine', e.target.value)}
+                    onChange={(e) => updateField("typeLine", e.target.value)}
                     placeholder="Creature — Human Soldier"
                     disabled={readOnly}
                   />
@@ -381,18 +422,25 @@ export function CustomCardEditor({
                     {COLOR_OPTIONS.map((color) => (
                       <Button
                         key={color}
-                        variant={card.colors.includes(color) ? 'default' : 'outline'}
+                        variant={
+                          card.colors.includes(color) ? "default" : "outline"
+                        }
                         size="sm"
                         className={cn(
-                          'gap-2',
-                          card.colors.includes(color) && 
-                          `bg-[${CARD_COLORS[color].hex}] hover:bg-[${CARD_COLORS[color].hex}]/90`
+                          "gap-2",
+                          card.colors.includes(color) &&
+                            `bg-[${CARD_COLORS[color].hex}] hover:bg-[${CARD_COLORS[color].hex}]/90`,
                         )}
                         onClick={() => toggleColor(color)}
                         disabled={readOnly}
                         style={{
-                          backgroundColor: card.colors.includes(color) ? CARD_COLORS[color].hex : undefined,
-                          color: color === 'white' || color === 'colorless' ? '#000' : '#fff',
+                          backgroundColor: card.colors.includes(color)
+                            ? CARD_COLORS[color].hex
+                            : undefined,
+                          color:
+                            color === "white" || color === "colorless"
+                              ? "#000"
+                              : "#fff",
                         }}
                       >
                         <span className="w-4 h-4 rounded-full border border-current flex items-center justify-center">
@@ -408,7 +456,9 @@ export function CustomCardEditor({
                   <Label htmlFor="rarity">Rarity</Label>
                   <Select
                     value={card.rarity}
-                    onValueChange={(value) => updateField('rarity', value as CardRarity)}
+                    onValueChange={(value) =>
+                      updateField("rarity", value as CardRarity)
+                    }
                     disabled={readOnly}
                   >
                     <SelectTrigger>
@@ -418,7 +468,11 @@ export function CustomCardEditor({
                       {RARITIES.map((rarity) => (
                         <SelectItem key={rarity.value} value={rarity.value}>
                           <span className="flex items-center gap-2">
-                            <span style={{ color: RARITY_COLORS[rarity.value] }}>●</span>
+                            <span
+                              style={{ color: RARITY_COLORS[rarity.value] }}
+                            >
+                              ●
+                            </span>
                             {rarity.label}
                           </span>
                         </SelectItem>
@@ -438,16 +492,18 @@ export function CustomCardEditor({
                   <Type className="w-4 h-4" />
                   Card Types
                 </CardTitle>
-                <CardDescription>
-                  Select one or more card types
-                </CardDescription>
+                <CardDescription>Select one or more card types</CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
                   {CARD_TYPES.map((type) => (
                     <Button
                       key={type.value}
-                      variant={card.cardTypes.includes(type.value) ? 'default' : 'outline'}
+                      variant={
+                        card.cardTypes.includes(type.value)
+                          ? "default"
+                          : "outline"
+                      }
                       className="justify-start gap-2"
                       onClick={() => toggleCardType(type.value)}
                       disabled={readOnly}
@@ -464,22 +520,27 @@ export function CustomCardEditor({
                   <Label htmlFor="subtypes">Subtypes</Label>
                   <Input
                     id="subtypes"
-                    value={card.subtypes?.join(' ') || ''}
-                    onChange={(e) => updateField('subtypes', e.target.value.split(' ').filter(Boolean))}
+                    value={card.subtypes?.join(" ") || ""}
+                    onChange={(e) =>
+                      updateField(
+                        "subtypes",
+                        e.target.value.split(" ").filter(Boolean),
+                      )
+                    }
                     placeholder="Human Soldier (space separated)"
                     disabled={readOnly}
                   />
                 </div>
 
                 {/* Power/Toughness for creatures */}
-                {card.cardTypes.includes('creature') && (
+                {card.cardTypes.includes("creature") && (
                   <div className="grid grid-cols-2 gap-4">
                     <div className="grid gap-2">
                       <Label htmlFor="power">Power</Label>
                       <Input
                         id="power"
                         value={card.power}
-                        onChange={(e) => updateField('power', e.target.value)}
+                        onChange={(e) => updateField("power", e.target.value)}
                         placeholder="1"
                         disabled={readOnly}
                       />
@@ -489,7 +550,9 @@ export function CustomCardEditor({
                       <Input
                         id="toughness"
                         value={card.toughness}
-                        onChange={(e) => updateField('toughness', e.target.value)}
+                        onChange={(e) =>
+                          updateField("toughness", e.target.value)
+                        }
                         placeholder="1"
                         disabled={readOnly}
                       />
@@ -498,13 +561,13 @@ export function CustomCardEditor({
                 )}
 
                 {/* Loyalty for planeswalkers */}
-                {card.cardTypes.includes('planeswalker') && (
+                {card.cardTypes.includes("planeswalker") && (
                   <div className="grid gap-2">
                     <Label htmlFor="loyalty">Starting Loyalty</Label>
                     <Input
                       id="loyalty"
                       value={card.loyalty}
-                      onChange={(e) => updateField('loyalty', e.target.value)}
+                      onChange={(e) => updateField("loyalty", e.target.value)}
                       placeholder="3"
                       disabled={readOnly}
                     />
@@ -532,13 +595,14 @@ export function CustomCardEditor({
                   <Textarea
                     id="oracleText"
                     value={card.oracleText}
-                    onChange={(e) => updateField('oracleText', e.target.value)}
+                    onChange={(e) => updateField("oracleText", e.target.value)}
                     placeholder="Enter card abilities and rules text..."
                     rows={6}
                     disabled={readOnly}
                   />
                   <p className="text-xs text-muted-foreground">
-                    Use Enter for new lines. {'{T}'} for tap, {'{Q}'} for untap, etc.
+                    Use Enter for new lines. {"{T}"} for tap, {"{Q}"} for untap,
+                    etc.
                   </p>
                 </div>
 
@@ -547,7 +611,7 @@ export function CustomCardEditor({
                   <Textarea
                     id="flavorText"
                     value={card.flavorText}
-                    onChange={(e) => updateField('flavorText', e.target.value)}
+                    onChange={(e) => updateField("flavorText", e.target.value)}
                     placeholder="Enter flavor text (optional)..."
                     rows={3}
                     disabled={readOnly}
@@ -574,7 +638,9 @@ export function CustomCardEditor({
                   <Label htmlFor="frameStyle">Frame Style</Label>
                   <Select
                     value={card.frameStyle}
-                    onValueChange={(value) => updateField('frameStyle', value as CardFrameStyle)}
+                    onValueChange={(value) =>
+                      updateField("frameStyle", value as CardFrameStyle)
+                    }
                     disabled={readOnly}
                   >
                     <SelectTrigger>
@@ -597,8 +663,13 @@ export function CustomCardEditor({
                   <div className="flex gap-2">
                     <Input
                       id="artUrl"
-                      value={card.art.imageUrl || ''}
-                      onChange={(e) => updateField('art', { ...card.art, imageUrl: e.target.value })}
+                      value={card.art.imageUrl || ""}
+                      onChange={(e) =>
+                        updateField("art", {
+                          ...card.art,
+                          imageUrl: e.target.value,
+                        })
+                      }
                       placeholder="https://example.com/art.jpg"
                       disabled={readOnly}
                     />
@@ -606,7 +677,12 @@ export function CustomCardEditor({
                       <Button
                         variant="outline"
                         size="icon"
-                        onClick={() => updateField('art', { ...card.art, imageUrl: undefined })}
+                        onClick={() =>
+                          updateField("art", {
+                            ...card.art,
+                            imageUrl: undefined,
+                          })
+                        }
                         disabled={readOnly}
                       >
                         <X className="w-4 h-4" />
@@ -618,22 +694,35 @@ export function CustomCardEditor({
                 <div className="grid gap-2">
                   <Label>Procedural Art Colors</Label>
                   <div className="flex flex-wrap gap-2">
-                    {(['white', 'blue', 'black', 'red', 'green'] as CardColor[]).map((color) => (
+                    {(
+                      ["white", "blue", "black", "red", "green"] as CardColor[]
+                    ).map((color) => (
                       <Button
                         key={color}
-                        variant={card.art.proceduralColors?.includes(color) ? 'default' : 'outline'}
+                        variant={
+                          card.art.proceduralColors?.includes(color)
+                            ? "default"
+                            : "outline"
+                        }
                         size="sm"
                         onClick={() => {
                           const colors = card.art.proceduralColors || [];
                           const newColors = colors.includes(color)
-                            ? colors.filter(c => c !== color)
+                            ? colors.filter((c) => c !== color)
                             : [...colors, color];
-                          updateField('art', { ...card.art, proceduralColors: newColors });
+                          updateField("art", {
+                            ...card.art,
+                            proceduralColors: newColors,
+                          });
                         }}
                         disabled={readOnly}
                         style={{
-                          backgroundColor: card.art.proceduralColors?.includes(color) ? CARD_COLORS[color].hex : undefined,
-                          color: color === 'white' ? '#000' : '#fff',
+                          backgroundColor: card.art.proceduralColors?.includes(
+                            color,
+                          )
+                            ? CARD_COLORS[color].hex
+                            : undefined,
+                          color: color === "white" ? "#000" : "#fff",
                         }}
                       >
                         {CARD_COLORS[color].name}
@@ -648,7 +737,7 @@ export function CustomCardEditor({
                   <Label>Artist Credit</Label>
                   <Input
                     value={card.artist}
-                    onChange={(e) => updateField('artist', e.target.value)}
+                    onChange={(e) => updateField("artist", e.target.value)}
                     placeholder="Artist Name"
                     disabled={readOnly}
                   />
@@ -658,7 +747,7 @@ export function CustomCardEditor({
                   <Label>Copyright</Label>
                   <Input
                     value={card.copyright}
-                    onChange={(e) => updateField('copyright', e.target.value)}
+                    onChange={(e) => updateField("copyright", e.target.value)}
                     placeholder="© 2024 Custom Cards"
                     disabled={readOnly}
                   />
@@ -686,7 +775,9 @@ export function CustomCardEditor({
                     <Input
                       id="setCode"
                       value={card.setCode}
-                      onChange={(e) => updateField('setCode', e.target.value.toUpperCase())}
+                      onChange={(e) =>
+                        updateField("setCode", e.target.value.toUpperCase())
+                      }
                       placeholder="CUS"
                       maxLength={3}
                       disabled={readOnly}
@@ -697,7 +788,9 @@ export function CustomCardEditor({
                     <Input
                       id="collectorNumber"
                       value={card.collectorNumber}
-                      onChange={(e) => updateField('collectorNumber', e.target.value)}
+                      onChange={(e) =>
+                        updateField("collectorNumber", e.target.value)
+                      }
                       placeholder="001"
                       disabled={readOnly}
                     />
@@ -709,7 +802,7 @@ export function CustomCardEditor({
                   <Input
                     id="setName"
                     value={card.setName}
-                    onChange={(e) => updateField('setName', e.target.value)}
+                    onChange={(e) => updateField("setName", e.target.value)}
                     placeholder="Custom"
                     disabled={readOnly}
                   />
@@ -739,9 +832,7 @@ export function CustomCardEditor({
         <Card className="sticky top-4">
           <CardHeader>
             <CardTitle>Card Preview</CardTitle>
-            <CardDescription>
-              Live preview of your card
-            </CardDescription>
+            <CardDescription>Live preview of your card</CardDescription>
           </CardHeader>
           <CardContent className="flex justify-center">
             {/* Import dynamically to avoid SSR issues */}
@@ -758,16 +849,17 @@ export function CustomCardEditor({
 
 // Preview renderer component (dynamically loaded)
 function PreviewRenderer({ card }: { card: CustomCardDefinition }) {
-  const [CustomCardPreview, setCustomCardPreview] = useState<React.ComponentType<{
-    card: CustomCardDefinition;
-    scale?: number;
-    interactive?: boolean;
-    className?: string;
-    showBack?: boolean;
-  }> | null>(null);
+  const [CustomCardPreview, setCustomCardPreview] =
+    useState<React.ComponentType<{
+      card: CustomCardDefinition;
+      scale?: number;
+      interactive?: boolean;
+      className?: string;
+      showBack?: boolean;
+    }> | null>(null);
 
   useEffect(() => {
-    import('@/components/custom-card-preview').then((module) => {
+    import("@/components/custom-card-preview").then((module) => {
       setCustomCardPreview(() => module.CustomCardPreview);
     });
   }, []);

--- a/src/components/storage-backup-manager.tsx
+++ b/src/components/storage-backup-manager.tsx
@@ -50,6 +50,7 @@ import {
   validateBackupFile,
   getBackupMetadata,
 } from "@/hooks/use-storage-backup";
+import { toast } from "@/hooks/use-toast";
 
 /**
  * Storage Backup Manager Component
@@ -93,7 +94,11 @@ export function StorageBackupManager() {
 
     const isValid = await validateBackupFile(importFile);
     if (!isValid) {
-      alert("Invalid backup file. Please select a valid Planar Nexus backup.");
+      toast({
+        title: "Invalid backup file",
+        description: "Please select a valid Planar Nexus backup.",
+        variant: "destructive",
+      });
       return;
     }
 

--- a/src/hooks/use-confirm-dialog.tsx
+++ b/src/hooks/use-confirm-dialog.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export interface ConfirmDialogOptions {
+  title: string;
+  description?: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+}
+
+/**
+ * Promise-returning confirm dialog built on the accessible AlertDialog
+ * primitive. Replaces native blocking `window.confirm()` (issue #1100).
+ *
+ * @example
+ * const { confirm, confirmDialog } = useConfirmDialog();
+ * async function handleDelete() {
+ *   if (await confirm({ title: "Delete?", destructive: true })) {
+ *     doDelete();
+ *   }
+ * }
+ * // render the dialog once inside the component's JSX:
+ * return <div>{confirmDialog}</div>;
+ */
+export function useConfirmDialog() {
+  const [open, setOpen] = React.useState(false);
+  const [options, setOptions] = React.useState<ConfirmDialogOptions | null>(
+    null,
+  );
+  const resolverRef = React.useRef<((value: boolean) => void) | null>(null);
+
+  const confirm = React.useCallback(
+    (opts: ConfirmDialogOptions): Promise<boolean> => {
+      setOptions(opts);
+      setOpen(true);
+      return new Promise<boolean>((resolve) => {
+        resolverRef.current = resolve;
+      });
+    },
+    [],
+  );
+
+  const settle = React.useCallback((value: boolean) => {
+    const resolver = resolverRef.current;
+    resolverRef.current = null;
+    setOpen(false);
+    if (resolver) resolver(value);
+  }, []);
+
+  const handleOpenChange = React.useCallback(
+    (next: boolean) => {
+      if (!next) settle(false);
+    },
+    [settle],
+  );
+
+  const confirmDialog = (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{options?.title}</AlertDialogTitle>
+          {options?.description ? (
+            <AlertDialogDescription>
+              {options.description}
+            </AlertDialogDescription>
+          ) : null}
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={() => settle(false)}>
+            {options?.cancelLabel ?? "Cancel"}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            className={cn(
+              options?.destructive &&
+                buttonVariants({ variant: "destructive" }),
+            )}
+            onClick={() => settle(true)}
+          >
+            {options?.confirmLabel ?? "Confirm"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+
+  return { confirm, confirmDialog };
+}


### PR DESCRIPTION
## Summary

Resolves #1100 — finishes removing native blocking `alert()` / `confirm()` / `prompt()` calls from production source, replacing them with the repo's accessible primitives.

Native browser dialogs are blocking, inconsistent across browsers, and inaccessible (not screen-reader friendly, trap focus, can't be styled). This PR replaces every remaining native call site with:
- **`AlertDialog`** (accessible modal) for confirm-style decisions, via a new promise-returning helper so call sites keep their original control flow (`if (await confirm(...))`).
- **`toast`** for transient `alert()`-style notifications.

## What changed

### New shared primitive
- **`src/hooks/use-confirm-dialog.tsx`** — `useConfirmDialog()` hook built on the existing `AlertDialog` primitives. Returns `{ confirm, confirmDialog }` where `confirm(opts) => Promise<boolean>` and `confirmDialog` is rendered once in the component's JSX. Supports `title`, `description`, `confirmLabel`, `cancelLabel`, and `destructive` styling. Replaces native synchronous `confirm()` while preserving the same `if (...){ ... }` control flow via async/await.

### Native call sites replaced (9 calls)

| File | Native call | Replacement |
|---|---|---|
| `src/components/storage-backup-manager.tsx` | `alert("Invalid backup file...")` | `toast({ variant: "destructive" })` |
| `src/components/card-sleeve.tsx` | `alert('Image size must be less than 5MB')` | `toast({ variant: "destructive" })` |
| `src/components/custom-card-editor.tsx` | `confirm('You have unsaved changes...')` | `useConfirmDialog` (AlertDialog) |
| `src/app/(app)/game-history/page.tsx` | `confirm('...clear all game history?...')` | `useConfirmDialog` (AlertDialog, destructive) |
| `src/app/(app)/database-management/page.tsx` | `confirm('...clear the entire card database?...')` | `useConfirmDialog` (AlertDialog, destructive) |
| `src/app/(app)/sideboards/page.tsx` | `confirm(\`Delete "${plan.name}"?...\`)` | `useConfirmDialog` (AlertDialog, destructive) |
| `src/app/(app)/multiplayer/host/page.tsx` | `confirm('...close the lobby?...')` | `useConfirmDialog` (AlertDialog, destructive) |
| `src/app/(app)/multiplayer/host/page.tsx` | `confirm('...want to leave?...')` | `useConfirmDialog` (AlertDialog, destructive) |
| `src/app/(app)/game/[id]/page.tsx` | `confirm("Are you sure you want to concede?")` | `useConfirmDialog` (AlertDialog, destructive) |

### Deliberately NOT changed
- `src/components/service-worker-registration.tsx` — the `prompt()` references here are the **PWA `BeforeInstallPromptEvent` API** (`deferredPrompt.prompt()` + its type declaration `prompt(): Promise<void>`), **not** native `window.prompt()`. They are method calls on the deferred-install event, unrelated to native dialogs. The SW telemetry wiring (`initTelemetry` / `captureError`) is preserved untouched.

## Behavior preservation
- Each confirm site keeps its exact original control flow: native `if (confirm(msg)) { action }` becomes `if (await confirm({ title, description, destructive })) { action }`. Handlers were made `async` where needed.
- Alert→toast sites convey the same information (now with `destructive` variant for errors).
- Cancel/Esc/overlay-click all resolve `false`, matching the old `confirm()` returning `false`.

## Verification
- ✅ `grep` confirms **zero** native `window.alert`/`window.confirm`/`window.prompt` calls remain in `src/`. Remaining `confirm(`/`prompt(` matches are the hook's local `confirm` binding, the PWA install API method call, and JSDoc text.
- ✅ `npx tsc --noEmit` — 0 errors
- ✅ `npm run lint` — 0 errors (672 pre-existing warnings, none in changed files, under the `--max-warnings 1000` cap)
- ✅ `npm test` — 241 suites / 4578 tests pass, 0 failures

Resolves #1100
