### PR TITLE
test(p2p): resolve #1096 — add unit tests for P2P conflict resolution and deterministic-sync edge cases

### DIFF
--- a/src/lib/__tests__/desync-logger.test.ts
+++ b/src/lib/__tests__/desync-logger.test.ts
@@ -1,0 +1,461 @@
+/**
+ * Desync Logger Tests
+ * Issue #1096: cover desync detection/resolution logging edge cases.
+ *
+ * The DesyncLogger records multiplayer desync events (detected/resolved/
+ * ignored/escalated), aggregates statistics, persists to localStorage, and
+ * emits human-readable debug reportsers. These tests assert concrete event
+ * shape, type transitions, and aggregation math — not just "no throw".
+ */
+
+import {
+  DesyncLogger,
+  getDesyncLogger,
+  resetDesyncLogger,
+  createDesyncLogger,
+  type DesyncEvent,
+} from "../desync-logger";
+import type {
+  HashDiscrepancy,
+  ConflictResolution,
+} from "../game-state/deterministic-sync";
+
+const SAMPLE_DISCREPANCIES: HashDiscrepancy[] = [
+  {
+    category: "player",
+    description: "Life total for p2",
+    localValue: "20",
+    remoteValue: "17",
+  },
+  {
+    category: "stack",
+    description: "Stack size",
+    localValue: "2",
+    remoteValue: "1",
+  },
+];
+
+const SAMPLE_RESOLUTION: ConflictResolution = {
+  resolved: true,
+  strategy: "authoritative",
+  resolutionActions: [],
+  conflictDescription: "authoritative replay",
+};
+
+describe("DesyncLogger - construction & config", () => {
+  it("applies default config when none provided", () => {
+    const logger = new DesyncLogger({ persistToStorage: false });
+    const stats = logger.getStatistics();
+    expect(stats.totalEvents).toBe(0);
+    expect(stats.successRate).toBe(1);
+  });
+
+  it("honours a custom maxEvents cap", () => {
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+      maxEvents: 3,
+    });
+    for (let i = 0; i < 5; i++) {
+      logger.logIgnored("local", "remote", "h-l", "h-r", `reason-${i}`);
+    }
+    // Only the most recent `maxEvents` are retained.
+    expect(logger.getEvents().length).toBe(3);
+    const reasons = logger.getEvents().map((e) => (e.context as any).reason);
+    expect(reasons).toEqual(["reason-2", "reason-3", "reason-4"]);
+  });
+
+  it("does not touch storage when persistence is disabled", () => {
+    const key = `desync_disabled_${Date.now()}`;
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+      storageKey: key,
+    });
+    logger.logIgnored("local", "remote", "a", "b", "x");
+    expect(localStorage.getItem(key)).toBeNull();
+  });
+});
+
+describe("DesyncLogger - logDetection", () => {
+  it('records a "detected" event with full context', () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: true,
+    });
+
+    const event = logger.logDetection(
+      "local-peer",
+      "remote-peer",
+      "hash-local",
+      "hash-remote",
+      42,
+      SAMPLE_DISCREPANCIES,
+      { turn: 5 },
+    );
+
+    expect(event.type).toBe("detected");
+    expect(event.localPeerId).toBe("local-peer");
+    expect(event.remotePeerId).toBe("remote-peer");
+    expect(event.localHash).toBe("hash-local");
+    expect(event.remoteHash).toBe("hash-remote");
+    expect(event.sequenceNumber).toBe(42);
+    expect(event.discrepancies).toBe(SAMPLE_DISCREPANCIES);
+    expect(event.context).toEqual({ turn: 5 });
+    expect(event.id).toMatch(/^desync_/);
+
+    expect(logger.getEvents()).toHaveLength(1);
+    expect(logger.getEvents()[0]).toBe(event);
+    // Console warning carries the desync summary.
+    expect(warnSpy).toHaveBeenCalled();
+    const logged = warnSpy.mock.calls[0][1] as any;
+    expect(logged.peer).toBe("remote-peer");
+    expect(logged.discrepancies).toBe(2);
+
+    warnSpy.mockRestore();
+  });
+
+  it("suppresses console output when logToConsole is false", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+    });
+
+    logger.logDetection("l", "r", "a", "b", 1, []);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
+describe("DesyncLogger - lifecycle transitions", () => {
+  it("transitions detected -> resolved and records resolution time", () => {
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+    });
+    const detected = logger.logDetection(
+      "l",
+      "r",
+      "a",
+      "b",
+      1,
+      SAMPLE_DISCREPANCIES,
+    );
+
+    logger.logResolution(detected.id, SAMPLE_RESOLUTION, 37);
+
+    const resolved = logger.getEvents().find((e) => e.id === detected.id)!;
+    expect(resolved.type).toBe("resolved");
+    expect(resolved.resolution).toEqual(SAMPLE_RESOLUTION);
+    expect(resolved.resolutionTime).toBe(37);
+  });
+
+  it('logs an "ignored" event carrying the reason', () => {
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+    });
+    const ev = logger.logIgnored("l", "r", "a", "b", "stale handshake");
+    expect(ev.type).toBe("ignored");
+    expect(ev.context).toEqual({ reason: "stale handshake" });
+    expect(ev.sequenceNumber).toBe(0);
+    expect(ev.discrepancies).toEqual([]);
+  });
+
+  it("escalates a previously-detected event and annotates context", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: true,
+    });
+    const detected = logger.logDetection("l", "r", "a", "b", 1, []);
+
+    logger.logEscalated(detected.id, "manual review required");
+
+    const escalated = logger.getEvents().find((e) => e.id === detected.id)!;
+    expect(escalated.type).toBe("escalated");
+    expect((escalated.context as any).escalationReason).toBe(
+      "manual review required",
+    );
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("is a no-op when resolving/escalating an unknown event id", () => {
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+    });
+    expect(() =>
+      logger.logResolution("nope", SAMPLE_RESOLUTION, 1),
+    ).not.toThrow();
+    expect(() => logger.logEscalated("nope", "x")).not.toThrow();
+    // No events were mutated into resolved/escalated.
+    expect(logger.getEventsByType("resolved")).toHaveLength(0);
+    expect(logger.getEventsByType("escalated")).toHaveLength(0);
+  });
+});
+
+describe("DesyncLogger - querying", () => {
+  function populated(): DesyncLogger {
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+    });
+    const a = logger.logDetection(
+      "me",
+      "peerA",
+      "h",
+      "hX",
+      1,
+      SAMPLE_DISCREPANCIES,
+    );
+    logger.logResolution(a.id, SAMPLE_RESOLUTION, 10);
+    logger.logIgnored("me", "peerB", "h", "hY", "transient");
+    return logger;
+  }
+
+  it("filters events by type", () => {
+    const logger = populated();
+    expect(logger.getEventsByType("resolved")).toHaveLength(1);
+    expect(logger.getEventsByType("ignored")).toHaveLength(1);
+    expect(logger.getEventsByType("detected")).toHaveLength(0);
+  });
+
+  it("filters events by peer", () => {
+    const logger = populated();
+    expect(logger.getEventsByPeer("peerA")).toHaveLength(1);
+    expect(logger.getEventsByPeer("peerB")).toHaveLength(1);
+    expect(logger.getEventsByPeer("peerC")).toHaveLength(0);
+  });
+
+  it("returns the N most recent events", () => {
+    const logger = populated();
+    const recent = logger.getRecentEvents(1);
+    expect(recent).toHaveLength(1);
+    expect(recent[0].type).toBe("ignored");
+  });
+});
+
+describe("DesyncLogger - statistics aggregation", () => {
+  it("aggregates counts, peer map, average resolution time, and success rate", () => {
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+    });
+    const a = logger.logDetection(
+      "me",
+      "peerA",
+      "h",
+      "hX",
+      1,
+      SAMPLE_DISCREPANCIES,
+    );
+    logger.logResolution(a.id, SAMPLE_RESOLUTION, 40);
+    const b = logger.logDetection("me", "peerA", "h", "hX2", 2, [
+      {
+        category: "player",
+        description: "Life total for p1",
+        localValue: "20",
+        remoteValue: "18",
+      },
+    ]);
+    logger.logEscalated(b.id, "unrecoverable");
+    logger.logIgnored("me", "peerB", "h", "hY", "stale");
+
+    const stats = logger.getStatistics();
+    expect(stats.totalEvents).toBe(3);
+    expect(stats.byType.resolved).toBe(1);
+    expect(stats.byType.escalated).toBe(1);
+    expect(stats.byType.ignored).toBe(1);
+    expect(stats.byPeer.get("peerA")).toBe(2);
+    expect(stats.byPeer.get("peerB")).toBe(1);
+    expect(stats.avgResolutionTime).toBe(40);
+    // successRate = resolved / (resolved + escalated) = 1/2
+    expect(stats.successRate).toBeCloseTo(0.5, 5);
+    // commonDiscrepancies iterates every event's discrepancies regardless of
+    // type. "player" appears once in `a` (SAMPLE_DISCREPANCIES) and once in
+    // `b` => count 2; "stack" appears once in `a` => count 1. Sorted desc.
+    expect(stats.commonDiscrepancies).toEqual([
+      { category: "player", count: 2 },
+      { category: "stack", count: 1 },
+    ]);
+  });
+
+  it("reports successRate 1.0 when there are no resolved/escalated events", () => {
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+    });
+    logger.logIgnored("me", "peer", "a", "b", "x");
+    expect(logger.getStatistics().successRate).toBe(1);
+    expect(logger.getStatistics().avgResolutionTime).toBe(0);
+  });
+});
+
+describe("DesyncLogger - debug report", () => {
+  it("renders a report for a known event", () => {
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+    });
+    const ev = logger.logDetection(
+      "local",
+      "remote",
+      "hL",
+      "hR",
+      9,
+      SAMPLE_DISCREPANCIES,
+    );
+    logger.logResolution(ev.id, SAMPLE_RESOLUTION, 12);
+
+    const report = logger.createDebugReport(ev.id);
+    expect(report).toContain("Desync Event Report");
+    expect(report).toContain(ev.id);
+    expect(report).toContain("Local:  hL");
+    expect(report).toContain("Remote: hR");
+    expect(report).toContain("Sequence: 9");
+    expect(report).toContain("Life total for p2");
+    expect(report).toContain("Strategy: authoritative");
+    expect(report).toContain("Time: 12ms");
+  });
+
+  it("returns a not-found message for an unknown id", () => {
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+    });
+    expect(logger.createDebugReport("missing")).toBe("Event not found");
+  });
+});
+
+describe("DesyncLogger - export / import", () => {
+  it("round-trips events through export and import", () => {
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+    });
+    logger.logIgnored("l", "r", "a", "b", "round-trip");
+    const exported = logger.exportLogs();
+
+    const parsed = JSON.parse(exported);
+    expect(parsed.events).toHaveLength(1);
+    expect(parsed.statistics.totalEvents).toBe(1);
+
+    const target = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+    });
+    target.importLogs(exported);
+    expect(target.getEvents()).toHaveLength(1);
+    expect((target.getEvents()[0].context as any).reason).toBe("round-trip");
+  });
+
+  it("ignores malformed import payload without throwing", () => {
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+    });
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => logger.importLogs("{ not json")).not.toThrow();
+    expect(logger.getEvents()).toHaveLength(0);
+    errorSpy.mockRestore();
+  });
+
+  it("ignores import payload without an events array", () => {
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+    });
+    logger.logIgnored("l", "r", "a", "b", "keep");
+    logger.importLogs(JSON.stringify({ events: "not-an-array" }));
+    // Existing events are preserved when payload is invalid.
+    expect(logger.getEvents()).toHaveLength(1);
+  });
+});
+
+describe("DesyncLogger - persistence", () => {
+  it("persists events to localStorage and reloads them on construction", () => {
+    const key = `desync_persist_${Date.now()}_${Math.random()}`;
+    localStorage.removeItem(key);
+
+    const writer = new DesyncLogger({
+      persistToStorage: true,
+      logToConsole: false,
+      storageKey: key,
+    });
+    writer.logDetection("local", "remote", "hL", "hR", 7, SAMPLE_DISCREPANCIES);
+    const stored = localStorage.getItem(key);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!).length).toBe(1);
+
+    // A fresh instance with the same key must rehydrate from storage.
+    const reader = new DesyncLogger({
+      persistToStorage: true,
+      logToConsole: false,
+      storageKey: key,
+    });
+    expect(reader.getEvents()).toHaveLength(1);
+    expect(reader.getEvents()[0].sequenceNumber).toBe(7);
+
+    localStorage.removeItem(key);
+  });
+
+  it("clearLogs empties memory and storage", () => {
+    const key = `desync_clear_${Date.now()}`;
+    const logger = new DesyncLogger({
+      persistToStorage: true,
+      logToConsole: false,
+      storageKey: key,
+    });
+    logger.logIgnored("l", "r", "a", "b", "temp");
+    expect(localStorage.getItem(key)).not.toBeNull();
+
+    logger.clearLogs();
+    expect(logger.getEvents()).toHaveLength(0);
+    expect(localStorage.getItem(key)).toBeNull();
+  });
+});
+
+describe("DesyncLogger - singleton & factory", () => {
+  it("getDesyncLogger returns a shared singleton until reset", () => {
+    resetDesyncLogger();
+    const a = getDesyncLogger({ persistToStorage: false, logToConsole: false });
+    const b = getDesyncLogger();
+    expect(a).toBe(b);
+    resetDesyncLogger();
+    const c = getDesyncLogger({ persistToStorage: false, logToConsole: false });
+    expect(c).not.toBe(a);
+    resetDesyncLogger();
+  });
+
+  it("createDesyncLogger always returns a fresh instance", () => {
+    const a = createDesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+    });
+    const b = createDesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+    });
+    expect(a).not.toBe(b);
+    expect(a).toBeInstanceOf(DesyncLogger);
+  });
+});
+
+describe("DesyncLogger - event id uniqueness", () => {
+  it("generates monotonically unique ids", () => {
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+    });
+    const ids = new Set<string>();
+    for (let i = 0; i < 50; i++) {
+      ids.add(logger.logIgnored("l", "r", "a", "b", "r").id);
+    }
+    expect(ids.size).toBe(50);
+  });
+});

--- a/src/lib/__tests__/p2p-conflict-resolution.test.ts
+++ b/src/lib/__tests__/p2p-conflict-resolution.test.ts
@@ -1,37 +1,47 @@
 /**
  * P2P Conflict Resolution Tests
+ *
+ * Includes the issue #1096 edge-case suite (concurrent conflicting actions,
+ * deterministic tie-breaking, priority ordering, out-of-order/queue
+ * application, last-writer-wins, and merge policies). Those tests mock
+ * `Date.now` so timestamps (and therefore every tie-break) are fully
+ * deterministic rather than wall-clock dependent.
  */
 
 import {
   ConflictResolutionManager,
+  createConflictResolutionManager,
+  mergeActions,
   type ConflictResolutionConfig,
   type ActionPriority,
   type ConflictStrategy,
-} from '../p2p-conflict-resolution';
+  type TimestampedAction,
+  type ActionConflict,
+} from "../p2p-conflict-resolution";
 
-describe('ConflictResolutionManager', () => {
+describe("ConflictResolutionManager", () => {
   let manager: ConflictResolutionManager;
 
   beforeEach(() => {
     manager = new ConflictResolutionManager({
-      hostId: 'host-1',
-      strategy: 'host-wins',
+      hostId: "host-1",
+      strategy: "host-wins",
       actionWindow: 100,
       enablePriority: true,
       enableSequenceNumbers: true,
     });
   });
 
-  describe('constructor', () => {
-    it('should create manager with default config', () => {
+  describe("constructor", () => {
+    it("should create manager with default config", () => {
       const defaultManager = new ConflictResolutionManager();
       expect(defaultManager).toBeDefined();
     });
 
-    it('should create manager with custom config', () => {
+    it("should create manager with custom config", () => {
       const customManager = new ConflictResolutionManager({
-        hostId: 'custom-host',
-        strategy: 'timestamp-based',
+        hostId: "custom-host",
+        strategy: "timestamp-based",
         actionWindow: 200,
         enablePriority: false,
         enableSequenceNumbers: false,
@@ -40,70 +50,100 @@ describe('ConflictResolutionManager', () => {
     });
   });
 
-  describe('processAction', () => {
-    it('should process action without conflict', () => {
+  describe("processAction", () => {
+    it("should process action without conflict", () => {
       const result = manager.processAction(
-        'play-card',
-        { cardId: 'card-1' },
-        'player-1',
-        'Player One'
+        "play-card",
+        { cardId: "card-1" },
+        "player-1",
+        "Player One",
       );
 
       expect(result.shouldProcess).toBe(true);
       expect(result.action).toBeDefined();
-      expect(result.action?.actionType).toBe('play-card');
-      expect(result.action?.playerId).toBe('player-1');
+      expect(result.action?.actionType).toBe("play-card");
+      expect(result.action?.playerId).toBe("player-1");
       expect(result.conflict).toBeUndefined();
     });
 
-    it('should return action with correct priority', () => {
+    it("should return action with correct priority", () => {
       const result = manager.processAction(
-        'game-end',
+        "game-end",
         {},
-        'player-1',
-        'Player One'
+        "player-1",
+        "Player One",
       );
 
       expect(result.shouldProcess).toBe(true);
-      expect(result.action?.priority).toBe('critical');
+      expect(result.action?.priority).toBe("critical");
     });
 
-    it('should assign sequence numbers', () => {
-      const result1 = manager.processAction('play-card', {}, 'player-1', 'Player One');
-      const result2 = manager.processAction('play-card', {}, 'player-1', 'Player One');
+    it("should assign sequence numbers", () => {
+      const result1 = manager.processAction(
+        "play-card",
+        {},
+        "player-1",
+        "Player One",
+      );
+      const result2 = manager.processAction(
+        "play-card",
+        {},
+        "player-1",
+        "Player One",
+      );
 
       expect(result1.action?.sequenceNumber).toBe(1);
       expect(result2.action?.sequenceNumber).toBe(2);
     });
   });
 
-  describe('processAction return values', () => {
-    it('should return shouldQueue when action should be queued', () => {
+  describe("processAction return values", () => {
+    it("should return shouldQueue when action should be queued", () => {
       // First process a normal action
-      manager.processAction('chat', { message: 'hello' }, 'player-1', 'Player One');
-      
+      manager.processAction(
+        "chat",
+        { message: "hello" },
+        "player-1",
+        "Player One",
+      );
+
       // The chat action should be processed
-      const result = manager.processAction('chat', { message: 'world' }, 'player-1', 'Player One');
+      const result = manager.processAction(
+        "chat",
+        { message: "world" },
+        "player-1",
+        "Player One",
+      );
       expect(result.shouldProcess).toBeDefined();
     });
 
-    it('should handle critical actions immediately', () => {
-      const result = manager.processAction('game-end', {}, 'player-1', 'Player One');
+    it("should handle critical actions immediately", () => {
+      const result = manager.processAction(
+        "game-end",
+        {},
+        "player-1",
+        "Player One",
+      );
       expect(result.shouldProcess).toBe(true);
-      expect(result.action?.priority).toBe('critical');
+      expect(result.action?.priority).toBe("critical");
     });
 
-    it('should handle high priority actions', () => {
-      const result = manager.processAction('spell-cast', { spellId: 'lightning' }, 'player-1', 'Player One');
+    it("should handle high priority actions", () => {
+      const result = manager.processAction(
+        "spell-cast",
+        { spellId: "lightning" },
+        "player-1",
+        "Player One",
+      );
       expect(result.shouldProcess).toBe(true);
-      expect(result.action?.priority).toBe('high');
+      expect(result.action?.priority).toBe("high");
     });
   });
 
-  describe('updateConfig', () => {
-    it('should update configuration', () => {
+  describe("updateConfig", () => {
+    it("should update configuration", () => {
       manager.updateConfig({
-        strategy: 'priority-based',
+        strategy: "priority-based",
         actionWindow: 500,
       });
 
@@ -111,9 +151,9 @@ describe('ConflictResolutionManager', () => {
       expect(manager).toBeDefined();
     });
 
-    it('should update host ID', () => {
+    it("should update host ID", () => {
       manager.updateConfig({
-        hostId: 'new-host',
+        hostId: "new-host",
       });
 
       expect(manager).toBeDefined();
@@ -121,172 +161,728 @@ describe('ConflictResolutionManager', () => {
   });
 });
 
-describe('Action Priority Mapping', () => {
-  it('should map critical actions correctly', () => {
-    const manager = new ConflictResolutionManager({ hostId: 'host' });
-    
-    const gameEndResult = manager.processAction('game-end', {}, 'p1', 'P1');
-    expect(gameEndResult.action?.priority).toBe('critical');
-    
-    const eliminatedResult = manager.processAction('player-eliminated', {}, 'p1', 'P1');
-    expect(eliminatedResult.action?.priority).toBe('critical');
-    
-    const correctionResult = manager.processAction('state-correction', {}, 'p1', 'P1');
-    expect(correctionResult.action?.priority).toBe('critical');
+describe("Action Priority Mapping", () => {
+  it("should map critical actions correctly", () => {
+    const manager = new ConflictResolutionManager({ hostId: "host" });
+
+    const gameEndResult = manager.processAction("game-end", {}, "p1", "P1");
+    expect(gameEndResult.action?.priority).toBe("critical");
+
+    const eliminatedResult = manager.processAction(
+      "player-eliminated",
+      {},
+      "p1",
+      "P1",
+    );
+    expect(eliminatedResult.action?.priority).toBe("critical");
+
+    const correctionResult = manager.processAction(
+      "state-correction",
+      {},
+      "p1",
+      "P1",
+    );
+    expect(correctionResult.action?.priority).toBe("critical");
   });
 
-  it('should map high priority actions correctly', () => {
-    const manager = new ConflictResolutionManager({ hostId: 'host' });
-    
-    const combatResult = manager.processAction('combat-declare', {}, 'p1', 'P1');
-    expect(combatResult.action?.priority).toBe('high');
-    
-    const spellResult = manager.processAction('spell-cast', {}, 'p1', 'P1');
-    expect(spellResult.action?.priority).toBe('high');
-    
-    const abilityResult = manager.processAction('ability-activate', {}, 'p1', 'P1');
-    expect(abilityResult.action?.priority).toBe('high');
+  it("should map high priority actions correctly", () => {
+    const manager = new ConflictResolutionManager({ hostId: "host" });
+
+    const combatResult = manager.processAction(
+      "combat-declare",
+      {},
+      "p1",
+      "P1",
+    );
+    expect(combatResult.action?.priority).toBe("high");
+
+    const spellResult = manager.processAction("spell-cast", {}, "p1", "P1");
+    expect(spellResult.action?.priority).toBe("high");
+
+    const abilityResult = manager.processAction(
+      "ability-activate",
+      {},
+      "p1",
+      "P1",
+    );
+    expect(abilityResult.action?.priority).toBe("high");
   });
 
-  it('should map normal priority actions correctly', () => {
-    const manager = new ConflictResolutionManager({ hostId: 'host' });
-    
-    const playCardResult = manager.processAction('play-card', {}, 'p1', 'P1');
-    expect(playCardResult.action?.priority).toBe('normal');
-    
-    const attackResult = manager.processAction('attack', {}, 'p1', 'P1');
-    expect(attackResult.action?.priority).toBe('normal');
-    
-    const blockResult = manager.processAction('block', {}, 'p1', 'P1');
-    expect(blockResult.action?.priority).toBe('normal');
-    
-    const tapResult = manager.processAction('tap', {}, 'p1', 'P1');
-    expect(tapResult.action?.priority).toBe('normal');
-    
-    const untapResult = manager.processAction('untap', {}, 'p1', 'P1');
-    expect(untapResult.action?.priority).toBe('normal');
+  it("should map normal priority actions correctly", () => {
+    const manager = new ConflictResolutionManager({ hostId: "host" });
+
+    const playCardResult = manager.processAction("play-card", {}, "p1", "P1");
+    expect(playCardResult.action?.priority).toBe("normal");
+
+    const attackResult = manager.processAction("attack", {}, "p1", "P1");
+    expect(attackResult.action?.priority).toBe("normal");
+
+    const blockResult = manager.processAction("block", {}, "p1", "P1");
+    expect(blockResult.action?.priority).toBe("normal");
+
+    const tapResult = manager.processAction("tap", {}, "p1", "P1");
+    expect(tapResult.action?.priority).toBe("normal");
+
+    const untapResult = manager.processAction("untap", {}, "p1", "P1");
+    expect(untapResult.action?.priority).toBe("normal");
   });
 
-  it('should map low priority actions correctly', () => {
-    const manager = new ConflictResolutionManager({ hostId: 'host' });
-    
-    const chatResult = manager.processAction('chat', {}, 'p1', 'P1');
-    expect(chatResult.action?.priority).toBe('low');
-    
-    const emoteResult = manager.processAction('emote', {}, 'p1', 'P1');
-    expect(emoteResult.action?.priority).toBe('low');
-    
-    const surrenderResult = manager.processAction('surrender', {}, 'p1', 'P1');
-    expect(surrenderResult.action?.priority).toBe('low');
+  it("should map low priority actions correctly", () => {
+    const manager = new ConflictResolutionManager({ hostId: "host" });
+
+    const chatResult = manager.processAction("chat", {}, "p1", "P1");
+    expect(chatResult.action?.priority).toBe("low");
+
+    const emoteResult = manager.processAction("emote", {}, "p1", "P1");
+    expect(emoteResult.action?.priority).toBe("low");
+
+    const surrenderResult = manager.processAction("surrender", {}, "p1", "P1");
+    expect(surrenderResult.action?.priority).toBe("low");
   });
 
-  it('should default to normal priority for unknown actions', () => {
-    const manager = new ConflictResolutionManager({ hostId: 'host' });
-    
-    const unknownResult = manager.processAction('unknown-action', {}, 'p1', 'P1');
-    expect(unknownResult.action?.priority).toBe('normal');
+  it("should default to normal priority for unknown actions", () => {
+    const manager = new ConflictResolutionManager({ hostId: "host" });
+
+    const unknownResult = manager.processAction(
+      "unknown-action",
+      {},
+      "p1",
+      "P1",
+    );
+    expect(unknownResult.action?.priority).toBe("normal");
   });
 });
 
-describe('Conflict Strategy Configurations', () => {
-  it('should handle host-wins strategy', () => {
+describe("Conflict Strategy Configurations", () => {
+  it("should handle host-wins strategy", () => {
     const manager = new ConflictResolutionManager({
-      hostId: 'host-1',
-      strategy: 'host-wins',
+      hostId: "host-1",
+      strategy: "host-wins",
     });
-    
+
     // Process actions from host - should always process
-    const hostAction = manager.processAction('play-card', {}, 'host-1', 'Host');
+    const hostAction = manager.processAction("play-card", {}, "host-1", "Host");
     expect(hostAction.shouldProcess).toBe(true);
-    
+
     // Non-host action may or may not process depending on conflict
-    const playerAction = manager.processAction('play-card', {}, 'player-2', 'Player 2');
+    const playerAction = manager.processAction(
+      "play-card",
+      {},
+      "player-2",
+      "Player 2",
+    );
     // Just verify it returns a valid result
     expect(playerAction.shouldProcess).toBeDefined();
   });
 
-  it('should handle timestamp-based strategy', () => {
+  it("should handle timestamp-based strategy", () => {
     const manager = new ConflictResolutionManager({
-      hostId: 'host-1',
-      strategy: 'timestamp-based',
+      hostId: "host-1",
+      strategy: "timestamp-based",
     });
-    
+
     expect(manager).toBeDefined();
-    
-    const result = manager.processAction('play-card', {}, 'player-1', 'Player One');
+
+    const result = manager.processAction(
+      "play-card",
+      {},
+      "player-1",
+      "Player One",
+    );
     expect(result.shouldProcess).toBe(true);
   });
 
-  it('should handle priority-based strategy', () => {
+  it("should handle priority-based strategy", () => {
     const manager = new ConflictResolutionManager({
-      hostId: 'host-1',
-      strategy: 'priority-based',
+      hostId: "host-1",
+      strategy: "priority-based",
     });
-    
+
     expect(manager).toBeDefined();
   });
 
-  it('should handle round-robin strategy', () => {
+  it("should handle round-robin strategy", () => {
     const manager = new ConflictResolutionManager({
-      hostId: 'host-1',
-      strategy: 'round-robin',
+      hostId: "host-1",
+      strategy: "round-robin",
     });
-    
+
     expect(manager).toBeDefined();
   });
 
-  it('should handle consensus strategy', () => {
+  it("should handle consensus strategy", () => {
     const manager = new ConflictResolutionManager({
-      hostId: 'host-1',
-      strategy: 'consensus',
+      hostId: "host-1",
+      strategy: "consensus",
     });
-    
+
     expect(manager).toBeDefined();
   });
 
-  it('should handle disabled priority system', () => {
+  it("should handle disabled priority system", () => {
     const manager = new ConflictResolutionManager({
-      hostId: 'host-1',
+      hostId: "host-1",
       enablePriority: false,
     });
-    
-    const result = manager.processAction('game-end', {}, 'player-1', 'Player One');
+
+    const result = manager.processAction(
+      "game-end",
+      {},
+      "player-1",
+      "Player One",
+    );
     // With priority disabled, even critical actions process normally
     expect(result.shouldProcess).toBe(true);
   });
 
-  it('should handle disabled sequence numbers', () => {
+  it("should handle disabled sequence numbers", () => {
     const manager = new ConflictResolutionManager({
-      hostId: 'host-1',
+      hostId: "host-1",
       enableSequenceNumbers: false,
     });
-    
-    const result1 = manager.processAction('play-card', {}, 'player-1', 'Player One');
-    const result2 = manager.processAction('play-card', {}, 'player-1', 'Player One');
-    
+
+    const result1 = manager.processAction(
+      "play-card",
+      {},
+      "player-1",
+      "Player One",
+    );
+    const result2 = manager.processAction(
+      "play-card",
+      {},
+      "player-1",
+      "Player One",
+    );
+
     expect(result1.action?.sequenceNumber).toBeDefined();
     expect(result2.action?.sequenceNumber).toBeDefined();
   });
 });
 
-describe('Type exports', () => {
-  it('should export ActionPriority type', () => {
-    const priority: ActionPriority = 'critical';
-    expect(['critical', 'high', 'normal', 'low']).toContain(priority);
+describe("Type exports", () => {
+  it("should export ActionPriority type", () => {
+    const priority: ActionPriority = "critical";
+    expect(["critical", "high", "normal", "low"]).toContain(priority);
   });
 
-  it('should export ConflictStrategy type', () => {
-    const strategy: ConflictStrategy = 'host-wins';
-    expect(['host-wins', 'timestamp-based', 'priority-based', 'round-robin', 'consensus']).toContain(strategy);
+  it("should export ConflictStrategy type", () => {
+    const strategy: ConflictStrategy = "host-wins";
+    expect([
+      "host-wins",
+      "timestamp-based",
+      "priority-based",
+      "round-robin",
+      "consensus",
+    ]).toContain(strategy);
   });
 
-  it('should accept all ActionPriority values', () => {
-    const priorities: ActionPriority[] = ['critical', 'high', 'normal', 'low'];
-    priorities.forEach(p => expect(p).toBeDefined());
+  it("should accept all ActionPriority values", () => {
+    const priorities: ActionPriority[] = ["critical", "high", "normal", "low"];
+    priorities.forEach((p) => expect(p).toBeDefined());
   });
 
-  it('should accept all ConflictStrategy values', () => {
-    const strategies: ConflictStrategy[] = ['host-wins', 'timestamp-based', 'priority-based', 'round-robin', 'consensus'];
-    strategies.forEach(s => expect(s).toBeDefined());
+  it("should accept all ConflictStrategy values", () => {
+    const strategies: ConflictStrategy[] = [
+      "host-wins",
+      "timestamp-based",
+      "priority-based",
+      "round-robin",
+      "consensus",
+    ];
+    strategies.forEach((s) => expect(s).toBeDefined());
+  });
+});
+
+// =============================================================================
+// Issue #1096 — conflict-resolution edge cases
+//
+// These tests drive REAL conflicts (two players acting within the action
+// window) and assert WHICH action wins under each strategy. `Date.now` is
+// mocked so every timestamp — and therefore every tie-break — is fully
+// deterministic instead of wall-clock dependent.
+// =============================================================================
+
+/**
+ * Return the action that won a conflict, independent of which side (action1
+ * vs action2) it was. Used to prove the winner is the same regardless of the
+ * order in which two simultaneous actions arrive.
+ */
+function winnerOf(conflict: ActionConflict): TimestampedAction {
+  return conflict.resolution === "action2-wins"
+    ? conflict.action2
+    : conflict.action1;
+}
+
+/**
+ * Read the most-recently recorded conflict from a manager's pending list.
+ *
+ * IMPORTANT real behaviour: `processAction()` only surfaces `conflict` on its
+ * RETURN value for the 'queue' and 'action2-wins' branches. An 'action1-wins'
+ * or 'merge' outcome falls through and returns `shouldProcess: true` WITHOUT a
+ * `conflict` field — even though the conflict was detected and recorded. So
+ * tests read conflicts from `getPendingConflicts()` (populated for every
+ * resolution branch at p2p-conflict-resolution.ts:170) to assert uniformly.
+ */
+function lastConflict(m: ConflictResolutionManager): ActionConflict {
+  const all = m.getPendingConflicts();
+  return all[all.length - 1];
+}
+
+describe("Issue #1096 — conflict detection within the action window", () => {
+  let now: number;
+
+  beforeEach(() => {
+    now = 1_000_000;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  const tick = (ms = 1) => {
+    now += ms;
+  };
+  const manager = (extra: Partial<ConflictResolutionConfig> = {}) =>
+    new ConflictResolutionManager({
+      hostId: "host",
+      strategy: "timestamp-based",
+      actionWindow: 100,
+      enablePriority: true,
+      enableSequenceNumbers: true,
+      ...extra,
+    });
+
+  it("flags a conflict when two different players act within the window", () => {
+    const m = manager();
+    m.processAction("play-card", {}, "p1", "One");
+    tick(10);
+    m.processAction("play-card", {}, "p2", "Two");
+
+    expect(m.getPendingConflicts()).toHaveLength(1);
+    const conflict = lastConflict(m);
+    expect(conflict.action1.playerId).toBe("p2"); // action1 is the newly-arriving action
+    expect(conflict.action2.playerId).toBe("p1");
+  });
+
+  it("does NOT conflict when the two actions fall outside the action window", () => {
+    const m = manager();
+    m.processAction("play-card", {}, "p1", "One");
+    tick(200); // > actionWindow (100)
+    const result = m.processAction("play-card", {}, "p2", "Two");
+
+    expect(result.conflict).toBeUndefined();
+    expect(result.shouldProcess).toBe(true);
+  });
+
+  it("does NOT conflict when both actions come from the same player", () => {
+    const m = manager();
+    m.processAction("play-card", {}, "p1", "One");
+    tick(5);
+    const result = m.processAction("attack", {}, "p1", "One");
+
+    expect(result.conflict).toBeUndefined();
+    expect(result.shouldProcess).toBe(true);
+  });
+});
+
+describe("Issue #1096 — host-wins strategy", () => {
+  let now: number;
+  beforeEach(() => {
+    now = 1_000_000;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+  });
+  afterEach(() => jest.restoreAllMocks());
+  const tick = (ms = 1) => {
+    now += ms;
+  };
+
+  it("the host action wins regardless of arrival order", () => {
+    // Order A: non-host first, host second.
+    const a = new ConflictResolutionManager({
+      hostId: "host",
+      strategy: "host-wins",
+      actionWindow: 100,
+    });
+    a.processAction("play-card", {}, "guest", "Guest");
+    tick(5);
+    const aResult = a.processAction("play-card", {}, "host", "Host");
+    expect(aResult.shouldProcess).toBe(true); // host wins, processed immediately
+    expect(lastConflict(a).resolution).toBe("action1-wins");
+
+    // Order B: host first, non-host second.
+    const b = new ConflictResolutionManager({
+      hostId: "host",
+      strategy: "host-wins",
+      actionWindow: 100,
+    });
+    b.processAction("play-card", {}, "host", "Host");
+    tick(5);
+    const bResult = b.processAction("play-card", {}, "guest", "Guest");
+    expect(bResult.shouldProcess).toBe(false); // guest loses, queued
+    expect(bResult.shouldQueue).toBe(true);
+    expect(lastConflict(b).resolution).toBe("action2-wins");
+    expect(winnerOf(lastConflict(b)).playerId).toBe("host");
+  });
+
+  it("when neither player is the host, falls back to the earlier timestamp", () => {
+    const m = new ConflictResolutionManager({
+      hostId: "host",
+      strategy: "host-wins",
+      actionWindow: 100,
+    });
+    m.processAction("play-card", {}, "aaa", "A"); // earlier
+    tick(7);
+    m.processAction("play-card", {}, "bbb", "B"); // later
+
+    expect(m.getPendingConflicts()).toHaveLength(1);
+    expect(winnerOf(lastConflict(m)).playerId).toBe("aaa"); // earlier timestamp wins
+  });
+});
+
+describe("Issue #1096 — timestamp-based strategy (last-writer-loses)", () => {
+  let now: number;
+  beforeEach(() => {
+    now = 1_000_000;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+  });
+  afterEach(() => jest.restoreAllMocks());
+  const tick = (ms = 1) => {
+    now += ms;
+  };
+
+  it("the earlier-timestamp action wins even if it arrives later", () => {
+    const m = new ConflictResolutionManager({
+      hostId: "h",
+      strategy: "timestamp-based",
+      actionWindow: 100,
+    });
+    m.processAction("play-card", {}, "p1", "One"); // ts = T0
+    // Move the clock BACK so the second action has an earlier timestamp.
+    now -= 5;
+    const result = m.processAction("play-card", {}, "p2", "Two"); // ts = T0-5
+
+    expect(m.getPendingConflicts()).toHaveLength(1);
+    expect(result.shouldProcess).toBe(true); // earlier timestamp (p2) wins
+    expect(winnerOf(lastConflict(m)).playerId).toBe("p2");
+  });
+
+  it("the later-timestamp action loses and is enqueued for replay", () => {
+    const m = new ConflictResolutionManager({
+      hostId: "h",
+      strategy: "timestamp-based",
+      actionWindow: 100,
+    });
+    m.processAction("play-card", {}, "p1", "One"); // ts = T0
+    tick(8);
+    const result = m.processAction("play-card", {}, "p2", "Two"); // ts = T0+8
+
+    expect(result.shouldProcess).toBe(false);
+    expect(result.shouldQueue).toBe(true);
+    expect(result.queueReason).toBe("Lower priority in conflict resolution");
+    expect(m.getQueueSize()).toBe(1);
+
+    const next = m.getNextQueuedAction();
+    expect(next).not.toBeNull();
+    expect(next?.playerId).toBe("p2");
+    expect(m.getQueueSize()).toBe(0);
+  });
+});
+
+describe("Issue #1096 — REGRESSION: deterministic tie-break on equal timestamps", () => {
+  // BUG (fixed): previously `action1.timestamp < action2.timestamp ? action1 : action2`
+  // resolved equal-timestamp ties to "action2-wins" — i.e. whichever action was
+  // processed FIRST. That depends on message arrival order, so two peers
+  // receiving the same simultaneous pair in opposite orders picked different
+  // winners and silently diverged. The fix breaks ties by lexicographic
+  // playerId (mirroring resolveSimultaneousConflict in deterministic-sync),
+  // so every peer computes the identical winner. These two tests process the
+  // SAME pair in opposite orders and require the SAME winner.
+
+  let now: number;
+  beforeEach(() => {
+    now = 1_000_000;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it("picks the lexicographically-smaller playerId when timestamps tie (order A)", () => {
+    const m = new ConflictResolutionManager({
+      hostId: "h",
+      strategy: "timestamp-based",
+      actionWindow: 100,
+    });
+    // 'aaa' processed first (becomes action2 in the conflict), 'bbb' second (action1).
+    m.processAction("play-card", {}, "aaa", "A"); // ts = T0 (now constant)
+    m.processAction("play-card", {}, "bbb", "B"); // ts = T0  -> tie
+
+    const conflict = lastConflict(m);
+    expect(conflict.action1.timestamp).toBe(conflict.action2.timestamp);
+    expect(winnerOf(conflict).playerId).toBe("aaa");
+  });
+
+  it("picks the same winner when the arrival order is reversed (order B)", () => {
+    const m = new ConflictResolutionManager({
+      hostId: "h",
+      strategy: "timestamp-based",
+      actionWindow: 100,
+    });
+    m.processAction("play-card", {}, "bbb", "B"); // first
+    m.processAction("play-card", {}, "aaa", "A"); // second -> tie
+
+    const conflict = lastConflict(m);
+    expect(conflict.action1.timestamp).toBe(conflict.action2.timestamp);
+    // Same winner as order A despite reversed arrival — the fix guarantees convergence.
+    expect(winnerOf(conflict).playerId).toBe("aaa");
+  });
+});
+
+describe("Issue #1096 — priority-based ordering", () => {
+  let now: number;
+  beforeEach(() => {
+    now = 1_000_000;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+  });
+  afterEach(() => jest.restoreAllMocks());
+  const tick = (ms = 1) => {
+    now += ms;
+  };
+
+  it("a higher-priority action beats a lower-priority action regardless of order", () => {
+    // 'game-end' is critical, 'play-card' is normal.
+    const m1 = new ConflictResolutionManager({
+      hostId: "h",
+      strategy: "priority-based",
+      actionWindow: 100,
+    });
+    m1.processAction("play-card", {}, "p1", "One"); // normal
+    tick(3);
+    m1.processAction("game-end", {}, "p2", "Two"); // critical, arrives second
+    expect(winnerOf(lastConflict(m1)).priority).toBe("critical");
+
+    const m2 = new ConflictResolutionManager({
+      hostId: "h",
+      strategy: "priority-based",
+      actionWindow: 100,
+    });
+    m2.processAction("game-end", {}, "p2", "Two"); // critical first
+    tick(3);
+    m2.processAction("play-card", {}, "p1", "One"); // normal second
+    expect(winnerOf(lastConflict(m2)).priority).toBe("critical");
+  });
+
+  it("equal priority + equal timestamp tie-breaks deterministically by playerId", () => {
+    const m = new ConflictResolutionManager({
+      hostId: "h",
+      strategy: "priority-based",
+      actionWindow: 100,
+    });
+    m.processAction("play-card", {}, "zzz", "Z"); // normal, ts T0
+    m.processAction("play-card", {}, "aaa", "A"); // normal, ts T0 -> tie
+
+    const conflict = lastConflict(m);
+    expect(conflict.action1.priority).toBe(conflict.action2.priority);
+    expect(winnerOf(conflict).playerId).toBe("aaa"); // smaller playerId wins
+  });
+});
+
+describe("Issue #1096 — round-robin & consensus strategies", () => {
+  let now: number;
+  beforeEach(() => {
+    now = 1_000_000;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+  });
+  afterEach(() => jest.restoreAllMocks());
+  const tick = (ms = 1) => {
+    now += ms;
+  };
+
+  it("round-robin resolves via turn order (stateful, not timestamp-based)", () => {
+    const m = new ConflictResolutionManager({
+      hostId: "h",
+      strategy: "round-robin",
+      actionWindow: 100,
+    });
+    m.processAction("play-card", {}, "p1", "One");
+    tick(2);
+    m.processAction("play-card", {}, "p2", "Two");
+
+    expect(m.getPendingConflicts()).toHaveLength(1);
+    const conflict = lastConflict(m);
+    expect(conflict.reason).toBe("Round-robin order");
+    // The newly-arriving action is appended to the turn order first, so on the
+    // very first conflict it wins. This is the documented behaviour: round-
+    // robin is turn-based and intentionally arrival-order-sensitive, unlike the
+    // timestamp strategies whose determinism is guaranteed separately above.
+    expect(conflict.resolution).toBe("action1-wins");
+  });
+
+  it("consensus defers both actions for peer agreement without enqueuing", () => {
+    const m = new ConflictResolutionManager({
+      hostId: "h",
+      strategy: "consensus",
+      actionWindow: 100,
+    });
+    m.processAction("play-card", {}, "p1", "One");
+    tick(2);
+    const result = m.processAction("play-card", {}, "p2", "Two");
+
+    expect(result.conflict?.resolution).toBe("queue");
+    expect(result.shouldProcess).toBe(false);
+    expect(result.shouldQueue).toBe(true);
+    expect(result.queueReason).toBe("Conflicting action being processed");
+    // The consensus branch returns early and does NOT place the action on the
+    // replay queue (it waits for explicit peer agreement).
+    expect(m.getQueueSize()).toBe(0);
+    expect(m.getPendingConflicts()).toHaveLength(1);
+  });
+});
+
+describe("Issue #1096 — out-of-order replay queue", () => {
+  let now: number;
+  beforeEach(() => {
+    now = 1_000_000;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+  });
+  afterEach(() => jest.restoreAllMocks());
+  const tick = (ms = 1) => {
+    now += ms;
+  };
+
+  it("replays queued actions oldest-first (FIFO by queuedAt)", () => {
+    const m = new ConflictResolutionManager({
+      hostId: "h",
+      strategy: "timestamp-based",
+      actionWindow: 100,
+    });
+    m.processAction("play-card", {}, "p1", "One"); // ts T0, stays processed (earliest => wins ties)
+
+    tick(10);
+    const r2 = m.processAction("play-card", {}, "p2", "Two"); // ts T0+10 => loses, queued
+    expect(r2.shouldQueue).toBe(true);
+    tick(20);
+    const r3 = m.processAction("play-card", {}, "p3", "Three"); // conflicts with p1, loses, queued
+    expect(r3.shouldQueue).toBe(true);
+    expect(m.getQueueSize()).toBe(2);
+
+    // Oldest queuedAt (p2) must come out before p3.
+    const first = m.getNextQueuedAction();
+    const second = m.getNextQueuedAction();
+    expect(first?.playerId).toBe("p2");
+    expect(second?.playerId).toBe("p3");
+    expect(m.getNextQueuedAction()).toBeNull();
+  });
+
+  it("returns null when the queue is empty", () => {
+    const m = new ConflictResolutionManager({
+      hostId: "h",
+      strategy: "timestamp-based",
+    });
+    expect(m.getNextQueuedAction()).toBeNull();
+  });
+
+  it("clearConflict removes a recorded conflict and reset clears sequence numbers", () => {
+    const m = new ConflictResolutionManager({
+      hostId: "h",
+      strategy: "consensus",
+      actionWindow: 100,
+    });
+    m.processAction("play-card", {}, "p1", "One");
+    tick(2);
+    const result = m.processAction("play-card", {}, "p2", "Two");
+    expect(m.getPendingConflicts()).toHaveLength(1);
+
+    m.clearConflict(result.conflict!.action1.actionId);
+    expect(m.getPendingConflicts()).toHaveLength(0);
+
+    // Sequence numbers are per-player and reset() clears them.
+    expect(
+      m.processAction("play-card", {}, "p1", "One").action?.sequenceNumber,
+    ).toBe(2);
+    m.reset();
+    expect(
+      m.processAction("play-card", {}, "p1", "One").action?.sequenceNumber,
+    ).toBe(1);
+  });
+});
+
+describe("Issue #1096 — cleanup evicts stale processed actions", () => {
+  it("removes actions older than maxAge so they no longer trigger conflicts", () => {
+    let now = 1_000_000;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+
+    // Use a wide window so p1 WOULD conflict without cleanup.
+    const m = new ConflictResolutionManager({
+      hostId: "h",
+      strategy: "timestamp-based",
+      actionWindow: 10_000,
+    });
+    m.processAction("play-card", {}, "p1", "One"); // ts T0
+
+    now += 5_000; // 5s later, still within the 10s window
+    m.cleanup(1_000); // evict actions older than 1s (p1 is 5s old)
+
+    const result = m.processAction("play-card", {}, "p2", "Two");
+    // p1 was evicted, so there is no recent other-player action to conflict with.
+    expect(result.conflict).toBeUndefined();
+    expect(result.shouldProcess).toBe(true);
+
+    jest.restoreAllMocks();
+  });
+});
+
+describe("Issue #1096 — mergeActions (CRDT-style merge policy)", () => {
+  function act(
+    actionType: string,
+    playerId: string,
+    ts: number,
+    data: unknown,
+  ): TimestampedAction {
+    return {
+      actionId: `${playerId}-1`,
+      playerId,
+      playerName: playerId,
+      actionType,
+      actionData: data,
+      timestamp: ts,
+      priority: "low",
+      sequenceNumber: 1,
+      receivedAt: ts,
+    };
+  }
+
+  it("merges two mergeable chat actions, keeping both payloads and the later timestamp", () => {
+    const a = act("chat", "p1", 100, { msg: "hi" });
+    const b = act("chat", "p2", 200, { msg: "yo" });
+    const merged = mergeActions(a, b);
+
+    expect(merged).not.toBeNull();
+    expect(merged?.timestamp).toBe(200); // Math.max
+    expect(merged?.actionData).toEqual({
+      merged: true,
+      actions: [{ msg: "hi" }, { msg: "yo" }],
+    });
+  });
+
+  it("returns null when either action is non-mergeable (e.g. play-card)", () => {
+    const chat = act("chat", "p1", 100, {});
+    const card = act("play-card", "p2", 100, { cardId: "c1" });
+    expect(mergeActions(chat, card)).toBeNull();
+    expect(mergeActions(card, chat)).toBeNull();
+  });
+
+  it("merges emote and surrender actions (all mergeable types)", () => {
+    const emote = act("emote", "p1", 5, { kind: "wave" });
+    const surrender = act("surrender", "p2", 9, {});
+    expect(mergeActions(emote, emote)).not.toBeNull();
+    expect(mergeActions(surrender, surrender)).not.toBeNull();
+  });
+});
+
+describe("Issue #1096 — factory", () => {
+  it("createConflictResolutionManager returns a configured manager instance", () => {
+    const m = createConflictResolutionManager({
+      hostId: "factory-host",
+      strategy: "priority-based",
+    });
+    expect(m).toBeInstanceOf(ConflictResolutionManager);
+    expect(m.getQueueSize()).toBe(0);
   });
 });

--- a/src/lib/game-state/__tests__/deterministic-sync-edge-cases.test.ts
+++ b/src/lib/game-state/__tests__/deterministic-sync-edge-cases.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Deterministic Sync — Edge Cases (Issue #1096)
+ *
+ * The existing deterministic-sync.test.ts / -extended.test.ts suites cover the
+ * happy path. This file targets the edge cases called out by #1096:
+ *   - Out-of-order action arrival still converges (AC #2).
+ *   - PROPERTY: the same input action set yields an identical final state hash
+ *     regardless of the order in which the actions arrive (AC #4).
+ *   - Simultaneous-action conflict tie-break is deterministic (lower timestamp,
+ *     then lower initiatorId) — mirroring p2p-conflict-resolution.
+ *   - Divergence is detected, the desync handler fires, and the peers
+ *     re-converge; the DesyncLogger records the injected divergence (AC #3).
+ *   - validateAction rejects actions whose previousStateHash does not match the
+ *     current state, and resolveConflict exercises its rollback / merge paths.
+ */
+
+import {
+  DeterministicGameStateEngine,
+  createDeterministicEngine,
+  serializeSyncMessage,
+  deserializeSyncMessage,
+  createDesyncAlertMessage,
+  type DeterministicAction,
+} from "../deterministic-sync";
+import { computeStateHash } from "../state-hash";
+import { createInitialGameState } from "../game-state";
+import type { GameState, GameAction, ActionType, ActionData } from "../types";
+import { DesyncLogger } from "../../desync-logger";
+
+/** Minimal game-action fixture (same shape used by deterministic-sync-extended). */
+function makeGameAction(type = "play_card"): GameAction {
+  return {
+    type: type as ActionType,
+    playerId: "player1",
+    timestamp: 1,
+    data: {} as ActionData,
+  };
+}
+
+/**
+ * Build a DeterministicAction with an EXPLICIT sequence number and a derived
+ * hash chain (h0 -> h1 -> ...). The hash strings are opaque tokens: the engine
+ * stores them verbatim, so we can assert convergence by comparing the final
+ * action's resultingStateHash without depending on real state transitions.
+ */
+function makeRemoteAction(
+  seq: number,
+  initiatorId: string,
+  timestamp = 100,
+): DeterministicAction {
+  return {
+    sequenceNumber: seq,
+    action: makeGameAction(),
+    previousStateHash: `h${seq - 1}`,
+    resultingStateHash: `h${seq}`,
+    initiatorId,
+    timestamp,
+  };
+}
+
+const BASE_STATE = (): GameState =>
+  createInitialGameState(["Alice", "Bob"], 20, false);
+
+/** Two states that differ only in turn number (=> a non-mergeable discrepancy). */
+function divergentState(): GameState {
+  const state = BASE_STATE();
+  state.turn.turnNumber = 9;
+  return state;
+}
+
+describe("Issue #1096 — out-of-order arrival converges", () => {
+  it("currentSequence tracks the high-water mark regardless of arrival order", () => {
+    const engine = createDeterministicEngine("me");
+    const state = BASE_STATE();
+
+    // Arrive badly out of order: 3, then 1, then 2.
+    engine.applyRemoteAction(makeRemoteAction(3, "peer", 300), state);
+    engine.applyRemoteAction(makeRemoteAction(1, "peer", 100), state);
+    engine.applyRemoteAction(makeRemoteAction(2, "peer", 200), state);
+
+    // Sequence is the max seen, not the last arrived.
+    expect(engine.getCurrentSequence()).toBe(3);
+    // Every action is retained.
+    expect(engine.getActionHistory()).toHaveLength(3);
+  });
+
+  it("a stale (low-sequence) remote action never rewinds the high-water mark", () => {
+    const engine = createDeterministicEngine("me");
+    const state = BASE_STATE();
+
+    engine.applyRemoteAction(makeRemoteAction(7, "peer", 700), state);
+    engine.applyRemoteAction(makeRemoteAction(2, "peer", 200), state); // stale
+
+    expect(engine.getCurrentSequence()).toBe(7);
+    // The next locally-created action continues from the high-water mark (8),
+    // not from the stale sequence (2).
+    const next = engine.createAction(makeGameAction(), state, state);
+    expect(next.sequenceNumber).toBe(8);
+  });
+
+  // AC #4 — the headline property.
+  it("PROPERTY: same action set => identical final state hash regardless of arrival order", () => {
+    const actions = [
+      makeRemoteAction(1, "peerA", 100),
+      makeRemoteAction(2, "peerB", 200),
+      makeRemoteAction(3, "peerA", 300),
+      makeRemoteAction(4, "peerB", 400),
+    ];
+
+    const inOrder = createDeterministicEngine("me");
+    actions.forEach((a) => inOrder.applyRemoteAction(a, BASE_STATE()));
+
+    const reversed = createDeterministicEngine("me");
+    [...actions]
+      .reverse()
+      .forEach((a) => reversed.applyRemoteAction(a, BASE_STATE()));
+
+    const scrambled = createDeterministicEngine("me");
+    [actions[2], actions[0], actions[3], actions[1]].forEach((a) =>
+      scrambled.applyRemoteAction(a, BASE_STATE()),
+    );
+
+    // All engines agree on the final sequence number.
+    expect(inOrder.getCurrentSequence()).toBe(4);
+    expect(reversed.getCurrentSequence()).toBe(4);
+    expect(scrambled.getCurrentSequence()).toBe(4);
+
+    // The "final state hash" is the resultingStateHash of the highest-sequence
+    // action — identical across all arrival orderings.
+    const finalHash = (eng: DeterministicGameStateEngine) =>
+      eng.getActionHistory().find((a) => a.sequenceNumber === 4)!
+        .resultingStateHash;
+    expect(finalHash(inOrder)).toBe("h4");
+    expect(finalHash(reversed)).toBe("h4");
+    expect(finalHash(scrambled)).toBe("h4");
+
+    // The applied sequence-number sets are identical.
+    const seqSet = (eng: DeterministicGameStateEngine) =>
+      new Set(eng.getActionHistory().map((a) => a.sequenceNumber));
+    expect(seqSet(inOrder)).toEqual(seqSet(reversed));
+    expect(seqSet(inOrder)).toEqual(seqSet(scrambled));
+  });
+});
+
+describe("Issue #1096 — validateAction hash-mismatch rejection", () => {
+  it("rejects an action whose previousStateHash does not match the current state", () => {
+    const engine = new DeterministicGameStateEngine("local");
+    const state = BASE_STATE();
+
+    const action: DeterministicAction = {
+      sequenceNumber: 1, // > currentSequence (0) so it skips the duplicate check
+      action: makeGameAction(),
+      previousStateHash: "definitely-wrong-hash",
+      resultingStateHash: "h1",
+      initiatorId: "remote",
+      timestamp: 1,
+    };
+
+    const result = engine.validateAction(action, state);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/State hash mismatch/);
+  });
+});
+
+describe("Issue #1096 — verifySync divergence detection & recovery (convergence)", () => {
+  it("detects divergence, fires the desync handler, then re-converges after re-sync", () => {
+    const engine = new DeterministicGameStateEngine("local");
+    const local = BASE_STATE();
+    const remote = divergentState();
+    expect(computeStateHash(local)).not.toBe(computeStateHash(remote));
+
+    engine.registerPeer("peer");
+    let handlerCalls = 0;
+    engine.setDesyncHandler(() => {
+      handlerCalls++;
+    });
+
+    // Inject divergence: peer advertises a different hash.
+    engine.updatePeerState("peer", 1, computeStateHash(remote));
+    const desyncResult = engine.verifySync(local);
+    expect(desyncResult.isInSync).toBe(false);
+    expect(desyncResult.discrepancies.has("peer")).toBe(true);
+    expect(handlerCalls).toBe(1);
+
+    // Recovery: peer's advertised hash now matches local.
+    engine.updatePeerState("peer", 1, computeStateHash(local));
+    const reconverged = engine.verifySync(local);
+    expect(reconverged.isInSync).toBe(true);
+    expect(reconverged.discrepancies.size).toBe(0);
+    // The handler must NOT fire again once peers have re-converged.
+    expect(handlerCalls).toBe(1);
+  });
+});
+
+describe("Issue #1096 — DesyncLogger records an injected divergence (AC #3)", () => {
+  it("logs a 'detected' event with the full local/remote hash context", () => {
+    const engine = new DeterministicGameStateEngine("local");
+    const logger = new DesyncLogger({
+      persistToStorage: false,
+      logToConsole: false,
+    });
+    const local = BASE_STATE();
+    const remote = divergentState();
+
+    engine.registerPeer("peer");
+    engine.setDesyncHandler((result) => {
+      logger.logDetection(
+        "local",
+        "peer",
+        result.localHash,
+        result.remoteHashes.get("peer") ?? "",
+        engine.getCurrentSequence(),
+        result.discrepancies.get("peer") ?? [],
+      );
+    });
+
+    engine.updatePeerState("peer", 3, computeStateHash(remote));
+    engine.verifySync(local);
+
+    expect(logger.getEvents()).toHaveLength(1);
+    const ev = logger.getEvents()[0];
+    expect(ev.type).toBe("detected");
+    expect(ev.localPeerId).toBe("local");
+    expect(ev.remotePeerId).toBe("peer");
+    expect(ev.localHash).toBe(computeStateHash(local));
+    expect(ev.remoteHash).toBe(computeStateHash(remote));
+    expect(ev.discrepancies.length).toBeGreaterThan(0);
+  });
+});
+
+describe("Issue #1096 — resolveConflict simultaneous-action tie-break", () => {
+  it("on equal timestamps, the lower initiatorId wins (deterministic across peers)", () => {
+    const engine = new DeterministicGameStateEngine("local");
+    const local = BASE_STATE();
+    const remote = divergentState(); // non-mergeable discrepancy
+
+    // Two remote actions sharing sequence number 5, identical timestamps.
+    engine.applyRemoteAction(makeRemoteAction(5, "peerA", 100), local);
+    engine.applyRemoteAction(makeRemoteAction(5, "peerB", 100), local);
+
+    const resolution = engine.resolveConflict(local, remote, "peerB", 5);
+    expect(resolution.resolved).toBe(true);
+    expect(resolution.strategy).toBe("authoritative");
+    expect(resolution.resolutionActions).toHaveLength(1);
+    // Equal timestamps => lexicographic initiatorId tie-break: "peerA" < "peerB".
+    expect(resolution.resolutionActions[0].initiatorId).toBe("peerA");
+    expect(resolution.conflictDescription).toContain("peerA");
+  });
+
+  it("a lower timestamp beats a lower initiatorId when timestamps differ", () => {
+    const engine = new DeterministicGameStateEngine("local");
+    const local = BASE_STATE();
+    const remote = divergentState();
+
+    engine.applyRemoteAction(makeRemoteAction(5, "peerZ", 300), local);
+    engine.applyRemoteAction(makeRemoteAction(5, "peerA", 100), local);
+
+    const resolution = engine.resolveConflict(local, remote, "peerA", 5);
+    // peerA has the lower timestamp (100) and wins despite "peerA" < "peerZ"
+    // already; the point is timestamp is the primary key.
+    expect(resolution.resolutionActions[0].initiatorId).toBe("peerA");
+  });
+});
+
+describe("Issue #1096 — resolveConflict rollback & merge paths", () => {
+  it("rolls back to the latest snapshot when there are no simultaneous actions", () => {
+    const engine = new DeterministicGameStateEngine("local");
+    const local = BASE_STATE();
+    const remote = divergentState();
+
+    engine.takeSnapshot(local); // snapshot recorded at sequence 0
+    // No actions share sequence 10 => findSimultaneousActions is empty.
+    const resolution = engine.resolveConflict(local, remote, "peerB", 10);
+
+    expect(resolution.resolved).toBe(true);
+    expect(resolution.strategy).toBe("rollback");
+    expect(resolution.rollbackSequence).toBe(0);
+    expect(resolution.rollbackState).toBeDefined();
+  });
+
+  it("uses authoritative resolution when only life totals differ (mergeable)", () => {
+    const engine = new DeterministicGameStateEngine("local");
+    const local = BASE_STATE();
+    const remote = BASE_STATE();
+    // Differ ONLY in one player's life total => discrepancy is player/Life-total
+    // => mergeable => authoritative resolution path.
+    const firstPlayerId = Array.from(remote.players.keys())[0];
+    remote.players.get(firstPlayerId)!.life = 17;
+
+    const resolution = engine.resolveConflict(local, remote, "peer", 1);
+    expect(resolution.resolved).toBe(true);
+    expect(resolution.strategy).toBe("authoritative");
+  });
+});
+
+describe("Issue #1096 — sync message (de)serialization round-trip", () => {
+  it("round-trips a desync-alert message and rejects malformed input", () => {
+    const msg = createDesyncAlertMessage("hashLocal", "hashRemote", 5, "me");
+    const round = deserializeSyncMessage(serializeSyncMessage(msg));
+
+    expect(round).not.toBeNull();
+    expect((round as { type: string }).type).toBe("desync-alert");
+    expect((round as { localHash: string }).localHash).toBe("hashLocal");
+    expect((round as { remoteHash: string }).remoteHash).toBe("hashRemote");
+
+    expect(deserializeSyncMessage("{ not json")).toBeNull();
+  });
+});

--- a/src/lib/p2p-conflict-resolution.ts
+++ b/src/lib/p2p-conflict-resolution.ts
@@ -1,6 +1,6 @@
 /**
  * P2P Conflict Resolution for Simultaneous Actions
- * 
+ *
  * This module handles conflict resolution when multiple players
  * perform actions simultaneously in P2P mode.
  */
@@ -8,17 +8,17 @@
 /**
  * Action priority levels for conflict resolution
  */
-export type ActionPriority = 'critical' | 'high' | 'normal' | 'low';
+export type ActionPriority = "critical" | "high" | "normal" | "low";
 
 /**
  * Conflict resolution strategy
  */
 export type ConflictStrategy =
-  | 'host-wins'        // Host's action takes priority
-  | 'timestamp-based'  // Earlier timestamp wins
-  | 'priority-based'   // Higher priority action wins
-  | 'round-robin'      // Alternate between players
-  | 'consensus'        // Require agreement from all peers;
+  | "host-wins" // Host's action takes priority
+  | "timestamp-based" // Earlier timestamp wins
+  | "priority-based" // Higher priority action wins
+  | "round-robin" // Alternate between players
+  | "consensus"; // Require agreement from all peers;
 
 /**
  * Action wrapper with metadata for conflict resolution
@@ -41,7 +41,7 @@ export interface TimestampedAction {
 export interface ActionConflict {
   action1: TimestampedAction;
   action2: TimestampedAction;
-  resolution: 'action1-wins' | 'action2-wins' | 'merge' | 'queue';
+  resolution: "action1-wins" | "action2-wins" | "merge" | "queue";
   reason: string;
   resolvedAt: number;
 }
@@ -70,9 +70,9 @@ export interface ConflictResolutionConfig {
  * Default configuration
  */
 const DEFAULT_CONFIG: ConflictResolutionConfig = {
-  strategy: 'host-wins',
+  strategy: "host-wins",
   actionWindow: 100, // 100ms window
-  hostId: '',
+  hostId: "",
   enablePriority: true,
   enableSequenceNumbers: true,
 };
@@ -82,26 +82,26 @@ const DEFAULT_CONFIG: ConflictResolutionConfig = {
  */
 const ACTION_PRIORITY_MAP: Record<string, ActionPriority> = {
   // Critical actions that must be processed immediately
-  'game-end': 'critical',
-  'player-eliminated': 'critical',
-  'state-correction': 'critical',
-  
+  "game-end": "critical",
+  "player-eliminated": "critical",
+  "state-correction": "critical",
+
   // High priority actions
-  'combat-declare': 'high',
-  'spell-cast': 'high',
-  'ability-activate': 'high',
-  
+  "combat-declare": "high",
+  "spell-cast": "high",
+  "ability-activate": "high",
+
   // Normal game actions
-  'play-card': 'normal',
-  'attack': 'normal',
-  'block': 'normal',
-  'tap': 'normal',
-  'untap': 'normal',
-  
+  "play-card": "normal",
+  attack: "normal",
+  block: "normal",
+  tap: "normal",
+  untap: "normal",
+
   // Low priority actions
-  'chat': 'low',
-  'emote': 'low',
-  'surrender': 'low',
+  chat: "low",
+  emote: "low",
+  surrender: "low",
 };
 
 /**
@@ -136,7 +136,7 @@ export class ConflictResolutionManager {
     actionType: string,
     actionData: unknown,
     playerId: string,
-    playerName: string
+    playerName: string,
   ): {
     shouldProcess: boolean;
     action?: TimestampedAction;
@@ -145,7 +145,7 @@ export class ConflictResolutionManager {
     queueReason?: string;
   } {
     const now = Date.now();
-    
+
     // Create timestamped action
     const sequenceNumber = this.getNextSequenceNumber(playerId);
     const action: TimestampedAction = {
@@ -169,22 +169,22 @@ export class ConflictResolutionManager {
       const conflict = this.resolveConflict(action, conflictingAction);
       this.pendingConflicts.set(conflict.action1.actionId, conflict);
 
-      if (conflict.resolution === 'queue') {
+      if (conflict.resolution === "queue") {
         return {
           shouldProcess: false,
           shouldQueue: true,
-          queueReason: 'Conflicting action being processed',
+          queueReason: "Conflicting action being processed",
           conflict,
         };
       }
 
-      if (conflict.resolution === 'action2-wins') {
+      if (conflict.resolution === "action2-wins") {
         // Other action wins, queue this one
         this.queueAction(action);
         return {
           shouldProcess: false,
           shouldQueue: true,
-          queueReason: 'Lower priority in conflict resolution',
+          queueReason: "Lower priority in conflict resolution",
           conflict,
         };
       }
@@ -206,11 +206,11 @@ export class ConflictResolutionManager {
    */
   private findConflict(
     newAction: TimestampedAction,
-    recentActions: TimestampedAction[]
+    recentActions: TimestampedAction[],
   ): TimestampedAction | null {
     // Only check for conflicts if there are recent actions from other players
     const otherPlayerActions = recentActions.filter(
-      a => a.playerId !== newAction.playerId
+      (a) => a.playerId !== newAction.playerId,
     );
 
     if (otherPlayerActions.length === 0) {
@@ -219,7 +219,7 @@ export class ConflictResolutionManager {
 
     // Find the most recent action from another player
     const mostRecent = otherPlayerActions.reduce((latest, current) =>
-      current.timestamp > latest.timestamp ? current : latest
+      current.timestamp > latest.timestamp ? current : latest,
     );
 
     // Check if within the action window
@@ -236,52 +236,57 @@ export class ConflictResolutionManager {
    */
   private resolveConflict(
     action1: TimestampedAction,
-    action2: TimestampedAction
+    action2: TimestampedAction,
   ): ActionConflict {
     const now = Date.now();
-    let resolution: 'action1-wins' | 'action2-wins' | 'merge' | 'queue';
+    let resolution: "action1-wins" | "action2-wins" | "merge" | "queue";
     let reason: string;
 
     switch (this.config.strategy) {
-      case 'host-wins':
+      case "host-wins":
         if (action1.playerId === this.config.hostId) {
-          resolution = 'action1-wins';
-          reason = 'Host action takes priority';
+          resolution = "action1-wins";
+          reason = "Host action takes priority";
         } else if (action2.playerId === this.config.hostId) {
-          resolution = 'action2-wins';
-          reason = 'Host action takes priority';
+          resolution = "action2-wins";
+          reason = "Host action takes priority";
         } else {
           // Neither is host, fall back to timestamp
-          resolution = action1.timestamp < action2.timestamp ? 'action1-wins' : 'action2-wins';
-          reason = 'Earlier timestamp wins (neither is host)';
+          resolution = this.pickWinnerByTimestamp(action1, action2);
+          reason = "Earlier timestamp wins (neither is host)";
         }
         break;
 
-      case 'timestamp-based':
-        resolution = action1.timestamp < action2.timestamp ? 'action1-wins' : 'action2-wins';
-        reason = 'Earlier timestamp wins';
+      case "timestamp-based":
+        resolution = this.pickWinnerByTimestamp(action1, action2);
+        reason = "Earlier timestamp wins";
         break;
 
-      case 'priority-based': {
-        const priorityOrder: ActionPriority[] = ['critical', 'high', 'normal', 'low'];
+      case "priority-based": {
+        const priorityOrder: ActionPriority[] = [
+          "critical",
+          "high",
+          "normal",
+          "low",
+        ];
         const action1Priority = priorityOrder.indexOf(action1.priority);
         const action2Priority = priorityOrder.indexOf(action2.priority);
 
         if (action1Priority < action2Priority) {
-          resolution = 'action1-wins';
-          reason = 'Higher priority action wins';
+          resolution = "action1-wins";
+          reason = "Higher priority action wins";
         } else if (action2Priority < action1Priority) {
-          resolution = 'action2-wins';
-          reason = 'Higher priority action wins';
+          resolution = "action2-wins";
+          reason = "Higher priority action wins";
         } else {
-          // Same priority, use timestamp
-          resolution = action1.timestamp < action2.timestamp ? 'action1-wins' : 'action2-wins';
-          reason = 'Same priority, earlier timestamp wins';
+          // Same priority, use timestamp (with a deterministic tie-break)
+          resolution = this.pickWinnerByTimestamp(action1, action2);
+          reason = "Same priority, earlier timestamp wins";
         }
         break;
       }
 
-      case 'round-robin': {
+      case "round-robin": {
         // Track turn order for round-robin
         if (!this.roundRobinOrder.includes(action1.playerId)) {
           this.roundRobinOrder.push(action1.playerId);
@@ -295,24 +300,24 @@ export class ConflictResolutionManager {
         const action2Index = this.roundRobinOrder.indexOf(action2.playerId);
 
         if (action1Index < action2Index) {
-          resolution = 'action1-wins';
-          reason = 'Round-robin order';
+          resolution = "action1-wins";
+          reason = "Round-robin order";
         } else {
-          resolution = 'action2-wins';
-          reason = 'Round-robin order';
+          resolution = "action2-wins";
+          reason = "Round-robin order";
         }
         break;
       }
 
-      case 'consensus':
+      case "consensus":
         // For consensus, we queue both actions and wait for agreement
-        resolution = 'queue';
-        reason = 'Waiting for consensus from all peers';
+        resolution = "queue";
+        reason = "Waiting for consensus from all peers";
         break;
 
       default:
-        resolution = 'timestamp-based' as any;
-        reason = 'Default resolution';
+        resolution = "timestamp-based" as any;
+        reason = "Default resolution";
     }
 
     return {
@@ -347,7 +352,7 @@ export class ConflictResolutionManager {
     entries.sort((a, b) => a[1].queuedAt - b[1].queuedAt);
 
     const [actionId, queuedAction] = entries[0];
-    
+
     // Check if dependency is resolved
     if (queuedAction.processAfter) {
       if (!this.processedActions.has(queuedAction.processAfter)) {
@@ -365,15 +370,46 @@ export class ConflictResolutionManager {
   private getRecentActions(windowMs: number): TimestampedAction[] {
     const now = Date.now();
     return Array.from(this.processedActions.values()).filter(
-      action => now - action.timestamp <= windowMs
+      (action) => now - action.timestamp <= windowMs,
     );
+  }
+
+  /**
+   * Pick the winner between two actions by timestamp.
+   *
+   * When the timestamps are EQUAL (a true simultaneous tie) the previous
+   * implementation fell back to "action2-wins", i.e. whichever action was
+   * processed first. That is dependent on message arrival order, so two peers
+   * receiving the same pair of simultaneous actions in opposite orders would
+   * pick different winners and silently diverge — exactly the class of bug
+   * this module exists to prevent.
+   *
+   * The tie is now broken deterministically by lexicographic playerId: the
+   * action whose playerId sorts lower wins. Because findConflict() only pairs
+   * actions from DIFFERENT players, the playerIds always differ, so every
+   * peer independently computes the identical winner regardless of arrival
+   * order. This mirrors resolveSimultaneousConflict() in deterministic-sync.
+   * (Issue #1096.)
+   */
+  private pickWinnerByTimestamp(
+    action1: TimestampedAction,
+    action2: TimestampedAction,
+  ): "action1-wins" | "action2-wins" {
+    if (action1.timestamp !== action2.timestamp) {
+      return action1.timestamp < action2.timestamp
+        ? "action1-wins"
+        : "action2-wins";
+    }
+    return action1.playerId < action2.playerId
+      ? "action1-wins"
+      : "action2-wins";
   }
 
   /**
    * Get action priority based on type
    */
   private getActionPriority(actionType: string): ActionPriority {
-    return ACTION_PRIORITY_MAP[actionType] || 'normal';
+    return ACTION_PRIORITY_MAP[actionType] || "normal";
   }
 
   /**
@@ -443,7 +479,7 @@ export class ConflictResolutionManager {
  * Create a conflict resolution manager
  */
 export function createConflictResolutionManager(
-  config: Partial<ConflictResolutionConfig> = {}
+  config: Partial<ConflictResolutionConfig> = {},
 ): ConflictResolutionManager {
   return new ConflictResolutionManager(config);
 }
@@ -453,13 +489,15 @@ export function createConflictResolutionManager(
  */
 export function mergeActions(
   action1: TimestampedAction,
-  action2: TimestampedAction
+  action2: TimestampedAction,
 ): TimestampedAction | null {
   // Only certain action types can be merged
-  const mergeableTypes = ['chat', 'emote', 'surrender'];
+  const mergeableTypes = ["chat", "emote", "surrender"];
 
-  if (!mergeableTypes.includes(action1.actionType) ||
-      !mergeableTypes.includes(action2.actionType)) {
+  if (
+    !mergeableTypes.includes(action1.actionType) ||
+    !mergeableTypes.includes(action2.actionType)
+  ) {
     return null;
   }
 


### PR DESCRIPTION
Adds edge-case unit tests for the P2P conflict-resolution, deterministic-sync, and desync-logger modules.

## Changes
- `src/lib/__tests__/p2p-conflict-resolution.test.ts` — extended with concurrent-conflict, deterministic tie-breaking, priority ordering, and out-of-order application cases
- `src/lib/__tests__/deterministic-sync-edge-cases.test.ts` (new) — identical-inputs-converge, divergence detection, re-sync/recovery
- `src/lib/__tests__/desync-logger.test.ts` (new) — desync events logged with correct context
- `src/lib/p2p-conflict-resolution.ts` — correctness fix found while writing the tests (regression test included)

Resolves #1096