### PR TITLE
test(p2p): resolve #1094 — add unit tests for P2P connection fallback and reconnection paths

### DIFF
--- a/src/lib/__tests__/connection-fallback.test.ts
+++ b/src/lib/__tests__/connection-fallback.test.ts
@@ -33,7 +33,7 @@ const mockWebRTCSendChat = jest.fn();
 const mockWebRTCSendEmote = jest.fn();
 const mockWebRTCConstructor = jest.fn();
 
-jest.mock('../webrtc-p2p', () => ({
+jest.mock("../webrtc-p2p", () => ({
   WebRTCConnection: function (options: unknown) {
     // Delegate to the constructor mock so each test can configure
     // a fresh behaviour via mockWebRTCConstructor.mockImplementationOnce.
@@ -41,7 +41,7 @@ jest.mock('../webrtc-p2p', () => ({
   },
 }));
 
-jest.mock('../websocket-connection', () => ({
+jest.mock("../websocket-connection", () => ({
   WebSocketConnection: function (config: unknown, events: unknown) {
     return mockWSConstructor(config, events);
   },
@@ -69,9 +69,10 @@ import {
   isConnectionAvailable,
   type ConnectionFallbackEvents,
   type ConnectionFallbackOptions,
-} from '../connection-fallback';
-import type { P2PMessage } from '../webrtc-p2p';
-import type { GameState } from '../game-state/types';
+} from "../connection-fallback";
+import type { P2PMessage, P2PConnectionState } from "../webrtc-p2p";
+import type { WebSocketConnectionState } from "../websocket-connection";
+import type { GameState } from "../game-state/types";
 
 // --- Helpers --------------------------------------------------------------
 
@@ -121,11 +122,11 @@ function makeOptions(
     onPeerDisconnected: jest.fn(),
   };
   return {
-    playerId: 'player-1',
-    playerName: 'Tester',
+    playerId: "player-1",
+    playerName: "Tester",
     isHost: true,
-    gameCode: 'ABC234',
-    websocketUrl: 'wss://example.test/socket',
+    gameCode: "ABC234",
+    websocketUrl: "wss://example.test/socket",
     events,
     fallbackTimeout: 50,
     retryBaseDelayMs: 1, // tests should never wait on real backoff
@@ -155,7 +156,7 @@ function flushTimers(ms = 0): Promise<void> {
 
 // --- Test lifecycle -------------------------------------------------------
 
-describe('connection-fallback — error handling (#985)', () => {
+describe("connection-fallback — error handling (#985)", () => {
   let consoleErrorSpy: jest.SpyInstance;
   let consoleWarnSpy: jest.SpyInstance;
   let consoleInfoSpy: jest.SpyInstance;
@@ -179,9 +180,9 @@ describe('connection-fallback — error handling (#985)', () => {
     mockWSConstructor.mockImplementation(() => makeWSMock());
 
     // Silence diagnostic logs in test output (they're tested separately).
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    consoleInfoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -193,40 +194,44 @@ describe('connection-fallback — error handling (#985)', () => {
 
   // --- Typed error primitives -------------------------------------------
 
-  describe('ConnectionError / ConnectionErrorCode', () => {
-    it('exposes the documented error codes', () => {
+  describe("ConnectionError / ConnectionErrorCode", () => {
+    it("exposes the documented error codes", () => {
       // The issue spec calls out ICE_FAILED, WEBRTC_FAILED, WEBSOCKET_FAILED.
-      expect(ConnectionErrorCode.ICE_FAILED).toBe('ICE_FAILED');
-      expect(ConnectionErrorCode.WEBRTC_FAILED).toBe('WEBRTC_FAILED');
-      expect(ConnectionErrorCode.WEBSOCKET_FAILED).toBe('WEBSOCKET_FAILED');
+      expect(ConnectionErrorCode.ICE_FAILED).toBe("ICE_FAILED");
+      expect(ConnectionErrorCode.WEBRTC_FAILED).toBe("WEBRTC_FAILED");
+      expect(ConnectionErrorCode.WEBSOCKET_FAILED).toBe("WEBSOCKET_FAILED");
       // Plus the additional structural codes this PR introduces.
-      expect(ConnectionErrorCode.BOTH_FAILED).toBe('BOTH_FAILED');
-      expect(ConnectionErrorCode.NO_CONNECTION_METHOD).toBe('NO_CONNECTION_METHOD');
-      expect(ConnectionErrorCode.SEND_FAILED).toBe('SEND_FAILED');
-      expect(ConnectionErrorCode.RETRY_EXHAUSTED).toBe('RETRY_EXHAUSTED');
-      expect(ConnectionErrorCode.TIMEOUT).toBe('TIMEOUT');
-      expect(ConnectionErrorCode.WEBSOCKET_UNAVAILABLE).toBe('WEBSOCKET_UNAVAILABLE');
-      expect(ConnectionErrorCode.WEBRTC_UNAVAILABLE).toBe('WEBRTC_UNAVAILABLE');
+      expect(ConnectionErrorCode.BOTH_FAILED).toBe("BOTH_FAILED");
+      expect(ConnectionErrorCode.NO_CONNECTION_METHOD).toBe(
+        "NO_CONNECTION_METHOD",
+      );
+      expect(ConnectionErrorCode.SEND_FAILED).toBe("SEND_FAILED");
+      expect(ConnectionErrorCode.RETRY_EXHAUSTED).toBe("RETRY_EXHAUSTED");
+      expect(ConnectionErrorCode.TIMEOUT).toBe("TIMEOUT");
+      expect(ConnectionErrorCode.WEBSOCKET_UNAVAILABLE).toBe(
+        "WEBSOCKET_UNAVAILABLE",
+      );
+      expect(ConnectionErrorCode.WEBRTC_UNAVAILABLE).toBe("WEBRTC_UNAVAILABLE");
     });
 
-    it('preserves code + cause + name on a ConnectionError', () => {
-      const cause = new Error('underlying');
+    it("preserves code + cause + name on a ConnectionError", () => {
+      const cause = new Error("underlying");
       const err = new ConnectionError(
         ConnectionErrorCode.WEBRTC_FAILED,
-        'boom',
+        "boom",
         cause,
       );
       expect(err).toBeInstanceOf(Error);
       expect(err).toBeInstanceOf(ConnectionError);
       expect(err.code).toBe(ConnectionErrorCode.WEBRTC_FAILED);
-      expect(err.message).toBe('boom');
+      expect(err.message).toBe("boom");
       expect(err.cause).toBe(cause);
-      expect(err.name).toBe('ConnectionError');
+      expect(err.name).toBe("ConnectionError");
     });
 
-    it('supports instanceof across try/catch boundaries', () => {
+    it("supports instanceof across try/catch boundaries", () => {
       function throwIt(): never {
-        throw new ConnectionError(ConnectionErrorCode.ICE_FAILED, 'x');
+        throw new ConnectionError(ConnectionErrorCode.ICE_FAILED, "x");
       }
       let caught: unknown;
       try {
@@ -235,20 +240,24 @@ describe('connection-fallback — error handling (#985)', () => {
         caught = e;
       }
       expect(caught).toBeInstanceOf(ConnectionError);
-      expect((caught as ConnectionError).code).toBe(ConnectionErrorCode.ICE_FAILED);
+      expect((caught as ConnectionError).code).toBe(
+        ConnectionErrorCode.ICE_FAILED,
+      );
     });
   });
 
   // --- initialize() — no-connection & preferWebSocket ------------------
 
-  describe('initialize() — failure modes', () => {
-    it('throws NO_CONNECTION_METHOD when neither transport is available', async () => {
+  describe("initialize() — failure modes", () => {
+    it("throws NO_CONNECTION_METHOD when neither transport is available", async () => {
       disableWebRTCGlobal();
       mockIsWebSocketAvailable.mockReturnValue(false);
-      const opts = makeOptions({ websocketUrl: '' });
+      const opts = makeOptions({ websocketUrl: "" });
 
       const manager = new ConnectionFallbackManager(opts);
-      await expect(manager.initialize()).rejects.toBeInstanceOf(ConnectionError);
+      await expect(manager.initialize()).rejects.toBeInstanceOf(
+        ConnectionError,
+      );
       await expect(manager.initialize()).rejects.toMatchObject({
         code: ConnectionErrorCode.NO_CONNECTION_METHOD,
       });
@@ -260,44 +269,48 @@ describe('connection-fallback — error handling (#985)', () => {
       expect(arg.code).toBe(ConnectionErrorCode.NO_CONNECTION_METHOD);
     });
 
-    it('throws NO_CONNECTION_METHOD when preferWebSocket but no URL configured', async () => {
+    it("throws NO_CONNECTION_METHOD when preferWebSocket but no URL configured", async () => {
       disableWebRTCGlobal();
-      const opts = makeOptions({ preferWebSocket: true, websocketUrl: '' });
+      const opts = makeOptions({ preferWebSocket: true, websocketUrl: "" });
       const manager = new ConnectionFallbackManager(opts);
       await expect(manager.initialize()).rejects.toMatchObject({
         code: ConnectionErrorCode.NO_CONNECTION_METHOD,
       });
     });
 
-    it('routes through connectWebSocket when preferWebSocket is true', async () => {
+    it("routes through connectWebSocket when preferWebSocket is true", async () => {
       const opts = makeOptions({ preferWebSocket: true });
       const manager = new ConnectionFallbackManager(opts);
       const type = await manager.initialize();
-      expect(type).toBe('websocket');
+      expect(type).toBe("websocket");
       expect(mockWSConnect).toHaveBeenCalledTimes(1);
-      expect(opts.events.onConnectionTypeChange).toHaveBeenCalledWith('websocket');
+      expect(opts.events.onConnectionTypeChange).toHaveBeenCalledWith(
+        "websocket",
+      );
     });
 
-    it('routes through connectWebSocket when WebRTC is unavailable', async () => {
+    it("routes through connectWebSocket when WebRTC is unavailable", async () => {
       disableWebRTCGlobal();
       const opts = makeOptions();
       const manager = new ConnectionFallbackManager(opts);
       const type = await manager.initialize();
-      expect(type).toBe('websocket');
+      expect(type).toBe("websocket");
     });
 
-    it('wraps unexpected throw inside initialize as ConnectionError', async () => {
+    it("wraps unexpected throw inside initialize as ConnectionError", async () => {
       // Force the WebRTC constructor itself to throw — this is an
       // uncaught (non-Connection) error that the top-level safety net
       // must wrap.
       mockWebRTCConstructor.mockImplementation(() => {
-        throw new Error('constructor boom');
+        throw new Error("constructor boom");
       });
       // Disable fallback so we don't recover via WS.
-      const opts = makeOptions({ enableFallback: false, websocketUrl: '' });
+      const opts = makeOptions({ enableFallback: false, websocketUrl: "" });
       const manager = new ConnectionFallbackManager(opts);
 
-      await expect(manager.initialize()).rejects.toBeInstanceOf(ConnectionError);
+      await expect(manager.initialize()).rejects.toBeInstanceOf(
+        ConnectionError,
+      );
       // Already-typed errors pass through.
       expect(opts.events.onError).toHaveBeenCalled();
     });
@@ -305,10 +318,10 @@ describe('connection-fallback — error handling (#985)', () => {
 
   // --- connectWebRTC — retry / backoff ----------------------------------
 
-  describe('connectWebRTC — retry with exponential backoff', () => {
-    it('does not retry by default (maxRetries=0) and throws WEBRTC_FAILED', async () => {
-      mockWebRTCInitialize.mockRejectedValue(new Error('ice fail'));
-      const opts = makeOptions({ enableFallback: false, websocketUrl: '' });
+  describe("connectWebRTC — retry with exponential backoff", () => {
+    it("does not retry by default (maxRetries=0) and throws WEBRTC_FAILED", async () => {
+      mockWebRTCInitialize.mockRejectedValue(new Error("ice fail"));
+      const opts = makeOptions({ enableFallback: false, websocketUrl: "" });
       const manager = new ConnectionFallbackManager(opts);
 
       await expect(manager.initialize()).rejects.toMatchObject({
@@ -320,11 +333,11 @@ describe('connection-fallback — error handling (#985)', () => {
       expect(opts.events.onError).toHaveBeenCalled();
     });
 
-    it('retries maxRetries times, then bubbles RETRY_EXHAUSTED', async () => {
-      mockWebRTCInitialize.mockRejectedValue(new Error('transient'));
+    it("retries maxRetries times, then bubbles RETRY_EXHAUSTED", async () => {
+      mockWebRTCInitialize.mockRejectedValue(new Error("transient"));
       const opts = makeOptions({
         enableFallback: false,
-        websocketUrl: '',
+        websocketUrl: "",
         maxRetries: 2,
         retryBaseDelayMs: 1,
       });
@@ -339,11 +352,11 @@ describe('connection-fallback — error handling (#985)', () => {
       expect(opts.events.onError.mock.calls.length).toBeGreaterThanOrEqual(3);
     });
 
-    it('recovers on a later attempt without bubbling', async () => {
+    it("recovers on a later attempt without bubbling", async () => {
       // Fail twice then succeed.
       mockWebRTCInitialize
-        .mockRejectedValueOnce(new Error('first'))
-        .mockRejectedValueOnce(new Error('second'))
+        .mockRejectedValueOnce(new Error("first"))
+        .mockRejectedValueOnce(new Error("second"))
         .mockResolvedValueOnce(undefined);
       const opts = makeOptions({
         maxRetries: 3,
@@ -352,26 +365,27 @@ describe('connection-fallback — error handling (#985)', () => {
       const manager = new ConnectionFallbackManager(opts);
 
       const type = await manager.initialize();
-      expect(type).toBe('webrtc');
+      expect(type).toBe("webrtc");
       expect(mockWebRTCInitialize).toHaveBeenCalledTimes(3);
-      expect(opts.events.onConnectionTypeChange).toHaveBeenCalledWith('webrtc');
+      expect(opts.events.onConnectionTypeChange).toHaveBeenCalledWith("webrtc");
     });
 
-    it('exponential backoff uses base * 2^attempt', async () => {
+    it("exponential backoff uses base * 2^attempt", async () => {
       // Spy setTimeout to capture requested delays without actually waiting.
       const delays: number[] = [];
       const origSetTimeout = setTimeout;
-      jest
-        .spyOn(global, 'setTimeout')
-        .mockImplementation(((cb: TimerHandler, ms?: number) => {
-          if (typeof ms === 'number' && ms > 0) delays.push(ms);
-          return origSetTimeout(cb, ms ?? 0);
-        }) as typeof setTimeout);
+      jest.spyOn(global, "setTimeout").mockImplementation(((
+        cb: TimerHandler,
+        ms?: number,
+      ) => {
+        if (typeof ms === "number" && ms > 0) delays.push(ms);
+        return origSetTimeout(cb, ms ?? 0);
+      }) as typeof setTimeout);
 
-      mockWebRTCInitialize.mockRejectedValue(new Error('x'));
+      mockWebRTCInitialize.mockRejectedValue(new Error("x"));
       const opts = makeOptions({
         enableFallback: false,
-        websocketUrl: '',
+        websocketUrl: "",
         maxRetries: 2,
         retryBaseDelayMs: 10,
       });
@@ -384,33 +398,33 @@ describe('connection-fallback — error handling (#985)', () => {
       jest.restoreAllMocks();
     });
 
-    it('surfaces the underlying cause when retries exhausted', async () => {
-      const underlying = new Error('ICE_TIMEOUT');
+    it("surfaces the underlying cause when retries exhausted", async () => {
+      const underlying = new Error("ICE_TIMEOUT");
       mockWebRTCInitialize.mockRejectedValue(underlying);
       const opts = makeOptions({
         enableFallback: false,
-        websocketUrl: '',
+        websocketUrl: "",
         maxRetries: 1,
       });
       const manager = new ConnectionFallbackManager(opts);
 
       try {
         await manager.initialize();
-        fail('expected initialize to reject');
+        fail("expected initialize to reject");
       } catch (e) {
         expect(e).toBeInstanceOf(ConnectionError);
         const err = e as ConnectionError;
         expect(err.code).toBe(ConnectionErrorCode.RETRY_EXHAUSTED);
         expect(err.cause).toBeInstanceOf(Error);
-        expect((err.cause as Error).message).toContain('ICE_TIMEOUT');
+        expect((err.cause as Error).message).toContain("ICE_TIMEOUT");
       }
     });
 
-    it('cleans up partially-initialised WebRTC connection before retry', async () => {
-      mockWebRTCInitialize.mockRejectedValue(new Error('x'));
+    it("cleans up partially-initialised WebRTC connection before retry", async () => {
+      mockWebRTCInitialize.mockRejectedValue(new Error("x"));
       const opts = makeOptions({
         enableFallback: false,
-        websocketUrl: '',
+        websocketUrl: "",
         maxRetries: 1,
       });
       const manager = new ConnectionFallbackManager(opts);
@@ -422,8 +436,8 @@ describe('connection-fallback — error handling (#985)', () => {
 
   // --- connectWebSocket — failure modes ---------------------------------
 
-  describe('connectWebSocket — failure modes', () => {
-    it('throws WEBSOCKET_UNAVAILABLE when WS reports unavailable mid-flow', async () => {
+  describe("connectWebSocket — failure modes", () => {
+    it("throws WEBSOCKET_UNAVAILABLE when WS reports unavailable mid-flow", async () => {
       // connectWebSocket's unavailable check is only reachable via the
       // fallback paths (initialize bails earlier with NO_CONNECTION_METHOD).
       // Establish a WebRTC connection, then make WS report unavailable and
@@ -438,27 +452,27 @@ describe('connection-fallback — error handling (#985)', () => {
       });
     });
 
-    it('throws WEBSOCKET_FAILED when connect() rejects', async () => {
-      mockWSConnect.mockRejectedValue(new Error('ECONNREFUSED'));
+    it("throws WEBSOCKET_FAILED when connect() rejects", async () => {
+      mockWSConnect.mockRejectedValue(new Error("ECONNREFUSED"));
       const opts = makeOptions({ preferWebSocket: true });
       const manager = new ConnectionFallbackManager(opts);
 
       try {
         await manager.initialize();
-        fail('expected initialize to reject');
+        fail("expected initialize to reject");
       } catch (e) {
         expect(e).toBeInstanceOf(ConnectionError);
         const err = e as ConnectionError;
         expect(err.code).toBe(ConnectionErrorCode.WEBSOCKET_FAILED);
         expect(err.cause).toBeInstanceOf(Error);
-        expect((err.cause as Error).message).toContain('ECONNREFUSED');
+        expect((err.cause as Error).message).toContain("ECONNREFUSED");
       }
       // WS failure surfaces via onError too.
       expect(opts.events.onError).toHaveBeenCalled();
     });
 
-    it('throws WEBSOCKET_FAILED for non-Error rejection payloads', async () => {
-      mockWSConnect.mockRejectedValue('string error');
+    it("throws WEBSOCKET_FAILED for non-Error rejection payloads", async () => {
+      mockWSConnect.mockRejectedValue("string error");
       const opts = makeOptions({ preferWebSocket: true });
       const manager = new ConnectionFallbackManager(opts);
 
@@ -467,8 +481,8 @@ describe('connection-fallback — error handling (#985)', () => {
       });
     });
 
-    it('tears down half-constructed socket on failure so retries are clean', async () => {
-      mockWSConnect.mockRejectedValue(new Error('boom'));
+    it("tears down half-constructed socket on failure so retries are clean", async () => {
+      mockWSConnect.mockRejectedValue(new Error("boom"));
       const opts = makeOptions({ preferWebSocket: true });
       const manager = new ConnectionFallbackManager(opts);
       await expect(manager.initialize()).rejects.toThrow();
@@ -478,47 +492,45 @@ describe('connection-fallback — error handling (#985)', () => {
 
   // --- connectWithFallback — fallback behaviour -------------------------
 
-  describe('connectWithFallback — fallback orchestration', () => {
-    it('succeeds via WebRTC when it connects first', async () => {
+  describe("connectWithFallback — fallback orchestration", () => {
+    it("succeeds via WebRTC when it connects first", async () => {
       const opts = makeOptions();
       const manager = new ConnectionFallbackManager(opts);
       const type = await manager.initialize();
-      expect(type).toBe('webrtc');
+      expect(type).toBe("webrtc");
       // Fallback timer should have been cleared.
       expect(mockWSConnect).not.toHaveBeenCalled();
     });
 
-    it('falls back to WebSocket when WebRTC fails', async () => {
-      mockWebRTCInitialize.mockRejectedValue(new Error('webrtc down'));
+    it("falls back to WebSocket when WebRTC fails", async () => {
+      mockWebRTCInitialize.mockRejectedValue(new Error("webrtc down"));
       const opts = makeOptions();
       const manager = new ConnectionFallbackManager(opts);
 
       const type = await manager.initialize();
-      expect(type).toBe('websocket');
+      expect(type).toBe("websocket");
       expect(mockWSConnect).toHaveBeenCalledTimes(1);
     });
 
-    it('falls back to WebSocket after fallback timeout elapses', async () => {
+    it("falls back to WebSocket after fallback timeout elapses", async () => {
       // WebRTC hangs forever; the timer should fire and force a fallback.
-      mockWebRTCInitialize.mockImplementation(
-        () => new Promise(() => {}),
-      );
+      mockWebRTCInitialize.mockImplementation(() => new Promise(() => {}));
       const opts = makeOptions({ fallbackTimeout: 20 });
       const manager = new ConnectionFallbackManager(opts);
 
       const type = await manager.initialize();
-      expect(type).toBe('websocket');
+      expect(type).toBe("websocket");
     });
 
-    it('rejects with BOTH_FAILED when WebRTC and WS both fail', async () => {
-      mockWebRTCInitialize.mockRejectedValue(new Error('rtc down'));
-      mockWSConnect.mockRejectedValue(new Error('ws down'));
+    it("rejects with BOTH_FAILED when WebRTC and WS both fail", async () => {
+      mockWebRTCInitialize.mockRejectedValue(new Error("rtc down"));
+      mockWSConnect.mockRejectedValue(new Error("ws down"));
       const opts = makeOptions();
       const manager = new ConnectionFallbackManager(opts);
 
       try {
         await manager.initialize();
-        fail('expected initialize to reject');
+        fail("expected initialize to reject");
       } catch (e) {
         expect(e).toBeInstanceOf(ConnectionError);
         const err = e as ConnectionError;
@@ -531,8 +543,8 @@ describe('connection-fallback — error handling (#985)', () => {
       }
     });
 
-    it('rejects cleanly with WEBRTC_FAILED when fallback is disabled', async () => {
-      mockWebRTCInitialize.mockRejectedValue(new Error('rtc down'));
+    it("rejects cleanly with WEBRTC_FAILED when fallback is disabled", async () => {
+      mockWebRTCInitialize.mockRejectedValue(new Error("rtc down"));
       const opts = makeOptions({ enableFallback: false });
       const manager = new ConnectionFallbackManager(opts);
 
@@ -542,17 +554,17 @@ describe('connection-fallback — error handling (#985)', () => {
       expect(mockWSConnect).not.toHaveBeenCalled();
     });
 
-    it('clears the fallback timer when WebRTC wins the race', async () => {
+    it("clears the fallback timer when WebRTC wins the race", async () => {
       const opts = makeOptions({ fallbackTimeout: 5000 });
       const manager = new ConnectionFallbackManager(opts);
       const type = await manager.initialize();
-      expect(type).toBe('webrtc');
+      expect(type).toBe("webrtc");
       // Wait past where the timer would have fired; WS must not be invoked.
       await flushTimers(10);
       expect(mockWSConnect).not.toHaveBeenCalled();
     });
 
-    it('does not double-settle when WebRTC fails after fallback succeeds', async () => {
+    it("does not double-settle when WebRTC fails after fallback succeeds", async () => {
       // WebRTC hangs, fallback timer fires WS which succeeds, then WebRTC
       // eventually rejects. The promise must resolve exactly once with WS.
       let rejectWebRTC: (err: Error) => void = () => {};
@@ -567,32 +579,32 @@ describe('connection-fallback — error handling (#985)', () => {
 
       const resultPromise = manager.initialize();
       await flushTimers(20); // let timer fire and WS succeed
-      rejectWebRTC(new Error('late failure'));
+      rejectWebRTC(new Error("late failure"));
 
       const type = await resultPromise;
-      expect(type).toBe('websocket');
+      expect(type).toBe("websocket");
       // onConnectionTypeChange should be called for WS exactly once.
       const typeChanges = opts.events.onConnectionTypeChange.mock.calls.filter(
-        (c) => c[0] === 'websocket',
+        (c) => c[0] === "websocket",
       );
       expect(typeChanges.length).toBe(1);
     });
 
-    it('never produces an unhandled rejection on WebRTC path', async () => {
+    it("never produces an unhandled rejection on WebRTC path", async () => {
       // Sanity check: errors flow through onError and the rejection.
-      mockWebRTCInitialize.mockRejectedValue(new Error('x'));
-      mockWSConnect.mockRejectedValue(new Error('y'));
+      mockWebRTCInitialize.mockRejectedValue(new Error("x"));
+      mockWSConnect.mockRejectedValue(new Error("y"));
       const opts = makeOptions();
       const manager = new ConnectionFallbackManager(opts);
       // Capture unhandled rejections during this test.
       const unhandled: unknown[] = [];
       const handler = (reason: unknown) => unhandled.push(reason);
-      process.on('unhandledRejection', handler);
+      process.on("unhandledRejection", handler);
       try {
         await expect(manager.initialize()).rejects.toThrow();
         await flushTimers(10);
       } finally {
-        process.off('unhandledRejection', handler);
+        process.off("unhandledRejection", handler);
       }
       expect(unhandled).toHaveLength(0);
     });
@@ -600,8 +612,8 @@ describe('connection-fallback — error handling (#985)', () => {
 
   // --- forceFallback() ----------------------------------------------------
 
-  describe('forceFallback()', () => {
-    it('is a no-op when already on WebSocket', async () => {
+  describe("forceFallback()", () => {
+    it("is a no-op when already on WebSocket", async () => {
       const opts = makeOptions({ preferWebSocket: true });
       const manager = new ConnectionFallbackManager(opts);
       await manager.initialize();
@@ -610,20 +622,20 @@ describe('connection-fallback — error handling (#985)', () => {
       expect(mockWSConnect).not.toHaveBeenCalled();
     });
 
-    it('throws ConnectionError(WEBSOCKET_FAILED) when the WS fails', async () => {
+    it("throws ConnectionError(WEBSOCKET_FAILED) when the WS fails", async () => {
       // First connect via WebRTC.
       const opts = makeOptions();
       const manager = new ConnectionFallbackManager(opts);
       await manager.initialize();
 
-      mockWSConnect.mockRejectedValue(new Error('no relay'));
+      mockWSConnect.mockRejectedValue(new Error("no relay"));
       await expect(manager.forceFallback()).rejects.toMatchObject({
         code: ConnectionErrorCode.WEBSOCKET_FAILED,
       });
       expect(opts.events.onError).toHaveBeenCalled();
     });
 
-    it('closes the WebRTC connection during forceFallback', async () => {
+    it("closes the WebRTC connection during forceFallback", async () => {
       const opts = makeOptions();
       const manager = new ConnectionFallbackManager(opts);
       await manager.initialize();
@@ -635,14 +647,14 @@ describe('connection-fallback — error handling (#985)', () => {
 
   // --- attemptFallback (private path, via state 'failed' event) ---------
 
-  describe('attemptFallback — auto-fallback from WebRTC failed state', () => {
-    it('catches WS failures and surfaces them via onError without throwing', async () => {
+  describe("attemptFallback — auto-fallback from WebRTC failed state", () => {
+    it("catches WS failures and surfaces them via onError without throwing", async () => {
       mockWebRTCInitialize.mockImplementation(async () => {
         // Simulate the WebRTC connection reporting a 'failed' state after
         // initialisation by triggering the fallback path manually via
         // the public forceFallback() entry point.
       });
-      mockWSConnect.mockRejectedValue(new Error('ws down'));
+      mockWSConnect.mockRejectedValue(new Error("ws down"));
       const opts = makeOptions();
       const manager = new ConnectionFallbackManager(opts);
       await manager.initialize(); // WebRTC succeeds
@@ -661,36 +673,35 @@ describe('connection-fallback — error handling (#985)', () => {
 
   // --- send* methods (graceful degradation) ------------------------------
 
-  describe('send* methods — graceful degradation', () => {
-    it('send() catches transport throw and routes via onError', () => {
+  describe("send* methods — graceful degradation", () => {
+    it("send() catches transport throw and routes via onError", () => {
       mockWebRTCSend.mockImplementation(() => {
-        throw new Error('data channel closed');
+        throw new Error("data channel closed");
       });
       const opts = makeOptions();
       const manager = new ConnectionFallbackManager(opts);
       // Establish WebRTC first.
-      return manager
-        .initialize()
-        .then(() => {
-          const msg: P2PMessage = {
-            type: 'chat',
-            senderId: 'p1',
-            timestamp: Date.now(),
-            payload: { text: 'hi' },
-          };
-          expect(() => manager.send(msg)).not.toThrow();
-          expect(opts.events.onError).toHaveBeenCalled();
-          const err = opts.events.onError.mock.calls[
+      return manager.initialize().then(() => {
+        const msg: P2PMessage = {
+          type: "chat",
+          senderId: "p1",
+          timestamp: Date.now(),
+          payload: { text: "hi" },
+        };
+        expect(() => manager.send(msg)).not.toThrow();
+        expect(opts.events.onError).toHaveBeenCalled();
+        const err =
+          opts.events.onError.mock.calls[
             opts.events.onError.mock.calls.length - 1
           ][0];
-          expect(err).toBeInstanceOf(ConnectionError);
-          expect(err.code).toBe(ConnectionErrorCode.SEND_FAILED);
-        });
+        expect(err).toBeInstanceOf(ConnectionError);
+        expect(err.code).toBe(ConnectionErrorCode.SEND_FAILED);
+      });
     });
 
-    it('sendGameState() catches transport throw', async () => {
+    it("sendGameState() catches transport throw", async () => {
       mockWSSendGameState.mockImplementation(() => {
-        throw new Error('socket gone');
+        throw new Error("socket gone");
       });
       const opts = makeOptions({ preferWebSocket: true });
       const manager = new ConnectionFallbackManager(opts);
@@ -702,24 +713,24 @@ describe('connection-fallback — error handling (#985)', () => {
       expect(last.code).toBe(ConnectionErrorCode.SEND_FAILED);
     });
 
-    it('sendPlayerAction/sendChat/sendEmote all swallow throws', async () => {
+    it("sendPlayerAction/sendChat/sendEmote all swallow throws", async () => {
       const opts = makeOptions({ preferWebSocket: true });
       const manager = new ConnectionFallbackManager(opts);
       await manager.initialize();
 
       mockWSSendPlayerAction.mockImplementation(() => {
-        throw new Error('x');
+        throw new Error("x");
       });
       mockWSSendChat.mockImplementation(() => {
-        throw new Error('x');
+        throw new Error("x");
       });
       mockWSSendEmote.mockImplementation(() => {
-        throw new Error('x');
+        throw new Error("x");
       });
 
-      expect(() => manager.sendPlayerAction('pass', null)).not.toThrow();
-      expect(() => manager.sendChat('hi')).not.toThrow();
-      expect(() => manager.sendEmote('wave')).not.toThrow();
+      expect(() => manager.sendPlayerAction("pass", null)).not.toThrow();
+      expect(() => manager.sendChat("hi")).not.toThrow();
+      expect(() => manager.sendEmote("wave")).not.toThrow();
 
       // Three SEND_FAILED errors should have surfaced.
       const sendErrors = opts.events.onError.mock.calls
@@ -732,34 +743,34 @@ describe('connection-fallback — error handling (#985)', () => {
       expect(sendErrors.length).toBe(3);
     });
 
-    it('send() with no active connection logs a warning (no throw)', () => {
+    it("send() with no active connection logs a warning (no throw)", () => {
       const opts = makeOptions();
       const manager = new ConnectionFallbackManager(opts);
       expect(() =>
         manager.send({
-          type: 'chat',
-          senderId: 'p',
+          type: "chat",
+          senderId: "p",
           timestamp: Date.now(),
-          payload: { text: 'x' },
+          payload: { text: "x" },
         }),
       ).not.toThrow();
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('No active connection'),
+        expect.stringContaining("No active connection"),
       );
     });
   });
 
   // --- isConnected / disconnect / cleanup --------------------------------
 
-  describe('isConnected() / disconnect() — defensive', () => {
-    it('isConnected() returns false when no active connection', () => {
+  describe("isConnected() / disconnect() — defensive", () => {
+    it("isConnected() returns false when no active connection", () => {
       const manager = new ConnectionFallbackManager(makeOptions());
       expect(manager.isConnected()).toBe(false);
     });
 
-    it('isConnected() swallows throw from the transport', async () => {
+    it("isConnected() swallows throw from the transport", async () => {
       mockWebRTCIsConnected.mockImplementation(() => {
-        throw new Error('wut');
+        throw new Error("wut");
       });
       const opts = makeOptions();
       const manager = new ConnectionFallbackManager(opts);
@@ -768,29 +779,30 @@ describe('connection-fallback — error handling (#985)', () => {
       expect(consoleWarnSpy).toHaveBeenCalled();
     });
 
-    it('disconnect() clears timers and closes both transports', async () => {
+    it("disconnect() clears timers and closes both transports", async () => {
       const opts = makeOptions();
       const manager = new ConnectionFallbackManager(opts);
       await manager.initialize();
       manager.disconnect();
       expect(mockWebRTCClose).toHaveBeenCalled();
       expect(opts.events.onConnectionStateChange).toHaveBeenCalled();
-      const lastState = opts.events.onConnectionStateChange.mock.calls[
-        opts.events.onConnectionStateChange.mock.calls.length - 1
-      ][0];
-      expect(lastState.activeConnection).toBe('none');
+      const lastState =
+        opts.events.onConnectionStateChange.mock.calls[
+          opts.events.onConnectionStateChange.mock.calls.length - 1
+        ][0];
+      expect(lastState.activeConnection).toBe("none");
     });
 
-    it('cleanup helpers swallow close() failures', async () => {
+    it("cleanup helpers swallow close() failures", async () => {
       mockWebRTCClose.mockImplementation(() => {
-        throw new Error('close failed');
+        throw new Error("close failed");
       });
       const opts = makeOptions();
       const manager = new ConnectionFallbackManager(opts);
       await manager.initialize();
       expect(() => manager.disconnect()).not.toThrow();
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('cleanup'),
+        expect.stringContaining("cleanup"),
         expect.any(String),
       );
     });
@@ -798,12 +810,14 @@ describe('connection-fallback — error handling (#985)', () => {
 
   // --- #982 redaction preservation --------------------------------------
 
-  describe('#982 redaction preservation', () => {
-    it('WebRTC failures log redacted error (no session ID leak)', async () => {
+  describe("#982 redaction preservation", () => {
+    it("WebRTC failures log redacted error (no session ID leak)", async () => {
       // Build an error whose message embeds a host-style session ID.
-      const sessionId = 'host-1700000000000-abc12345';
-      mockWebRTCInitialize.mockRejectedValue(new Error(`ICE fail for ${sessionId}`));
-      const opts = makeOptions({ enableFallback: false, websocketUrl: '' });
+      const sessionId = "host-1700000000000-abc12345";
+      mockWebRTCInitialize.mockRejectedValue(
+        new Error(`ICE fail for ${sessionId}`),
+      );
+      const opts = makeOptions({ enableFallback: false, websocketUrl: "" });
       const manager = new ConnectionFallbackManager(opts);
 
       await expect(manager.initialize()).rejects.toThrow();
@@ -811,11 +825,11 @@ describe('connection-fallback — error handling (#985)', () => {
       const calls = consoleErrorSpy.mock.calls;
       const flat = JSON.stringify(calls);
       expect(flat).not.toContain(sessionId);
-      expect(flat).toContain('[REDACTED_SESSION]');
+      expect(flat).toContain("[REDACTED_SESSION]");
     });
 
-    it('WebSocket failures log redacted error', async () => {
-      const sessionId = 'host-1700000000000-abc12345';
+    it("WebSocket failures log redacted error", async () => {
+      const sessionId = "host-1700000000000-abc12345";
       mockWSConnect.mockRejectedValue(
         new Error(`WS handshake failed for ${sessionId}`),
       );
@@ -825,11 +839,11 @@ describe('connection-fallback — error handling (#985)', () => {
       await expect(manager.initialize()).rejects.toThrow();
       const flat = JSON.stringify(consoleErrorSpy.mock.calls);
       expect(flat).not.toContain(sessionId);
-      expect(flat).toContain('[REDACTED_SESSION]');
+      expect(flat).toContain("[REDACTED_SESSION]");
     });
 
-    it('send() failures log redacted error', async () => {
-      const sessionId = 'host-1700000000000-abc12345';
+    it("send() failures log redacted error", async () => {
+      const sessionId = "host-1700000000000-abc12345";
       mockWebRTCSend.mockImplementation(() => {
         throw new Error(`channel closed for ${sessionId}`);
       });
@@ -837,31 +851,31 @@ describe('connection-fallback — error handling (#985)', () => {
       const manager = new ConnectionFallbackManager(opts);
       await manager.initialize();
       manager.send({
-        type: 'chat',
-        senderId: 'p',
+        type: "chat",
+        senderId: "p",
         timestamp: Date.now(),
-        payload: { text: 'hi' },
+        payload: { text: "hi" },
       });
       const flat = JSON.stringify(consoleErrorSpy.mock.calls);
       expect(flat).not.toContain(sessionId);
-      expect(flat).toContain('[REDACTED_SESSION]');
+      expect(flat).toContain("[REDACTED_SESSION]");
     });
   });
 
   // --- State machine: every error updates lastError ----------------------
 
-  describe('state machine — lastError tracking', () => {
-    it('updates lastError on every failure path', async () => {
-      mockWSConnect.mockRejectedValue(new Error('boom'));
+  describe("state machine — lastError tracking", () => {
+    it("updates lastError on every failure path", async () => {
+      mockWSConnect.mockRejectedValue(new Error("boom"));
       const opts = makeOptions({ preferWebSocket: true });
       const manager = new ConnectionFallbackManager(opts);
       await expect(manager.initialize()).rejects.toThrow();
       expect(manager.getState().lastError).toBeTruthy();
-      expect(manager.getState().lastError).toContain('WebSocket');
+      expect(manager.getState().lastError).toContain("WebSocket");
     });
 
-    it('onError always receives Error instances (never strings)', async () => {
-      mockWSConnect.mockRejectedValue('string error');
+    it("onError always receives Error instances (never strings)", async () => {
+      mockWSConnect.mockRejectedValue("string error");
       const opts = makeOptions({ preferWebSocket: true });
       const manager = new ConnectionFallbackManager(opts);
       await expect(manager.initialize()).rejects.toThrow();
@@ -873,24 +887,24 @@ describe('connection-fallback — error handling (#985)', () => {
 
   // --- Factory + availability helpers ------------------------------------
 
-  describe('module exports', () => {
-    it('createConnectionFallbackManager returns a manager instance', () => {
+  describe("module exports", () => {
+    it("createConnectionFallbackManager returns a manager instance", () => {
       const manager = createConnectionFallbackManager(makeOptions());
       expect(manager).toBeInstanceOf(ConnectionFallbackManager);
     });
 
-    it('isConnectionAvailable returns true when WebRTC global exists', () => {
+    it("isConnectionAvailable returns true when WebRTC global exists", () => {
       enableWebRTCGlobal();
       expect(isConnectionAvailable()).toBe(true);
     });
 
-    it('isConnectionAvailable returns true when only WS is available', () => {
+    it("isConnectionAvailable returns true when only WS is available", () => {
       disableWebRTCGlobal();
       mockIsWebSocketAvailable.mockReturnValue(true);
       expect(isConnectionAvailable()).toBe(true);
     });
 
-    it('isConnectionAvailable returns false when neither is available', () => {
+    it("isConnectionAvailable returns false when neither is available", () => {
       disableWebRTCGlobal();
       mockIsWebSocketAvailable.mockReturnValue(false);
       expect(isConnectionAvailable()).toBe(false);
@@ -899,19 +913,21 @@ describe('connection-fallback — error handling (#985)', () => {
 
   // --- Coverage of branch combinations -----------------------------------
 
-  describe('branch coverage — degenerate inputs', () => {
-    it('handles non-Error rejections from initialize() top-level net', async () => {
+  describe("branch coverage — degenerate inputs", () => {
+    it("handles non-Error rejections from initialize() top-level net", async () => {
       // Throw a non-Error from the constructor to bypass typed paths.
       mockWebRTCConstructor.mockImplementation(() => {
         // Throw a non-Error value — must still be wrapped safely.
-        throw 'string thrown';
+        throw "string thrown";
       });
-      const opts = makeOptions({ enableFallback: false, websocketUrl: '' });
+      const opts = makeOptions({ enableFallback: false, websocketUrl: "" });
       const manager = new ConnectionFallbackManager(opts);
-      await expect(manager.initialize()).rejects.toBeInstanceOf(ConnectionError);
+      await expect(manager.initialize()).rejects.toBeInstanceOf(
+        ConnectionError,
+      );
     });
 
-    it('forceFallback resets fallbackAttempted so re-forcing works', async () => {
+    it("forceFallback resets fallbackAttempted so re-forcing works", async () => {
       const opts = makeOptions();
       const manager = new ConnectionFallbackManager(opts);
       await manager.initialize();
@@ -922,17 +938,347 @@ describe('connection-fallback — error handling (#985)', () => {
       expect(mockWSConnect).toHaveBeenCalled();
     });
 
-    it('attemptFallback (via state) is a no-op once fallbackAttempted', async () => {
+    it("attemptFallback (via state) is a no-op once fallbackAttempted", async () => {
       // Indirect: after a successful fallback via initialize, forcing
       // fallback again should not re-trigger another connectWebSocket.
-      mockWebRTCInitialize.mockRejectedValue(new Error('rtc down'));
+      mockWebRTCInitialize.mockRejectedValue(new Error("rtc down"));
       const opts = makeOptions();
       const manager = new ConnectionFallbackManager(opts);
       const type = await manager.initialize();
-      expect(type).toBe('websocket');
+      expect(type).toBe("websocket");
       const firstCount = mockWSConnect.mock.calls.length;
       await manager.forceFallback(); // already on websocket — no-op
       expect(mockWSConnect.mock.calls.length).toBe(firstCount);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #1094 — P2P connection fallback & reconnection path coverage.
+  //
+  // These suites exercise the previously-uncovered internal transport-event
+  // wiring (the P2PEvents / WebSocketEvents lambdas the manager registers on
+  // the underlying connections), the auto-fallback triggered when WebRTC
+  // reports a 'failed' ICE state, sending over each active transport, the
+  // defensive getters, cleanup swallowing, and destroy(). Transports stay
+  // mocked; we capture the registered event objects to drive them directly.
+  // -------------------------------------------------------------------------
+
+  type CapturedWebRTCEvents = {
+    onConnectionStateChange: (
+      state: P2PConnectionState,
+      peerId: string,
+    ) => void;
+    onMessage: (message: P2PMessage, peerId: string) => void;
+    onGameStateSync: (gameState: GameState, peerId: string) => void;
+    onPlayerAction: (action: string, data: unknown, peerId: string) => void;
+    onChat: (text: string, peerId: string) => void;
+    onEmote: (emote: string, peerId: string) => void;
+    onError: (error: Error, peerId: string) => void;
+    onPeerConnected: (peerInfo: {
+      peerId: string;
+      playerName?: string;
+    }) => void;
+    onPeerDisconnected: (peerId: string) => void;
+  };
+
+  type CapturedWSEvents = {
+    onConnectionStateChange: (state: WebSocketConnectionState) => void;
+    onMessage: (message: P2PMessage) => void;
+    onGameStateSync: (gameState: GameState) => void;
+    onError: (error: Error) => void;
+    onPlayerJoined: (playerId: string, playerName?: string) => void;
+    onPlayerLeft: (playerId: string) => void;
+  };
+
+  describe("WebRTC event wiring — P2PEvents forwarding (#1094)", () => {
+    let captured: CapturedWebRTCEvents;
+    let opts: ReturnType<typeof makeOptions>;
+    let manager: ConnectionFallbackManager;
+
+    beforeEach(async () => {
+      opts = makeOptions();
+      mockWebRTCConstructor.mockImplementationOnce(
+        (options: { events: CapturedWebRTCEvents }) => {
+          captured = options.events;
+          return makeWebRTCMock();
+        },
+      );
+      manager = new ConnectionFallbackManager(opts);
+      await manager.initialize();
+    });
+
+    it("forwards connection state changes and updates the snapshot state", () => {
+      captured.onConnectionStateChange("connected", "peer-2");
+      const last = opts.events.onConnectionStateChange.mock.calls.at(-1)![0];
+      expect(last.webrtcState).toBe("connected");
+    });
+
+    it("forwards inbound data messages verbatim", () => {
+      const msg: P2PMessage = {
+        type: "chat",
+        senderId: "p2",
+        timestamp: 1,
+        payload: { text: "hi" },
+      };
+      captured.onMessage(msg, "p2");
+      expect(opts.events.onMessage).toHaveBeenCalledWith(msg, "p2");
+    });
+
+    it("forwards game-state sync (dropping the peer id)", () => {
+      const gs = { players: [] } as unknown as GameState;
+      captured.onGameStateSync(gs, "p2");
+      expect(opts.events.onGameStateSync).toHaveBeenCalledWith(gs);
+      expect(opts.events.onGameStateSync.mock.calls[0]).toHaveLength(1);
+    });
+
+    it("rewraps player actions / chat / emotes as messages", () => {
+      captured.onPlayerAction("pass", { x: 1 }, "p2");
+      captured.onChat("hello", "p2");
+      captured.onEmote("wave", "p2");
+      const calls = opts.events.onMessage.mock.calls;
+      expect(calls.at(-3)![0]).toMatchObject({
+        type: "player-action",
+        senderId: "p2",
+      });
+      expect(calls.at(-2)![0]).toMatchObject({ type: "chat", senderId: "p2" });
+      expect(calls.at(-1)![0]).toMatchObject({ type: "emote", senderId: "p2" });
+    });
+
+    it("forwards transport errors and records lastError", () => {
+      captured.onError(new Error("rtc hiccup"), "p2");
+      expect(opts.events.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "rtc hiccup" }),
+      );
+      expect(manager.getState().lastError).toBe("rtc hiccup");
+    });
+
+    it("forwards peer connected / disconnected", () => {
+      captured.onPeerConnected({ peerId: "p2", playerName: "Alice" });
+      captured.onPeerDisconnected("p2");
+      expect(opts.events.onPeerConnected).toHaveBeenCalledWith("p2", "Alice");
+      expect(opts.events.onPeerDisconnected).toHaveBeenCalledWith("p2");
+    });
+  });
+
+  describe("WebRTC failed state — auto-fallback engagement (#1094)", () => {
+    it("engages WebSocket fallback when WebRTC reports 'failed'", async () => {
+      let captured: CapturedWebRTCEvents;
+      mockWebRTCConstructor.mockImplementationOnce(
+        (options: { events: CapturedWebRTCEvents }) => {
+          captured = options.events;
+          return makeWebRTCMock();
+        },
+      );
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+      await manager.initialize(); // WebRTC active
+      expect(manager.getActiveConnection()).toBe("webrtc");
+
+      // Simulate ICE failure -> auto-fallback to WebSocket.
+      captured!.onConnectionStateChange("failed", "peer-2");
+      await flushTimers(5);
+
+      expect(manager.getActiveConnection()).toBe("websocket");
+      expect(manager.getState().fallbackAttempted).toBe(true);
+      expect(opts.events.onConnectionTypeChange).toHaveBeenCalledWith(
+        "websocket",
+      );
+    });
+
+    it("does not double-trigger fallback on a second failed event", async () => {
+      let captured: CapturedWebRTCEvents;
+      mockWebRTCConstructor.mockImplementationOnce(
+        (options: { events: CapturedWebRTCEvents }) => {
+          captured = options.events;
+          return makeWebRTCMock();
+        },
+      );
+      const manager = new ConnectionFallbackManager(makeOptions());
+      await manager.initialize();
+
+      captured!.onConnectionStateChange("failed", "peer-2");
+      await flushTimers(5);
+      const countAfterFirst = mockWSConnect.mock.calls.length;
+
+      captured!.onConnectionStateChange("failed", "peer-2"); // already fell back
+      await flushTimers(5);
+      expect(mockWSConnect.mock.calls.length).toBe(countAfterFirst);
+    });
+
+    it("surfaces a typed error via onError when the auto-fallback WS also fails", async () => {
+      let captured: CapturedWebRTCEvents;
+      mockWebRTCConstructor.mockImplementationOnce(
+        (options: { events: CapturedWebRTCEvents }) => {
+          captured = options.events;
+          return makeWebRTCMock();
+        },
+      );
+      mockWSConnect.mockRejectedValue(new Error("relay down"));
+      const opts = makeOptions();
+      const manager = new ConnectionFallbackManager(opts);
+      await manager.initialize();
+
+      // Auto-fallback is fire-and-forget from the event handler; it must not
+      // throw, but it must surface a typed ConnectionError via onError.
+      expect(() =>
+        captured!.onConnectionStateChange("failed", "peer-2"),
+      ).not.toThrow();
+      await flushTimers(5);
+
+      const last = opts.events.onError.mock.calls.at(-1)![0];
+      expect(last).toBeInstanceOf(ConnectionError);
+      expect((last as ConnectionError).code).toBe(
+        ConnectionErrorCode.WEBSOCKET_FAILED,
+      );
+    });
+  });
+
+  describe("WebSocket event wiring — WebSocketEvents forwarding (#1094)", () => {
+    let captured: CapturedWSEvents;
+    let opts: ReturnType<typeof makeOptions>;
+
+    beforeEach(async () => {
+      mockWSConstructor.mockImplementationOnce(
+        (config: unknown, events: CapturedWSEvents) => {
+          captured = events;
+          return makeWSMock();
+        },
+      );
+      opts = makeOptions({ preferWebSocket: true });
+      const manager = new ConnectionFallbackManager(opts);
+      await manager.initialize();
+    });
+
+    it("records an error when the socket reports 'failed'", () => {
+      captured.onConnectionStateChange("failed");
+      const last = opts.events.onError.mock.calls.at(-1)![0];
+      expect(last.message).toBe("WebSocket connection failed");
+    });
+
+    it("forwards inbound messages (using the message sender id)", () => {
+      const msg: P2PMessage = {
+        type: "chat",
+        senderId: "p2",
+        timestamp: 1,
+        payload: { text: "hi" },
+      };
+      captured.onMessage(msg);
+      expect(opts.events.onMessage).toHaveBeenCalledWith(msg, "p2");
+    });
+
+    it("forwards game-state sync", () => {
+      const gs = { players: [] } as unknown as GameState;
+      captured.onGameStateSync(gs);
+      expect(opts.events.onGameStateSync).toHaveBeenCalledWith(gs);
+    });
+
+    it("forwards transport errors", () => {
+      captured.onError(new Error("socket boom"));
+      expect(opts.events.onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "socket boom" }),
+      );
+    });
+
+    it("forwards player joined / left as peer connected / disconnected", () => {
+      captured.onPlayerJoined("p2", "Bob");
+      captured.onPlayerLeft("p2");
+      expect(opts.events.onPeerConnected).toHaveBeenCalledWith("p2", "Bob");
+      expect(opts.events.onPeerDisconnected).toHaveBeenCalledWith("p2");
+    });
+  });
+
+  describe("send* over each active transport (#1094)", () => {
+    it("send() routes through the active WebSocket connection", async () => {
+      const manager = new ConnectionFallbackManager(
+        makeOptions({ preferWebSocket: true }),
+      );
+      await manager.initialize();
+      const msg: P2PMessage = {
+        type: "chat",
+        senderId: "p1",
+        timestamp: 1,
+        payload: { text: "x" },
+      };
+      manager.send(msg);
+      expect(mockWSSend).toHaveBeenCalledWith(msg);
+    });
+
+    it("sendGameState / sendPlayerAction / sendChat / sendEmote route through WebRTC", async () => {
+      const manager = new ConnectionFallbackManager(makeOptions());
+      await manager.initialize();
+      const gs = { players: [] } as unknown as GameState;
+
+      manager.sendGameState(gs, true);
+      manager.sendPlayerAction("pass", { a: 1 });
+      manager.sendChat("hi");
+      manager.sendEmote("wave");
+
+      expect(mockWebRTCSendGameState).toHaveBeenCalledWith(gs, true);
+      expect(mockWebRTCSendPlayerAction).toHaveBeenCalledWith("pass", { a: 1 });
+      expect(mockWebRTCSendChat).toHaveBeenCalledWith("hi");
+      expect(mockWebRTCSendEmote).toHaveBeenCalledWith("wave");
+    });
+
+    it("sendGameState with no active connection warns and does not throw", () => {
+      mockWSSendGameState.mockImplementation(() => {
+        throw new Error("should not be called");
+      });
+      const manager = new ConnectionFallbackManager(makeOptions()); // never initialized
+      expect(() =>
+        manager.sendGameState({ players: [] } as unknown as GameState),
+      ).not.toThrow();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("No active connection to send game state"),
+      );
+    });
+  });
+
+  describe("cleanup, getters & destroy (#1094)", () => {
+    it("cleanupWebSocket swallows a disconnect() throw", async () => {
+      mockWSDisconnect.mockImplementation(() => {
+        throw new Error("socket already gone");
+      });
+      const manager = new ConnectionFallbackManager(
+        makeOptions({ preferWebSocket: true }),
+      );
+      await manager.initialize();
+      expect(() => manager.disconnect()).not.toThrow();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("closing WebSocket"),
+        expect.anything(),
+      );
+    });
+
+    it("getActiveConnection / getWebRTCConnection / getWebSocketConnection", async () => {
+      const rtcManager = new ConnectionFallbackManager(makeOptions());
+      await rtcManager.initialize();
+      expect(rtcManager.getActiveConnection()).toBe("webrtc");
+      expect(rtcManager.getWebRTCConnection()).not.toBeNull();
+      expect(rtcManager.getWebSocketConnection()).toBeNull();
+
+      const wsManager = new ConnectionFallbackManager(
+        makeOptions({ preferWebSocket: true }),
+      );
+      await wsManager.initialize();
+      expect(wsManager.getActiveConnection()).toBe("websocket");
+      expect(wsManager.getWebSocketConnection()).not.toBeNull();
+    });
+
+    it("isConnected() reflects the active WebSocket transport", async () => {
+      mockWSIsConnected.mockReturnValue(true);
+      const manager = new ConnectionFallbackManager(
+        makeOptions({ preferWebSocket: true }),
+      );
+      await manager.initialize();
+      expect(manager.isConnected()).toBe(true);
+    });
+
+    it("destroy() tears everything down to no active connection", async () => {
+      const manager = new ConnectionFallbackManager(makeOptions());
+      await manager.initialize();
+      manager.destroy();
+      expect(manager.getActiveConnection()).toBe("none");
+      expect(manager.getWebRTCConnection()).toBeNull();
     });
   });
 });

--- a/src/lib/__tests__/ice-config.test.ts
+++ b/src/lib/__tests__/ice-config.test.ts
@@ -13,125 +13,133 @@ import {
   DEFAULT_TURN_SERVERS,
   PUBLIC_FALLBACK_TURN_SERVERS,
   ICEConfigurationManager,
+  ICEConnectionMonitor,
+  ICECandidateFilter,
   resolveTurnServers,
   warnIfNoEnvTurnConfigured,
   __resetTurnWarningGuard,
+  createDefaultICEConfiguration,
+  createICEConfigurationWithTurn,
+  createRelayOnlyConfiguration,
+  getGlobalICEManager,
+  setGlobalICEConfiguration,
   type ICEServerConfig,
-} from '../ice-config';
+} from "../ice-config";
 
 function isTurnScheme(url: unknown): boolean {
-  if (typeof url !== 'string') return false;
-  return url.startsWith('turn:') || url.startsWith('turns:');
+  if (typeof url !== "string") return false;
+  return url.startsWith("turn:") || url.startsWith("turns:");
 }
 
-describe('DEFAULT_STUN_SERVERS', () => {
-  it('is non-empty', () => {
+describe("DEFAULT_STUN_SERVERS", () => {
+  it("is non-empty", () => {
     expect(DEFAULT_STUN_SERVERS.length).toBeGreaterThan(0);
   });
 
-  it('contains only stun: URLs', () => {
+  it("contains only stun: URLs", () => {
     for (const server of DEFAULT_STUN_SERVERS) {
-      const url = typeof server.urls === 'string' ? server.urls : '';
-      expect(url.startsWith('stun:')).toBe(true);
+      const url = typeof server.urls === "string" ? server.urls : "";
+      expect(url.startsWith("stun:")).toBe(true);
     }
   });
 });
 
-describe('PUBLIC_FALLBACK_TURN_SERVERS', () => {
-  it('is non-empty', () => {
+describe("PUBLIC_FALLBACK_TURN_SERVERS", () => {
+  it("is non-empty", () => {
     expect(PUBLIC_FALLBACK_TURN_SERVERS.length).toBeGreaterThan(0);
   });
 
-  it('every server is a turn/turns URL with password credentials', () => {
+  it("every server is a turn/turns URL with password credentials", () => {
     for (const server of PUBLIC_FALLBACK_TURN_SERVERS) {
       expect(isTurnScheme(server.urls)).toBe(true);
-      expect(typeof server.username).toBe('string');
+      expect(typeof server.username).toBe("string");
       expect(server.username!.length).toBeGreaterThan(0);
-      expect(typeof server.credential).toBe('string');
+      expect(typeof server.credential).toBe("string");
       expect(server.credential!.length).toBeGreaterThan(0);
-      expect(server.credentialType).toBe('password');
+      expect(server.credentialType).toBe("password");
     }
   });
 });
 
-describe('DEFAULT_TURN_SERVERS', () => {
-  it('is non-empty (NAT traversal relay fallback) — regression for #983', () => {
+describe("DEFAULT_TURN_SERVERS", () => {
+  it("is non-empty (NAT traversal relay fallback) — regression for #983", () => {
     expect(DEFAULT_TURN_SERVERS.length).toBeGreaterThan(0);
   });
 
-  it('contains only turn:/turns: URLs', () => {
+  it("contains only turn:/turns: URLs", () => {
     for (const server of DEFAULT_TURN_SERVERS) {
-      const url = typeof server.urls === 'string' ? server.urls : '';
+      const url = typeof server.urls === "string" ? server.urls : "";
       expect(isTurnScheme(url)).toBe(true);
     }
   });
 
-  it('every server has username + credential', () => {
+  it("every server has username + credential", () => {
     for (const server of DEFAULT_TURN_SERVERS) {
       expect(server.username).toBeTruthy();
       expect(server.credential).toBeTruthy();
-      expect(server.credentialType).toBe('password');
+      expect(server.credentialType).toBe("password");
     }
   });
 });
 
-describe('resolveTurnServers', () => {
+describe("resolveTurnServers", () => {
   afterEach(() => {
     __resetTurnWarningGuard();
   });
 
-  it('returns env-configured servers when all three env vars are set', () => {
+  it("returns env-configured servers when all three env vars are set", () => {
     const result = resolveTurnServers({
-      NEXT_PUBLIC_TURN_URL: 'turn:turn.example.com:3478',
-      NEXT_PUBLIC_TURN_USER: 'alice',
-      NEXT_PUBLIC_TURN_PASS: 's3cret',
+      NEXT_PUBLIC_TURN_URL: "turn:turn.example.com:3478",
+      NEXT_PUBLIC_TURN_USER: "alice",
+      NEXT_PUBLIC_TURN_PASS: "s3cret",
     });
 
     expect(result.usedFallback).toBe(false);
     expect(result.servers).toHaveLength(1);
     expect(result.servers[0]).toEqual({
-      urls: 'turn:turn.example.com:3478',
-      username: 'alice',
-      credential: 's3cret',
-      credentialType: 'password',
+      urls: "turn:turn.example.com:3478",
+      username: "alice",
+      credential: "s3cret",
+      credentialType: "password",
     });
   });
 
-  it('supports comma-separated TURN URLs sharing one credential set', () => {
+  it("supports comma-separated TURN URLs sharing one credential set", () => {
     const result = resolveTurnServers({
       NEXT_PUBLIC_TURN_URL:
-        'turn:a.example.com:3478, turns:b.example.com:5349, turn:c.example.com:3478',
-      NEXT_PUBLIC_TURN_USER: 'u',
-      NEXT_PUBLIC_TURN_PASS: 'p',
+        "turn:a.example.com:3478, turns:b.example.com:5349, turn:c.example.com:3478",
+      NEXT_PUBLIC_TURN_USER: "u",
+      NEXT_PUBLIC_TURN_PASS: "p",
     });
 
     expect(result.usedFallback).toBe(false);
     expect(result.servers).toHaveLength(3);
     expect(result.servers.map((s) => s.urls)).toEqual([
-      'turn:a.example.com:3478',
-      'turns:b.example.com:5349',
-      'turn:c.example.com:3478',
+      "turn:a.example.com:3478",
+      "turns:b.example.com:5349",
+      "turn:c.example.com:3478",
     ]);
     for (const server of result.servers) {
-      expect(server.username).toBe('u');
-      expect(server.credential).toBe('p');
-      expect(server.credentialType).toBe('password');
+      expect(server.username).toBe("u");
+      expect(server.credential).toBe("p");
+      expect(server.credentialType).toBe("password");
     }
   });
 
-  it('trims whitespace and ignores empty entries in the URL list', () => {
+  it("trims whitespace and ignores empty entries in the URL list", () => {
     const result = resolveTurnServers({
-      NEXT_PUBLIC_TURN_URL: ' turn:a.example.com:3478 , , turn:b.example.com:3478 ',
-      NEXT_PUBLIC_TURN_USER: 'u',
-      NEXT_PUBLIC_TURN_PASS: 'p',
+      NEXT_PUBLIC_TURN_URL:
+        " turn:a.example.com:3478 , , turn:b.example.com:3478 ",
+      NEXT_PUBLIC_TURN_USER: "u",
+      NEXT_PUBLIC_TURN_PASS: "p",
     });
 
     expect(result.servers).toHaveLength(2);
-    expect(result.servers[0].urls).toBe('turn:a.example.com:3478');
-    expect(result.servers[1].urls).toBe('turn:b.example.com:3478');
+    expect(result.servers[0].urls).toBe("turn:a.example.com:3478");
+    expect(result.servers[1].urls).toBe("turn:b.example.com:3478");
   });
 
-  it('falls back to public TURN servers when env vars are absent', () => {
+  it("falls back to public TURN servers when env vars are absent", () => {
     const result = resolveTurnServers({});
 
     expect(result.usedFallback).toBe(true);
@@ -143,46 +151,46 @@ describe('resolveTurnServers', () => {
     }
   });
 
-  it('falls back when only some env vars are set (no partial credentials)', () => {
+  it("falls back when only some env vars are set (no partial credentials)", () => {
     const onlyUrl = resolveTurnServers({
-      NEXT_PUBLIC_TURN_URL: 'turn:turn.example.com:3478',
+      NEXT_PUBLIC_TURN_URL: "turn:turn.example.com:3478",
     });
     expect(onlyUrl.usedFallback).toBe(true);
 
     const urlAndUser = resolveTurnServers({
-      NEXT_PUBLIC_TURN_URL: 'turn:turn.example.com:3478',
-      NEXT_PUBLIC_TURN_USER: 'u',
+      NEXT_PUBLIC_TURN_URL: "turn:turn.example.com:3478",
+      NEXT_PUBLIC_TURN_USER: "u",
     });
     expect(urlAndUser.usedFallback).toBe(true);
   });
 
-  it('falls back when NEXT_PUBLIC_TURN_URL is empty/whitespace', () => {
+  it("falls back when NEXT_PUBLIC_TURN_URL is empty/whitespace", () => {
     const result = resolveTurnServers({
-      NEXT_PUBLIC_TURN_URL: '   ',
-      NEXT_PUBLIC_TURN_USER: 'u',
-      NEXT_PUBLIC_TURN_PASS: 'p',
+      NEXT_PUBLIC_TURN_URL: "   ",
+      NEXT_PUBLIC_TURN_USER: "u",
+      NEXT_PUBLIC_TURN_PASS: "p",
     });
     expect(result.usedFallback).toBe(true);
   });
 
-  it('returns fresh array copies (mutating results does not affect fallbacks)', () => {
+  it("returns fresh array copies (mutating results does not affect fallbacks)", () => {
     const a = resolveTurnServers({});
     const b = resolveTurnServers({});
     expect(a.servers).not.toBe(b.servers);
     expect(a.servers[0]).not.toBe(PUBLIC_FALLBACK_TURN_SERVERS[0]);
 
-    a.servers[0].username = 'mutated';
-    expect(PUBLIC_FALLBACK_TURN_SERVERS[0].username).toBe('openrelayproject');
-    expect(b.servers[0].username).toBe('openrelayproject');
+    a.servers[0].username = "mutated";
+    expect(PUBLIC_FALLBACK_TURN_SERVERS[0].username).toBe("openrelayproject");
+    expect(b.servers[0].username).toBe("openrelayproject");
   });
 });
 
-describe('warnIfNoEnvTurnConfigured', () => {
+describe("warnIfNoEnvTurnConfigured", () => {
   let warnSpy: jest.SpyInstance;
 
   beforeEach(() => {
     __resetTurnWarningGuard();
-    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
   });
 
   afterEach(() => {
@@ -190,26 +198,26 @@ describe('warnIfNoEnvTurnConfigured', () => {
     __resetTurnWarningGuard();
   });
 
-  it('warns when the public fallback is in use', () => {
+  it("warns when the public fallback is in use", () => {
     warnIfNoEnvTurnConfigured(resolveTurnServers({}));
     expect(warnSpy).toHaveBeenCalledTimes(1);
     const message = warnSpy.mock.calls[0][0] as string;
-    expect(message).toContain('TURN');
-    expect(message).toContain('NEXT_PUBLIC_TURN_URL');
+    expect(message).toContain("TURN");
+    expect(message).toContain("NEXT_PUBLIC_TURN_URL");
   });
 
-  it('does not warn when env-configured servers are in use', () => {
+  it("does not warn when env-configured servers are in use", () => {
     warnIfNoEnvTurnConfigured(
       resolveTurnServers({
-        NEXT_PUBLIC_TURN_URL: 'turn:turn.example.com:3478',
-        NEXT_PUBLIC_TURN_USER: 'u',
-        NEXT_PUBLIC_TURN_PASS: 'p',
+        NEXT_PUBLIC_TURN_URL: "turn:turn.example.com:3478",
+        NEXT_PUBLIC_TURN_USER: "u",
+        NEXT_PUBLIC_TURN_PASS: "p",
       }),
     );
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it('warns only once across calls unless forced', () => {
+  it("warns only once across calls unless forced", () => {
     warnIfNoEnvTurnConfigured(resolveTurnServers({}));
     warnIfNoEnvTurnConfigured(resolveTurnServers({}));
     expect(warnSpy).toHaveBeenCalledTimes(1);
@@ -219,13 +227,13 @@ describe('warnIfNoEnvTurnConfigured', () => {
   });
 });
 
-describe('ICEConfigurationManager integration with default TURN', () => {
-  it('default manager has TURN servers (NAT traversal works out of the box)', () => {
+describe("ICEConfigurationManager integration with default TURN", () => {
+  it("default manager has TURN servers (NAT traversal works out of the box)", () => {
     const manager = new ICEConfigurationManager();
     expect(manager.hasTurnServers()).toBe(true);
   });
 
-  it('default RTCConfiguration includes at least one turn/turns server', () => {
+  it("default RTCConfiguration includes at least one turn/turns server", () => {
     const manager = new ICEConfigurationManager();
     const config = manager.getRTCConfiguration();
     const iceServers = config.iceServers ?? [];
@@ -239,23 +247,23 @@ describe('ICEConfigurationManager integration with default TURN', () => {
     expect(hasTurn).toBe(true);
   });
 
-  it('still allows callers to override with their own TURN servers', () => {
+  it("still allows callers to override with their own TURN servers", () => {
     const custom: ICEServerConfig[] = [
       {
-        urls: 'turn:custom.example.com:3478',
-        username: 'me',
-        credential: 'pw',
-        credentialType: 'password',
+        urls: "turn:custom.example.com:3478",
+        username: "me",
+        credential: "pw",
+        credentialType: "password",
       },
     ];
     const manager = new ICEConfigurationManager({ customTurnServers: custom });
     expect(manager.getTurnServers()).toEqual(custom);
   });
 
-  it('turn-relay mode surfaces TURN servers for forced relay', () => {
-    const manager = new ICEConfigurationManager({ mode: 'turn-relay' });
+  it("turn-relay mode surfaces TURN servers for forced relay", () => {
+    const manager = new ICEConfigurationManager({ mode: "turn-relay" });
     const config = manager.getRTCConfiguration();
-    expect(config.iceTransportPolicy).toBe('relay');
+    expect(config.iceTransportPolicy).toBe("relay");
     const iceServers = config.iceServers ?? [];
     expect(iceServers.length).toBeGreaterThan(0);
     const allTurn = iceServers.every((server) => {
@@ -263,5 +271,416 @@ describe('ICEConfigurationManager integration with default TURN', () => {
       return urls.every((url) => isTurnScheme(url));
     });
     expect(allTurn).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #1094 — ICE restart / reconnection & candidate-filtering coverage.
+//
+// `ICEConnectionMonitor` is the component that watches
+// `iceconnectionstatechange` and fires the onFailed/onDisconnected callbacks
+// that the connection layer uses to trigger ICE restart / reconnection. The
+// `ICECandidateFilter` enforces candidate policy. Both were previously
+// untested, along with several ICEConfigurationManager modes/methods, the
+// factory helpers, and the global singleton. All browser APIs are faked — no
+// real network or RTCPeerConnection is used.
+// ---------------------------------------------------------------------------
+
+/** Minimal fake RTCPeerConnection exposing only what the monitor touches. */
+function makeFakePC(initialState: RTCIceConnectionState = "new"): {
+  iceConnectionState: RTCIceConnectionState;
+  oniceconnectionstatechange: (() => void) | null;
+} {
+  return {
+    iceConnectionState: initialState,
+    oniceconnectionstatechange: null,
+  };
+}
+
+describe("ICEConfigurationManager — modes & server management (#1094)", () => {
+  it("stun-only mode yields only STUN servers in the RTC configuration", () => {
+    const manager = new ICEConfigurationManager({ mode: "stun-only" });
+    expect(manager.getMode()).toBe("stun-only");
+    const config = manager.getRTCConfiguration();
+    const iceServers = config.iceServers ?? [];
+    expect(iceServers.length).toBeGreaterThan(0);
+    for (const server of iceServers) {
+      const urls = Array.isArray(server.urls) ? server.urls : [server.urls];
+      for (const url of urls) expect(url.startsWith("stun:")).toBe(true);
+    }
+    // Relay-only transport policy must NOT be set in stun-only mode.
+    expect(config.iceTransportPolicy).toBeUndefined();
+  });
+
+  it("custom mode surfaces both STUN and TURN servers", () => {
+    const customStun: ICEServerConfig[] = [
+      { urls: "stun:custom.example.com:3478" },
+    ];
+    const customTurn: ICEServerConfig[] = [
+      {
+        urls: "turn:custom.example.com:3478",
+        username: "u",
+        credential: "p",
+        credentialType: "password",
+      },
+    ];
+    const manager = new ICEConfigurationManager({
+      mode: "custom",
+      customStunServers: customStun,
+      customTurnServers: customTurn,
+    });
+    const iceServers = manager.getRTCConfiguration().iceServers ?? [];
+    expect(iceServers.length).toBe(2);
+  });
+
+  it("auto mode includes TURN servers only when configured", () => {
+    const withTurn = new ICEConfigurationManager({ mode: "auto" });
+    expect(
+      (withTurn.getRTCConfiguration().iceServers ?? []).length,
+    ).toBeGreaterThan(0);
+    expect(withTurn.hasTurnServers()).toBe(true);
+
+    const noTurn = new ICEConfigurationManager({
+      mode: "auto",
+      customStunServers: [{ urls: "stun:stun.example.com:3478" }],
+      customTurnServers: [],
+    });
+    expect(noTurn.hasTurnServers()).toBe(false);
+  });
+
+  it("addStunServer / addTurnServer append to the server lists", () => {
+    const manager = new ICEConfigurationManager({ customTurnServers: [] });
+    const stunBefore = manager.getStunServers().length;
+    manager.addStunServer({ urls: "stun:added.example.com:3478" });
+    expect(manager.getStunServers().length).toBe(stunBefore + 1);
+
+    expect(manager.getTurnServers().length).toBe(0);
+    manager.addTurnServer({
+      urls: "turn:added.example.com:3478",
+      username: "u",
+      credential: "c",
+    });
+    expect(manager.getTurnServers().length).toBe(1);
+  });
+
+  it("setMode / getMode round-trip", () => {
+    const manager = new ICEConfigurationManager();
+    expect(manager.getMode()).toBe("auto");
+    manager.setMode("stun-only");
+    expect(manager.getMode()).toBe("stun-only");
+  });
+
+  it("setTurnCredentials updates username/credential on every TURN server", () => {
+    const manager = new ICEConfigurationManager({
+      customTurnServers: [
+        {
+          urls: "turn:a.example.com:3478",
+          username: "old",
+          credential: "old",
+          credentialType: "password",
+        },
+        {
+          urls: "turn:b.example.com:3478",
+          username: "old",
+          credential: "old",
+          credentialType: "password",
+        },
+      ],
+    });
+    manager.setTurnCredentials("newuser", "newpass");
+    for (const server of manager.getTurnServers()) {
+      expect(server.username).toBe("newuser");
+      expect(server.credential).toBe("newpass");
+    }
+  });
+
+  it("getStunServers / getTurnServers return defensive copies", () => {
+    const manager = new ICEConfigurationManager();
+    const a = manager.getStunServers();
+    a.push({ urls: "stun:mutant.example.com:3478" });
+    expect(manager.getStunServers().length).not.toBe(a.length);
+  });
+
+  it("createTestConfiguration() returns a STUN-only RTCConfiguration with a candidate pool", () => {
+    const config = ICEConfigurationManager.createTestConfiguration();
+    expect(config.iceServers).toBe(DEFAULT_STUN_SERVERS);
+    expect(config.iceCandidatePoolSize).toBe(10);
+  });
+});
+
+describe("ICEConnectionMonitor — ICE restart / reconnection triggers (#1094)", () => {
+  let infoSpy: jest.SpyInstance;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // The monitor logs every ICE state change; silence it in test output.
+    infoSpy = jest.spyOn(console, "info").mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    infoSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it("attach() wires oniceconnectionstatechange and detach() removes it", () => {
+    const monitor = new ICEConnectionMonitor();
+    const pc = makeFakePC("new");
+    monitor.attach(pc as unknown as RTCPeerConnection);
+    expect(pc.oniceconnectionstatechange).not.toBeNull();
+
+    monitor.detach();
+    expect(pc.oniceconnectionstatechange).toBeNull();
+    expect(monitor.getState()).toBeNull();
+  });
+
+  it("reports connected/completed states and fires onConnected", () => {
+    const onConnected = jest.fn();
+    const onStateChange = jest.fn();
+    const monitor = new ICEConnectionMonitor({ onConnected, onStateChange });
+    const pc = makeFakePC("new");
+    monitor.attach(pc as unknown as RTCPeerConnection);
+
+    pc.iceConnectionState = "connected";
+    pc.oniceconnectionstatechange!();
+
+    expect(onStateChange).toHaveBeenCalledWith("connected");
+    expect(onConnected).toHaveBeenCalledTimes(1);
+    expect(monitor.isConnected()).toBe(true);
+
+    pc.iceConnectionState = "completed";
+    pc.oniceconnectionstatechange!();
+    expect(onConnected).toHaveBeenCalledTimes(2);
+    expect(monitor.getState()).toBe("completed");
+  });
+
+  it("failed state fires onFailed immediately and clears the failure timer", () => {
+    const onFailed = jest.fn();
+    const monitor = new ICEConnectionMonitor({
+      onFailed,
+      failureTimeoutMs: 5000,
+    });
+    const pc = makeFakePC("connected");
+    monitor.attach(pc as unknown as RTCPeerConnection);
+
+    pc.iceConnectionState = "failed";
+    pc.oniceconnectionstatechange!();
+
+    expect(onFailed).toHaveBeenCalledTimes(1);
+    // Advancing the clock must NOT fire a second onFailed (timer was cleared).
+    jest.advanceTimersByTime(10000);
+    expect(onFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it("disconnected starts a failure timer that triggers onFailed after the window (ICE restart trigger)", () => {
+    const onFailed = jest.fn();
+    const onDisconnected = jest.fn();
+    const monitor = new ICEConnectionMonitor({
+      onFailed,
+      onDisconnected,
+      failureTimeoutMs: 3000,
+    });
+    const pc = makeFakePC("connected");
+    monitor.attach(pc as unknown as RTCPeerConnection);
+
+    pc.iceConnectionState = "disconnected";
+    pc.oniceconnectionstatechange!();
+
+    expect(onDisconnected).toHaveBeenCalledTimes(1);
+    expect(monitor.isConnected()).toBe(false);
+
+    // Just before the window — no failure yet.
+    jest.advanceTimersByTime(2999);
+    expect(onFailed).not.toHaveBeenCalled();
+
+    // Crossing the window triggers the failure that drives ICE restart upstream.
+    jest.advanceTimersByTime(1);
+    expect(onFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconnects before the failure window cancels the pending failure (no spurious restart)", () => {
+    const onFailed = jest.fn();
+    const onConnected = jest.fn();
+    const monitor = new ICEConnectionMonitor({
+      onFailed,
+      onConnected,
+      failureTimeoutMs: 3000,
+    });
+    const pc = makeFakePC("connected");
+    monitor.attach(pc as unknown as RTCPeerConnection);
+
+    // Drop, then recover before the timeout fires.
+    pc.iceConnectionState = "disconnected";
+    pc.oniceconnectionstatechange!();
+    jest.advanceTimersByTime(2000);
+    pc.iceConnectionState = "connected";
+    pc.oniceconnectionstatechange!();
+
+    expect(onConnected).toHaveBeenCalled();
+    jest.advanceTimersByTime(5000);
+    expect(onFailed).not.toHaveBeenCalled();
+  });
+
+  it("a fresh disconnected event resets the failure timer (debounce)", () => {
+    const onFailed = jest.fn();
+    const monitor = new ICEConnectionMonitor({
+      onFailed,
+      failureTimeoutMs: 3000,
+    });
+    const pc = makeFakePC("connected");
+    monitor.attach(pc as unknown as RTCPeerConnection);
+
+    pc.iceConnectionState = "disconnected";
+    pc.oniceconnectionstatechange!();
+    jest.advanceTimersByTime(2500);
+
+    // A second disconnected event should restart the window, not stack.
+    pc.iceConnectionState = "disconnected";
+    pc.oniceconnectionstatechange!();
+    jest.advanceTimersByTime(2500); // would have fired if not reset
+    expect(onFailed).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(500);
+    expect(onFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it("closed state clears timers and fires no transport callbacks", () => {
+    const onFailed = jest.fn();
+    const onConnected = jest.fn();
+    const monitor = new ICEConnectionMonitor({
+      onFailed,
+      onConnected,
+      failureTimeoutMs: 1000,
+    });
+    const pc = makeFakePC("disconnected");
+    monitor.attach(pc as unknown as RTCPeerConnection);
+
+    pc.iceConnectionState = "closed";
+    pc.oniceconnectionstatechange!();
+
+    jest.advanceTimersByTime(5000);
+    expect(onFailed).not.toHaveBeenCalled();
+    expect(onConnected).not.toHaveBeenCalled();
+  });
+
+  it("handleStateChange is a no-op when no connection is attached", () => {
+    const onStateChange = jest.fn();
+    const monitor = new ICEConnectionMonitor({ onStateChange });
+    // Detach first to guarantee no connection, then fire the handler path.
+    monitor.detach();
+    // No throw and no callback invocation.
+    expect(() => monitor.getState()).not.toThrow();
+    expect(onStateChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("ICECandidateFilter — candidate filtering (#1094)", () => {
+  /** Build a candidate-shaped object the filter can read. */
+  function cand(address: string): RTCIceCandidate {
+    return { address, candidate: address } as unknown as RTCIceCandidate;
+  }
+
+  it("passes through a normal public IPv4 candidate by default", () => {
+    const filter = new ICECandidateFilter();
+    const c = cand("203.0.113.5");
+    expect(filter.filter(c)).toBe(c);
+  });
+
+  it("drops IPv6 candidates when allowIPv6 is false", () => {
+    const filter = new ICECandidateFilter({ allowIPv6: false });
+    expect(filter.filter(cand("2001:db8::1"))).toBeNull();
+  });
+
+  it("keeps IPv6 candidates when allowIPv6 is true (default)", () => {
+    const filter = new ICECandidateFilter();
+    expect(filter.filter(cand("2001:db8::1"))).not.toBeNull();
+  });
+
+  it("drops loopback candidates by default (127.0.0.1, ::1, localhost)", () => {
+    const filter = new ICECandidateFilter();
+    expect(filter.filter(cand("127.0.0.1"))).toBeNull();
+    expect(filter.filter(cand("::1"))).toBeNull();
+    expect(filter.filter(cand("localhost"))).toBeNull();
+  });
+
+  it("allows loopback when allowLoopback is true", () => {
+    const filter = new ICECandidateFilter({ allowLoopback: true });
+    expect(filter.filter(cand("127.0.0.1"))).not.toBeNull();
+  });
+
+  it("drops link-local candidates by default (169.254.*, fe80::)", () => {
+    const filter = new ICECandidateFilter();
+    expect(filter.filter(cand("169.254.1.2"))).toBeNull();
+    expect(filter.filter(cand("fe80::1"))).toBeNull();
+    expect(filter.filter(cand("fe80:1234"))).toBeNull();
+  });
+
+  it("allows link-local when allowLinkLocal is true", () => {
+    const filter = new ICECandidateFilter({ allowLinkLocal: true });
+    expect(filter.filter(cand("169.254.1.2"))).not.toBeNull();
+  });
+
+  it("keeps the candidate when address is null/empty", () => {
+    const filter = new ICECandidateFilter({
+      allowIPv6: false,
+      allowLoopback: false,
+      allowLinkLocal: false,
+    });
+    // No address → the isIPv6/isLoopback/isLinkLocal guards all short-circuit false.
+    expect(filter.filter(cand(""))).not.toBeNull();
+  });
+});
+
+describe("ICE factory helpers & global singleton (#1094)", () => {
+  it("createDefaultICEConfiguration returns a populated RTCConfiguration", () => {
+    const config = createDefaultICEConfiguration();
+    expect((config.iceServers ?? []).length).toBeGreaterThan(0);
+    expect(config.iceCandidatePoolSize).toBe(10);
+  });
+
+  it("createICEConfigurationWithTurn merges custom TURN + STUN servers", () => {
+    const turn: ICEServerConfig[] = [
+      {
+        urls: "turn:turn.example.com:3478",
+        username: "u",
+        credential: "p",
+        credentialType: "password",
+      },
+    ];
+    const stun: ICEServerConfig[] = [{ urls: "stun:stun.example.com:3478" }];
+    const config = createICEConfigurationWithTurn(turn, stun);
+    const iceServers = config.iceServers ?? [];
+    expect(iceServers.length).toBe(2);
+    const hasTurn = iceServers.some((s) => {
+      const urls = Array.isArray(s.urls) ? s.urls : [s.urls];
+      return urls.some((u) => isTurnScheme(u));
+    });
+    expect(hasTurn).toBe(true);
+  });
+
+  it("createRelayOnlyConfiguration forces relay transport policy", () => {
+    const turn: ICEServerConfig[] = [
+      {
+        urls: "turn:turn.example.com:3478",
+        username: "u",
+        credential: "p",
+        credentialType: "password",
+      },
+    ];
+    const config = createRelayOnlyConfiguration(turn);
+    expect(config.iceTransportPolicy).toBe("relay");
+  });
+
+  it("getGlobalICEManager returns a stable singleton", () => {
+    const a = getGlobalICEManager();
+    const b = getGlobalICEManager();
+    expect(b).toBe(a);
+  });
+
+  it("setGlobalICEConfiguration replaces the singleton", () => {
+    const original = getGlobalICEManager();
+    setGlobalICEConfiguration({ mode: "stun-only" });
+    const next = getGlobalICEManager();
+    expect(next).not.toBe(original);
+    expect(next.getMode()).toBe("stun-only");
+    // Restore to auto so subsequent suites get the default.
+    setGlobalICEConfiguration({});
   });
 });

--- a/src/lib/__tests__/p2p-handshake.test.ts
+++ b/src/lib/__tests__/p2p-handshake.test.ts
@@ -1,290 +1,644 @@
 /**
  * Tests for P2P Handshake Protocol
  * Issue #604: Add tests for P2P networking and multiplayer systems
+ * Issue #1094: Cover reconnection handshake, stale-peer rejection, seq-number
+ *               resync, timeout/abort, and the checksum algorithms.
  */
+
+// The handshake state machine depends on serializeGameState(gameState) to
+// compute/verify checksums. We stub the serialization module so checksums are
+// deterministic and the tests can drive checksum-match / mismatch paths
+// without constructing a full engine GameState. The mock path mirrors the
+// source import specifier (`@/lib/game-state/serialization`).
+jest.mock("@/lib/game-state/serialization", () => ({
+  serializeGameState: (state: {
+    turn?: { turnNumber?: number };
+    __id?: string;
+  }) => ({
+    turnNumber: state?.turn?.turnNumber ?? 0,
+    id: state?.__id ?? "default-state",
+  }),
+}));
 
 import {
   calculateCRC32,
+  calculateStateChecksum,
   createHandshakeInit,
   createHandshakeChallenge,
+  createHandshakeResponse,
   createHandshakeAck,
   createHandshakeFailed,
   createStateChecksumRequest,
+  createStateChecksumResponse,
   createStateSyncRequest,
+  createStateSyncResponse,
+  verifyChecksum,
   HandshakeSession,
   PROTOCOL_VERSION,
   CHECKSUM_ALGORITHMS,
   DEFAULT_CHECKSUM_ALGORITHM,
-} from '../p2p-handshake';
+  type HandshakeInitMessage,
+  type HandshakeChallengeMessage,
+  type HandshakeResponseMessage,
+  type HandshakeAckMessage,
+} from "../p2p-handshake";
+import type { GameState } from "../game-state/types";
 
-describe('P2P Handshake Protocol', () => {
-  describe('CRC32 Checksum', () => {
-    it('should calculate CRC32 for empty string', () => {
-      const result = calculateCRC32('');
+describe("P2P Handshake Protocol", () => {
+  describe("CRC32 Checksum", () => {
+    it("should calculate CRC32 for empty string", () => {
+      const result = calculateCRC32("");
       expect(result).toBeDefined();
-      expect(typeof result).toBe('number');
+      expect(typeof result).toBe("number");
     });
 
-    it('should calculate CRC32 for simple string', () => {
-      const result = calculateCRC32('test');
+    it("should calculate CRC32 for simple string", () => {
+      const result = calculateCRC32("test");
       expect(result).toBeDefined();
-      expect(typeof result).toBe('number');
+      expect(typeof result).toBe("number");
     });
 
-    it('should produce consistent results', () => {
-      const result1 = calculateCRC32('hello world');
-      const result2 = calculateCRC32('hello world');
+    it("should produce consistent results", () => {
+      const result1 = calculateCRC32("hello world");
+      const result2 = calculateCRC32("hello world");
       expect(result1).toBe(result2);
     });
 
-    it('should produce different results for different inputs', () => {
-      const result1 = calculateCRC32('hello');
-      const result2 = calculateCRC32('world');
+    it("should produce different results for different inputs", () => {
+      const result1 = calculateCRC32("hello");
+      const result2 = calculateCRC32("world");
       expect(result1).not.toBe(result2);
     });
   });
 
-  describe('Constants', () => {
-    it('should have valid protocol version', () => {
-      expect(PROTOCOL_VERSION).toBe('1.0.0');
+  describe("Constants", () => {
+    it("should have valid protocol version", () => {
+      expect(PROTOCOL_VERSION).toBe("1.0.0");
     });
 
-    it('should have valid checksum algorithms', () => {
-      expect(CHECKSUM_ALGORITHMS).toContain('crc32');
-      expect(CHECKSUM_ALGORITHMS).toContain('md5');
-      expect(CHECKSUM_ALGORITHMS).toContain('sha256');
+    it("should have valid checksum algorithms", () => {
+      expect(CHECKSUM_ALGORITHMS).toContain("crc32");
+      expect(CHECKSUM_ALGORITHMS).toContain("md5");
+      expect(CHECKSUM_ALGORITHMS).toContain("sha256");
     });
 
-    it('should have default algorithm', () => {
-      expect(DEFAULT_CHECKSUM_ALGORITHM).toBe('crc32');
+    it("should have default algorithm", () => {
+      expect(DEFAULT_CHECKSUM_ALGORITHM).toBe("crc32");
     });
   });
 
-  describe('Message Creation', () => {
-    describe('createHandshakeInit', () => {
-      it('should create valid init message', () => {
-        const message = createHandshakeInit('sender1', 'Test Player', 'player1', 'GAME1');
+  describe("Message Creation", () => {
+    describe("createHandshakeInit", () => {
+      it("should create valid init message", () => {
+        const message = createHandshakeInit(
+          "sender1",
+          "Test Player",
+          "player1",
+          "GAME1",
+        );
 
-        expect(message.type).toBe('handshake-init');
-        expect(message.senderId).toBe('sender1');
+        expect(message.type).toBe("handshake-init");
+        expect(message.senderId).toBe("sender1");
         expect(message.payload.protocolVersion).toBe(PROTOCOL_VERSION);
-        expect(message.payload.playerName).toBe('Test Player');
-        expect(message.payload.playerId).toBe('player1');
-        expect(message.payload.gameCode).toBe('GAME1');
+        expect(message.payload.playerName).toBe("Test Player");
+        expect(message.payload.playerId).toBe("player1");
+        expect(message.payload.gameCode).toBe("GAME1");
         expect(message.timestamp).toBeDefined();
       });
 
-      it('should include default capabilities', () => {
-        const message = createHandshakeInit('sender1', 'Test Player', 'player1', 'GAME1');
-        expect(message.payload.capabilities).toContain('state-sync');
-        expect(message.payload.capabilities).toContain('chat');
-        expect(message.payload.capabilities).toContain('emotes');
+      it("should include default capabilities", () => {
+        const message = createHandshakeInit(
+          "sender1",
+          "Test Player",
+          "player1",
+          "GAME1",
+        );
+        expect(message.payload.capabilities).toContain("state-sync");
+        expect(message.payload.capabilities).toContain("chat");
+        expect(message.payload.capabilities).toContain("emotes");
       });
 
-      it('should accept custom capabilities', () => {
-        const message = createHandshakeInit('sender1', 'Test Player', 'player1', 'GAME1', ['custom']);
-        expect(message.payload.capabilities).toContain('custom');
+      it("should accept custom capabilities", () => {
+        const message = createHandshakeInit(
+          "sender1",
+          "Test Player",
+          "player1",
+          "GAME1",
+          ["custom"],
+        );
+        expect(message.payload.capabilities).toContain("custom");
       });
     });
 
-    describe('createHandshakeChallenge', () => {
-      it('should create valid challenge message', () => {
-        const message = createHandshakeChallenge('sender1');
+    describe("createHandshakeChallenge", () => {
+      it("should create valid challenge message", () => {
+        const message = createHandshakeChallenge("sender1");
 
-        expect(message.type).toBe('handshake-challenge');
-        expect(message.senderId).toBe('sender1');
+        expect(message.type).toBe("handshake-challenge");
+        expect(message.senderId).toBe("sender1");
         expect(message.payload.challenge).toBeDefined();
-        expect(message.payload.checksumAlgorithm).toBe(DEFAULT_CHECKSUM_ALGORITHM);
+        expect(message.payload.checksumAlgorithm).toBe(
+          DEFAULT_CHECKSUM_ALGORITHM,
+        );
       });
 
-      it('should accept custom algorithm', () => {
-        const message = createHandshakeChallenge('sender1', 'sha256');
-        expect(message.payload.checksumAlgorithm).toBe('sha256');
+      it("should accept custom algorithm", () => {
+        const message = createHandshakeChallenge("sender1", "sha256");
+        expect(message.payload.checksumAlgorithm).toBe("sha256");
       });
 
-      it('should generate unique challenges', () => {
-        const msg1 = createHandshakeChallenge('sender1');
-        const msg2 = createHandshakeChallenge('sender1');
+      it("should generate unique challenges", () => {
+        const msg1 = createHandshakeChallenge("sender1");
+        const msg2 = createHandshakeChallenge("sender1");
         expect(msg1.payload.challenge).not.toBe(msg2.payload.challenge);
       });
     });
 
-    describe('createHandshakeAck', () => {
-      it('should create acknowledgment with match', () => {
-        const message = createHandshakeAck('sender1', true, 5);
+    describe("createHandshakeAck", () => {
+      it("should create acknowledgment with match", () => {
+        const message = createHandshakeAck("sender1", true, 5);
 
-        expect(message.type).toBe('handshake-ack');
-        expect(message.senderId).toBe('sender1');
+        expect(message.type).toBe("handshake-ack");
+        expect(message.senderId).toBe("sender1");
         expect(message.payload.checksumMatch).toBe(true);
         expect(message.payload.stateVersion).toBe(5);
       });
 
-      it('should create acknowledgment with mismatch', () => {
-        const message = createHandshakeAck('sender1', false, 0);
+      it("should create acknowledgment with mismatch", () => {
+        const message = createHandshakeAck("sender1", false, 0);
 
         expect(message.payload.checksumMatch).toBe(false);
         expect(message.payload.stateVersion).toBe(0);
       });
     });
 
-    describe('createHandshakeFailed', () => {
-      it('should create failure message', () => {
-        const message = createHandshakeFailed('sender1', 'Version mismatch');
+    describe("createHandshakeFailed", () => {
+      it("should create failure message", () => {
+        const message = createHandshakeFailed("sender1", "Version mismatch");
 
-        expect(message.type).toBe('handshake-failed');
-        expect(message.senderId).toBe('sender1');
-        expect(message.payload.reason).toBe('Version mismatch');
+        expect(message.type).toBe("handshake-failed");
+        expect(message.senderId).toBe("sender1");
+        expect(message.payload.reason).toBe("Version mismatch");
       });
 
-      it('should include checksum details', () => {
-        const message = createHandshakeFailed('sender1', 'Checksum mismatch', 'expected', 'received');
+      it("should include checksum details", () => {
+        const message = createHandshakeFailed(
+          "sender1",
+          "Checksum mismatch",
+          "expected",
+          "received",
+        );
 
-        expect(message.payload.expectedChecksum).toBe('expected');
-        expect(message.payload.receivedChecksum).toBe('received');
+        expect(message.payload.expectedChecksum).toBe("expected");
+        expect(message.payload.receivedChecksum).toBe("received");
       });
     });
 
-    describe('createStateChecksumRequest', () => {
-      it('should create checksum request', () => {
-        const message = createStateChecksumRequest('sender1');
+    describe("createStateChecksumRequest", () => {
+      it("should create checksum request", () => {
+        const message = createStateChecksumRequest("sender1");
 
-        expect(message.type).toBe('state-checksum-request');
-        expect(message.senderId).toBe('sender1');
+        expect(message.type).toBe("state-checksum-request");
+        expect(message.senderId).toBe("sender1");
       });
 
-      it('should accept version request', () => {
-        const message = createStateChecksumRequest('sender1', 5);
+      it("should accept version request", () => {
+        const message = createStateChecksumRequest("sender1", 5);
         expect(message.payload.requestedVersion).toBe(5);
       });
     });
 
-    describe('createStateSyncRequest', () => {
-      it('should create sync request', () => {
-        const message = createStateSyncRequest('sender1', 5, 'abc123');
+    describe("createStateSyncRequest", () => {
+      it("should create sync request", () => {
+        const message = createStateSyncRequest("sender1", 5, "abc123");
 
-        expect(message.type).toBe('state-sync-request');
-        expect(message.senderId).toBe('sender1');
+        expect(message.type).toBe("state-sync-request");
+        expect(message.senderId).toBe("sender1");
         expect(message.payload.currentVersion).toBe(5);
-        expect(message.payload.checksum).toBe('abc123');
+        expect(message.payload.checksum).toBe("abc123");
       });
     });
   });
 
-  describe('HandshakeSession', () => {
-    describe('Initialization', () => {
-      it('should initialize with idle state', () => {
-        const session = new HandshakeSession('player1');
-        expect(session.getState()).toBe('idle');
+  describe("HandshakeSession", () => {
+    describe("Initialization", () => {
+      it("should initialize with idle state", () => {
+        const session = new HandshakeSession("player1");
+        expect(session.getState()).toBe("idle");
       });
 
-      it('should accept state change callback', () => {
+      it("should accept state change callback", () => {
         const callback = jest.fn();
-        const session = new HandshakeSession('player1', callback);
+        const session = new HandshakeSession("player1", callback);
         expect(callback).toBeDefined();
       });
     });
 
-    describe('start()', () => {
-      it('should initiate handshake', () => {
-        const session = new HandshakeSession('player1');
-        const message = session.start('player2');
+    describe("start()", () => {
+      it("should initiate handshake", () => {
+        const session = new HandshakeSession("player1");
+        const message = session.start("player2");
 
-        expect(message.type).toBe('handshake-init');
-        expect(session.getState()).toBe('initiated');
+        expect(message.type).toBe("handshake-init");
+        expect(session.getState()).toBe("initiated");
       });
 
-      it('should set remote player id', () => {
-        const session = new HandshakeSession('player1');
-        session.start('player2');
+      it("should set remote player id", () => {
+        const session = new HandshakeSession("player1");
+        session.start("player2");
 
-        expect(session.getState()).toBe('initiated');
+        expect(session.getState()).toBe("initiated");
       });
     });
 
-    describe('handleInit()', () => {
-      it('should handle incoming init and send challenge', () => {
-        const session = new HandshakeSession('player1');
-        const initMessage = createHandshakeInit('player2', 'Player 2', 'player2', 'GAME1');
+    describe("handleInit()", () => {
+      it("should handle incoming init and send challenge", () => {
+        const session = new HandshakeSession("player1");
+        const initMessage = createHandshakeInit(
+          "player2",
+          "Player 2",
+          "player2",
+          "GAME1",
+        );
 
         const challengeMessage = session.handleInit(initMessage);
 
-        expect(challengeMessage.type).toBe('handshake-challenge');
-        expect(session.getState()).toBe('challenged');
+        expect(challengeMessage.type).toBe("handshake-challenge");
+        expect(session.getState()).toBe("challenged");
       });
 
-      it('should reject invalid protocol version', () => {
-        const session = new HandshakeSession('player1');
+      it("should reject invalid protocol version", () => {
+        const session = new HandshakeSession("player1");
         const initMessage = {
-          type: 'handshake-init' as const,
-          senderId: 'player2',
+          type: "handshake-init" as const,
+          senderId: "player2",
           timestamp: Date.now(),
           payload: {
-            protocolVersion: '0.0.1',
-            playerName: 'Player 2',
-            playerId: 'player2',
-            gameCode: 'GAME1',
+            protocolVersion: "0.0.1",
+            playerName: "Player 2",
+            playerId: "player2",
+            gameCode: "GAME1",
             capabilities: [],
           },
         };
 
-        expect(() => session.handleInit(initMessage)).toThrow('Protocol version mismatch');
+        expect(() => session.handleInit(initMessage)).toThrow(
+          "Protocol version mismatch",
+        );
       });
     });
 
-    describe('handleAck()', () => {
-      it('should complete on successful ack', () => {
+    describe("handleAck()", () => {
+      it("should complete on successful ack", () => {
         const onComplete = jest.fn();
-        const session = new HandshakeSession('player1', undefined, onComplete);
+        const session = new HandshakeSession("player1", undefined, onComplete);
         // Need to progress through the handshake state machine
-        session.start('player2');
-        
+        session.start("player2");
+
         // Simulate receiving a challenge and responding to get to 'responded' state
-        const initMsg = createHandshakeInit('player2', 'Player 2', 'player2', 'GAME1');
+        const initMsg = createHandshakeInit(
+          "player2",
+          "Player 2",
+          "player2",
+          "GAME1",
+        );
         const challengeMsg = session.handleInit(initMsg);
-        
+
         // Now we need to handle the challenge to respond
         // Since we can't easily do this without a full game state, let's test a different path
         // Let's just verify the session was created properly
-        
+
         // Actually, we need to test using the handleFailed path which works from any state
-        session.handleFailed(createHandshakeFailed('player2', 'Test failure'));
-        
+        session.handleFailed(createHandshakeFailed("player2", "Test failure"));
+
         // After failure, state is 'failed' - let's verify
-        expect(session.getState()).toBe('failed');
+        expect(session.getState()).toBe("failed");
       });
 
-      it('should reject handleAck in invalid state', () => {
-        const session = new HandshakeSession('player1');
-        const ackMessage = createHandshakeAck('player2', true, 1);
+      it("should reject handleAck in invalid state", () => {
+        const session = new HandshakeSession("player1");
+        const ackMessage = createHandshakeAck("player2", true, 1);
 
-        expect(() => session.handleAck(ackMessage)).toThrow('Invalid handshake state');
+        expect(() => session.handleAck(ackMessage)).toThrow(
+          "Invalid handshake state",
+        );
       });
     });
 
-    describe('handleFailed()', () => {
-      it('should handle failure message', () => {
+    describe("handleFailed()", () => {
+      it("should handle failure message", () => {
         const onComplete = jest.fn();
         const onStateChange = jest.fn();
-        const session = new HandshakeSession('player1', onStateChange, onComplete);
+        const session = new HandshakeSession(
+          "player1",
+          onStateChange,
+          onComplete,
+        );
 
-        const failedMessage = createHandshakeFailed('player2', 'Connection lost');
+        const failedMessage = createHandshakeFailed(
+          "player2",
+          "Connection lost",
+        );
         session.handleFailed(failedMessage);
 
-        expect(session.getState()).toBe('failed');
-        expect(onStateChange).toHaveBeenCalledWith('failed');
-        expect(onComplete).toHaveBeenCalledWith(false, 'Connection lost');
+        expect(session.getState()).toBe("failed");
+        expect(onStateChange).toHaveBeenCalledWith("failed");
+        expect(onComplete).toHaveBeenCalledWith(false, "Connection lost");
       });
     });
 
-    describe('cleanup()', () => {
-      it('should cleanup properly', () => {
-        const session = new HandshakeSession('player1');
-        session.start('player2');
+    describe("cleanup()", () => {
+      it("should cleanup properly", () => {
+        const session = new HandshakeSession("player1");
+        session.start("player2");
         session.cleanup();
 
-        expect(session.getState()).toBe('idle');
+        expect(session.getState()).toBe("idle");
         expect(session.getRemoteChecksum()).toBeNull();
       });
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #1094 — reconnection handshake, stale-peer rejection, seq-number
+// resync, timeout/abort, and checksum-algorithm coverage.
+//
+// These suites drive the previously-uncovered HandshakeSession transitions
+// (handleChallenge / handleResponse / handleAck), the timeout abort path, the
+// checksum algorithms beyond crc32, and the remaining state-sync message
+// creators. `serializeGameState` is mocked (top of file) so checksums are
+// deterministic and can be driven through match / mismatch paths.
+// ---------------------------------------------------------------------------
+
+/** Minimal GameState shaped to survive the mocked serializeGameState. */
+function makeGameState(turnNumber: number, id = "default-state"): GameState {
+  return { turn: { turnNumber }, __id: id } as unknown as GameState;
+}
+
+describe("calculateStateChecksum / verifyChecksum — algorithms (#1094)", () => {
+  const state = makeGameState(7, "algo-state");
+
+  it("crc32 (default) yields an 8-char hex string", () => {
+    const sum = calculateStateChecksum(state);
+    expect(sum).toMatch(/^[0-9a-f]{8}$/);
+    expect(calculateStateChecksum(state, "crc32")).toBe(sum);
+  });
+
+  it("md5 yields a 32-char hex string (128 bits / 4)", () => {
+    expect(calculateStateChecksum(state, "md5")).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("sha256 yields a 64-char hex string (256 bits / 4)", () => {
+    expect(calculateStateChecksum(state, "sha256")).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("produces deterministic, input-sensitive checksums", () => {
+    expect(calculateStateChecksum(state, "md5")).toBe(
+      calculateStateChecksum(state, "md5"),
+    );
+    expect(calculateStateChecksum(state)).not.toBe(
+      calculateStateChecksum(makeGameState(8, "other")),
+    );
+  });
+
+  it("verifyChecksum returns true for a matching checksum and false otherwise", () => {
+    const sum = calculateStateChecksum(state, "sha256");
+    expect(verifyChecksum(state, sum, "sha256")).toBe(true);
+    expect(verifyChecksum(state, "deadbeef", "sha256")).toBe(false);
+  });
+
+  it("createStateChecksumResponse carries checksum + stateVersion", () => {
+    const msg = createStateChecksumResponse("me", state, "md5");
+    expect(msg.type).toBe("state-checksum-response");
+    expect(msg.payload.checksum).toBe(calculateStateChecksum(state, "md5"));
+    expect(msg.payload.stateVersion).toBe(7);
+    expect(msg.payload.timestamp).toBeDefined();
+  });
+
+  it("createStateSyncResponse serializes state and tags full vs partial sync", () => {
+    const full = createStateSyncResponse("me", state, true, "crc32");
+    expect(full.type).toBe("state-sync-response");
+    expect(full.payload.isFullSync).toBe(true);
+    expect(full.payload.checksum).toBe(calculateStateChecksum(state));
+    expect(typeof full.payload.gameState).toBe("string");
+    expect(full.payload.stateVersion).toBe(7);
+
+    const partial = createStateSyncResponse("me", state, false);
+    expect(partial.payload.isFullSync).toBe(false);
+  });
+});
+
+describe("HandshakeSession.handleChallenge (#1094)", () => {
+  it("answers a challenge from the initiated state and moves to responded", () => {
+    const onStateChange = jest.fn();
+    const session = new HandshakeSession("me", onStateChange);
+    session.start("remote"); // -> 'initiated'
+
+    const challenge = createHandshakeChallenge("remote", "crc32");
+    const response = session.handleChallenge(challenge, makeGameState(3));
+
+    expect(response.type).toBe("handshake-response");
+    expect(response.payload.challenge).toBe(challenge.payload.challenge);
+    expect(response.payload.checksum).toBeDefined();
+    expect(response.payload.stateVersion).toBe(3);
+    expect(session.getState()).toBe("responded");
+    expect(onStateChange).toHaveBeenCalledWith("responded");
+  });
+
+  it("throws on an invalid state (idle)", () => {
+    const session = new HandshakeSession("me");
+    const challenge = createHandshakeChallenge("remote");
+    expect(() => session.handleChallenge(challenge, makeGameState(0))).toThrow(
+      "Invalid handshake state",
+    );
+  });
+});
+
+describe("HandshakeSession.handleResponse — stale-peer rejection & verification (#1094)", () => {
+  function initAsResponder() {
+    const onStateChange = jest.fn();
+    const onComplete = jest.fn();
+    const session = new HandshakeSession("me", onStateChange, onComplete);
+    // Drive into the 'challenged' state; handleInit also stores the challenge
+    // it issues (regression fix for the previously-dead success branch).
+    const initMsg = createHandshakeInit("remote", "Remote", "remote", "GAME");
+    const challengeMsg = session.handleInit(initMsg);
+    return {
+      session,
+      onStateChange,
+      onComplete,
+      challenge: challengeMsg.payload.challenge,
+    };
+  }
+
+  it("verifies a matching challenge + checksum and moves to verified", () => {
+    const { session, onComplete, challenge } = initAsResponder();
+    const localState = makeGameState(5, "synced");
+    // Build a well-formed response that echoes our challenge and carries a
+    // checksum computed over the same local state.
+    const response = createHandshakeResponse("remote", challenge, localState);
+
+    const ack = session.handleResponse(response, localState);
+
+    expect(ack.payload.checksumMatch).toBe(true);
+    expect(ack.payload.stateVersion).toBe(5);
+    expect(session.getState()).toBe("verified");
+    expect(session.getRemoteChecksum()).toBe(response.payload.checksum);
+    expect(onComplete).toHaveBeenCalledWith(true);
+  });
+
+  it("rejects a stale / replayed response whose challenge does not match", () => {
+    const { session, onComplete } = initAsResponder();
+    const localState = makeGameState(5, "synced");
+    const response = createHandshakeResponse(
+      "remote",
+      "stale-challenge",
+      localState,
+    );
+
+    const ack = session.handleResponse(response, localState);
+
+    expect(ack.payload.checksumMatch).toBe(false);
+    expect(ack.payload.stateVersion).toBe(0);
+    expect(session.getState()).toBe("failed");
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("fails on checksum mismatch even when the challenge matches", () => {
+    const { session, onComplete, challenge } = initAsResponder();
+    const localState = makeGameState(5, "synced");
+    const response = createHandshakeResponse("remote", challenge, localState);
+    response.payload.checksum = "deadbeef"; // corrupt the checksum
+
+    const ack = session.handleResponse(response, localState);
+
+    expect(ack.payload.checksumMatch).toBe(false);
+    expect(session.getState()).toBe("failed");
+    expect(onComplete).toHaveBeenCalledWith(false, "Checksum mismatch");
+  });
+
+  it("throws when called from a state other than challenged", () => {
+    const session = new HandshakeSession("me");
+    const response = createHandshakeResponse("remote", "c", makeGameState(0));
+    expect(() => session.handleResponse(response, makeGameState(0))).toThrow(
+      "Invalid handshake state",
+    );
+  });
+
+  it("seq-number resync: getStateVersion() reflects the remote sequence after verify", () => {
+    const { session, challenge } = initAsResponder();
+    expect(session.getStateVersion()).toBe(0);
+    const localState = makeGameState(42, "synced");
+    const response = createHandshakeResponse("remote", challenge, localState);
+    session.handleResponse(response, localState);
+    expect(session.getStateVersion()).toBe(42);
+  });
+});
+
+describe("HandshakeSession.handleAck — completion (#1094)", () => {
+  function respondSession() {
+    const onStateChange = jest.fn();
+    const onComplete = jest.fn();
+    const session = new HandshakeSession("me", onStateChange, onComplete);
+    session.start("remote"); // -> initiated
+    session.handleChallenge(
+      createHandshakeChallenge("remote"),
+      makeGameState(1),
+    ); // -> responded
+    return { session, onStateChange, onComplete };
+  }
+
+  it("completes on a positive ack", () => {
+    const { session, onComplete, onStateChange } = respondSession();
+    session.handleAck(createHandshakeAck("remote", true, 1));
+    expect(session.getState()).toBe("completed");
+    expect(onComplete).toHaveBeenCalledWith(true);
+    expect(onStateChange).toHaveBeenCalledWith("completed");
+  });
+
+  it("fails on a negative ack", () => {
+    const { session, onComplete } = respondSession();
+    session.handleAck(createHandshakeAck("remote", false, 0));
+    expect(session.getState()).toBe("failed");
+    expect(onComplete).toHaveBeenCalledWith(
+      false,
+      "Checksum verification failed",
+    );
+  });
+});
+
+describe("HandshakeSession.handleInit — state guards (#1094)", () => {
+  it("throws when init arrives after the session already progressed", () => {
+    const session = new HandshakeSession("me");
+    const initMsg = createHandshakeInit("remote", "Remote", "remote", "GAME");
+    session.handleInit(initMsg); // idle -> challenged
+    // A second init while challenged is illegal.
+    expect(() => session.handleInit(initMsg)).toThrow(
+      "Invalid handshake state",
+    );
+    expect(session.getState()).toBe("challenged");
+  });
+});
+
+describe("HandshakeSession — timeout / abort path (#1094)", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('fails the session with "Handshake timeout" when no completion occurs in time', () => {
+    const onStateChange = jest.fn();
+    const onComplete = jest.fn();
+    const session = new HandshakeSession("me", onStateChange, onComplete);
+
+    session.start("remote");
+    expect(session.getState()).toBe("initiated");
+
+    // P2P_HANDSHAKE_TIMEOUT_MS is 10000ms.
+    jest.advanceTimersByTime(10000);
+
+    expect(session.getState()).toBe("failed");
+    expect(onStateChange).toHaveBeenCalledWith("failed");
+    expect(onComplete).toHaveBeenCalledWith(false, "Handshake timeout");
+  });
+
+  it("does NOT time out when the handshake completes before the window", () => {
+    const onComplete = jest.fn();
+    const session = new HandshakeSession("me", undefined, onComplete);
+    session.start("remote");
+    const initMsg = createHandshakeInit("remote", "Remote", "remote", "GAME");
+    const challengeMsg = session.handleInit(initMsg); // -> challenged, stores challenge
+    const localState = makeGameState(2, "s");
+    const response = createHandshakeResponse(
+      "remote",
+      challengeMsg.payload.challenge,
+      localState,
+    );
+    session.handleResponse(response, localState); // -> verified (clears timeout)
+
+    jest.advanceTimersByTime(20000);
+    expect(session.getState()).toBe("verified");
+    expect(onComplete).not.toHaveBeenCalledWith(false, "Handshake timeout");
+  });
+
+  it("cleanup() cancels a pending timeout so it never fires", () => {
+    const onComplete = jest.fn();
+    const session = new HandshakeSession("me", undefined, onComplete);
+    session.start("remote");
+    session.cleanup();
+    jest.advanceTimersByTime(20000);
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(session.getState()).toBe("idle");
+  });
+});
+
+describe("createHandshakeResponse — message shape (#1094)", () => {
+  it("embeds the computed checksum and remote state version", () => {
+    const state = makeGameState(9, "r");
+    const msg = createHandshakeResponse("me", "chal", state, "sha256");
+    expect(msg.type).toBe("handshake-response");
+    expect(msg.senderId).toBe("me");
+    expect(msg.payload.challenge).toBe("chal");
+    expect(msg.payload.checksum).toBe(calculateStateChecksum(state, "sha256"));
+    expect(msg.payload.stateVersion).toBe(9);
   });
 });

--- a/src/lib/p2p-handshake.ts
+++ b/src/lib/p2p-handshake.ts
@@ -1,27 +1,27 @@
 /**
  * P2P Handshake Protocol for State Verification
- * 
+ *
  * This module implements a handshake protocol to verify state checksums
  * between peers during connection establishment and game state synchronization.
  */
 
-import type { GameState } from '@/lib/game-state/types';
-import { serializeGameState } from '@/lib/game-state/serialization';
-import { TIMEOUTS } from './config/timeouts';
+import type { GameState } from "@/lib/game-state/types";
+import { serializeGameState } from "@/lib/game-state/serialization";
+import { TIMEOUTS } from "./config/timeouts";
 
 /**
  * Handshake message types
  */
 export type HandshakeMessageType =
-  | 'handshake-init'
-  | 'handshake-challenge'
-  | 'handshake-response'
-  | 'handshake-ack'
-  | 'handshake-failed'
-  | 'state-checksum-request'
-  | 'state-checksum-response'
-  | 'state-sync-request'
-  | 'state-sync-response';
+  | "handshake-init"
+  | "handshake-challenge"
+  | "handshake-response"
+  | "handshake-ack"
+  | "handshake-failed"
+  | "state-checksum-request"
+  | "state-checksum-response"
+  | "state-sync-request"
+  | "state-sync-response";
 
 /**
  * Handshake message structure
@@ -37,7 +37,7 @@ export interface HandshakeMessage {
  * Initial handshake message
  */
 export interface HandshakeInitMessage extends HandshakeMessage {
-  type: 'handshake-init';
+  type: "handshake-init";
   payload: {
     protocolVersion: string;
     playerName: string;
@@ -51,7 +51,7 @@ export interface HandshakeInitMessage extends HandshakeMessage {
  * Challenge message for verification
  */
 export interface HandshakeChallengeMessage extends HandshakeMessage {
-  type: 'handshake-challenge';
+  type: "handshake-challenge";
   payload: {
     challenge: string; // Random nonce
     checksumAlgorithm: string;
@@ -62,7 +62,7 @@ export interface HandshakeChallengeMessage extends HandshakeMessage {
  * Response to challenge with checksum
  */
 export interface HandshakeResponseMessage extends HandshakeMessage {
-  type: 'handshake-response';
+  type: "handshake-response";
   payload: {
     challenge: string;
     checksum: string;
@@ -75,7 +75,7 @@ export interface HandshakeResponseMessage extends HandshakeMessage {
  * Acknowledgment message
  */
 export interface HandshakeAckMessage extends HandshakeMessage {
-  type: 'handshake-ack';
+  type: "handshake-ack";
   payload: {
     checksumMatch: boolean;
     stateVersion: number;
@@ -86,7 +86,7 @@ export interface HandshakeAckMessage extends HandshakeMessage {
  * Handshake failed message
  */
 export interface HandshakeFailedMessage extends HandshakeMessage {
-  type: 'handshake-failed';
+  type: "handshake-failed";
   payload: {
     reason: string;
     expectedChecksum?: string;
@@ -98,7 +98,7 @@ export interface HandshakeFailedMessage extends HandshakeMessage {
  * State checksum request
  */
 export interface StateChecksumRequestMessage extends HandshakeMessage {
-  type: 'state-checksum-request';
+  type: "state-checksum-request";
   payload: {
     requestedVersion?: number;
   };
@@ -108,7 +108,7 @@ export interface StateChecksumRequestMessage extends HandshakeMessage {
  * State checksum response
  */
 export interface StateChecksumResponseMessage extends HandshakeMessage {
-  type: 'state-checksum-response';
+  type: "state-checksum-response";
   payload: {
     checksum: string;
     stateVersion: number;
@@ -120,7 +120,7 @@ export interface StateChecksumResponseMessage extends HandshakeMessage {
  * State sync request
  */
 export interface StateSyncRequestMessage extends HandshakeMessage {
-  type: 'state-sync-request';
+  type: "state-sync-request";
   payload: {
     currentVersion: number;
     checksum: string;
@@ -131,7 +131,7 @@ export interface StateSyncRequestMessage extends HandshakeMessage {
  * State sync response
  */
 export interface StateSyncResponseMessage extends HandshakeMessage {
-  type: 'state-sync-response';
+  type: "state-sync-response";
   payload: {
     gameState?: string; // Serialized game state
     stateVersion: number;
@@ -143,18 +143,18 @@ export interface StateSyncResponseMessage extends HandshakeMessage {
 /**
  * Current protocol version
  */
-export const PROTOCOL_VERSION = '1.0.0';
+export const PROTOCOL_VERSION = "1.0.0";
 
 /**
  * Supported checksum algorithms
  */
-export const CHECKSUM_ALGORITHMS = ['crc32', 'md5', 'sha256'] as const;
-export type ChecksumAlgorithm = typeof CHECKSUM_ALGORITHMS[number];
+export const CHECKSUM_ALGORITHMS = ["crc32", "md5", "sha256"] as const;
+export type ChecksumAlgorithm = (typeof CHECKSUM_ALGORITHMS)[number];
 
 /**
  * Default checksum algorithm
  */
-export const DEFAULT_CHECKSUM_ALGORITHM: ChecksumAlgorithm = 'crc32';
+export const DEFAULT_CHECKSUM_ALGORITHM: ChecksumAlgorithm = "crc32";
 
 /**
  * Calculate CRC32 checksum (simple implementation)
@@ -176,36 +176,39 @@ export function calculateCRC32(data: string): number {
  */
 function getCRC32Table(): Uint32Array {
   const table = new Uint32Array(256);
-  
+
   for (let i = 0; i < 256; i++) {
     let crc = i;
     for (let j = 0; j < 8; j++) {
-      crc = (crc & 1) ? (0xedb88320 ^ (crc >>> 1)) : (crc >>> 1);
+      crc = crc & 1 ? 0xedb88320 ^ (crc >>> 1) : crc >>> 1;
     }
     table[i] = crc >>> 0;
   }
-  
+
   return table;
 }
 
 /**
  * Calculate checksum for game state
  */
-export function calculateStateChecksum(gameState: GameState, algorithm: ChecksumAlgorithm = DEFAULT_CHECKSUM_ALGORITHM): string {
+export function calculateStateChecksum(
+  gameState: GameState,
+  algorithm: ChecksumAlgorithm = DEFAULT_CHECKSUM_ALGORITHM,
+): string {
   const serialized = serializeGameState(gameState);
   const data = JSON.stringify(serialized);
 
   switch (algorithm) {
-    case 'crc32':
-      return calculateCRC32(data).toString(16).padStart(8, '0');
-    case 'md5':
+    case "crc32":
+      return calculateCRC32(data).toString(16).padStart(8, "0");
+    case "md5":
       // Simple MD5-like hash (for production, use crypto.subtle)
       return simpleHash(data);
-    case 'sha256':
+    case "sha256":
       // Simple SHA256-like hash (for production, use crypto.subtle)
       return simpleHash(data, 256);
     default:
-      return calculateCRC32(data).toString(16).padStart(8, '0');
+      return calculateCRC32(data).toString(16).padStart(8, "0");
   }
 }
 
@@ -216,12 +219,12 @@ function simpleHash(data: string, bits: number = 128): string {
   let hash = 0;
   for (let i = 0; i < data.length; i++) {
     const char = data.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
+    hash = (hash << 5) - hash + char;
     hash = hash & hash; // Convert to 32bit integer
   }
-  
+
   // Convert to hex string with specified bits
-  const hex = (hash >>> 0).toString(16).padStart(bits / 4, '0');
+  const hex = (hash >>> 0).toString(16).padStart(bits / 4, "0");
   return hex.slice(0, bits / 4);
 }
 
@@ -231,7 +234,9 @@ function simpleHash(data: string, bits: number = 128): string {
 export function generateChallenge(): string {
   const array = new Uint8Array(16);
   crypto.getRandomValues(array);
-  return Array.from(array, byte => byte.toString(16).padStart(2, '0')).join('');
+  return Array.from(array, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
 }
 
 /**
@@ -242,10 +247,10 @@ export function createHandshakeInit(
   playerName: string,
   playerId: string,
   gameCode: string,
-  capabilities: string[] = ['state-sync', 'chat', 'emotes']
+  capabilities: string[] = ["state-sync", "chat", "emotes"],
 ): HandshakeInitMessage {
   return {
-    type: 'handshake-init',
+    type: "handshake-init",
     senderId,
     timestamp: Date.now(),
     payload: {
@@ -263,10 +268,10 @@ export function createHandshakeInit(
  */
 export function createHandshakeChallenge(
   senderId: string,
-  algorithm: ChecksumAlgorithm = DEFAULT_CHECKSUM_ALGORITHM
+  algorithm: ChecksumAlgorithm = DEFAULT_CHECKSUM_ALGORITHM,
 ): HandshakeChallengeMessage {
   return {
-    type: 'handshake-challenge',
+    type: "handshake-challenge",
     senderId,
     timestamp: Date.now(),
     payload: {
@@ -283,12 +288,12 @@ export function createHandshakeResponse(
   senderId: string,
   challenge: string,
   gameState: GameState,
-  algorithm: ChecksumAlgorithm = DEFAULT_CHECKSUM_ALGORITHM
+  algorithm: ChecksumAlgorithm = DEFAULT_CHECKSUM_ALGORITHM,
 ): HandshakeResponseMessage {
   const checksum = calculateStateChecksum(gameState, algorithm);
-  
+
   return {
-    type: 'handshake-response',
+    type: "handshake-response",
     senderId,
     timestamp: Date.now(),
     payload: {
@@ -305,10 +310,10 @@ export function createHandshakeResponse(
 export function createHandshakeAck(
   senderId: string,
   checksumMatch: boolean,
-  stateVersion: number
+  stateVersion: number,
 ): HandshakeAckMessage {
   return {
-    type: 'handshake-ack',
+    type: "handshake-ack",
     senderId,
     timestamp: Date.now(),
     payload: {
@@ -325,10 +330,10 @@ export function createHandshakeFailed(
   senderId: string,
   reason: string,
   expectedChecksum?: string,
-  receivedChecksum?: string
+  receivedChecksum?: string,
 ): HandshakeFailedMessage {
   return {
-    type: 'handshake-failed',
+    type: "handshake-failed",
     senderId,
     timestamp: Date.now(),
     payload: {
@@ -344,10 +349,10 @@ export function createHandshakeFailed(
  */
 export function createStateChecksumRequest(
   senderId: string,
-  requestedVersion?: number
+  requestedVersion?: number,
 ): StateChecksumRequestMessage {
   return {
-    type: 'state-checksum-request',
+    type: "state-checksum-request",
     senderId,
     timestamp: Date.now(),
     payload: {
@@ -362,12 +367,12 @@ export function createStateChecksumRequest(
 export function createStateChecksumResponse(
   senderId: string,
   gameState: GameState,
-  algorithm: ChecksumAlgorithm = DEFAULT_CHECKSUM_ALGORITHM
+  algorithm: ChecksumAlgorithm = DEFAULT_CHECKSUM_ALGORITHM,
 ): StateChecksumResponseMessage {
   const checksum = calculateStateChecksum(gameState, algorithm);
-  
+
   return {
-    type: 'state-checksum-response',
+    type: "state-checksum-response",
     senderId,
     timestamp: Date.now(),
     payload: {
@@ -384,10 +389,10 @@ export function createStateChecksumResponse(
 export function createStateSyncRequest(
   senderId: string,
   currentVersion: number,
-  checksum: string
+  checksum: string,
 ): StateSyncRequestMessage {
   return {
-    type: 'state-sync-request',
+    type: "state-sync-request",
     senderId,
     timestamp: Date.now(),
     payload: {
@@ -404,13 +409,13 @@ export function createStateSyncResponse(
   senderId: string,
   gameState: GameState,
   isFullSync: boolean,
-  algorithm: ChecksumAlgorithm = DEFAULT_CHECKSUM_ALGORITHM
+  algorithm: ChecksumAlgorithm = DEFAULT_CHECKSUM_ALGORITHM,
 ): StateSyncResponseMessage {
   const serialized = serializeGameState(gameState);
   const checksum = calculateStateChecksum(gameState, algorithm);
-  
+
   return {
-    type: 'state-sync-response',
+    type: "state-sync-response",
     senderId,
     timestamp: Date.now(),
     payload: {
@@ -428,7 +433,7 @@ export function createStateSyncResponse(
 export function verifyChecksum(
   gameState: GameState,
   expectedChecksum: string,
-  algorithm: ChecksumAlgorithm = DEFAULT_CHECKSUM_ALGORITHM
+  algorithm: ChecksumAlgorithm = DEFAULT_CHECKSUM_ALGORITHM,
 ): boolean {
   const actualChecksum = calculateStateChecksum(gameState, algorithm);
   return actualChecksum === expectedChecksum;
@@ -438,19 +443,19 @@ export function verifyChecksum(
  * Handshake state machine
  */
 export type HandshakeState =
-  | 'idle'
-  | 'initiated'
-  | 'challenged'
-  | 'responded'
-  | 'verified'
-  | 'completed'
-  | 'failed';
+  | "idle"
+  | "initiated"
+  | "challenged"
+  | "responded"
+  | "verified"
+  | "completed"
+  | "failed";
 
 /**
  * Handshake session manager
  */
 export class HandshakeSession {
-  private state: HandshakeState = 'idle';
+  private state: HandshakeState = "idle";
   private remotePlayerId: string | null = null;
   private remoteChecksum: string | null = null;
   private localChecksum: string | null = null;
@@ -462,14 +467,14 @@ export class HandshakeSession {
   constructor(
     private localPlayerId: string,
     private onStateChange?: (state: HandshakeState) => void,
-    private onComplete?: (success: boolean, error?: string) => void
+    private onComplete?: (success: boolean, error?: string) => void,
   ) {}
 
   /**
    * Start handshake as initiator
    */
   start(remotePlayerId: string): HandshakeInitMessage {
-    this.state = 'initiated';
+    this.state = "initiated";
     this.remotePlayerId = remotePlayerId;
     this.onStateChange?.(this.state);
 
@@ -478,9 +483,9 @@ export class HandshakeSession {
 
     return createHandshakeInit(
       this.localPlayerId,
-      'Local Player', // Should be passed in
+      "Local Player", // Should be passed in
       this.localPlayerId,
-      'GAME' // Should be passed in
+      "GAME", // Should be passed in
     );
   }
 
@@ -488,33 +493,43 @@ export class HandshakeSession {
    * Handle received init message
    */
   handleInit(message: HandshakeInitMessage): HandshakeChallengeMessage {
-    if (this.state !== 'idle' && this.state !== 'initiated') {
-      throw new Error('Invalid handshake state');
+    if (this.state !== "idle" && this.state !== "initiated") {
+      throw new Error("Invalid handshake state");
     }
 
-    this.state = 'challenged';
+    this.state = "challenged";
     this.remotePlayerId = message.senderId;
     this.onStateChange?.(this.state);
 
     // Validate protocol version
     if (message.payload.protocolVersion !== PROTOCOL_VERSION) {
-      throw new Error(`Protocol version mismatch: expected ${PROTOCOL_VERSION}, got ${message.payload.protocolVersion}`);
+      throw new Error(
+        `Protocol version mismatch: expected ${PROTOCOL_VERSION}, got ${message.payload.protocolVersion}`,
+      );
     }
 
-    // Send challenge
-    return createHandshakeChallenge(this.localPlayerId);
+    // Send challenge. Store it so handleResponse can verify the echoed
+    // challenge on the responder side (the only state, 'challenged', from
+    // which handleResponse is reachable). Without this, the challenge-match
+    // check in handleResponse always failed, making the success branch dead.
+    const challenge = createHandshakeChallenge(this.localPlayerId);
+    this.challenge = challenge.payload.challenge;
+    return challenge;
   }
 
   /**
    * Handle received challenge
    */
-  handleChallenge(message: HandshakeChallengeMessage, gameState: GameState): HandshakeResponseMessage {
-    if (this.state !== 'challenged' && this.state !== 'initiated') {
-      throw new Error('Invalid handshake state');
+  handleChallenge(
+    message: HandshakeChallengeMessage,
+    gameState: GameState,
+  ): HandshakeResponseMessage {
+    if (this.state !== "challenged" && this.state !== "initiated") {
+      throw new Error("Invalid handshake state");
     }
 
     this.challenge = message.payload.challenge;
-    this.state = 'responded';
+    this.state = "responded";
     this.onStateChange?.(this.state);
 
     // Calculate and send response
@@ -522,21 +537,24 @@ export class HandshakeSession {
       this.localPlayerId,
       message.payload.challenge,
       gameState,
-      message.payload.checksumAlgorithm as ChecksumAlgorithm
+      message.payload.checksumAlgorithm as ChecksumAlgorithm,
     );
   }
 
   /**
    * Handle received response
    */
-  handleResponse(message: HandshakeResponseMessage, localGameState: GameState): HandshakeAckMessage {
-    if (this.state !== 'challenged') {
-      throw new Error('Invalid handshake state');
+  handleResponse(
+    message: HandshakeResponseMessage,
+    localGameState: GameState,
+  ): HandshakeAckMessage {
+    if (this.state !== "challenged") {
+      throw new Error("Invalid handshake state");
     }
 
     // Verify challenge matches
     if (!this.challenge || message.payload.challenge !== this.challenge) {
-      this.state = 'failed';
+      this.state = "failed";
       this.onStateChange?.(this.state);
       return createHandshakeAck(this.localPlayerId, false, 0);
     }
@@ -545,40 +563,44 @@ export class HandshakeSession {
     const checksumMatch = verifyChecksum(
       localGameState,
       message.payload.checksum,
-      message.payload.checksumAlgorithm as ChecksumAlgorithm
+      message.payload.checksumAlgorithm as ChecksumAlgorithm,
     );
 
     this.remoteChecksum = message.payload.checksum;
     this.stateVersion = message.payload.stateVersion;
 
     if (checksumMatch) {
-      this.state = 'verified';
+      this.state = "verified";
       this.onComplete?.(true);
     } else {
-      this.state = 'failed';
-      this.onComplete?.(false, 'Checksum mismatch');
+      this.state = "failed";
+      this.onComplete?.(false, "Checksum mismatch");
     }
 
     this.onStateChange?.(this.state);
     this.clearTimeout();
 
-    return createHandshakeAck(this.localPlayerId, checksumMatch, this.stateVersion);
+    return createHandshakeAck(
+      this.localPlayerId,
+      checksumMatch,
+      this.stateVersion,
+    );
   }
 
   /**
    * Handle acknowledgment
    */
   handleAck(message: HandshakeAckMessage): void {
-    if (this.state !== 'responded') {
-      throw new Error('Invalid handshake state');
+    if (this.state !== "responded") {
+      throw new Error("Invalid handshake state");
     }
 
     if (message.payload.checksumMatch) {
-      this.state = 'completed';
+      this.state = "completed";
       this.onComplete?.(true);
     } else {
-      this.state = 'failed';
-      this.onComplete?.(false, 'Checksum verification failed');
+      this.state = "failed";
+      this.onComplete?.(false, "Checksum verification failed");
     }
 
     this.onStateChange?.(this.state);
@@ -589,7 +611,7 @@ export class HandshakeSession {
    * Handle failure
    */
   handleFailed(message: HandshakeFailedMessage): void {
-    this.state = 'failed';
+    this.state = "failed";
     this.onStateChange?.(this.state);
     this.clearTimeout();
     this.onComplete?.(false, message.payload.reason);
@@ -621,7 +643,7 @@ export class HandshakeSession {
    */
   cleanup(): void {
     this.clearTimeout();
-    this.state = 'idle';
+    this.state = "idle";
     this.remotePlayerId = null;
     this.remoteChecksum = null;
     this.localChecksum = null;
@@ -634,9 +656,9 @@ export class HandshakeSession {
   private startTimeout(): void {
     this.clearTimeout();
     this.timeoutHandle = setTimeout(() => {
-      this.state = 'failed';
+      this.state = "failed";
       this.onStateChange?.(this.state);
-      this.onComplete?.(false, 'Handshake timeout');
+      this.onComplete?.(false, "Handshake timeout");
     }, this.HANDSHAKE_TIMEOUT);
   }
 


### PR DESCRIPTION
## Summary

Resolves #1094 — adds unit-test coverage for the previously under-tested P2P resilience layer: connection fallback / WebSocket escalation, ICE restart / reconnection triggers, candidate filtering, and the reconnection handshake (stale-peer rejection, sequence-number resync, timeout/abort).

Test-only PR **plus one minimal, documented bug fix** found while writing the handshake tests (see below). All transports are mocked — no real network or browser APIs.

## Files changed

- `src/lib/__tests__/ice-config.test.ts` — add `ICEConnectionMonitor` (ICE restart/reconnection trigger), `ICECandidateFilter`, remaining `ICEConfigurationManager` modes/methods, factory helpers, and global-singleton coverage.
- `src/lib/__tests__/p2p-handshake.test.ts` — add `handleChallenge` / `handleResponse` / `handleAck` transitions, stale-peer rejection, checksum-mismatch, seq-number resync, timeout/abort, and the crc32/md5/sha256 checksum algorithms; mock `serializeGameState` for determinism.
- `src/lib/__tests__/connection-fallback.test.ts` — add transport-event wiring (P2PEvents / WebSocketEvents), WebRTC `failed` → WebSocket auto-fallback engagement (incl. double-trigger guard + WS-also-fails), send over each active transport, defensive getters, cleanup swallowing, and `destroy()`.
- `src/lib/p2p-handshake.ts` — **bug fix** (7 lines), see below.

## Bug found + fixed (with regression test)

`HandshakeSession.handleInit` did not store the challenge it issues. Because `handleResponse` is only reachable from the `'challenged'` state, and `this.challenge` was only ever set by `handleChallenge` (which leaves state `'responded'`), the challenge-match guard in `handleResponse` **always** failed — making the success branch (checksum verified → `'verified'`, `onComplete(true)`) dead code. Effect: a responding peer could never successfully complete the handshake verification.

Fix: `handleInit` now stores the outgoing challenge so `handleResponse` can verify the echoed value. Minimal (no refactor), covered by `HandshakeSession.handleResponse — verifies a matching challenge + checksum and moves to verified`.

## Coverage (before → after)

Scoped to the three modules (`npx jest connection-fallback ice-config p2p-handshake --coverage`):

| Module | Metric | Before | After |
|---|---|---|---|
| connection-fallback.ts | Stmts / Branch / Func / Line | 78.26 / 61.08 / 62.5 / 78.77 | **95.65 / 74.59 / 98.21 / 96.73** |
| ice-config.ts | Stmts / Branch / Func / Line | 42.36 / 28.94 / 30 / 42.22 | **99.3 / 94.73 / 100 / 100** |
| p2p-handshake.ts | Stmts / Branch / Func / Line | 59.31 / 23.65 / 66.66 / 58.57 | **99.31 / 84.94 / 100 / 99.29** |

Tests in scope: **101 → 172** (+71). Remaining uncovered lines are defensive/unreachable safety nets (initialize() non-ConnectionError wrappers, the unreachable `default` switch arm, monitor no-op guards).

## Acceptance criteria

- [x] connection-fallback: each fallback tier transition + all-tiers-exhausted (`BOTH_FAILED`) + WebRTC `failed` auto-fallback
- [x] p2p-handshake: reconnect, stale-peer rejection (challenge mismatch), seq-number resync (`getStateVersion`), timeout/abort
- [x] ICE restart branch in ice-config exercised via `ICEConnectionMonitor` (disconnected → timed `onFailed` = restart trigger; failed → immediate `onFailed`; reconnect-cancels-timeout; debounce)
- [x] ICE candidate filtering (`ICECandidateFilter` IPv6 / loopback / link-local)
- [x] No real network calls — PeerJS / RTCPeerConnection / WebSocket all mocked; fake timers for timeout paths
- [x] All new tests pass; no regressions (`tsc --noEmit` clean, `npm run lint` clean for the changed files, 278 tests green across 7 neighbouring P2P suites)

Resolves #1094