### PR TITLE
test(coverage): resolve #1099 — add ratcheting coverage-threshold script toward 70%

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -30,12 +30,12 @@ pipeline, and how coverage is measured and enforced.
 
 ## 1. Testing Stack
 
-| Layer            | Tool                                            | Config                  |
-| ---------------- | ----------------------------------------------- | ----------------------- |
-| Unit / component | [Jest](https://jestjs.io/) + `ts-jest`          | `jest.config.js`        |
-| DOM assertions   | [React Testing Library](https://testing-library.com/) | `jest.setup.js`  |
-| API mocking      | [MSW](https://mswjs.io/) (Mock Service Worker)  | `src/test-utils/msw/`   |
-| E2E              | [Playwright](https://playwright.dev/)           | `playwright.config.ts`  |
+| Layer            | Tool                                                  | Config                 |
+| ---------------- | ----------------------------------------------------- | ---------------------- |
+| Unit / component | [Jest](https://jestjs.io/) + `ts-jest`                | `jest.config.js`       |
+| DOM assertions   | [React Testing Library](https://testing-library.com/) | `jest.setup.js`        |
+| API mocking      | [MSW](https://mswjs.io/) (Mock Service Worker)        | `src/test-utils/msw/`  |
+| E2E              | [Playwright](https://playwright.dev/)                 | `playwright.config.ts` |
 
 The Jest test environment is `jsdom` (see `jest.config.js`). Path alias `@/*`
 maps to `src/*`, matching `tsconfig.json`.
@@ -115,11 +115,11 @@ planar-nexus/
 
 ### Naming
 
-| Type         | Pattern                 | Location            |
-| ------------ | ----------------------- | ------------------- |
-| Unit         | `*.test.ts` / `.test.tsx` | co-located `__tests__/` |
-| Integration  | `*.integration.test.ts` | `tests/`            |
-| E2E          | `*.spec.ts`             | `e2e/`              |
+| Type        | Pattern                   | Location                |
+| ----------- | ------------------------- | ----------------------- |
+| Unit        | `*.test.ts` / `.test.tsx` | co-located `__tests__/` |
+| Integration | `*.integration.test.ts`   | `tests/`                |
+| E2E         | `*.spec.ts`               | `e2e/`                  |
 
 ---
 
@@ -130,26 +130,26 @@ then by function.
 
 ```typescript
 // src/ai/__tests__/archetype-detector.test.ts
-import { detectArchetype } from '../archetype-detector';
+import { detectArchetype } from "../archetype-detector";
 
-describe('detectArchetype', () => {
-  it('should detect the Burn archetype', () => {
+describe("detectArchetype", () => {
+  it("should detect the Burn archetype", () => {
     // Arrange
     const deck = [
-      { name: 'Lightning Bolt', count: 4 },
-      { name: 'Goblin Guide', count: 4 },
+      { name: "Lightning Bolt", count: 4 },
+      { name: "Goblin Guide", count: 4 },
     ];
 
     // Act
     const result = detectArchetype(deck);
 
     // Assert
-    expect(result.primary).toBe('Burn');
+    expect(result.primary).toBe("Burn");
     expect(result.confidence).toBeGreaterThan(0.7);
   });
 
-  it('should throw on an empty deck', () => {
-    expect(() => detectArchetype([])).toThrow('empty');
+  it("should throw on an empty deck", () => {
+    expect(() => detectArchetype([])).toThrow("empty");
   });
 });
 ```
@@ -159,8 +159,8 @@ describe('detectArchetype', () => {
 The project uses Jest, so prefer `jest.mock` / `jest.fn` (not vitest's `vi`):
 
 ```typescript
-jest.mock('@/lib/card-database', () => ({
-  getCard: jest.fn().mockResolvedValue({ name: 'Lightning Bolt' }),
+jest.mock("@/lib/card-database", () => ({
+  getCard: jest.fn().mockResolvedValue({ name: "Lightning Bolt" }),
 }));
 ```
 
@@ -170,10 +170,10 @@ jest.mock('@/lib/card-database', () => ({
 `sessionStorage` use the reusable mocks from `@/test-utils`:
 
 ```typescript
-import { mockLocalStorage } from '@/test-utils';
+import { mockLocalStorage } from "@/test-utils";
 
 beforeEach(() => {
-  mockLocalStorage({ theme: 'dark' });
+  mockLocalStorage({ theme: "dark" });
 });
 ```
 
@@ -224,11 +224,11 @@ They use **MSW** to intercept network calls instead of hitting real APIs.
 
 ```typescript
 // tests/deck-construction.integration.test.ts
-import { createMockDeck } from '@/test-utils/integration';
+import { createMockDeck } from "@/test-utils/integration";
 
-describe('Deck construction flow', () => {
-  it('builds and validates a deck end-to-end', async () => {
-    const deck = createMockDeck({ name: 'Burn' });
+describe("Deck construction flow", () => {
+  it("builds and validates a deck end-to-end", async () => {
+    const deck = createMockDeck({ name: "Burn" });
     // ... drive the real code paths, assert on the resulting deck
   });
 });
@@ -237,11 +237,11 @@ describe('Deck construction flow', () => {
 MSW setup (server handlers in `src/test-utils/msw/`):
 
 ```typescript
-import { createServer } from '@/test-utils/msw/server';
-import { http, HttpResponse } from 'msw';
+import { createServer } from "@/test-utils/msw/server";
+import { http, HttpResponse } from "msw";
 
 const server = createServer(
-  http.get('/api/cards/search', () => HttpResponse.json({ data: [] })),
+  http.get("/api/cards/search", () => HttpResponse.json({ data: [] })),
 );
 
 beforeAll(() => server.listen());
@@ -259,15 +259,15 @@ automatically (`webServer` config), so you do not need to start it manually.
 
 ```typescript
 // e2e/deck-builder.spec.ts
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test('complete deck building flow', async ({ page }) => {
-  await page.goto('/deck-builder');
+test("complete deck building flow", async ({ page }) => {
+  await page.goto("/deck-builder");
 
-  await page.fill('[data-testid="card-search"]', 'Lightning');
+  await page.fill('[data-testid="card-search"]', "Lightning");
   await page.click('[data-testid="add-card"]:first-child');
 
-  await expect(page.locator('.deck-list')).toContainText('Lightning');
+  await expect(page.locator(".deck-list")).toContainText("Lightning");
 });
 ```
 
@@ -299,10 +299,10 @@ import {
   createGameState,
   createCombatState,
   createMulliganState,
-} from '@/test-utils';
+} from "@/test-utils";
 
-const bolt = createCard({ name: 'Lightning Bolt' });
-const deck = createDeck({ name: 'Burn', cards: [bolt] });
+const bolt = createCard({ name: "Lightning Bolt" });
+const deck = createDeck({ name: "Burn", cards: [bolt] });
 const state = createGameState({ players: 2 });
 ```
 
@@ -310,7 +310,7 @@ For integration tests, the convenience wrappers live in
 `@/test-utils/integration`:
 
 ```typescript
-import { createMockDeck, createMockCard } from '@/test-utils/integration';
+import { createMockDeck, createMockCard } from "@/test-utils/integration";
 ```
 
 ### Helpers
@@ -413,19 +413,20 @@ npm test -- --testPathPattern=video-derived --coverage
 
 ### Target vs. enforced floor
 
-| Metric      | Project target | CI-enforced floor (`jest.config.js`) |
-| ----------- | -------------- | ------------------------------------ |
-| Lines       | **70%**        | 29%                                  |
-| Functions   | **70%**        | 23%                                  |
-| Statements  | **70%**        | 29%                                  |
-| Branches    | **60%**        | 22%                                  |
+| Metric     | Project target | CI-enforced floor (`jest.config.js`) |
+| ---------- | -------------- | ------------------------------------ |
+| Lines      | **70%**        | 29%                                  |
+| Functions  | **70%**        | 23%                                  |
+| Statements | **70%**        | 29%                                  |
+| Branches   | **60%**        | 22%                                  |
 
 - The **target** is 70% across all metrics (60% for branches). This is the
   documented project goal and is referenced from `README.md`,
   `docs/CONTRIBUTING.md`, and `jest.config.js`.
-- The **CI-enforced floor** is set *just below currently-measured coverage* so
+- The **CI-enforced floor** is set _just below currently-measured coverage_ so
   the gate catches real regressions without being flaky. It is raised toward
-  the 70% target as coverage improves (tracked via issue #922).
+  the 70% target as coverage improves (tracked via issue #922) — automatically,
+  via the [ratchet script](#ratcheting-the-coverage-floor) (issue #1099).
 
 > **Do not** raise a threshold above currently-measured coverage or CI will
 > fail. Always re-measure with `npm run test:coverage` before adjusting
@@ -458,20 +459,56 @@ Outputs:
 The video-derived workflow additionally writes `coverage-final.json` and posts
 a coverage delta comment on pull requests.
 
+### Ratcheting the coverage floor
+
+Coverage gains are locked in by [`scripts/ratchet-coverage.js`](../scripts/ratchet-coverage.js),
+which raises the `coverageThreshold.global` block in `jest.config.js` toward
+the currently measured coverage (minus a small safety margin) so the floor can
+move up but never silently decay.
+
+```bash
+# Measure coverage, then ratchet the floor up to the measured value:
+npm run test:coverage:ratchet
+
+# Preview the change without writing jest.config.js:
+npm run test:coverage && node scripts/ratchet-coverage.js --dry-run
+```
+
+How it works:
+
+- Reads `coverage/coverage-summary.json` (emitted by the `json-summary`
+  reporter in `coverageReporters`).
+- For each metric, computes `floor = max(current, floor(measured - margin))`.
+  The default `margin` is **1** percentage point; override it with
+  `--margin <n>` or the `RATCHET_MARGIN` env var. The ratchet is **monotonic** —
+  a floor is never lowered, even when the margin would dip below the current
+  value.
+- **Regression guard:** if any measured metric falls _below_ the current floor,
+  the script exits non-zero (CI fails) and leaves `jest.config.js` untouched.
+- **Idempotent:** running it twice produces no further change — the second run
+  reports "already at the ratcheted floor" and writes nothing.
+
+Jest's own `coverageThreshold` check fails the build on any regression (a drop
+below the floor). The ratchet is the mechanism that moves the gate _forward_
+as coverage improves. Commit the resulting `jest.config.js` bump as part of the
+PR that raised coverage. The documented target remains **70%** across all
+metrics (60% for branches); the ratchet is how we get there without the floor
+ever sliding back.
+
 ---
 
 ## 11. Decision Guide
 
-| Scenario                  | Test type      |
-| ------------------------- | -------------- |
-| Pure function / utility   | Unit (co-located) |
-| Custom hook               | Unit           |
-| Single React component    | Unit (RTL)     |
-| Component + providers     | Unit (`renderWithProviders`) |
-| Server action / route     | Integration (`tests/`) |
-| Cross-module workflow     | Integration (`tests/`) |
-| Critical user flow in browser | E2E (`e2e/`)   |
-| Game-state regression     | Video-derived fixture |
+| Scenario                      | Test type                    |
+| ----------------------------- | ---------------------------- |
+| Pure function / utility       | Unit (co-located)            |
+| Custom hook                   | Unit                         |
+| Single React component        | Unit (RTL)                   |
+| Component + providers         | Unit (`renderWithProviders`) |
+| Server action / route         | Integration (`tests/`)       |
+| Cross-module workflow         | Integration (`tests/`)       |
+| Critical user flow in browser | E2E (`e2e/`)                 |
+| Game-state regression         | Video-derived fixture        |
 
 **Choose E2E** when you need a real browser, real DOM, or unmocked network.
 **Choose integration** when you can mock external dependencies and want faster
@@ -512,3 +549,9 @@ Tests run automatically on:
 
 A coverage regression that drops a metric below the `coverageThreshold` floor
 will fail CI and block the merge.
+
+To **raise** the floor after improving coverage, run
+`npm run test:coverage:ratchet` (see
+[Ratcheting the coverage floor](#10-coverage)) and commit the resulting
+`jest.config.js` bump. This is how the floor moves toward the 70% target
+without ever sliding backward.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -69,6 +69,10 @@ const eslintConfig = [
       "jest.setup.js",
       "jest.config.js",
       "commitlint.config.js",
+      // Plain Node CommonJS tooling (uses require/module/process globals that
+      // the flat config has no Node environment for), same class of file as
+      // jest.config.js above.
+      "scripts/ratchet-coverage.js",
       ".claude/skills/pr-automation/**",
     ],
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -50,20 +50,24 @@ module.exports = {
   ],
   // Coverage thresholds — ENFORCED by CI (ci.yml "Run unit tests with coverage").
   // Values are set just below MEASURED coverage so the gate catches real
-  // regressions without being flaky. Measured 2026-06-24 (jest --coverage):
-  //   statements 32.86% | branches 25.58% | functions 26.99% | lines 33.19%
-  // These ~double the previous 15/17/22 floor. The documented project target
-  // is 70% (README/TESTING/CONTRIBUTING); raising toward 70% is tracked as
-  // follow-up work — DO NOT raise a threshold above measured coverage or CI
-  // will fail. Re-measure with `npm run test:coverage` before adjusting.
+  // regressions without being flaky. Measured 2026-06-26 (jest --coverage):
+  //   statements 37.66% | branches 29.97% | functions 31.09% | lines 37.98%
+  // The documented project target is 70% (README/TESTING/CONTRIBUTING). This
+  // floor is ratcheted upward automatically by `scripts/ratchet-coverage.js`
+  // (`npm run test:coverage:ratchet`, issue #1099) — the floor moves toward 70%
+  // as coverage improves and can never silently decay. DO NOT raise a threshold
+  // above measured coverage or CI will fail. Re-measure with
+  // `npm run test:coverage` before adjusting by hand.
   // See: https://github.com/anchapin/planar-nexus/issues/922
   coverageThreshold: {
     global: {
-      branches: 22,
-      functions: 23,
-      lines: 29,
-      statements: 29,
+      branches: 28,
+      functions: 30,
+      lines: 36,
+      statements: 36,
     },
   },
-  coverageReporters: ["text-summary", "lcov", "html"],
+  // `json-summary` emits coverage/coverage-summary.json, consumed by
+  // scripts/ratchet-coverage.js (npm run test:coverage:ratchet, issue #1099).
+  coverageReporters: ["text-summary", "lcov", "html", "json-summary"],
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
+    "test:coverage:ratchet": "npm run test:coverage && node scripts/ratchet-coverage.js",
     "test:e2e": "playwright test",
     "prepare": "husky"
   },

--- a/scripts/ratchet-coverage.d.ts
+++ b/scripts/ratchet-coverage.d.ts
@@ -1,0 +1,77 @@
+/**
+ * Type declarations for scripts/ratchet-coverage.js (issue #1099).
+ *
+ * The implementation is plain CommonJS (no runtime deps); this file gives it
+ * precise types for TypeScript consumers (e.g. the Jest suite in
+ * tests/ratchet-coverage.test.ts). The signatures mirror the runtime exports.
+ */
+
+export type Metric = "branches" | "functions" | "lines" | "statements";
+
+export interface Metrics {
+  branches: number;
+  functions: number;
+  lines: number;
+  statements: number;
+}
+
+export interface Change {
+  metric: string;
+  from: number;
+  to: number;
+  measured: number;
+}
+
+export interface Regression {
+  metric: string;
+  measured: number;
+  current: number;
+}
+
+export interface ComputeResult {
+  floors: Metrics;
+  regressions: Regression[];
+  bumps: Change[];
+}
+
+export type RatchetKind = "bump" | "noop" | "regression";
+
+export interface RatchetResult {
+  kind: RatchetKind;
+  current: Metrics;
+  floors: Metrics;
+  bumps: Change[];
+  regressions: Regression[];
+  nextSource: string | null;
+}
+
+export const METRICS: Metric[];
+export const DEFAULT_MARGIN: number;
+export const BLOCK_RE: RegExp;
+
+export function parseArgs(argv: string[]): {
+  margin: number;
+  coveragePath: string;
+  configPath: string;
+  dryRun: boolean;
+};
+
+export function readCoverageSummary(filePath: string): unknown;
+
+export function extractMeasured(summary: unknown): Metrics;
+
+export function readCurrentValues(inner: string): Metrics;
+
+export function computeFloors(
+  measured: Metrics,
+  current: Metrics,
+  margin: number,
+): ComputeResult;
+
+export function applyRatchet(
+  source: string,
+  measured: Metrics,
+  margin: number,
+): RatchetResult;
+
+export function main(): void;

--- a/scripts/ratchet-coverage.js
+++ b/scripts/ratchet-coverage.js
@@ -1,0 +1,394 @@
+#!/usr/bin/env node
+/**
+ * Ratcheting coverage-threshold script (issue #1099).
+ *
+ * Reads `coverage/coverage-summary.json` (emitted by Jest's `json-summary`
+ * reporter), compares the measured global coverage against the
+ * `coverageThreshold.global` block in `jest.config.js`, and rewrites that
+ * block up to `floor(measured - margin)` per metric.
+ *
+ * Behavior:
+ *   - measured < current threshold -> REGRESSION: print a clear report and
+ *     exit non-zero (CI fails). jest.config.js is NOT modified.
+ *   - measured > threshold         -> BUMP: raise the floor (monotonically;
+ *     it is never lowered) and rewrite jest.config.js, preserving formatting.
+ *   - measured == ratcheted floor  -> NO-OP (idempotent; second run is a nop).
+ *
+ * The floor for each metric is `max(current, floor(measured - margin))`, so the
+ * ratchet only ever moves up and always leaves `margin` headroom to avoid
+ * flapping. Default margin = 1 percentage point; override with `--margin <n>`
+ * or the `RATCHET_MARGIN` env var.
+ *
+ * Usage:
+ *   npm run test:coverage            # produce coverage/coverage-summary.json
+ *   node scripts/ratchet-coverage.js [--margin <n>] [--coverage <path>]
+ *                                    [--config <path>] [--dry-run]
+ *
+ * Exit codes: 0 = success (bump applied or already at floor), 1 = regression
+ * or error. Built-in Node modules only — no runtime dependencies.
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const METRICS = ["branches", "functions", "lines", "statements"];
+const DEFAULT_MARGIN = 1;
+
+/**
+ * Matches the `coverageThreshold.global { ... }` block in jest.config.js.
+ * group 1 = prefix ending at the `{` that opens `global`,
+ * group 2 = the inner property list (captured lazily up to global's `}`),
+ * group 3 = global's closing `}`.
+ * Tolerant of whitespace; the first `}` after `global: {` is always global's
+ * own close because its direct children are scalar key/value pairs.
+ */
+const BLOCK_RE = /(coverageThreshold:\s*\{\s*global:\s*\{)([\s\S]*?)(\})/;
+
+function pad(name) {
+  return String(name).padEnd(10);
+}
+
+function parseArgs(argv) {
+  const opts = {
+    margin: DEFAULT_MARGIN,
+    coveragePath: "coverage/coverage-summary.json",
+    configPath: "jest.config.js",
+    dryRun: false,
+  };
+  let marginSet = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === "--margin") {
+      opts.margin = parseFloat(next);
+      if (!Number.isFinite(opts.margin)) {
+        throw new Error("--margin requires a numeric value, e.g. --margin 1.5");
+      }
+      marginSet = true;
+      i++;
+    } else if (arg === "--coverage") {
+      if (!next) throw new Error("--coverage requires a path");
+      opts.coveragePath = next;
+      i++;
+    } else if (arg === "--config") {
+      if (!next) throw new Error("--config requires a path");
+      opts.configPath = next;
+      i++;
+    } else if (arg === "--dry-run") {
+      opts.dryRun = true;
+    } else if (arg === "--help" || arg === "-h") {
+      process.stdout.write(
+        [
+          "Usage: node scripts/ratchet-coverage.js [options]",
+          "",
+          "Options:",
+          "  --margin <n>      Safety margin in percentage points (default: 1).",
+          "                    Floor is computed as floor(measured - margin).",
+          "  --coverage <path> Path to coverage-summary.json",
+          "                    (default: coverage/coverage-summary.json).",
+          "  --config <path>   Path to jest.config.js (default: jest.config.js).",
+          "  --dry-run         Print the planned change without writing.",
+          "  --help, -h        Show this help.",
+          "",
+          "Env: RATCHET_MARGIN overrides the default margin (ignored if --margin set).",
+          "",
+        ].join("\n"),
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg} (see --help)`);
+    }
+  }
+  if (!marginSet && process.env.RATCHET_MARGIN != null) {
+    const envMargin = parseFloat(process.env.RATCHET_MARGIN);
+    if (Number.isFinite(envMargin)) opts.margin = envMargin;
+  }
+  return opts;
+}
+
+function readCoverageSummary(filePath) {
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, "utf-8");
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      throw new Error(
+        `Coverage summary not found at ${filePath}.\n` +
+          `Run "npm run test:coverage" first — Jest must enable the "json-summary" ` +
+          `reporter (see coverageReporters in jest.config.js).`,
+      );
+    }
+    throw new Error(
+      `Failed to read coverage summary (${filePath}): ${err.message}`,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Coverage summary is not valid JSON (${filePath}): ${err.message}`,
+    );
+  }
+  return parsed;
+}
+
+function extractMeasured(summary) {
+  const total = summary && summary.total;
+  if (!total || typeof total !== "object") {
+    throw new Error("coverage-summary.json is missing the 'total' object.");
+  }
+  const measured = {};
+  for (const metric of METRICS) {
+    const entry = total[metric];
+    const pct = entry && entry.pct;
+    if (typeof pct !== "number" || !Number.isFinite(pct)) {
+      throw new Error(
+        `coverage-summary.json has no numeric total.${metric}.pct ` +
+          `(got ${JSON.stringify(pct)}). Re-run coverage before ratcheting.`,
+      );
+    }
+    measured[metric] = pct;
+  }
+  return measured;
+}
+
+function readCurrentValues(inner) {
+  const values = {};
+  for (const metric of METRICS) {
+    const re = new RegExp(`["']?${metric}["']?\\s*:\\s*([0-9]+(?:\\.[0-9]+)?)`);
+    const match = inner.match(re);
+    if (!match) {
+      throw new Error(
+        `coverageThreshold.global is missing the "${metric}" key.`,
+      );
+    }
+    values[metric] = parseFloat(match[1]);
+  }
+  return values;
+}
+
+/**
+ * Compute the ratcheted floor for each metric plus the change report.
+ * Floors are monotonic: a floor is never lowered below the current value.
+ * Returns { floors, regressions, bumps }.
+ */
+function computeFloors(measured, current, margin) {
+  const floors = {};
+  const regressions = [];
+  const bumps = [];
+  for (const metric of METRICS) {
+    const meas = measured[metric];
+    const cur = current[metric];
+    if (meas < cur) {
+      regressions.push({ metric, measured: meas, current: cur });
+      floors[metric] = cur; // never lower
+    } else {
+      const target = Math.max(cur, Math.floor(meas - margin));
+      floors[metric] = target;
+      if (target > cur) {
+        bumps.push({ metric, from: cur, to: target, measured: meas });
+      }
+    }
+  }
+  return { floors, regressions, bumps };
+}
+
+function detectIndents(inner) {
+  const propMatch = inner.match(/\n([ \t]*)\S/);
+  const closeMatch = inner.match(/([ \t]*)$/);
+  return {
+    propIndent: propMatch ? propMatch[1] : "      ",
+    closeIndent: closeMatch ? closeMatch[1] : "    ",
+  };
+}
+
+function renderInner(floors, propIndent, closeIndent) {
+  const lines = METRICS.map((m) => `${propIndent}${m}: ${floors[m]},`);
+  return "\n" + lines.join("\n") + "\n" + closeIndent;
+}
+
+/**
+ * Compute the ratchet result for a jest.config.js source string.
+ * Returns { kind, current, floors, bumps, regressions, nextSource } where
+ * nextSource is null unless kind === "bump" (the rewritten, byte-stable source).
+ */
+function applyRatchet(configSource, measured, margin) {
+  const match = configSource.match(BLOCK_RE);
+  if (!match) {
+    throw new Error(
+      "Could not locate the coverageThreshold.global block in jest.config.js.",
+    );
+  }
+  const prefix = match[1];
+  const inner = match[2];
+  const close = match[3];
+  const current = readCurrentValues(inner);
+  const { floors, regressions, bumps } = computeFloors(
+    measured,
+    current,
+    margin,
+  );
+
+  if (regressions.length > 0) {
+    return {
+      kind: "regression",
+      current,
+      floors,
+      bumps,
+      regressions,
+      nextSource: null,
+    };
+  }
+  if (bumps.length === 0) {
+    return {
+      kind: "noop",
+      current,
+      floors,
+      bumps,
+      regressions,
+      nextSource: configSource,
+    };
+  }
+
+  const { propIndent, closeIndent } = detectIndents(inner);
+  const newInner = renderInner(floors, propIndent, closeIndent);
+  const nextSource =
+    configSource.slice(0, match.index) +
+    prefix +
+    newInner +
+    close +
+    configSource.slice(match.index + match[0].length);
+  return { kind: "bump", current, floors, bumps, regressions, nextSource };
+}
+
+function main() {
+  let opts;
+  try {
+    opts = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(`[ratchet] ${err.message}`);
+    process.exit(1);
+  }
+
+  const root = process.cwd();
+  const coveragePath = path.resolve(root, opts.coveragePath);
+  const configPath = path.resolve(root, opts.configPath);
+
+  let summary;
+  try {
+    summary = readCoverageSummary(coveragePath);
+  } catch (err) {
+    console.error(`[ratchet] ${err.message}`);
+    process.exit(1);
+  }
+
+  let measured;
+  try {
+    measured = extractMeasured(summary);
+  } catch (err) {
+    console.error(`[ratchet] ${err.message}`);
+    process.exit(1);
+  }
+
+  let source;
+  try {
+    source = fs.readFileSync(configPath, "utf-8");
+  } catch (err) {
+    console.error(
+      `[ratchet] Could not read Jest config at ${configPath}: ${err.message}`,
+    );
+    process.exit(1);
+  }
+
+  let result;
+  try {
+    result = applyRatchet(source, measured, opts.margin);
+  } catch (err) {
+    console.error(`[ratchet] ${err.message}`);
+    process.exit(1);
+  }
+
+  const fmt = (n) => `${n.toFixed(1)}%`;
+
+  if (result.kind === "regression") {
+    console.error(
+      "[ratchet] Coverage regression detected — thresholds NOT lowered.",
+    );
+    console.error("[ratchet] Metrics below the current floor:");
+    for (const r of result.regressions) {
+      const delta = (r.measured - r.current).toFixed(1);
+      console.error(
+        `  ${pad(r.metric)} measured ${fmt(r.measured)} < floor ${fmt(r.current)} (${delta})`,
+      );
+    }
+    console.error(
+      "\n[ratchet] Restore coverage above the floor, then re-run. CI will fail until then.",
+    );
+    process.exit(1);
+  }
+
+  if (result.kind === "noop") {
+    console.info(
+      "[ratchet] Thresholds already at the ratcheted floor — no change.",
+    );
+    for (const m of METRICS) {
+      console.info(
+        `  ${pad(m)} floor ${result.floors[m]}% (measured ${fmt(measured[m])})`,
+      );
+    }
+    process.exit(0);
+  }
+
+  console.info(
+    `[ratchet] Bumping coverage floor — floor(measured - ${opts.margin}pp margin):`,
+  );
+  for (const b of result.bumps) {
+    console.info(
+      `  ${pad(b.metric)} ${b.from}% -> ${b.to}% (measured ${fmt(b.measured)})`,
+    );
+  }
+  const unchanged = METRICS.filter(
+    (m) => !result.bumps.some((b) => b.metric === m),
+  );
+  if (unchanged.length) {
+    console.info(
+      `[ratchet] Already at floor (unchanged): ${unchanged.join(", ")}`,
+    );
+  }
+
+  if (opts.dryRun) {
+    console.info("\n[ratchet] --dry-run set: jest.config.js not modified.");
+    process.exit(0);
+  }
+
+  try {
+    fs.writeFileSync(configPath, result.nextSource, "utf-8");
+  } catch (err) {
+    console.error(`[ratchet] Failed to write Jest config: ${err.message}`);
+    process.exit(1);
+  }
+  console.info(
+    `\n[ratchet] Updated ${path.relative(root, configPath) || "jest.config.js"}.`,
+  );
+  process.exit(0);
+}
+
+module.exports = {
+  METRICS,
+  DEFAULT_MARGIN,
+  BLOCK_RE,
+  parseArgs,
+  readCoverageSummary,
+  extractMeasured,
+  readCurrentValues,
+  computeFloors,
+  applyRatchet,
+  main,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/tests/ratchet-coverage.test.ts
+++ b/tests/ratchet-coverage.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Unit tests for scripts/ratchet-coverage.js (issue #1099).
+ *
+ * The ratchet is a build/dev tool (plain CommonJS, no runtime deps), so these
+ * tests exercise its pure helpers directly rather than spawning a process.
+ * Focus: floor math (monotonic, never lowers), regression detection,
+ * idempotency, and byte-stable formatting of jest.config.js.
+ */
+
+import {
+  computeFloors,
+  applyRatchet,
+  readCurrentValues,
+} from "../scripts/ratchet-coverage";
+
+type Metrics = {
+  branches: number;
+  functions: number;
+  lines: number;
+  statements: number;
+};
+
+const MEASURED: Metrics = {
+  branches: 25.58,
+  functions: 26.99,
+  lines: 33.19,
+  statements: 32.86,
+};
+
+const CURRENT: Metrics = {
+  branches: 22,
+  functions: 23,
+  lines: 29,
+  statements: 29,
+};
+
+// Mirrors the real jest.config.js layout so the indent detection is realistic.
+const SAMPLE_CONFIG = `/** @type {import('jest').Config} */
+module.exports = {
+  preset: "ts-jest",
+  coverageThreshold: {
+    global: {
+      branches: 22,
+      functions: 23,
+      lines: 29,
+      statements: 29,
+    },
+  },
+  coverageReporters: ["text-summary", "lcov", "html", "json-summary"],
+};
+`;
+
+describe("ratchet-coverage computeFloors", () => {
+  it("bumps each floor to floor(measured - margin)", () => {
+    const { floors, bumps, regressions } = computeFloors(MEASURED, CURRENT, 1);
+    expect(regressions).toHaveLength(0);
+    expect(floors).toEqual({
+      branches: 24,
+      functions: 25,
+      lines: 32,
+      statements: 31,
+    });
+    expect(bumps).toHaveLength(4);
+    expect(bumps.map((b: { metric: string }) => b.metric).sort()).toEqual([
+      "branches",
+      "functions",
+      "lines",
+      "statements",
+    ]);
+  });
+
+  it("is monotonic: never lowers a floor below the current value", () => {
+    // measured just above current, so floor(measured - margin) would dip below
+    // current — the ratchet must keep the current floor instead.
+    const measured: Metrics = {
+      branches: 22.4,
+      functions: 23.3,
+      lines: 29.5,
+      statements: 29.2,
+    };
+    const { floors, bumps, regressions } = computeFloors(measured, CURRENT, 1);
+    expect(regressions).toHaveLength(0);
+    expect(floors).toEqual(CURRENT);
+    expect(bumps).toHaveLength(0);
+  });
+
+  it("flags regressions when measured < current and does not lower the floor", () => {
+    const measured: Metrics = {
+      branches: 21,
+      functions: 26.99,
+      lines: 33.19,
+      statements: 32.86,
+    };
+    const { floors, regressions, bumps } = computeFloors(measured, CURRENT, 1);
+    expect(regressions.map((r: { metric: string }) => r.metric)).toEqual([
+      "branches",
+    ]);
+    expect(floors.branches).toBe(22); // unchanged, not lowered
+    // other metrics still computed normally
+    expect(bumps.map((b: { metric: string }) => b.metric).sort()).toEqual([
+      "functions",
+      "lines",
+      "statements",
+    ]);
+  });
+
+  it("honours a custom margin", () => {
+    const { floors } = computeFloors(MEASURED, CURRENT, 2);
+    // branches: floor(25.58 - 2) = 23, functions: floor(26.99 - 2) = 24,
+    // lines: floor(33.19 - 2) = 31, statements: floor(32.86 - 2) = 30
+    expect(floors).toEqual({
+      branches: 23,
+      functions: 24,
+      lines: 31,
+      statements: 30,
+    });
+  });
+});
+
+describe("ratchet-coverage readCurrentValues", () => {
+  it("parses the four thresholds out of the global block body", () => {
+    const inner = `
+      branches: 22,
+      functions: 23,
+      lines: 29,
+      statements: 29,
+    `;
+    expect(readCurrentValues(inner)).toEqual(CURRENT);
+  });
+});
+
+describe("ratchet-coverage applyRatchet", () => {
+  it("rewrites the threshold block on a bump", () => {
+    const res = applyRatchet(SAMPLE_CONFIG, MEASURED, 1);
+    expect(res.kind).toBe("bump");
+    expect(res.nextSource).not.toBeNull();
+    expect(res.nextSource).toContain("branches: 24,");
+    expect(res.nextSource).toContain("functions: 25,");
+    expect(res.nextSource).toContain("lines: 32,");
+    expect(res.nextSource).toContain("statements: 31,");
+  });
+
+  it("is idempotent: re-running on the rewritten config is a no-op", () => {
+    const first = applyRatchet(SAMPLE_CONFIG, MEASURED, 1);
+    if (!first.nextSource) throw new Error("expected a bump on first run");
+    const second = applyRatchet(first.nextSource, MEASURED, 1);
+    expect(second.kind).toBe("noop");
+    // Byte-stable: applying again produces an identical string.
+    expect(second.nextSource).toBe(first.nextSource);
+  });
+
+  it("leaves the surrounding config untouched (only threshold numbers change)", () => {
+    const res = applyRatchet(SAMPLE_CONFIG, MEASURED, 1);
+    if (!res.nextSource) throw new Error("expected a bump");
+    const normalize = (s: string) =>
+      s.replace(/(branches|functions|lines|statements): \d+,/g, "X");
+    expect(normalize(res.nextSource)).toBe(normalize(SAMPLE_CONFIG));
+    // structural anchors still present
+    expect(res.nextSource).toContain('preset: "ts-jest"');
+    expect(res.nextSource).toContain('"json-summary"]');
+    expect(res.nextSource.trim().endsWith("};")).toBe(true);
+  });
+
+  it("reports a regression and does not modify the config", () => {
+    const regressed: Metrics = {
+      branches: 21,
+      functions: 26.99,
+      lines: 33.19,
+      statements: 32.86,
+    };
+    const res = applyRatchet(SAMPLE_CONFIG, regressed, 1);
+    expect(res.kind).toBe("regression");
+    expect(res.nextSource).toBeNull();
+    expect(res.regressions.map((r: { metric: string }) => r.metric)).toEqual([
+      "branches",
+    ]);
+  });
+
+  it("throws when the threshold block is absent", () => {
+    const broken = "module.exports = { preset: 'ts-jest' };\n";
+    expect(() => applyRatchet(broken, MEASURED, 1)).toThrow(
+      /coverageThreshold\.global/,
+    );
+  });
+});


### PR DESCRIPTION
Resolves #1099

## Summary

Adds a ratcheting coverage-threshold script that turns `jest.config.js`'s static `coverageThreshold.global` floor into a one-way ratchet: every coverage gain "sticks", and coverage can never silently decay. The floor auto-raises toward the documented 70% target as coverage improves.

## How it works

`scripts/ratchet-coverage.js` (plain Node, **zero runtime deps**, CommonJS):

1. Reads `coverage/coverage-summary.json` (now emitted by the `json-summary` reporter added to `coverageReporters`).
2. For each metric computes `floor = max(current, floor(measured - margin))`. Default **margin = 1pp** (`--margin <n>` or `RATCHET_MARGIN` env var to override). The ratchet is **monotonic** — a floor is never lowered, even when the margin would dip below the current value.
3. **Regression guard:** if any measured metric is *below* the current floor → prints a clear report, leaves `jest.config.js` untouched, **exits non-zero (CI fails)**.
4. **Bump:** if measured > threshold → rewrites **only** the `coverageThreshold.global` block in `jest.config.js`, preserving the file's formatting (regex-scoped, byte-stable).
5. **Idempotent:** running it again is a no-op ("already at the ratcheted floor").

Jest's own `coverageThreshold` still fails the build on any drop below the floor. The ratchet is purely the mechanism that moves the gate *forward*.

## npm script

```jsonc
"test:coverage": "jest --coverage",
"test:coverage:ratchet": "npm run test:coverage && node scripts/ratchet-coverage.js",
```

`npm run test:coverage:ratchet` measures coverage, then ratchets the floor up. With the `&&`, a real regression fails Jest's threshold check first; the ratchet additionally reports a clean regression message when invoked directly.

## Demo bump (applied locally ✅)

Ran the full suite (`jest --coverage`: 242 suites / 4588 tests pass), then `node scripts/ratchet-coverage.js`. The ratcheted floor moved up on all four metrics — committed as part of this PR:

| Metric     | Old floor | Measured (2026-06-26) | New floor |
| ---------- | --------- | --------------------- | --------- |
| branches   | 22        | 29.97%                | **28**    |
| functions  | 23        | 31.09%                | **30**    |
| lines      | 29        | 37.98%                | **36**    |
| statements | 29        | 37.66%                | **36**    |

Each new floor sits ~1–2pp below the measured value (the safety margin) so the gate doesn't flap. Verified the bumped floor still passes Jest's `coverageThreshold` (`jest --coverage` exits 0). Coverage has improved notably since the previous 2026-06-24 measurement, so this is a real, measured bump — nothing fabricated.

## Files changed

- `scripts/ratchet-coverage.js` — the ratchet (pure helpers + CLI; idempotent, monotonic, regression guard).
- `scripts/ratchet-coverage.d.ts` — precise types for TS consumers (doubles as API docs).
- `tests/ratchet-coverage.test.ts` — 10 unit tests: floor math, monotonicity, regression detection, idempotency, byte-stable formatting.
- `jest.config.js` — add `json-summary` reporter; apply the ratcheted floor (demo bump); refresh the measured-coverage comment.
- `package.json` — register `test:coverage:ratchet`.
- `eslint.config.mjs` — ignore the plain-JS Node tooling script (same precedent as `jest.config.js` / `commitlint.config.js`, which lack Node globals in the flat config).
- `docs/TESTING.md` — document the ratchet workflow in the Coverage section.

## Acceptance criteria

- [x] `scripts/ratchet-coverage.js` committed and **idempotent** (2nd/3rd runs are no-ops, verified)
- [x] `npm run test:coverage:ratchet` registered (runs coverage then ratchet; verified end-to-end, exit 0)
- [x] Script raises the floor when measured > threshold; **fails CI** (exit 1) when measured < threshold (regression branch tested)
- [x] One demo bump committed showing the floor moving upward (real measured numbers, applied locally)
- [x] Workflow documented in `docs/TESTING.md`

## Verification (local)

- `node scripts/ratchet-coverage.js` → exit 0; second run → no-op, exit 0.
- `npm run test:coverage:ratchet` → exit 0.
- `jest --coverage` against the **bumped** thresholds → exit 0 (242 suites / 4588 tests pass).
- `npm run typecheck` (`tsc --noEmit`) → exit 0, 0 errors.
- `npm run lint` (`eslint src --max-warnings 1000`) → exit 0, 0 errors.
- New test suite → 10/10 pass.
