### PR TITLE
test(e2e): resolve #1095 — stabilize and re-enable flaky import-export-roundtrip E2E suite

### DIFF
--- a/e2e/import-export-roundtrip.spec.ts
+++ b/e2e/import-export-roundtrip.spec.ts
@@ -3,79 +3,109 @@
  *
  * Verifies that decks remain identical after a full export/import cycle
  * across multiple formats (Text, JSON, Clipboard).
+ *
+ * Stability notes
+ * ---------------
+ * The previous version of this suite relied on fixed `waitForTimeout`
+ * sleeps and `waitForLoadState("networkidle")`, which raced the async
+ * deck-parse / clipboard / dialog-close operations on slower CI runners.
+ * Those have been replaced with state-based readiness signals:
+ *
+ *   - Page ready:   wait for the toolbar (`import-deck-button`) to render.
+ *   - Format set:   wait for the `format-select` trigger to reflect the
+ *                   chosen value before importing (the import reads the
+ *                   `format` state, so this removes a stale-state race).
+ *   - Import done:  on success `ImportExportControls` closes its dialog, so
+ *                   we wait for `import-textarea` to leave the DOM rather
+ *                   than sleeping a fixed number of milliseconds.
+ *   - Clipboard:    wait for the app's own toast ("Copied to clipboard" /
+ *                   "Pasted from clipboard") and the textarea value.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { seedCardDatabase, waitForDbSeed } from "./test-utils";
 
-// Run tests in CI but with longer timeouts and retries
-const testOptions =
-  process.env.CI === "true"
-    ? { retries: 2, timeout: 60000 }
-    : { retries: 0, timeout: 30000 };
+/**
+ * Select a deck-legality format from the toolbar `<Select>` and block until
+ * the trigger reflects the new value, guaranteeing the next import reads the
+ * intended format.
+ */
+async function selectFormat(page: Page, name: RegExp) {
+  const trigger = page.getByTestId("format-select");
+  await trigger.click();
+  await page.getByRole("option", { name }).click();
+  await expect(trigger).toContainText(name);
+}
+
+/**
+ * Deterministic "import resolved" signal: a successful import with no errors
+ * closes the import dialog, detaching the textarea from the DOM.
+ */
+async function waitForImportResolved(page: Page) {
+  await expect(page.getByTestId("import-textarea")).toBeHidden({
+    timeout: 15000,
+  });
+}
 
 test.describe("Import/Export Round Trip", () => {
   test.beforeEach(async ({ page }) => {
-    // Seed database before navigation so IndexedDB is ready when app initializes
+    // Seed the card database before navigation so IndexedDB is ready when
+    // the app initializes.
     await seedCardDatabase(page);
     await page.goto("/deck-builder");
-    await page.waitForLoadState("networkidle");
+
+    // Wait for the toolbar to render instead of `networkidle`, which never
+    // reliably settles on the HMR dev server.
+    await expect(page.getByTestId("import-deck-button")).toBeVisible({
+      timeout: 15000,
+    });
     await waitForDbSeed(page);
 
-    // Clear any existing deck if needed
-    const clearButton = page.getByTestId("clear-deck-button");
+    // Ensure every test starts from an empty deck.
     const deckCount = page.getByTestId("deck-count");
-
-    if (await deckCount.isVisible()) {
-      const text = await deckCount.textContent();
-      if (text && !text.includes("0 cards")) {
-        await clearButton.click();
-        await page.waitForLoadState("networkidle");
-        const confirmClear = page.getByTestId("confirm-clear-button");
-        await expect(confirmClear).toBeVisible();
-        await confirmClear.click();
-        await expect(deckCount).toContainText("0 cards");
-      }
+    await expect(deckCount).toBeVisible();
+    const current = (await deckCount.textContent()) ?? "";
+    if (!current.includes("0 cards")) {
+      await page.getByTestId("clear-deck-button").click();
+      const confirmClear = page.getByTestId("confirm-clear-button");
+      await expect(confirmClear).toBeVisible();
+      await confirmClear.click();
+      await expect(deckCount).toContainText("0 cards");
     }
   });
 
   test("should round-trip a simple deck via text import/export", async ({
     page,
   }) => {
-    // Extend timeout for CI
     test.setTimeout(60000);
+
+    // Set legality format to Standard first so 4x copies resolve.
+    await selectFormat(page, /standard/i);
 
     const sampleDeck = `4 Lightning Bolt
 4 Mountain
 20 Island`;
 
-    // Set format to Standard first so 4x copies are legal
-    const formatSelect = page.getByTestId("format-select");
-    await formatSelect.click();
-    await page.getByRole("option", { name: /standard/i }).click();
-
     // 1. Import
     await page.getByTestId("import-deck-button").click();
-    // Wait for dialog to be fully visible before filling textarea
     const textarea = page.getByTestId("import-textarea");
-    await textarea.waitFor({ state: "visible", timeout: 10000 });
+    await expect(textarea).toBeVisible({ timeout: 10000 });
     await textarea.fill(sampleDeck);
     await page.getByTestId("confirm-import-button").click();
 
-    // Wait for import to complete and cards to appear in deck list
-    await page.waitForTimeout(3000);
+    // Wait for the async import to resolve (dialog closes on success) and the
+    // deck count to update — no fixed sleeps.
+    await waitForImportResolved(page);
+    await expect(page.getByTestId("deck-count")).toContainText("28 cards");
 
     // 2. Export (as text)
     await page.getByTestId("export-deck-button").click();
-
-    // Wait for export dialog to be visible
     await expect(page.getByTestId("export-text-button")).toBeVisible({
       timeout: 10000,
     });
     await expect(page.getByTestId("export-copy-button")).toBeVisible();
 
-    // 3. Verify card count in UI matches
-    // The deck list should show these cards
+    // 3. Verify the imported cards rendered in the deck list.
     await expect(page.getByTestId("deck-item-lightning-bolt")).toBeVisible({
       timeout: 10000,
     });
@@ -84,20 +114,20 @@ test.describe("Import/Export Round Trip", () => {
   });
 
   test("should round-trip a complex deck via JSON", async ({ page }) => {
-    // Set format to Commander
-    const formatSelect = page.getByTestId("format-select");
-    await formatSelect.click();
-    await page.getByRole("option", { name: /commander/i }).click();
+    test.setTimeout(60000);
+
+    await selectFormat(page, /commander/i);
 
     // 1. Import JSON
     await page.getByTestId("import-deck-button").click();
-
-    // Wait for import dialog to be visible
     const textarea = page.getByTestId("import-textarea");
-    await textarea.waitFor({ state: "visible", timeout: 10000 });
+    await expect(textarea).toBeVisible({ timeout: 10000 });
 
-    // Select JSON format via the tabs - click on the JSON tab trigger
-    await page.getByRole("tab", { name: /json/i }).click();
+    // Switch the *input* format to JSON (distinct from the legality format
+    // above) and gate on the tab becoming active before filling.
+    const jsonTab = page.getByRole("tab", { name: /json/i });
+    await jsonTab.click();
+    await expect(jsonTab).toHaveAttribute("data-state", "active");
 
     const jsonDeck = JSON.stringify({
       cards: [
@@ -110,16 +140,17 @@ test.describe("Import/Export Round Trip", () => {
     await textarea.fill(jsonDeck);
     await page.getByTestId("confirm-import-button").click();
 
-    // Wait for import to complete - deck count should update
-    await page.waitForTimeout(2000);
-    await expect(page.getByTestId("deck-count")).toContainText(/[1-9] cards?/);
+    // Wait for import to resolve.
+    await waitForImportResolved(page);
+    await expect(page.getByTestId("deck-count")).toContainText("3 cards");
 
     // 2. Export JSON
     await page.getByTestId("export-deck-button").click();
-    await expect(page.getByTestId("export-json-button")).toBeVisible();
+    await expect(page.getByTestId("export-json-button")).toBeVisible({
+      timeout: 10000,
+    });
 
     // 3. Verify results
-    // Check if cards are in the deck list
     await expect(page.getByTestId("deck-item-sol-ring")).toBeVisible({
       timeout: 10000,
     });
@@ -128,23 +159,16 @@ test.describe("Import/Export Round Trip", () => {
   });
 
   test("should round-trip via clipboard", async ({ page, context }) => {
-    // Grant clipboard permissions
+    test.setTimeout(60000);
+
+    // Grant clipboard permissions for the round trip.
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    await selectFormat(page, /commander/i);
 
-    // Set format to Commander so cards are legal
-    const formatSelect = page.getByTestId("format-select");
-    await formatSelect.click();
-    await page.getByRole("option", { name: /commander/i }).click();
-
-    // Wait for page to settle
-    await page.waitForTimeout(1000);
-
-    // 1. Import a simple deck via the import dialog
+    // 1. Import a simple deck via the import dialog.
     await page.getByTestId("import-deck-button").click();
-
-    // Wait for import dialog to be fully visible
     const textarea = page.getByTestId("import-textarea");
-    await textarea.waitFor({ state: "visible", timeout: 10000 });
+    await expect(textarea).toBeVisible({ timeout: 10000 });
 
     const sampleDeck = `1 Lightning Bolt
 1 Sol Ring`;
@@ -152,10 +176,11 @@ test.describe("Import/Export Round Trip", () => {
     await textarea.fill(sampleDeck);
     await page.getByTestId("confirm-import-button").click();
 
-    // Wait for import to complete
-    await page.waitForTimeout(2000);
+    // Wait for import to resolve.
+    await waitForImportResolved(page);
+    await expect(page.getByTestId("deck-count")).toContainText("2 cards");
 
-    // Verify cards are in the deck
+    // Verify cards are in the deck.
     await expect(page.getByTestId("deck-item-lightning-bolt")).toBeVisible({
       timeout: 10000,
     });
@@ -163,51 +188,56 @@ test.describe("Import/Export Round Trip", () => {
       timeout: 10000,
     });
 
-    // 2. Export to clipboard
+    // 2. Export to clipboard.
     await page.getByTestId("export-deck-button").click();
-
-    // Wait for dialog to open and be visible
-    await page.waitForTimeout(500);
-
-    // Click copy to clipboard button
     const copyButton = page.getByTestId("export-copy-button");
     await expect(copyButton).toBeVisible({ timeout: 10000 });
     await copyButton.click();
 
-    // Wait briefly for clipboard operation
-    await page.waitForTimeout(500);
+    // Wait for the app's own completion toast, then assert the clipboard
+    // actually received the decklist (data-integrity check).
+    await expect(
+      page.getByText("Copied to clipboard", { exact: true }),
+    ).toBeVisible({ timeout: 10000 });
+    const clipboardText = await page.evaluate(() =>
+      navigator.clipboard.readText(),
+    );
+    expect(clipboardText).toContain("Lightning Bolt");
+    expect(clipboardText).toContain("Sol Ring");
 
-    // Press Escape to close the dialog
-    await page.keyboard.press("Escape");
-    await page.waitForTimeout(500);
+    // Close the export dialog via its Close (X) button before clearing the
+    // deck. A direct click is more reliable than Escape, which a toast layer
+    // can intercept.
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Close" })
+      .click();
+    await expect(page.getByTestId("export-copy-button")).toBeHidden({
+      timeout: 5000,
+    });
 
-    // 3. Clear deck
+    // 3. Clear the deck.
     await page.getByTestId("clear-deck-button").click();
-    await page.waitForTimeout(300);
-    await page.getByTestId("confirm-clear-button").click();
+    const confirmClear = page.getByTestId("confirm-clear-button");
+    await expect(confirmClear).toBeVisible();
+    await confirmClear.click();
     await expect(page.getByTestId("deck-count")).toContainText("0 cards");
 
-    // 4. Import from clipboard
+    // 4. Import from clipboard.
     await page.getByTestId("import-deck-button").click();
+    await expect(textarea).toBeVisible({ timeout: 10000 });
 
-    // Wait for dialog to open
-    await textarea.waitFor({ state: "visible", timeout: 10000 });
-
-    // Click the "Paste from Clipboard" button
     const pasteButton = page.getByTestId("paste-deck-button");
     await expect(pasteButton).toBeVisible({ timeout: 5000 });
     await pasteButton.click();
 
-    // Wait for paste to complete
-    await page.waitForTimeout(1000);
-
-    // The textarea should now have content
-    const textareaValue = await textarea.inputValue();
-    expect(textareaValue.length).toBeGreaterThan(0);
+    // Wait for the paste to populate the textarea (auto-waiting on value).
+    await expect(textarea).toHaveValue(/Lightning Bolt/, { timeout: 10000 });
 
     await page.getByTestId("confirm-import-button").click();
 
-    // 5. Verify cards are back
+    // 5. Verify cards are back.
+    await waitForImportResolved(page);
     await expect(page.getByTestId("deck-item-lightning-bolt")).toBeVisible({
       timeout: 10000,
     });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,49 +1,46 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig } from "@playwright/test";
 
 /**
  * Playwright Configuration for Planar Nexus E2E Tests
- * 
+ *
  * This configuration sets up E2E testing for the Planar Nexus application.
  * Tests run against a local dev server on port 9002.
  */
 
 // Dev-server origin (also used as the base URL for every test).
-const E2E_ORIGIN = process.env.BASE_URL || 'http://localhost:9002';
+const E2E_ORIGIN = process.env.BASE_URL || "http://localhost:9002";
 
 export default defineConfig({
   // Directory containing E2E tests
-  testDir: './e2e',
-  
+  testDir: "./e2e",
+
   // Timeout for individual tests (30 seconds)
   timeout: 30000,
-  
+
   // Timeout for expectations (5 seconds)
   expect: {
     timeout: 5000,
   },
-  
+
   // Run tests in parallel
   fullyParallel: true,
-  
+
   // Number of retries for flaky tests
   retries: process.env.CI ? 1 : 0,
-  
+
   // Number of workers (parallel processes)
   workers: process.env.CI ? 4 : undefined,
 
-  // Exclude flaky import-export-roundtrip tests in CI until underlying race conditions are fixed
-  grepInvert: process.env.CI ? /import-export-roundtrip/ : undefined,
-  
   // Fail the build on CI if you accidentally left test.only in the source code
   forbidOnly: !!process.env.CI,
-  
+
   // Reporter configuration
   reporter: [
-    ['html', { outputFolder: 'playwright-report' }],
-    ['list'],
-    ...(process.env.CI ? [['github'] as const] : []),
+    ["html", { outputFolder: "playwright-report" }],
+    ["list"],
+    ...(process.env.CI ? [["github"] as const] : []),
   ],
-  
+
   // Shared settings for all the projects below
   use: {
     // Base URL for all tests
@@ -59,52 +56,52 @@ export default defineConfig({
       origins: [
         {
           origin: E2E_ORIGIN,
-          localStorage: [{ name: 'planar-nexus:onboarded', value: 'true' }],
+          localStorage: [{ name: "planar-nexus:onboarded", value: "true" }],
         },
       ],
     },
 
     // Collect trace when retrying the failed test
-    trace: 'on-first-retry',
-    
+    trace: "on-first-retry",
+
     // Capture screenshot on failure
-    screenshot: 'only-on-failure',
-    
+    screenshot: "only-on-failure",
+
     // Record video on failure
-    video: 'retain-on-failure',
-    
+    video: "retain-on-failure",
+
     // Browser context options
     viewport: { width: 1280, height: 720 },
   },
-  
+
   // Configure projects for major browsers
   // Firefox and WebKit now installed for cross-browser testing
   projects: [
     {
-      name: 'chromium',
-      use: { 
+      name: "chromium",
+      use: {
         // Test against Chromium
-        channel: 'chromium',
+        channel: "chromium",
       },
     },
     {
-      name: 'firefox',
-      use: { 
+      name: "firefox",
+      use: {
         // Test against Firefox - don't specify channel for installed browsers
       },
     },
     {
-      name: 'webkit',
-      use: { 
+      name: "webkit",
+      use: {
         // Test against WebKit - don't specify channel for installed browsers
       },
     },
   ],
-  
+
   // Run local dev server before starting tests
   webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:9002',
+    command: "npm run dev",
+    url: "http://localhost:9002",
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
   },

--- a/src/app/(app)/deck-builder/page.tsx
+++ b/src/app/(app)/deck-builder/page.tsx
@@ -1,10 +1,21 @@
 "use client";
 
-import { useState, useTransition, useEffect, useRef, useCallback, Suspense, useMemo } from "react";
+import {
+  useState,
+  useTransition,
+  useEffect,
+  useRef,
+  useCallback,
+  Suspense,
+  useMemo,
+} from "react";
 import dynamic from "next/dynamic";
 import { useToast } from "@/hooks/use-toast";
 import type { ScryfallCard, DeckCard, SavedDeck } from "@/app/actions";
-import { importDecklistClient, type ImportDeckResult } from "@/lib/client-card-operations";
+import {
+  importDecklistClient,
+  type ImportDeckResult,
+} from "@/lib/client-card-operations";
 import { type DecklistFormat } from "@/lib/decklist-utils";
 import {
   formatRules,
@@ -16,7 +27,10 @@ import {
   type Format,
   type BannedCardSuggestion,
 } from "@/lib/game-rules";
-import { useFormatLegalityCheck, checkCardLegality } from "@/hooks/use-format-legality-check";
+import {
+  useFormatLegalityCheck,
+  checkCardLegality,
+} from "@/hooks/use-format-legality-check";
 import { CardSearch } from "./_components/card-search";
 import { CardGridSkeleton } from "./_components/card-grid-skeleton";
 import { DeckBuilderSkeleton } from "./_components/deck-builder-skeleton";
@@ -48,7 +62,8 @@ import { ComponentErrorBoundary } from "@/components/error-boundaries";
 // into a separate chunk and only loaded when the deck-builder renders.
 // (Issue #1022)
 const AIDeckAssistant = dynamic(
-  () => import("./_components/ai-deck-assistant").then((m) => m.AIDeckAssistant),
+  () =>
+    import("./_components/ai-deck-assistant").then((m) => m.AIDeckAssistant),
   {
     ssr: false,
     loading: () => null,
@@ -79,7 +94,10 @@ export default function DeckBuilderPage() {
   // When true, the card search hides any card that is not legal in the
   // active format. Off by default so users can still browse the full pool.
   const [formatFilter, setFormatFilter] = useState(false);
-  const searchInputRef = useRef<{ focus: () => void; search: (q: string) => void }>(null);
+  const searchInputRef = useRef<{
+    focus: () => void;
+    search: (q: string) => void;
+  }>(null);
 
   const { toast } = useToast();
   const [isImporting, startImportTransition] = useTransition();
@@ -88,7 +106,8 @@ export default function DeckBuilderPage() {
   // identity drives the deck-list violation highlighting and the search
   // "Match Commander Color Identity" filter. Color identity enforcement only
   // applies to commander-family formats.
-  const isCommanderFormat = format === "commander" || format === "legendary-commander";
+  const isCommanderFormat =
+    format === "commander" || format === "legendary-commander";
   const commander = useMemo(
     () => (isCommanderFormat ? getCommanderFromDeck(deck) : undefined),
     [deck, isCommanderFormat],
@@ -319,13 +338,16 @@ export default function DeckBuilderPage() {
   // One-click action for a suggested alternative: pre-fill the card search
   // box so the user can review the replacement and add it on confirm. This
   // satisfies the "add to deck or search for it" acceptance criterion.
-  const handleSelectAlternative = useCallback((cardName: string) => {
-    searchInputRef.current?.search(cardName);
-    toast({
-      title: "Searching for alternative",
-      description: `Showing results for "${cardName}".`,
-    });
-  }, [toast]);
+  const handleSelectAlternative = useCallback(
+    (cardName: string) => {
+      searchInputRef.current?.search(cardName);
+      toast({
+        title: "Searching for alternative",
+        description: `Showing results for "${cardName}".`,
+      });
+    },
+    [toast],
+  );
 
   const importDeck = (
     decklist: string,
@@ -385,7 +407,8 @@ export default function DeckBuilderPage() {
           toast({
             variant: "destructive",
             title: "Import Error",
-            description: "An unexpected error occurred while importing the deck.",
+            description:
+              "An unexpected error occurred while importing the deck.",
           });
           resolve(null);
         }
@@ -538,6 +561,11 @@ export default function DeckBuilderPage() {
             onSave={saveDeck}
             isDeckSaved={isDeckSaved}
             isImporting={isImporting}
+            deckName={deckName}
+            deckCards={deck.map((card) => ({
+              name: card.name,
+              quantity: card.count,
+            }))}
           />
         </div>
         <div className="flex-grow grid grid-cols-1 lg:grid-cols-4 gap-6">


### PR DESCRIPTION
## Summary

Stabilizes the flaky `import-export-roundtrip` E2E suite and **re-enables it in CI** by removing the `grepInvert` exclusion from `playwright.config.ts`. Resolves #1095.

## Root cause

The flakiness had two distinct layers:

1. **Timing-based waits (the original suspicion).** The spec relied on `page.waitForTimeout()` fixed sleeps (3000/2000/1000/500/300ms) and `waitForLoadState("networkidle")`. On slower CI runners the async deck-parse, dialog-close, or clipboard I/O resolved *after* the sleep, so subsequent assertions/clicks fired against not-yet-ready UI (e.g. clicking **Export** while the import dialog was still open → the click was intercepted and the export dialog never opened).

2. **A genuine app bug (the real clipboard killer).** `<ImportExportControls>` was rendered in `deck-builder/page.tsx` **without the `deckCards` prop**. Since `deckCards` is optional, `handleCopyToClipboard` always hit `if (!deckCards || deckCards.length === 0)` and bailed with a **"No cards to copy"** toast — the clipboard was *never* written. The old clipboard test then `waitForTimeout(500)`'d and read the clipboard, getting whatever stale/leftover content remained from a prior run → non-deterministic pass/fail. It was never actually testing a round-trip.

## Changes

- **`src/app/(app)/deck-builder/page.tsx`** — Pass `deckName` and `deckCards` (`deck` mapped to `{ name, quantity }`) into `ImportExportControls`. Fixes the broken "Copy to Clipboard" / "Share Deck" actions in the real app, not just the test.
- **`e2e/import-export-roundtrip.spec.ts`** — Rewritten to be deterministic:
  - Page readiness: wait for the toolbar (`import-deck-button`) instead of `networkidle`.
  - Format selection: gate on the `format-select` trigger reflecting the value before importing (removes a stale-`format` race where cards could be deemed illegal and skipped).
  - Import completion: wait for the import dialog to **close** (the success path) instead of a fixed sleep.
  - Clipboard copy: wait for the app's own `"Copied to clipboard"` toast + assert clipboard contents.
  - Clipboard paste: auto-wait on the textarea value.
  - Dialog dismissal: click the explicit Radix **Close** button (a toast layer was intercepting `Escape`).
  - All `waitForTimeout` / `networkidle` removed; no `test.skip`/`test.fixme`.
- **`playwright.config.ts`** — Removed the `grepInvert: /import-export-roundtrip/` CI exclusion (re-enabled in CI).

## Verification

- `npx tsc --noEmit` — clean.
- `npm run lint` — 0 errors (pre-existing warnings untouched).
- `npx playwright test import-export-roundtrip --project=chromium --retries=0`:
  - `--repeat-each=3` → **9/9 green**
  - `--repeat-each=5` → **15/15 green** (each of the 3 tests passed 8 consecutive times total).
- Regression sweep on the shared page: `e2e/import-export.spec.ts` + `e2e/deck-builder.spec.ts` → **21/21 green**.
- Confirmed `grepInvert`/`import-export-roundtrip` no longer appear in `playwright.config.ts` (CI runs `npx playwright test --project=chromium` with no other exclusion).

Resolves #1095
