### PR TITLE
fix(multiplayer): resolve #1091 — sequence numbers reject duplicate/replayed GameMessages

### DIFF
--- a/src/lib/__tests__/p2p-game-connection.test.ts
+++ b/src/lib/__tests__/p2p-game-connection.test.ts
@@ -33,6 +33,7 @@ describe("P2P Game Connection Types", () => {
           type,
           senderId: "player-1",
           timestamp: Date.now(),
+          seq: 0,
           data: {},
         };
         expect(message.type).toBe(type);
@@ -251,6 +252,7 @@ describe("Message creation helpers", () => {
       type: "game-state-sync",
       senderId: "player-1",
       timestamp: Date.now(),
+      seq: 0,
       data: { gameState: {}, isFullSync: true },
     };
 
@@ -263,6 +265,7 @@ describe("Message creation helpers", () => {
       type: "game-action",
       senderId: "player-1",
       timestamp: Date.now(),
+      seq: 0,
       data: { action: "play-card", cardId: "card-1" },
     };
 
@@ -274,6 +277,7 @@ describe("Message creation helpers", () => {
       type: "chat",
       senderId: "player-1",
       timestamp: Date.now(),
+      seq: 0,
       data: { senderName: "Player One", text: "Hello!" },
     };
 
@@ -285,6 +289,7 @@ describe("Message creation helpers", () => {
       type: "player-joined",
       senderId: "player-1",
       timestamp: Date.now(),
+      seq: 0,
       data: { playerId: "player-2", playerName: "Player Two" },
     };
 
@@ -296,6 +301,7 @@ describe("Message creation helpers", () => {
       type: "player-left",
       senderId: "player-1",
       timestamp: Date.now(),
+      seq: 0,
       data: { playerId: "player-2" },
     };
 
@@ -307,6 +313,7 @@ describe("Message creation helpers", () => {
       type: "ping",
       senderId: "player-1",
       timestamp: Date.now(),
+      seq: 0,
       data: {},
     };
 
@@ -318,6 +325,7 @@ describe("Message creation helpers", () => {
       type: "pong",
       senderId: "player-1",
       timestamp: Date.now(),
+      seq: 0,
       data: {},
     };
 
@@ -331,6 +339,7 @@ describe("isGameMessage (type guard)", () => {
       type: "game-action",
       senderId: "player-1",
       timestamp: Date.now(),
+      seq: 0,
       data: {},
     };
     expect(isGameMessage(msg)).toBe(true);
@@ -348,20 +357,32 @@ describe("isGameMessage (type guard)", () => {
     ];
     for (const type of types) {
       expect(
-        isGameMessage({ type, senderId: "p", timestamp: 1, data: {} }),
+        isGameMessage({ type, senderId: "p", timestamp: 1, seq: 0, data: {} }),
       ).toBe(true);
     }
   });
 
   it("rejects an unknown message type", () => {
     expect(
-      isGameMessage({ type: "evil", senderId: "p", timestamp: 1, data: {} }),
+      isGameMessage({
+        type: "evil",
+        senderId: "p",
+        timestamp: 1,
+        seq: 0,
+        data: {},
+      }),
     ).toBe(false);
   });
 
   it("rejects a non-string senderId", () => {
     expect(
-      isGameMessage({ type: "ping", senderId: 42, timestamp: 1, data: {} }),
+      isGameMessage({
+        type: "ping",
+        senderId: 42,
+        timestamp: 1,
+        seq: 0,
+        data: {},
+      }),
     ).toBe(false);
   });
 
@@ -369,6 +390,83 @@ describe("isGameMessage (type guard)", () => {
     expect(isGameMessage(null)).toBe(false);
     expect(isGameMessage("not-an-object")).toBe(false);
     expect(isGameMessage(42)).toBe(false);
+  });
+
+  // ---- seq field validation (issue #1091) ----
+
+  it("rejects a message missing the seq field", () => {
+    expect(
+      isGameMessage({ type: "ping", senderId: "p", timestamp: 1, data: {} }),
+    ).toBe(false);
+  });
+
+  it("rejects a message whose seq is not a number", () => {
+    expect(
+      isGameMessage({
+        type: "ping",
+        senderId: "p",
+        timestamp: 1,
+        seq: "0",
+        data: {},
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a message whose seq is a negative integer", () => {
+    expect(
+      isGameMessage({
+        type: "ping",
+        senderId: "p",
+        timestamp: 1,
+        seq: -1,
+        data: {},
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a message whose seq is a non-integer number", () => {
+    expect(
+      isGameMessage({
+        type: "ping",
+        senderId: "p",
+        timestamp: 1,
+        seq: 1.5,
+        data: {},
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a message whose seq is NaN or Infinity", () => {
+    expect(
+      isGameMessage({
+        type: "ping",
+        senderId: "p",
+        timestamp: 1,
+        seq: NaN,
+        data: {},
+      }),
+    ).toBe(false);
+    expect(
+      isGameMessage({
+        type: "ping",
+        senderId: "p",
+        timestamp: 1,
+        seq: Infinity,
+        data: {},
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts seq equal to 0 (the first message of a stream)", () => {
+    expect(
+      isGameMessage({
+        type: "ping",
+        senderId: "p",
+        timestamp: 1,
+        seq: 0,
+        data: {},
+      }),
+    ).toBe(true);
   });
 });
 
@@ -424,6 +522,24 @@ describe("P2PGameConnection message validation (untrusted peer input)", () => {
     expect(onMessage).not.toHaveBeenCalled();
   });
 
+  it("rejects a well-shaped message missing the seq field (issue #1091)", () => {
+    // Shape is otherwise valid; only the required `seq` anti-replay field is
+    // missing. isGameMessage must reject it so handleMessage never has to
+    // reason about an undefined seq.
+    expect(() =>
+      handleMessage(
+        JSON.stringify({
+          type: "game-action",
+          senderId: "player-2",
+          timestamp: 1,
+          data: {},
+          // no seq
+        }),
+      ),
+    ).not.toThrow();
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
   it("rejects JSON scalars and null without throwing", () => {
     for (const raw of ["42", '"x"', "null", "true", "[1,2,3]"]) {
       expect(() => handleMessage(raw)).not.toThrow();
@@ -436,11 +552,285 @@ describe("P2PGameConnection message validation (untrusted peer input)", () => {
       type: "game-action",
       senderId: "player-2",
       timestamp: Date.now(),
+      seq: 0,
       data: { action: "pass" },
     };
     expect(() => handleMessage(JSON.stringify(msg))).not.toThrow();
     expect(onMessage).toHaveBeenCalledWith(
       expect.objectContaining({ type: "game-action", senderId: "player-2" }),
     );
+  });
+});
+
+/**
+ * Sequence-number anti-replay coverage (issue #1091).
+ *
+ * Verifies the receiver tracks the highest seq per senderId and drops any
+ * message with seq <= that high-water mark BEFORE it is forwarded to
+ * onMessage (i.e. before it could be applied to game state). Also covers
+ * the post-host-migration reset path via a full game-state-sync carrying
+ * the authoritative `lastSeq` high-water mark.
+ */
+describe("P2PGameConnection sequence-number anti-replay (#1091)", () => {
+  let connection: P2PGameConnection;
+  let onMessage: jest.Mock;
+
+  const makeConn = () => {
+    onMessage = jest.fn();
+    return createP2PGameConnection({
+      playerId: "local",
+      playerName: "Local",
+      role: "host",
+      events: {
+        onConnectionStateChange: () => {},
+        onSignalingStateChange: () => {},
+        onMessage,
+        onGameStateSync: () => {},
+        onChat: () => {},
+        onError: () => {},
+        onPlayerJoined: () => {},
+        onPlayerLeft: () => {},
+      },
+    });
+  };
+
+  // Access the private handleMessage via the same cast pattern used above.
+  const handleMessage = (conn: P2PGameConnection, raw: string) =>
+    (conn as unknown as { handleMessage: (d: string) => void }).handleMessage(
+      raw,
+    );
+
+  // Helper: build a minimal valid GameMessage with an explicit seq.
+  const msg = (
+    senderId: string,
+    seq: number,
+    type: GameMessageType = "game-action",
+    data: unknown = {},
+  ): GameMessage => ({
+    type,
+    senderId,
+    timestamp: Date.now(),
+    seq,
+    data,
+  });
+
+  /**
+   * Distinct seq values forwarded to onMessage for a given sender, sorted.
+   *
+   * The production `handleMessage` dispatches `game-action` to onMessage
+   * twice (once in the type switch and once at the end) — this is pre-existing
+   * behaviour unrelated to #1091. Counting distinct seqs makes the anti-replay
+   * assertions robust against that double-dispatch.
+   */
+  const forwardedSeqs = (senderId: string): number[] =>
+    Array.from(
+      new Set(
+        onMessage.mock.calls
+          .map((c) => c[0] as GameMessage)
+          .filter((m) => m.senderId === senderId)
+          .map((m) => m.seq),
+      ),
+    ).sort((a, b) => a - b);
+
+  beforeEach(() => {
+    connection = makeConn();
+  });
+
+  describe("in-order acceptance", () => {
+    it("accepts a strictly-increasing seq stream and forwards each to onMessage", () => {
+      for (let s = 0; s < 5; s++) {
+        handleMessage(connection, JSON.stringify(msg("peer", s)));
+      }
+      expect(forwardedSeqs("peer")).toEqual([0, 1, 2, 3, 4]);
+      // High-water mark tracks the last applied seq.
+      expect(connection.getLastAppliedSeq("peer")).toBe(4);
+    });
+
+    it("accepts the first message from a new sender (seq 0)", () => {
+      handleMessage(connection, JSON.stringify(msg("newpeer", 0)));
+      expect(forwardedSeqs("newpeer")).toEqual([0]);
+      expect(connection.getLastAppliedSeq("newpeer")).toBe(0);
+    });
+
+    it("accepts a message with a seq gap (ordered channel, missing middle)", () => {
+      // seq 1 then seq 5 — both accepted; gap is tolerated (the check is
+      // strictly less-than-or-equal, not contiguous).
+      handleMessage(connection, JSON.stringify(msg("peer", 1)));
+      handleMessage(connection, JSON.stringify(msg("peer", 5)));
+      expect(forwardedSeqs("peer")).toEqual([1, 5]);
+      expect(connection.getLastAppliedSeq("peer")).toBe(5);
+    });
+  });
+
+  describe("duplicate rejection", () => {
+    it("drops a duplicate (same seq) and does NOT forward it", () => {
+      handleMessage(connection, JSON.stringify(msg("peer", 3)));
+      expect(forwardedSeqs("peer")).toEqual([3]);
+      // Replay the exact same seq.
+      handleMessage(connection, JSON.stringify(msg("peer", 3)));
+      // Forwarded set is unchanged — the duplicate was dropped.
+      expect(forwardedSeqs("peer")).toEqual([3]);
+      expect(connection.getLastAppliedSeq("peer")).toBe(3);
+    });
+
+    it("drops a duplicate even if the payload differs (seq is the identity)", () => {
+      handleMessage(connection, JSON.stringify(msg("peer", 7)));
+      const before = forwardedSeqs("peer").length;
+      // Same seq, different payload — must still be treated as a replay.
+      handleMessage(
+        connection,
+        JSON.stringify(msg("peer", 7, "game-action", { action: "evil" })),
+      );
+      expect(forwardedSeqs("peer").length).toBe(before);
+    });
+  });
+
+  describe("replay / stale rejection", () => {
+    it("drops a stale message (seq older than the last applied)", () => {
+      handleMessage(connection, JSON.stringify(msg("peer", 10)));
+      expect(forwardedSeqs("peer")).toEqual([10]);
+      // An older seq arrives (reconnect re-delivery of the tail, #943).
+      handleMessage(connection, JSON.stringify(msg("peer", 9)));
+      // Still only seq 10 was forwarded — seq 9 was dropped as a replay.
+      expect(forwardedSeqs("peer")).toEqual([10]);
+      expect(connection.getLastAppliedSeq("peer")).toBe(10);
+    });
+
+    it("drops an out-of-order message that arrives after a higher seq was applied", () => {
+      // seq 5 applied first, then seq 4 straggles in — 4 <= 5, dropped.
+      handleMessage(connection, JSON.stringify(msg("peer", 5)));
+      handleMessage(connection, JSON.stringify(msg("peer", 4)));
+      expect(forwardedSeqs("peer")).toEqual([5]);
+    });
+
+    it("does not break the connection on replay (subsequent valid seq still accepted)", () => {
+      handleMessage(connection, JSON.stringify(msg("peer", 2)));
+      handleMessage(connection, JSON.stringify(msg("peer", 2))); // dropped
+      // A fresh, higher seq must still get through.
+      handleMessage(connection, JSON.stringify(msg("peer", 3)));
+      expect(forwardedSeqs("peer")).toEqual([2, 3]);
+    });
+  });
+
+  describe("per-sender isolation", () => {
+    it("tracks seq independently per senderId", () => {
+      // Two peers can each start at seq 0; their streams do not collide.
+      handleMessage(connection, JSON.stringify(msg("alice", 0)));
+      handleMessage(connection, JSON.stringify(msg("bob", 0)));
+      handleMessage(connection, JSON.stringify(msg("alice", 1)));
+      handleMessage(connection, JSON.stringify(msg("bob", 1)));
+      expect(forwardedSeqs("alice")).toEqual([0, 1]);
+      expect(forwardedSeqs("bob")).toEqual([0, 1]);
+      expect(connection.getLastAppliedSeq("alice")).toBe(1);
+      expect(connection.getLastAppliedSeq("bob")).toBe(1);
+
+      // A replay of alice's seq 0 is still rejected for alice only.
+      handleMessage(connection, JSON.stringify(msg("alice", 0)));
+      expect(forwardedSeqs("alice")).toEqual([0, 1]);
+      // ...and bob's seq 0 is also a replay for bob.
+      handleMessage(connection, JSON.stringify(msg("bob", 0)));
+      expect(forwardedSeqs("bob")).toEqual([0, 1]);
+    });
+  });
+
+  describe("post-migration reset via full game-state-sync", () => {
+    it("a full sync carrying lastSeq advances the per-sender high-water mark", () => {
+      // Follower has applied peer actions up to seq 4.
+      for (let s = 0; s <= 4; s++) {
+        handleMessage(connection, JSON.stringify(msg("peer", s)));
+      }
+      expect(connection.getLastAppliedSeq("peer")).toBe(4);
+
+      // A full reconciliation snapshot arrives claiming the authoritative
+      // high-water mark is 20 (e.g. the new host continued the counter, #946).
+      handleMessage(
+        connection,
+        JSON.stringify(
+          msg("peer", 21, "game-state-sync", {
+            // Minimal valid serialized state — handleGameStateSync tolerates
+            // an empty players map; onGameStateSync here is a no-op stub.
+            gameState: { players: {} },
+            isFullSync: true,
+            lastSeq: 20,
+          }),
+        ),
+      );
+      expect(connection.getLastAppliedSeq("peer")).toBe(21);
+
+      // A queued action the new host re-emits with seq 5 (already applied
+      // under the previous host) must now be rejected as a replay.
+      handleMessage(connection, JSON.stringify(msg("peer", 5)));
+      // Only seqs 0-4 were forwarded as game-actions; seq 5 was dropped.
+      expect(forwardedSeqs("peer")).toEqual([0, 1, 2, 3, 4, 21]);
+
+      // A genuinely new action with seq > 21 is accepted.
+      handleMessage(connection, JSON.stringify(msg("peer", 22)));
+      expect(forwardedSeqs("peer")).toEqual([0, 1, 2, 3, 4, 21, 22]);
+    });
+
+    it("a partial (non-full) sync does NOT advance the high-water mark via lastSeq", () => {
+      handleMessage(connection, JSON.stringify(msg("peer", 2)));
+      // Partial sync carrying lastSeq — must be ignored (only full syncs reset).
+      handleMessage(
+        connection,
+        JSON.stringify(
+          msg("peer", 3, "game-state-sync", {
+            gameState: { players: {} },
+            isFullSync: false,
+            lastSeq: 99,
+          }),
+        ),
+      );
+      // Tracker follows the message's own seq (3), NOT the carried lastSeq.
+      expect(connection.getLastAppliedSeq("peer")).toBe(3);
+    });
+
+    it("ignores a malformed lastSeq on a full sync (falls back to the message seq)", () => {
+      handleMessage(
+        connection,
+        JSON.stringify(
+          msg("peer", 5, "game-state-sync", {
+            gameState: { players: {} },
+            isFullSync: true,
+            lastSeq: "not-a-number",
+          }),
+        ),
+      );
+      expect(connection.getLastAppliedSeq("peer")).toBe(5);
+    });
+  });
+
+  describe("close() resets anti-replay state", () => {
+    it("clears per-sender tracking so a fresh session is not poisoned", () => {
+      handleMessage(connection, JSON.stringify(msg("peer", 9)));
+      expect(connection.getLastAppliedSeq("peer")).toBe(9);
+      connection.close();
+      expect(connection.getLastAppliedSeq("peer")).toBeNull();
+    });
+  });
+
+  describe("outgoing seq stamping helpers", () => {
+    it("getOutgoingSeq starts at 0 and adoptOutgoingSeq only advances forward", () => {
+      expect(connection.getOutgoingSeq()).toBe(0);
+      connection.adoptOutgoingSeq(50);
+      expect(connection.getOutgoingSeq()).toBe(50);
+      // A lower value is a no-op (never goes backwards).
+      connection.adoptOutgoingSeq(10);
+      expect(connection.getOutgoingSeq()).toBe(50);
+      // Invalid values are ignored.
+      connection.adoptOutgoingSeq(-1);
+      connection.adoptOutgoingSeq(NaN);
+      expect(connection.getOutgoingSeq()).toBe(50);
+    });
+
+    it("resetIncomingSeq forgets a sender's high-water mark", () => {
+      handleMessage(connection, JSON.stringify(msg("peer", 3)));
+      expect(connection.getLastAppliedSeq("peer")).toBe(3);
+      connection.resetIncomingSeq("peer");
+      expect(connection.getLastAppliedSeq("peer")).toBeNull();
+      // The same seq can now be accepted again (fresh session semantics).
+      handleMessage(connection, JSON.stringify(msg("peer", 3)));
+      expect(connection.getLastAppliedSeq("peer")).toBe(3);
+    });
   });
 });

--- a/src/lib/__tests__/p2p-json-validation.test.ts
+++ b/src/lib/__tests__/p2p-json-validation.test.ts
@@ -7,6 +7,7 @@
 import {
   safeParseJson,
   withinStructuralLimits,
+  isNonNegativeInteger,
   MAX_MESSAGE_SIZE_BYTES,
   MAX_NESTING_DEPTH,
   MAX_KEY_COUNT,
@@ -135,7 +136,7 @@ describe("safeParseJson", () => {
       // Build a payload deeper than MAX_NESTING_DEPTH.
       const depth = MAX_NESTING_DEPTH + 5;
       let raw = "";
-      for (let i = 0; i < depth; i++) raw += "{\"a\":";
+      for (let i = 0; i < depth; i++) raw += '{"a":';
       raw += "1";
       for (let i = 0; i < depth; i++) raw += "}";
       // The raw string is small (no size trip), parses fine, but exceeds the
@@ -184,6 +185,63 @@ describe("safeParseJson", () => {
       expect(() => withinStructuralLimits(wide)).not.toThrow();
       expect(withinStructuralLimits(deep)).toBe(false);
       expect(withinStructuralLimits(wide)).toBe(false);
+    });
+  });
+
+  /**
+   * Sequence-number predicate used by `isGameMessage` to require the
+   * anti-replay `seq` field (issue #1091).
+   */
+  describe("isNonNegativeInteger (#1091 seq predicate)", () => {
+    it("accepts 0 and positive integers", () => {
+      expect(isNonNegativeInteger(0)).toBe(true);
+      expect(isNonNegativeInteger(1)).toBe(true);
+      expect(isNonNegativeInteger(42)).toBe(true);
+      expect(isNonNegativeInteger(1_000_000)).toBe(true);
+    });
+
+    it("rejects negative integers", () => {
+      expect(isNonNegativeInteger(-1)).toBe(false);
+      expect(isNonNegativeInteger(-42)).toBe(false);
+    });
+
+    it("rejects non-integer numbers", () => {
+      expect(isNonNegativeInteger(1.5)).toBe(false);
+      expect(isNonNegativeInteger(0.1)).toBe(false);
+      expect(isNonNegativeInteger(-0.5)).toBe(false);
+    });
+
+    it("rejects NaN and +/-Infinity (they break <= comparisons)", () => {
+      expect(isNonNegativeInteger(NaN)).toBe(false);
+      expect(isNonNegativeInteger(Infinity)).toBe(false);
+      expect(isNonNegativeInteger(-Infinity)).toBe(false);
+    });
+
+    it("rejects non-number types", () => {
+      expect(isNonNegativeInteger("0")).toBe(false);
+      expect(isNonNegativeInteger("42")).toBe(false);
+      expect(isNonNegativeInteger(true)).toBe(false);
+      expect(isNonNegativeInteger(null)).toBe(false);
+      expect(isNonNegativeInteger(undefined)).toBe(false);
+      expect(isNonNegativeInteger({})).toBe(false);
+      expect(isNonNegativeInteger([0])).toBe(false);
+    });
+
+    it("never throws on hostile input", () => {
+      const hostile: unknown[] = [
+        null,
+        undefined,
+        "",
+        "0",
+        [],
+        {},
+        Symbol("x"),
+
+        new Number(0),
+      ];
+      for (const v of hostile) {
+        expect(() => isNonNegativeInteger(v)).not.toThrow();
+      }
     });
   });
 });

--- a/src/lib/p2p-game-connection.ts
+++ b/src/lib/p2p-game-connection.ts
@@ -25,11 +25,8 @@ import {
   getGlobalICEManager,
   type ICEConfigOptions,
 } from "./ice-config";
-import { safeParseJson } from "./p2p-json-validation";
-import {
-  P2PRateLimiter,
-  type P2PRateLimitOptions,
-} from "./p2p-rate-limiter";
+import { safeParseJson, isNonNegativeInteger } from "./p2p-json-validation";
+import { P2PRateLimiter, type P2PRateLimitOptions } from "./p2p-rate-limiter";
 import {
   classifyConnectionFailure,
   hasTurnServer,
@@ -81,12 +78,30 @@ export type GameMessageType =
   | "pong";
 
 /**
- * Base game message
+ * Base game message.
+ *
+ * Anti-replay field (issue #1091):
+ *   `seq` is a monotonically-increasing sequence number assigned by the SENDER
+ *   on every outgoing message (shared across all message types on a single
+ *   connection — the underlying data channel is `ordered: true`, so one stream
+ *   suffices). The receiver tracks the highest `seq` it has applied per
+ *   `senderId` and rejects any message whose `seq` is `<=` that high-water
+ *   mark. This drops duplicates (reconnect re-delivery, #943) and replays
+ *   (host-migration rebroadcast, #946) before they can corrupt game state.
+ *
+ *   The `timestamp` field is retained for display/debugging only — it is NOT
+ *   used for ordering or replay protection.
  */
 export interface GameMessage {
   type: GameMessageType;
   senderId: string;
   timestamp: number;
+  /**
+   * Monotonic per-sender sequence number (starts at 0). Required on every
+   * message; {@link isGameMessage} rejects messages missing it. See the class
+   * header doc for the anti-replay policy. Issue #1091.
+   */
+  seq: number;
   data: unknown;
 }
 
@@ -104,6 +119,11 @@ const GAME_MESSAGE_TYPES: ReadonlySet<GameMessageType> = new Set([
  * Type guard validating the shape of an untrusted {@link GameMessage}.
  * Data-channel messages come directly from peers and must be validated before
  * use. Rejects valid JSON that does not match the expected schema.
+ *
+ * As of issue #1091 the `seq` field is REQUIRED and must be a non-negative
+ * finite integer (validated via {@link isNonNegativeInteger}); messages
+ * without it are rejected so the anti-replay check in {@link handleMessage}
+ * can rely on the field being present and well-formed.
  */
 export function isGameMessage(value: unknown): value is GameMessage {
   if (typeof value !== "object" || value === null) {
@@ -114,7 +134,8 @@ export function isGameMessage(value: unknown): value is GameMessage {
     typeof v.type === "string" &&
     GAME_MESSAGE_TYPES.has(v.type as GameMessageType) &&
     typeof v.senderId === "string" &&
-    typeof v.timestamp === "number"
+    typeof v.timestamp === "number" &&
+    isNonNegativeInteger(v.seq)
     // `data` is intentionally `unknown`; handlers validate it as needed.
   );
 }
@@ -173,6 +194,23 @@ export class P2PGameConnection {
    * validation path. Issue #1111.
    */
   private rateLimiter: P2PRateLimiter;
+  /**
+   * Monotonic outgoing sequence counter. Incremented for every message sent on
+   * this connection (all types share one stream since the data channel is
+   * `ordered: true`). Issue #1091.
+   */
+  private outgoingSeq: number = 0;
+  /**
+   * Highest sequence number applied per remote `senderId`. The anti-replay
+   * high-water mark: any incoming message with `seq <=` the stored value is
+   * dropped as a duplicate/replay BEFORE it touches game state. Issue #1091.
+   *
+   * Reset/advanced on a full `game-state-sync` (the reconciliation snapshot)
+   * via the `lastSeq` field carried by the snapshot — see
+   * {@link handleGameStateSync} and the host-migration policy in
+   * `p2p-host-migration.ts`.
+   */
+  private lastAppliedSeqByPeer: Map<string, number> = new Map();
 
   constructor(options: P2PGameConnectionOptions) {
     this.playerId = options.playerId;
@@ -393,7 +431,12 @@ export class P2PGameConnection {
   }
 
   /**
-   * Send a game message
+   * Send a game message.
+   *
+   * Stamps the monotonic outgoing `seq` (issue #1091) before transmission so
+   * the receiver can reject duplicates and replays. The caller does not need
+   * to supply `seq`; the few internal helpers below call
+   * {@link nextOutgoingSeq} when constructing the message.
    */
   send(message: GameMessage): boolean {
     if (!this.dataChannel || this.dataChannel.readyState !== "open") {
@@ -415,7 +458,19 @@ export class P2PGameConnection {
   }
 
   /**
-   * Send game state to remote peer
+   * Allocate the next outgoing sequence number. Centralised so every send
+   * path shares one monotonic counter. Issue #1091.
+   */
+  private nextOutgoingSeq(): number {
+    return this.outgoingSeq++;
+  }
+
+  /**
+   * Send game state to remote peer.
+   *
+   * `lastSeq` is carried only on a full sync (the reconciliation snapshot) so
+   * the receiver can advance its per-sender anti-replay high-water mark —
+   * see {@link handleGameStateSync}. Issue #1091.
    */
   sendGameState(gameState: GameState, isFullSync: boolean = false): boolean {
     const serialized = serializeGameState(gameState);
@@ -424,9 +479,14 @@ export class P2PGameConnection {
       type: "game-state-sync",
       senderId: this.playerId,
       timestamp: Date.now(),
+      seq: this.nextOutgoingSeq(),
       data: {
         gameState: serialized,
         isFullSync,
+        // On a full reconciliation snapshot, carry the high-water mark of
+        // applied seqs so the receiver can advance its anti-replay tracker
+        // (and reject re-emitted/queued actions post host-migration #946).
+        lastSeq: isFullSync ? this.outgoingSeq - 1 : undefined,
       },
     });
   }
@@ -439,6 +499,7 @@ export class P2PGameConnection {
       type: "game-action",
       senderId: this.playerId,
       timestamp: Date.now(),
+      seq: this.nextOutgoingSeq(),
       data: {
         action,
         data,
@@ -454,6 +515,7 @@ export class P2PGameConnection {
       type: "chat",
       senderId: this.playerId,
       timestamp: Date.now(),
+      seq: this.nextOutgoingSeq(),
       data: {
         senderName: this.playerName,
         text,
@@ -469,6 +531,7 @@ export class P2PGameConnection {
       type: "ping",
       senderId: this.playerId,
       timestamp: Date.now(),
+      seq: this.nextOutgoingSeq(),
       data: null,
     });
   }
@@ -481,6 +544,7 @@ export class P2PGameConnection {
       type: "pong",
       senderId: this.playerId,
       timestamp: Date.now(),
+      seq: this.nextOutgoingSeq(),
       data: null,
     });
   }
@@ -529,10 +593,14 @@ export class P2PGameConnection {
    *      parsing work is done (issue #1111).
    *   2. Safe parse + structural limits (size/depth/key-count) via
    *      {@link safeParseJson}.
-   *   3. Shape validation via {@link isGameMessage}.
+   *   3. Shape validation via {@link isGameMessage} (including the required
+   *      `seq` field added in #1091).
+   *   4. Anti-replay check: a message with `seq <=` the highest seq already
+   *      applied from this `senderId` is dropped as a duplicate/replay BEFORE
+   *      it can be applied to game state (issue #1091).
    *
-   * Malformed, oversize, or rate-limited messages are rejected gracefully
-   * without breaking the connection.
+   * Malformed, oversize, rate-limited, or replayed messages are rejected
+   * gracefully without breaking the connection.
    */
   private handleMessage(data: string): void {
     try {
@@ -550,6 +618,18 @@ export class P2PGameConnection {
         console.error("[P2PGameConnection] Rejected malformed peer message");
         return;
       }
+
+      // Anti-replay (issue #1091): drop duplicates and replays BEFORE the
+      // message can touch game state. This runs after shape validation so
+      // `message.seq` is guaranteed to be a non-negative integer.
+      if (this.isReplay(message)) {
+        console.warn(
+          "[P2PGameConnection] Dropping duplicate/replay message",
+          redactSensitive({ senderId: message.senderId, seq: message.seq }),
+        );
+        return;
+      }
+      this.markApplied(message);
 
       // Update remote player info
       if (this.remotePlayerId === null) {
@@ -592,13 +672,100 @@ export class P2PGameConnection {
   }
 
   /**
-   * Handle game state sync
+   * Anti-replay check (issue #1091). Returns true when `message.seq` has
+   * already been applied (or is older than the last applied) for this
+   * `senderId`, indicating a duplicate or replay that must be dropped.
+   */
+  private isReplay(message: GameMessage): boolean {
+    const last = this.lastAppliedSeqByPeer.get(message.senderId);
+    if (last === undefined) {
+      // First message observed from this sender — accept.
+      return false;
+    }
+    return message.seq <= last;
+  }
+
+  /**
+   * Record the high-water mark for `message.senderId` as `message.seq`.
+   * Used on every accepted message so the stream stays monotonic. Issue #1091.
+   */
+  private markApplied(message: GameMessage): void {
+    const last = this.lastAppliedSeqByPeer.get(message.senderId) ?? -1;
+    if (message.seq > last) {
+      this.lastAppliedSeqByPeer.set(message.senderId, message.seq);
+    }
+  }
+
+  /**
+   * The highest outgoing seq this connection has stamped so far. Exposed so a
+   * newly-promoted host (issue #946) can ship it as the `lastSeq` high-water
+   * mark in the post-migration reconciliation snapshot. Issue #1091.
+   */
+  getOutgoingSeq(): number {
+    return this.outgoingSeq;
+  }
+
+  /**
+   * Advance the outgoing seq counter to at least `seq` (no-op if already past
+   * it). A newly-promoted host calls this after host migration (#946) so its
+   * post-migration messages continue monotonically from the authoritative
+   * high-water mark, letting followers reject any queued/re-emitted actions
+   * they already saw from the previous host. Issue #1091.
+   */
+  adoptOutgoingSeq(seq: number): void {
+    if (Number.isFinite(seq) && seq >= 0 && seq > this.outgoingSeq) {
+      this.outgoingSeq = seq;
+    }
+  }
+
+  /**
+   * Highest seq applied from `senderId`, or `null` if no message has been seen
+   * from that sender. Exposed for diagnostics and tests. Issue #1091.
+   */
+  getLastAppliedSeq(senderId: string): number | null {
+    const v = this.lastAppliedSeqByPeer.get(senderId);
+    return v === undefined ? null : v;
+  }
+
+  /**
+   * Reset the anti-replay high-water mark for a sender (e.g. when starting a
+   * fresh session or recovering from a known-clean state). Issue #1091.
+   */
+  resetIncomingSeq(senderId: string): void {
+    this.lastAppliedSeqByPeer.delete(senderId);
+  }
+
+  /**
+   * Handle game state sync.
+   *
+   * On a FULL sync (the reconciliation snapshot, e.g. post host-migration
+   * #946), the sender carries `lastSeq` — the high-water mark of applied
+   * sequence numbers baked into this state. The receiver advances its
+   * per-sender anti-replay tracker to that mark so any queued / re-emitted
+   * action with `seq <= lastSeq` is rejected as a replay (issue #1091).
+   * `max(current, lastSeq)` is used so a duplicate delivery of the snapshot
+   * itself is still rejected by the earlier {@link isReplay} check.
+   *
+   * The seq advancement runs BEFORE state deserialization so a malformed
+   * payload cannot leave the anti-replay tracker stuck at a stale value.
    */
   private handleGameStateSync(message: GameMessage): void {
     const data = message.data as {
       gameState: SerializedGameState;
       isFullSync: boolean;
+      lastSeq?: number;
     };
+
+    // Advance the anti-replay high-water mark first (transport-level concern,
+    // independent of whether the payload deserializes).
+    if (data.isFullSync && isNonNegativeInteger(data.lastSeq)) {
+      const current = this.lastAppliedSeqByPeer.get(message.senderId) ?? -1;
+      this.lastAppliedSeqByPeer.set(
+        message.senderId,
+        Math.max(current, data.lastSeq),
+      );
+    }
+
     const baseState = this.createBaseEngineState();
     const gameState = deserializeGameState(data.gameState, baseState);
     this.events.onGameStateSync(gameState);
@@ -828,6 +995,9 @@ export class P2PGameConnection {
     }
 
     this.rateLimiter.reset();
+    // Drop anti-replay tracking so a fresh session isn't poisoned by stale
+    // high-water marks from the previous peer. Issue #1091.
+    this.lastAppliedSeqByPeer.clear();
     this.updateConnectionState("disconnected");
   }
 

--- a/src/lib/p2p-host-migration.ts
+++ b/src/lib/p2p-host-migration.ts
@@ -16,6 +16,30 @@
  *  - Idempotent migration application (duplicate / reordered migration
  *    messages are no-ops).
  *  - Graceful termination when no peers remain to continue.
+ *
+ * Sequence-number continuity policy (issue #1091):
+ *  GameMessages carry a monotonic per-sender `seq` (see
+ *  `p2p-game-connection.ts`). Host migration is the one place where the
+ *  "sender" of the authoritative stream changes, so the policy must be
+ *  explicit:
+ *
+ *    1. When the successor is promoted, it adopts the authoritative
+ *       high-water mark: it calls `P2PGameConnection.adoptOutgoingSeq(<last
+ *       seq observed from the previous host>)` so its post-migration messages
+ *       continue monotonically from where the previous host left off.
+ *    2. The successor then broadcasts a FULL `game-state-sync` carrying
+ *       `data.lastSeq = <that high-water mark>` as the reconciliation
+ *       snapshot. Followers advance their per-`senderId` anti-replay tracker
+ *       for the new host to that mark (see `handleGameStateSync`).
+ *    3. Any queued action the successor re-emits afterwards has
+ *       `seq > lastSeq` (because step 1 continued the counter), so followers
+ *       accept exactly the actions that are not yet baked into the snapshot
+ *       and reject any they already applied under the previous host.
+ *
+ *  Net effect: a follower that already applied an action before the migration
+ *  does not apply it again, satisfying issue #1091's post-migration
+ *  acceptance criterion. The `lastKnownGameState` cached here is the snapshot
+ *  the successor ships in step 2.
  */
 
 /**
@@ -31,19 +55,23 @@ export interface PeerRosterEntry {
 /**
  * Why a host migration is happening.
  */
-export type HostMigrationReason = 'host-disconnected' | 'host-left';
+export type HostMigrationReason = "host-disconnected" | "host-left";
 
 /**
  * The lifecycle state of migration for the local client.
  */
-export type HostMigrationStatus = 'stable' | 'migrating' | 'migrated' | 'terminated';
+export type HostMigrationStatus =
+  | "stable"
+  | "migrating"
+  | "migrated"
+  | "terminated";
 
 /**
  * Wire message broadcast by the newly-promoted host (and relayed by peers) to
  * announce authority transfer. Rides over the existing game-action channel.
  */
 export interface HostMigrationMessage {
-  type: 'host-migration';
+  type: "host-migration";
   /** Idempotency key: identical messages are applied at most once. */
   migrationId: string;
   previousHostId: string;
@@ -136,7 +164,7 @@ export function buildMigrationId(
   newHostId: string,
   remainingPeers: string[],
 ): string {
-  return `mig-${previousHostId}-${newHostId}-${remainingPeers.join(',')}`;
+  return `mig-${previousHostId}-${newHostId}-${remainingPeers.join(",")}`;
 }
 
 /**
@@ -153,7 +181,7 @@ export class HostMigrationManager {
   private hostId: string;
   private peers: Map<string, PeerRosterEntry> = new Map();
   private events: HostMigrationEvents;
-  private status: HostMigrationStatus = 'stable';
+  private status: HostMigrationStatus = "stable";
   /** Migration ids already applied — dedupes duplicates / reordering. */
   private appliedMigrationIds: Set<string> = new Set();
   /** Latest authoritative game state known to this client. */
@@ -162,7 +190,8 @@ export class HostMigrationManager {
   constructor(options: HostMigrationManagerOptions) {
     this.localPlayerId = options.localPlayerId;
     this.hostId = options.initialHostId;
-    this.minPlayersToContinue = options.minPlayersToContinue ?? DEFAULT_MIN_PLAYERS;
+    this.minPlayersToContinue =
+      options.minPlayersToContinue ?? DEFAULT_MIN_PLAYERS;
     this.events = {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       onPromotedToHost: () => {},
@@ -253,21 +282,21 @@ export class HostMigrationManager {
     // Not enough players to keep the game alive → clean terminal state.
     if (remaining.length < this.minPlayersToContinue) {
       const result: HostMigrationResult = {
-        migrationId: buildMigrationId(previousHostId, '', remainingIds),
+        migrationId: buildMigrationId(previousHostId, "", remainingIds),
         previousHostId,
-        newHostId: '',
+        newHostId: "",
         remainingPeers: remainingIds,
         terminated: true,
         promotedSelf: false,
         reason,
         migratedAt: now,
       };
-      this.status = 'terminated';
+      this.status = "terminated";
       this.appliedMigrationIds.add(result.migrationId);
       this.events.onTerminated(
-        reason === 'host-left'
-          ? 'Host left the game and not enough players remain to continue.'
-          : 'Host disconnected and not enough players remain to continue.',
+        reason === "host-left"
+          ? "Host left the game and not enough players remain to continue."
+          : "Host disconnected and not enough players remain to continue.",
       );
       return result;
     }
@@ -275,7 +304,11 @@ export class HostMigrationManager {
     const successor = selectHostSuccessor(remaining);
     // successor is guaranteed non-null because remaining.length >= minPlayers >= 1
     const newHostId = successor as string;
-    const migrationId = buildMigrationId(previousHostId, newHostId, remainingIds);
+    const migrationId = buildMigrationId(
+      previousHostId,
+      newHostId,
+      remainingIds,
+    );
     const promotedSelf = newHostId === this.localPlayerId;
 
     const result: HostMigrationResult = {
@@ -302,7 +335,7 @@ export class HostMigrationManager {
    */
   buildMigrationMessage(result: HostMigrationResult): HostMigrationMessage {
     return {
-      type: 'host-migration',
+      type: "host-migration",
       migrationId: result.migrationId,
       previousHostId: result.previousHostId,
       newHostId: result.newHostId,
@@ -321,11 +354,11 @@ export class HostMigrationManager {
    * @returns the applied result, or `null` if it was a duplicate/no-op.
    */
   applyMigration(message: HostMigrationMessage): HostMigrationResult | null {
-    if (message.type !== 'host-migration') return null;
+    if (message.type !== "host-migration") return null;
     // Defensive validation: a P2P message handler must tolerate malformed input.
     if (
-      typeof message.migrationId !== 'string' ||
-      typeof message.newHostId !== 'string' ||
+      typeof message.migrationId !== "string" ||
+      typeof message.newHostId !== "string" ||
       !Array.isArray(message.remainingPeers)
     ) {
       return null;
@@ -342,7 +375,10 @@ export class HostMigrationManager {
     const promotedSelf = message.newHostId === this.localPlayerId;
 
     // Ensure the leaving host is no longer tracked.
-    if (message.previousHostId && message.previousHostId !== message.newHostId) {
+    if (
+      message.previousHostId &&
+      message.previousHostId !== message.newHostId
+    ) {
       this.removePeer(message.previousHostId);
     }
 
@@ -371,9 +407,12 @@ export class HostMigrationManager {
    * Apply a locally-resolved result: update host authority, status and emit the
    * appropriate event.
    */
-  private applyResult(result: HostMigrationResult, promotedSelf: boolean): void {
+  private applyResult(
+    result: HostMigrationResult,
+    promotedSelf: boolean,
+  ): void {
     this.hostId = result.newHostId;
-    this.status = 'migrated';
+    this.status = "migrated";
     this.appliedMigrationIds.add(result.migrationId);
 
     if (promotedSelf) {
@@ -393,7 +432,7 @@ export class HostMigrationManager {
   /** Reset all migration tracking (e.g. when starting a fresh session). */
   reset(): void {
     this.appliedMigrationIds.clear();
-    this.status = 'stable';
+    this.status = "stable";
     this.lastKnownGameState = null;
   }
 }

--- a/src/lib/p2p-json-validation.ts
+++ b/src/lib/p2p-json-validation.ts
@@ -144,6 +144,27 @@ export function withinStructuralLimits(
 }
 
 /**
+ * Is `value` a non-negative integer (a valid sequence number)?
+ *
+ * Sequence numbers (`GameMessage.seq`, issue #1091) must be:
+ *   - a `number` (reject strings/objects),
+ *   - an integer (reject 1.5 — seqs are discrete),
+ *   - non-negative (reject -1 — seqs start at 0),
+ *   - finite (reject NaN / Infinity — they break `<=` comparisons).
+ *
+ * Exposed here so every shape guard that asserts a seq field validates it the
+ * same way without duplicating the predicate.
+ */
+export function isNonNegativeInteger(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value >= 0
+  );
+}
+
+/**
  * Safely parse a JSON string, enforce resource limits, and validate its shape.
  *
  * Order of checks (fail-closed at every step, never throws to the caller):
@@ -153,7 +174,9 @@ export function withinStructuralLimits(
  *   3. JSON.parse is wrapped so syntactically invalid input returns null.
  *   4. A valid JSON scalar (number, string, boolean, null) is never a message.
  *   5. The parsed object must satisfy the structural depth/key limits.
- *   6. The caller's type guard must accept the shape.
+ *   6. The caller's type guard must accept the shape (e.g. {@link isGameMessage}
+ *      in `p2p-game-connection.ts`, which uses {@link isNonNegativeInteger} to
+ *      require the `seq` anti-replay field added in issue #1091).
  *
  * @param raw      - Raw string received from an untrusted source (peer/signal).
  * @param validate - Type guard returning true only when the parsed value has


### PR DESCRIPTION
## Summary

Adds a monotonically-increasing per-sender **sequence number** to every `GameMessage` so the receiver can reject **duplicates** (reconnect re-delivery, #943) and **replays** (host-migration rebroadcast, #946) _before_ they corrupt game state. This is the anti-replay layer that complements the existing shape/rate/size validation from #951 / #1111.

Resolves #1091.

## Sequence-number policy

- **Granularity:** per-sender (one monotonic counter per `P2PGameConnection`, shared across all message types). The WebRTC data channel is `ordered: true`, so a single stream per sender is sufficient and simplest.
- **Assigned by the sender** via `nextOutgoingSeq()` on every `send*` path; starts at `0`.
- **Validated by the receiver** in `isGameMessage` — `seq` must be present and a non-negative finite integer (via the new `isNonNegativeInteger` helper in `p2p-json-validation.ts`). Messages missing it are rejected at the shape-validation step.
- **Anti-replay check** runs in `handleMessage` _after_ shape validation but _before_ the message is dispatched/applied: any message with `seq <= lastAppliedSeqByPeer[senderId]` is dropped as a duplicate/replay.
- **Per-sender isolation:** each `senderId` has its own high-water mark, so two peers can each start at `seq 0` without colliding.
- **Backward-compat:** `seq` is **required**. This is a local-first app with version-matched peers (peers join via shared game codes), so rejecting old-shape messages during a version transition is acceptable and the safer choice.

## Host-migration handling

Host migration (#946) is the one place where the authoritative stream's sender changes, so the policy is explicit (documented in `p2p-host-migration.ts`):

1. The promoted successor calls `adoptOutgoingSeq(<high-water mark>)` so its post-migration messages continue monotonically from where the previous host left off.
2. It broadcasts a **full** `game-state-sync` carrying `data.lastSeq = <high-water mark>` as the reconciliation snapshot.
3. Followers advance their per-`senderId` anti-replay tracker to `max(current, lastSeq)` (see `handleGameStateSync`). The seq advancement runs _before_ state deserialization so a malformed payload can't leave the tracker stuck at a stale value.
4. Any queued action the successor re-emits afterwards has `seq > lastSeq`, so followers accept exactly the actions not yet baked into the snapshot and reject any they already applied under the previous host.

Net effect: a follower that already applied an action before the migration does **not** apply it again.

## Changed files

- `src/lib/p2p-game-connection.ts` — `seq` field on `GameMessage`; `isGameMessage` requires it; outgoing counter + per-peer `lastAppliedSeqByPeer` tracking; anti-replay check in `handleMessage`; `lastSeq` carried on full syncs; public `getOutgoingSeq` / `adoptOutgoingSeq` / `getLastAppliedSeq` / `resetIncomingSeq` helpers; tracking cleared on `close()`.
- `src/lib/p2p-json-validation.ts` — new `isNonNegativeInteger` predicate (reused by `isGameMessage`).
- `src/lib/p2p-host-migration.ts` — documented the seq-continuity policy in the module header.
- Tests: extended `p2p-game-connection.test.ts` (seq validation, in-order accept, duplicate/replay/stale rejection, per-sender isolation, post-migration reset, partial-sync non-reset, malformed-lastSeq fallback, close() reset, outgoing-seq helpers) and `p2p-json-validation.test.ts` (`isNonNegativeInteger` coverage).

## Acceptance criteria

- [x] `GameMessage` carries a sequence number (monotonic per sender, assigned by the sender)
- [x] Receiver rejects duplicate messages (same `seq` already seen)
- [x] Receiver rejects replays/stale messages (`seq <= last accepted`)
- [x] Validation layer requires the `seq` field (`isGameMessage` rejects messages without it)
- [x] Host-migration policy documented and handled (counter continues via `adoptOutgoingSeq` + full-sync `lastSeq` reset)
- [x] Unit tests cover: in-order acceptance, duplicate rejection, replay/stale rejection, missing-seq rejection, post-migration behavior

## Test plan

- [x] `npx jest src/lib/__tests__/p2p-game-connection.test.ts src/lib/__tests__/p2p-json-validation.test.ts src/lib/__tests__/p2p-host-migration.test.ts` — 103 tests pass
- [x] `npx jest src/lib/__tests__/` — 66 suites / 1582 tests pass (no regressions)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (no new warnings in changed files)