### PR TITLE
fix(rules-engine): resolve #1157 — stop non-ETB triggered abilities firing on creature spell resolution

### DIFF
--- a/src/lib/game-state/__tests__/golden-scenarios.test.ts
+++ b/src/lib/game-state/__tests__/golden-scenarios.test.ts
@@ -41,12 +41,13 @@ const RAGAVAN: ScryfallCard = {
   name: "Ragavan, Nimble Pilferer",
   type_line: "Legendary Creature — Monkey Pirate",
   keywords: [],
-  // Vanilla oracle text: the scenario verifies the land -> cast -> resolve ->
-  // attack -> combat-damage turn flow, not Ragavan's combat-damage trigger.
-  // A non-empty triggered-ability oracle text causes the engine to queue a
-  // triggered-ability object on ETB (tracked separately as a bug), which
-  // blocks spell resolution in this happy-path scenario.
-  oracle_text: "",
+  // Real oracle text: Ragavan carries a NON-ETB triggered ability
+  // ("Whenever CARDNAME deals combat damage to a player, ..."). The scenario
+  // verifies the land -> cast -> resolve -> attack -> combat-damage turn flow
+  // and asserts that resolving the creature spell leaves the stack EMPTY — i.e.
+  // the non-ETB trigger must NOT fire on resolution (issue #1157, CR 603.2/603.6).
+  oracle_text:
+    "Whenever Ragavan, Nimble Pilferer deals combat damage to a player, create a Treasure token.",
   mana_cost: "{R}",
   cmc: 1,
   colors: ["red"],

--- a/src/lib/game-state/__tests__/oracle-text-parser-branches.test.ts
+++ b/src/lib/game-state/__tests__/oracle-text-parser-branches.test.ts
@@ -380,10 +380,8 @@ describe("parseTriggeredAbilities — trigger event branches", () => {
     ).toBe("dies");
   });
 
-  it("falls back to entersBattlefield for unrecognized triggers", () => {
-    expect(trigger("When ~ becomes monstrous, draw a card.")).toBe(
-      "entersBattlefield",
-    );
+  it("classifies unrecognized triggers as unknown (not entersBattlefield)", () => {
+    expect(trigger("When ~ becomes monstrous, draw a card.")).toBe("unknown");
   });
 
   it("parses a 'when' trigger that carries an intervening effect", () => {

--- a/src/lib/game-state/__tests__/triggered-abilities.test.ts
+++ b/src/lib/game-state/__tests__/triggered-abilities.test.ts
@@ -98,6 +98,91 @@ describe("Triggered Abilities System - detectTriggeredAbilities", () => {
     });
   });
 
+  describe("Issue #1157 — non-ETB triggers must NOT fire on enters-the-battlefield (CR 603.2/603.6)", () => {
+    // Regression: a creature's NON-ETB triggered ability (e.g. "Whenever
+    // CARDNAME deals combat damage ...") must not be misclassified as an
+    // enters-the-battlefield trigger and fire as a side effect of the creature
+    // spell resolving, which previously pushed a never-resolving object onto the
+    // stack and stalled the priority loop.
+    it("does not classify a non-ETB (combat-damage) trigger as entersBattlefield", () => {
+      const cardData = createMockCard({
+        id: "ragavan",
+        name: "Ragavan, Nimble Pilferer",
+        oracle_text:
+          "Whenever Ragavan, Nimble Pilferer deals combat damage to a player, create a Treasure token.",
+      });
+      const parsed = getTriggeredAbilities(cardData);
+      expect(parsed).toHaveLength(1);
+      // The trigger condition must NOT be assumed to be ETB.
+      expect(parsed[0].trigger.event).not.toBe("entersBattlefield");
+      expect(parsed[0].trigger.event).toBe("unknown");
+    });
+
+    it("does not fire a non-ETB trigger when checked against entersBattlefield", () => {
+      placeCardOnBattlefield(
+        createMockCard({
+          id: "ragavan",
+          name: "Ragavan, Nimble Pilferer",
+          oracle_text:
+            "Whenever Ragavan, Nimble Pilferer deals combat damage to a player, create a Treasure token.",
+        }),
+        aliceId,
+      );
+      // Resolving a creature spell calls checkTriggeredAbilities(state, "entersBattlefield");
+      // a non-ETB trigger must contribute nothing to the stack here.
+      const result = detectTriggeredAbilities(state, "entersBattlefield");
+      expect(result).toHaveLength(0);
+    });
+
+    it("does not fire a 'Whenever CARDNAME attacks' trigger on entersBattlefield", () => {
+      placeCardOnBattlefield(
+        createMockCard({
+          id: "attacks-trigger",
+          name: "Burglar Rat",
+          oracle_text: "Whenever Burglar Rat attacks, you draw a card.",
+        }),
+        aliceId,
+      );
+      const result = detectTriggeredAbilities(state, "entersBattlefield");
+      expect(result).toHaveLength(0);
+    });
+
+    it("checkTriggeredAbilities leaves the stack empty for a non-ETB creature on ETB", () => {
+      placeCardOnBattlefield(
+        createMockCard({
+          id: "ragavan",
+          name: "Ragavan, Nimble Pilferer",
+          oracle_text:
+            "Whenever Ragavan, Nimble Pilferer deals combat damage to a player, create a Treasure token.",
+        }),
+        aliceId,
+      );
+      const before = state.stack.length;
+      const { state: nextState } = checkTriggeredAbilities(
+        state,
+        "entersBattlefield",
+      );
+      // No spurious triggered-ability object is pushed onto the stack.
+      expect(nextState.stack.length).toBe(before);
+      expect(nextState.stack.every((o) => o.type !== "ability")).toBe(true);
+    });
+
+    it("still fires a genuine ETB trigger on entersBattlefield", () => {
+      // Guard: the fix must not suppress real ETB triggers (CR 603.6a).
+      placeCardOnBattlefield(
+        createMockCard({
+          id: "etb-trigger",
+          oracle_text:
+            "When this creature enters the battlefield, draw a card.",
+        }),
+        aliceId,
+      );
+      const result = detectTriggeredAbilities(state, "entersBattlefield");
+      expect(result).toHaveLength(1);
+      expect(result[0].triggerCondition).toBe("entersBattlefield");
+    });
+  });
+
   describe("Beginning of Turn Triggers (CR 603.2)", () => {
     it("should detect upkeep trigger on beginningOfTurn event", () => {
       const cardId = placeCardOnBattlefield(

--- a/src/lib/game-state/oracle-text-parser.ts
+++ b/src/lib/game-state/oracle-text-parser.ts
@@ -128,7 +128,8 @@ export interface TriggerCondition {
     | "beginningOfTurn"
     | "endOfTurn"
     | "cleanupStep"
-    | "creatureDies";
+    | "creatureDies"
+    | "unknown";
   condition?: string;
   target?: ParsedTarget;
   source?: string;
@@ -1178,8 +1179,16 @@ function parseTriggerText(triggerText: string): TriggerCondition | null {
     return { event: "dies" };
   }
 
-  // If we can't determine the trigger, return a generic one
-  return { event: "entersBattlefield" };
+  // If we can't classify the trigger condition, return an "unknown" event.
+  // Per CR 603.2 a triggered ability may only fire when its trigger condition
+  // is actually met, so an unrecognised condition must NOT be assumed to be an
+  // "enters the battlefield" trigger (issue #1157). Otherwise non-ETB triggers
+  // (e.g. "Whenever CARDNAME deals combat damage to a player") that the parser
+  // fails to classify would fire spuriously when the creature's spell resolves,
+  // pushing a never-resolving object onto the stack and stalling the game.
+  // "unknown" matches no detection switch case, so such abilities simply never
+  // fire until a precise classification is added.
+  return { event: "unknown" };
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes a stack-stall where a creature's **non-ETB** triggered ability (e.g. *"Whenever CARDNAME deals combat damage to a player…"*) was misclassified as an **enters-the-battlefield** trigger and fired as a side effect of the creature spell resolving, pushing a never-resolving object onto the stack and breaking the priority loop.

Resolves #1157.

## Root cause

`parseTriggerText()` in `src/lib/game-state/oracle-text-parser.ts` classified an unrecognized trigger condition by **defaulting to `entersBattlefield`**:

```ts
// If we can't determine the trigger, return a generic one
return { event: "entersBattlefield" };
```

This violates **CR 603.2**: a triggered ability may only fire when its trigger condition is *actually* met. Assuming "unknown ⇒ ETB" makes any unclassifiable non-ETB trigger fire when the permanent enters.

It surfaces concretely with **Ragavan, Nimble Pilferer** (*"Whenever Ragavan, Nimble Pilferer deals combat damage to a player, create a Treasure token."*):

1. The `parseTriggeredAbilities` regex `\b(when|whenever)\s+(.+?),?\s*,\s*(.+)` splits the sentence at the **first comma, which is inside the card name** ("Ragavan, Nimble Pilferer"), leaving `triggerText = "Ragavan"`.
2. `parseTriggerText("Ragavan")` matches no known pattern → falls through to the `entersBattlefield` default.
3. On spell resolution, `resolveTopOfStack` → `checkTriggeredAbilities(state, "entersBattlefield")` sees the misclassified trigger and pushes it on the stack.
4. The pushed ability object never resolves (its condition is never actually met), leaving a stuck item on the stack and continuously resetting both players' `hasPassedPriority`.

## The fix

Narrow the fallback so an unclassifiable trigger is **not** assumed to be ETB (CR 603.2 / 603.3 / 603.6a):

- Add `"unknown"` to the `TriggerCondition.event` union.
- Change the `parseTriggerText` default from `{ event: "entersBattlefield" }` → `{ event: "unknown" }`. `"unknown"` matches **no** case in `detectTriggeredAbilities`' switch, so such abilities simply never fire until a precise classification is added — instead of spuriously firing on ETB.

This is the minimal, targeted fix. The trigger-detection switch in `abilities.ts` was already correct (it requires an exact `ability.trigger.event === "entersBattlefield"` match); the bug lived entirely in the parser's unsafe default. The parallel parser in `trigger-system.ts` (`getTriggeredAbilitiesFromCard`) already only emits recognized events and needed no change.

Genuine ETB triggers (e.g. *"When this creature enters the battlefield, draw a card."*) are unaffected — a guard test asserts they still fire.

## CR reference

- **CR 603.2** — a triggered ability triggers only when its trigger condition is met.
- **CR 603.3 / 603.6a** — an "enters the battlefield" trigger goes on the stack the next time a player would receive priority *after* the permanent is on the battlefield; triggers with other conditions must not match the enters-the-battlefield event.

## Tests

- **Regression test** (`triggered-abilities.test.ts`, `describe("Issue #1157 …")`): a Ragavan (real oracle text) and a *"Whenever CARDNAME attacks"* creature are placed on the battlefield; `detectTriggeredAbilities(state, "entersBattlefield")` must return **empty**, the parsed event must **not** be `entersBattlefield`, and `checkTriggeredAbilities(state, "entersBattlefield")` must leave the stack empty. A guard asserts a real ETB trigger still fires. Verified to **fail before** the fix (3/5 fail, reproducing the bug) and **pass after**.
- Updated `oracle-text-parser-branches.test.ts`: the "unrecognized trigger" expectation changed from `entersBattlefield` → `unknown`.
- **Restored `golden-scenarios.test.ts`** to use Ragavan's *real* oracle text (the #1093 vanilla-text workaround is no longer needed) — this is itself the end-to-end regression for the exact card from the issue.

## Verification

- `npx jest game-state trigger keyword abilities oracle` → **253 suites / 5224 tests passed, 0 failed**.
- `npx tsc --noEmit` → clean (no engine errors).
- `npx eslint <changed files>` → clean.

## Golden-scenarios fixture

The original (non-vanilla) Ragavan fixture **was restored** — the fix makes the real card pass, so the #1093 workaround is removed.

## Summary by Sourcery

Ensure non-enters-the-battlefield triggered abilities are not misclassified or fired on creature spell resolution, preventing stuck stack objects and restoring correct priority flow.

Bug Fixes:
- Correct trigger parsing fallback to classify unrecognized triggers as `unknown` instead of treating them as enters-the-battlefield events, so non-ETB abilities no longer fire on ETB.
- Restore Ragavan, Nimble Pilferer’s real combat-damage trigger in golden scenario tests now that its trigger no longer incorrectly fires on ETB.

Tests:
- Add regression tests covering non-ETB triggers (combat damage and attacks) to ensure they do not fire on enters-the-battlefield events and that genuine ETB triggers still function.
- Update oracle text parser branch tests to expect `unknown` for unrecognized trigger conditions.