### PR TITLE
test(ai): resolve #1092 — add unit tests for AI action executor and turn loop

### DIFF
--- a/src/ai/__tests__/ai-action-executor.test.ts
+++ b/src/ai/__tests__/ai-action-executor.test.ts
@@ -1,0 +1,955 @@
+/**
+ * @fileoverview Unit tests for the AI Action Executor.
+ *
+ * Issue #1092: `src/ai/ai-action-executor.ts` reported 0% branch coverage. It
+ * translates AI decisions into engine mutations, so we exercise the REAL
+ * dispatch + result-assembly logic while stubbing the heavyweight rules-engine
+ * mutators (`mana`, `spell-casting`, `combat`, `keyword-actions`, `game-state`)
+ * and the serialization/evaluator helpers. The pure accessor helpers
+ * (`getAvailableLands`, `getAvailableAttackers`, ...) read zones/cards
+ * directly, so they are driven by real, deterministic fixtures.
+ *
+ * Also contains a regression test for a real bug fixed in `executeCastSpell`:
+ * the "cannot cast" guard tested the truthiness of the `{ canCast }` object
+ * (always truthy) instead of its `.canCast` field, so the short-circuit was
+ * dead code.
+ */
+
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+// --- Mocks for heavyweight rules-engine collaborators -----------------------
+// These are stubbed so tests stay fast/deterministic while the executor's own
+// dispatch + assembly logic (the unit under test) runs for real.
+jest.mock("@/lib/game-state/mana");
+jest.mock("@/lib/game-state/spell-casting");
+jest.mock("@/lib/game-state/combat");
+jest.mock("@/lib/game-state/keyword-actions");
+jest.mock("@/lib/game-state/game-state");
+jest.mock("@/lib/game-state/serialization");
+jest.mock("../game-state-evaluator", () => ({
+  ...(jest.requireActual("../game-state-evaluator") as Record<string, unknown>),
+  quickScore: jest.fn(() => 0),
+}));
+
+import { executeAIAction, type AIAction } from "../ai-action-executor";
+import {
+  getAvailableLands,
+  getAvailableAttackers,
+  getAvailableBlockers,
+  getAvailableResponses,
+  getAIGameState,
+  getAvailableLandsAI,
+  getAvailableAttackersAI,
+  getAvailableBlockersAI,
+  evaluateLookahead,
+} from "../ai-action-executor";
+
+import { canPlayLand, playLand } from "@/lib/game-state/mana";
+import { canCastSpell, castSpell } from "@/lib/game-state/spell-casting";
+import { declareAttackers } from "@/lib/game-state/combat";
+import {
+  tapCardAction,
+  untapCardAction,
+} from "@/lib/game-state/keyword-actions";
+import { passPriority } from "@/lib/game-state/game-state";
+import { engineToAIState } from "@/lib/game-state/serialization";
+import { quickScore } from "../game-state-evaluator";
+
+import type {
+  GameState as EngineGameState,
+  CardInstance,
+  CardInstanceId,
+  PlayerId,
+  Combat,
+} from "@/lib/game-state/types";
+
+const canPlayLandMock = canPlayLand as unknown as jest.Mock;
+const playLandMock = playLand as unknown as jest.Mock;
+const canCastSpellMock = canCastSpell as unknown as jest.Mock;
+const castSpellMock = castSpell as unknown as jest.Mock;
+const declareAttackersMock = declareAttackers as unknown as jest.Mock;
+const tapCardActionMock = tapCardAction as unknown as jest.Mock;
+const untapCardActionMock = untapCardAction as unknown as jest.Mock;
+const passPriorityMock = passPriority as unknown as jest.Mock;
+const engineToAIStateMock = engineToAIState as unknown as jest.Mock;
+const quickScoreMock = quickScore as unknown as jest.Mock;
+
+const AI = "player1" as PlayerId;
+const OPP = "player2" as PlayerId;
+
+/** A distinct sentinel state returned by stubbed mutators. */
+function sentinel(tag = "post"): EngineGameState {
+  return { gameId: tag } as unknown as EngineGameState;
+}
+
+/** Build a minimal card instance carrying only the fields the executor reads. */
+function mkCard(
+  id: CardInstanceId,
+  overrides: Partial<CardInstance> & {
+    type_line: string;
+    name?: string;
+    power?: string;
+    toughness?: string;
+    keywords?: string[];
+    mana_cost?: string;
+    cmc?: number;
+    oracle_text?: string;
+  } = { type_line: "Creature" },
+): CardInstance {
+  const {
+    type_line,
+    name,
+    power,
+    toughness,
+    keywords,
+    mana_cost,
+    cmc,
+    oracle_text,
+    ...rest
+  } = overrides;
+  return {
+    id,
+    oracleId: id,
+    cardData: {
+      name: name ?? id,
+      type_line,
+      power,
+      toughness,
+      keywords,
+      mana_cost,
+      cmc,
+      oracle_text,
+    } as any,
+    currentFaceIndex: 0,
+    isFaceDown: false,
+    controllerId: AI,
+    ownerId: AI,
+    isTapped: false,
+    isFlipped: false,
+    isTurnedFaceUp: false,
+    isPhasedOut: false,
+    hasSummoningSickness: false,
+    ...rest,
+  } as unknown as CardInstance;
+}
+
+/** Build a partial engine game state with only the pieces the executor reads. */
+function buildState(opts: {
+  cards?: Array<CardInstance>;
+  combat?: Partial<Combat>;
+  zoneCards?: Record<string, CardInstanceId[]>;
+  players?: PlayerId[];
+}): EngineGameState {
+  const cards = new Map<string, CardInstance>();
+  for (const c of opts.cards ?? []) cards.set(c.id, c);
+
+  const zones = new Map<string, { cardIds: CardInstanceId[] }>();
+  for (const [key, ids] of Object.entries(opts.zoneCards ?? {})) {
+    zones.set(key, { cardIds: ids });
+  }
+
+  const players = new Map<PlayerId, unknown>();
+  for (const p of opts.players ?? [AI, OPP]) players.set(p, { id: p });
+
+  const combat: Combat = {
+    inCombatPhase: false,
+    attackers: opts.combat?.attackers ?? [],
+    blockers: opts.combat?.blockers ?? new Map(),
+    remainingCombatPhases: 0,
+    ...opts.combat,
+  } as Combat;
+
+  return {
+    cards,
+    zones,
+    players,
+    combat,
+  } as unknown as EngineGameState;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Sensible defaults; individual tests override.
+  canPlayLandMock.mockReturnValue(true);
+  playLandMock.mockReturnValue({ success: true, state: sentinel("land") });
+  canCastSpellMock.mockReturnValue({ canCast: true });
+  castSpellMock.mockReturnValue({ success: true, state: sentinel("spell") });
+  declareAttackersMock.mockReturnValue({
+    success: true,
+    state: sentinel("attack"),
+    description: "",
+  });
+  tapCardActionMock.mockReturnValue({
+    success: true,
+    state: sentinel("tap"),
+    description: "",
+  });
+  untapCardActionMock.mockReturnValue({
+    success: true,
+    state: sentinel("untap"),
+    description: "",
+  });
+  passPriorityMock.mockReturnValue(sentinel("pass"));
+  engineToAIStateMock.mockReturnValue({ players: {} });
+  quickScoreMock.mockReturnValue(42);
+});
+
+// ===========================================================================
+// executeAIAction — dispatch table
+// ===========================================================================
+describe("executeAIAction dispatch", () => {
+  it("no_action returns the unchanged state with success", async () => {
+    const state = buildState({});
+    const res = await executeAIAction(state, { type: "no_action" }, AI);
+    expect(res.success).toBe(true);
+    expect(res.newState).toBe(state);
+    expect(res.action).toEqual({ type: "no_action" });
+  });
+
+  it("unknown action type yields a failure result", async () => {
+    const state = buildState({});
+    const res = await executeAIAction(state, { type: "bogus_type" as any }, AI);
+    expect(res.success).toBe(false);
+    expect(res.error).toContain("Unknown action type");
+    expect(res.action).toEqual({ type: "bogus_type" });
+  });
+
+  it("wraps a thrown error into a failure result (try/catch)", async () => {
+    passPriorityMock.mockImplementation(() => {
+      throw new Error("boom");
+    });
+    const state = buildState({});
+    const res = await executeAIAction(state, { type: "pass_priority" }, AI);
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("boom");
+  });
+
+  it("wraps a non-Error throw into a generic failure result", async () => {
+    passPriorityMock.mockImplementation(() => {
+      throw "string error";
+    });
+    const state = buildState({});
+    const res = await executeAIAction(state, { type: "pass_priority" }, AI);
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("Unknown error");
+  });
+});
+
+// ===========================================================================
+// play_land
+// ===========================================================================
+describe("executeAIAction: play_land", () => {
+  it("plays a land when allowed, returning the engine's new state", async () => {
+    const state = buildState({});
+    const res = await executeAIAction(
+      state,
+      { type: "play_land", cardId: "land-1" },
+      AI,
+    );
+    expect(canPlayLandMock).toHaveBeenCalledWith(state, AI);
+    expect(playLandMock).toHaveBeenCalledWith(state, AI, "land-1");
+    expect(res.success).toBe(true);
+    expect(res.newState).toEqual(sentinel("land"));
+    expect(res.action).toEqual({ type: "play_land", cardId: "land-1" });
+  });
+
+  it("rejects when the engine says a land cannot be played this turn", async () => {
+    canPlayLandMock.mockReturnValue(false);
+    const state = buildState({});
+    const res = await executeAIAction(
+      state,
+      { type: "play_land", cardId: "land-1" },
+      AI,
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toContain("Cannot play land");
+    expect(playLandMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the engine error when playLand itself fails", async () => {
+    playLandMock.mockReturnValue({
+      success: false,
+      state: sentinel("land"),
+      error: "Land drop already used",
+    });
+    const state = buildState({});
+    const res = await executeAIAction(
+      state,
+      { type: "play_land", cardId: "land-1" },
+      AI,
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("Land drop already used");
+  });
+});
+
+// ===========================================================================
+// cast_spell — includes the regression test for the canCastSpell guard bug
+// ===========================================================================
+describe("executeAIAction: cast_spell", () => {
+  it("casts a spell with no target when allowed", async () => {
+    const state = buildState({});
+    const res = await executeAIAction(
+      state,
+      { type: "cast_spell", cardId: "spell-1" },
+      AI,
+    );
+    expect(canCastSpellMock).toHaveBeenCalledWith(state, AI, "spell-1");
+    expect(castSpellMock).toHaveBeenCalledWith(
+      state,
+      AI,
+      "spell-1",
+      undefined,
+      [],
+      0,
+    );
+    expect(res.success).toBe(true);
+    expect(res.newState).toEqual(sentinel("spell"));
+    expect(res.action).toMatchObject({ type: "cast_spell", cardId: "spell-1" });
+  });
+
+  it("forwards a single target", async () => {
+    const state = buildState({});
+    const res = await executeAIAction(
+      state,
+      { type: "cast_spell", cardId: "bolt", targetId: "goblin" },
+      AI,
+    );
+    expect(castSpellMock).toHaveBeenCalledWith(
+      state,
+      AI,
+      "bolt",
+      [{ type: "card", targetId: "goblin", isValid: true }],
+      [],
+      0,
+    );
+    expect(res.success).toBe(true);
+  });
+
+  it("forwards multiple targets (targetIds array)", async () => {
+    const state = buildState({});
+    await executeAIAction(
+      state,
+      { type: "cast_spell", cardId: "multi", targetIds: ["a", "b"] },
+      AI,
+    );
+    expect(castSpellMock).toHaveBeenCalledWith(
+      state,
+      AI,
+      "multi",
+      [
+        { type: "card", targetId: "a", isValid: true },
+        { type: "card", targetId: "b", isValid: true },
+      ],
+      [],
+      0,
+    );
+  });
+
+  it("forwards chosen mode + X value for modal/variable spells", async () => {
+    const state = buildState({});
+    await executeAIAction(
+      state,
+      {
+        type: "cast_spell",
+        cardId: "modal",
+        mode: "draw",
+        xValue: 3,
+      },
+      AI,
+    );
+    expect(castSpellMock).toHaveBeenCalledWith(
+      state,
+      AI,
+      "modal",
+      undefined,
+      ["draw"],
+      3,
+    );
+  });
+
+  // REGRESSION TEST for the bug fixed in this issue:
+  // canCastSpell returns { canCast: boolean }; the guard previously checked the
+  // object's truthiness (always true), so this failure path never executed.
+  it("rejects when canCastSpell reports the spell is not castable (#1092 regression)", async () => {
+    canCastSpellMock.mockReturnValue({
+      canCast: false,
+      reason: "not enough mana",
+    });
+    const state = buildState({});
+    const res = await executeAIAction(
+      state,
+      { type: "cast_spell", cardId: "spell-1" },
+      AI,
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toContain("Cannot cast spell");
+    expect(castSpellMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the engine error when castSpell fails", async () => {
+    castSpellMock.mockReturnValue({
+      success: false,
+      state: sentinel("spell"),
+      error: "Invalid target",
+    });
+    const state = buildState({});
+    const res = await executeAIAction(
+      state,
+      { type: "cast_spell", cardId: "spell-1", targetId: "x" },
+      AI,
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("Invalid target");
+  });
+});
+
+// ===========================================================================
+// attack
+// ===========================================================================
+describe("executeAIAction: attack", () => {
+  const attacker = mkCard("bear", {
+    type_line: "Creature — Bear",
+    name: "Bear",
+    power: "2",
+    toughness: "2",
+    keywords: [],
+  });
+
+  it("declares an attacker and forwards to the combat engine", async () => {
+    const state = buildState({ cards: [attacker] });
+    const res = await executeAIAction(
+      state,
+      { type: "attack", cardId: "bear", targetId: OPP },
+      AI,
+    );
+    expect(declareAttackersMock).toHaveBeenCalledTimes(1);
+    const attackers = (
+      declareAttackersMock.mock.calls[0] as unknown[]
+    )[1] as any[];
+    expect(attackers).toHaveLength(1);
+    expect(attackers[0]).toMatchObject({
+      cardId: "bear",
+      defenderId: OPP,
+      isAttackingPlaneswalker: false,
+      damageToDeal: 2,
+      hasFirstStrike: false,
+      hasDoubleStrike: false,
+    });
+    expect(res.success).toBe(true);
+    expect(res.newState).toEqual(sentinel("attack"));
+  });
+
+  it("defaults the defender to the opponent when no target given", async () => {
+    const state = buildState({ cards: [attacker], players: [AI, OPP] });
+    await executeAIAction(state, { type: "attack", cardId: "bear" }, AI);
+    const attackers = (
+      declareAttackersMock.mock.calls[0] as unknown[]
+    )[1] as any[];
+    expect(attackers[0].defenderId).toBe(OPP);
+  });
+
+  it("preserves existing attackers when adding a new one", async () => {
+    const existing = {
+      cardId: "old",
+      defenderId: OPP,
+      isAttackingPlaneswalker: false,
+      damageToDeal: 1,
+      hasFirstStrike: false,
+      hasDoubleStrike: false,
+    };
+    const state = buildState({
+      cards: [attacker],
+      combat: { attackers: [existing] },
+    });
+    await executeAIAction(state, { type: "attack", cardId: "bear" }, AI);
+    const attackers = (
+      declareAttackersMock.mock.calls[0] as unknown[]
+    )[1] as any[];
+    expect(attackers).toHaveLength(2);
+    expect(attackers[0]).toBe(existing);
+  });
+
+  it("reads first_strike / double_strike from keywords", async () => {
+    const fs = mkCard("fs", {
+      type_line: "Creature",
+      power: "1",
+      keywords: ["first_strike", "double_strike"],
+    });
+    const state = buildState({ cards: [fs] });
+    await executeAIAction(state, { type: "attack", cardId: "fs" }, AI);
+    const attackers = (
+      declareAttackersMock.mock.calls[0] as unknown[]
+    )[1] as any[];
+    expect(attackers[0].hasFirstStrike).toBe(true);
+    expect(attackers[0].hasDoubleStrike).toBe(true);
+  });
+
+  it("rejects when the creature is not on the battlefield", async () => {
+    const state = buildState({ cards: [] });
+    const res = await executeAIAction(
+      state,
+      { type: "attack", cardId: "ghost" },
+      AI,
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("Creature not found");
+    expect(declareAttackersMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a tapped creature", async () => {
+    const tapped = mkCard("tapped-bear", {
+      type_line: "Creature",
+      isTapped: true,
+    });
+    const state = buildState({ cards: [tapped] });
+    const res = await executeAIAction(
+      state,
+      { type: "attack", cardId: "tapped-bear" },
+      AI,
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toContain("tapped");
+  });
+
+  it("rejects a creature with summoning sickness", async () => {
+    const sick = mkCard("sick", {
+      type_line: "Creature",
+      hasSummoningSickness: true,
+    });
+    const state = buildState({ cards: [sick] });
+    const res = await executeAIAction(
+      state,
+      { type: "attack", cardId: "sick" },
+      AI,
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toContain("summoning sickness");
+  });
+
+  it("surfaces joined errors when declareAttackers fails", async () => {
+    declareAttackersMock.mockReturnValue({
+      success: false,
+      state: sentinel("attack"),
+      errors: ["bad attacker", "no defender"],
+    });
+    const state = buildState({ cards: [attacker] });
+    const res = await executeAIAction(
+      state,
+      { type: "attack", cardId: "bear" },
+      AI,
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("bad attacker, no defender");
+  });
+});
+
+// ===========================================================================
+// block
+// ===========================================================================
+describe("executeAIAction: block", () => {
+  const blocker = mkCard("wall", {
+    type_line: "Creature — Wall",
+    toughness: "4",
+    keywords: [],
+  });
+
+  it("records a blocker against an attacker and returns success", async () => {
+    const state = buildState({ cards: [blocker] });
+    const res = await executeAIAction(
+      state,
+      { type: "block", cardId: "wall", targetId: "attkr-1" },
+      AI,
+    );
+    expect(res.success).toBe(true);
+    // Block does not call a dedicated engine mutator yet; it returns state.
+    expect(res.newState).toBe(state);
+    expect(res.action).toEqual({
+      type: "block",
+      cardId: "wall",
+      targetId: "attkr-1",
+    });
+  });
+
+  it("rejects when the blocker is not found", async () => {
+    const state = buildState({ cards: [] });
+    const res = await executeAIAction(
+      state,
+      { type: "block", cardId: "ghost", targetId: "attkr-1" },
+      AI,
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("Creature not found");
+  });
+
+  it("rejects a tapped blocker", async () => {
+    const tapped = mkCard("tapped-wall", {
+      type_line: "Creature",
+      isTapped: true,
+    });
+    const state = buildState({ cards: [tapped] });
+    const res = await executeAIAction(
+      state,
+      { type: "block", cardId: "tapped-wall", targetId: "attkr-1" },
+      AI,
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toContain("tapped");
+  });
+});
+
+// ===========================================================================
+// tap_card / untap_card
+// ===========================================================================
+describe("executeAIAction: tap_card / untap_card", () => {
+  it("taps a card via the engine action", async () => {
+    const state = buildState({});
+    const res = await executeAIAction(
+      state,
+      { type: "tap_card", cardId: "llanowar" },
+      AI,
+    );
+    expect(tapCardActionMock).toHaveBeenCalledWith(state, "llanowar");
+    expect(res.success).toBe(true);
+    expect(res.newState).toEqual(sentinel("tap"));
+  });
+
+  it("surfaces a tap failure", async () => {
+    const state = buildState({});
+    tapCardActionMock.mockReturnValue({
+      success: false,
+      state,
+      description: "",
+      error: "already tapped",
+    });
+    const res = await executeAIAction(
+      state,
+      { type: "tap_card", cardId: "c" },
+      AI,
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("already tapped");
+  });
+
+  it("untaps a card via the engine action", async () => {
+    const state = buildState({});
+    const res = await executeAIAction(
+      state,
+      { type: "untap_card", cardId: "llanowar" },
+      AI,
+    );
+    expect(untapCardActionMock).toHaveBeenCalledWith(state, "llanowar");
+    expect(res.success).toBe(true);
+    expect(res.newState).toEqual(sentinel("untap"));
+  });
+
+  it("surfaces an untap failure with a default message", async () => {
+    const state = buildState({});
+    untapCardActionMock.mockReturnValue({
+      success: false,
+      state,
+      description: "",
+      // no error field
+    });
+    const res = await executeAIAction(
+      state,
+      { type: "untap_card", cardId: "c" },
+      AI,
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("Failed to untap card");
+  });
+});
+
+// ===========================================================================
+// pass_priority
+// ===========================================================================
+describe("executeAIAction: pass_priority", () => {
+  it("passes priority and returns the engine's new state", async () => {
+    const state = buildState({});
+    const res = await executeAIAction(state, { type: "pass_priority" }, AI);
+    expect(passPriorityMock).toHaveBeenCalledWith(state, AI);
+    expect(res.success).toBe(true);
+    expect(res.newState).toEqual(sentinel("pass"));
+    expect(res.action).toEqual({ type: "pass_priority" });
+  });
+});
+
+// ===========================================================================
+// Pure accessor helpers (real fixtures, no engine mocks exercised)
+// ===========================================================================
+describe("getAvailableLands", () => {
+  it("returns land card ids from the player's hand", () => {
+    const forest = mkCard("forest", { type_line: "Land — Forest" });
+    const bear = mkCard("bear", { type_line: "Creature" });
+    const state = buildState({
+      cards: [forest, bear],
+      zoneCards: { [`${AI}-hand`]: ["forest", "bear"] },
+    });
+    expect(getAvailableLands(state, AI)).toEqual(["forest"]);
+  });
+
+  it("returns an empty array when the hand zone is absent", () => {
+    const state = buildState({});
+    expect(getAvailableLands(state, AI)).toEqual([]);
+  });
+
+  it("ignores non-land cards", () => {
+    const bear = mkCard("bear", { type_line: "Creature" });
+    const state = buildState({
+      cards: [bear],
+      zoneCards: { [`${AI}-hand`]: ["bear"] },
+    });
+    expect(getAvailableLands(state, AI)).toEqual([]);
+  });
+});
+
+describe("getAvailableAttackers", () => {
+  it("returns untapped creatures without summoning sickness", () => {
+    const ready = mkCard("r", { type_line: "Creature" });
+    const tapped = mkCard("t", { type_line: "Creature", isTapped: true });
+    const sick = mkCard("s", {
+      type_line: "Creature",
+      hasSummoningSickness: true,
+    });
+    const land = mkCard("l", { type_line: "Land" });
+    const state = buildState({
+      cards: [ready, tapped, sick, land],
+      zoneCards: {
+        [`${AI}-battlefield`]: ["r", "t", "s", "l"],
+      },
+    });
+    expect(getAvailableAttackers(state, AI)).toEqual(["r"]);
+  });
+
+  it("returns empty when the battlefield zone is absent", () => {
+    expect(getAvailableAttackers(buildState({}), AI)).toEqual([]);
+  });
+});
+
+describe("getAvailableBlockers", () => {
+  it("returns untapped creatures (summoning sickness does NOT prevent blocking)", () => {
+    const ready = mkCard("r", { type_line: "Creature" });
+    const sick = mkCard("s", {
+      type_line: "Creature",
+      hasSummoningSickness: true,
+    });
+    const tapped = mkCard("t", { type_line: "Creature", isTapped: true });
+    const state = buildState({
+      cards: [ready, sick, tapped],
+      zoneCards: { [`${AI}-battlefield`]: ["r", "s", "t"] },
+    });
+    // Blocking ignores summoning sickness; only tapped creatures are excluded.
+    expect(getAvailableBlockers(state, AI).sort()).toEqual(["r", "s"]);
+  });
+
+  it("returns empty when the battlefield zone is absent", () => {
+    expect(getAvailableBlockers(buildState({}), AI)).toEqual([]);
+  });
+});
+
+describe("getAvailableResponses", () => {
+  it("returns instants and flash cards from hand with parsed mana costs", () => {
+    const bolt = mkCard("bolt", {
+      type_line: "Instant",
+      name: "Lightning Bolt",
+      mana_cost: "{R}",
+      cmc: 1,
+      oracle_text: "Lightning Bolt deals 3 damage to any target.",
+    });
+    const flash = mkCard("flash", {
+      type_line: "Creature",
+      name: "FlashBear",
+      keywords: ["flash"],
+      mana_cost: "{1}{G}",
+      cmc: 2,
+    });
+    const sorcery = mkCard("sorc", {
+      type_line: "Sorcery",
+      name: "Divination",
+      mana_cost: "{2}{U}",
+    });
+    const state = buildState({
+      cards: [bolt, flash, sorcery],
+      zoneCards: { [`${AI}-hand`]: ["bolt", "flash", "sorc"] },
+    });
+    const responses = getAvailableResponses(state, AI);
+    expect(responses).toHaveLength(2);
+    const boltR = responses.find((r) => r.cardId === "bolt")!;
+    expect(boltR.type).toBe("instant");
+    expect(boltR.canCounter).toBe(false);
+    expect(boltR.manaValue).toBe(1);
+    // {R} parses to { R: 1 }
+    expect(boltR.manaCost).toEqual({ R: 1 });
+    const flashR = responses.find((r) => r.cardId === "flash")!;
+    expect(flashR.type).toBe("flash");
+    // {1}{G} parses to { G: 1, generic: 1 }
+    expect(flashR.manaCost).toEqual({ G: 1, generic: 1 });
+  });
+
+  it("flags cards whose oracle text can counter a spell", () => {
+    const counter = mkCard("cs", {
+      type_line: "Instant",
+      name: "Counterspell",
+      mana_cost: "{U}{U}",
+      oracle_text: "Counter target spell.",
+    });
+    const state = buildState({
+      cards: [counter],
+      zoneCards: { [`${AI}-hand`]: ["cs"] },
+    });
+    const responses = getAvailableResponses(state, AI);
+    expect(responses[0].canCounter).toBe(true);
+  });
+
+  it("returns empty when the hand zone is absent", () => {
+    expect(getAvailableResponses(buildState({}), AI)).toEqual([]);
+  });
+});
+
+// ===========================================================================
+// getAIGameState — delegates to the serialization converter
+// ===========================================================================
+describe("getAIGameState", () => {
+  it("delegates to engineToAIState", () => {
+    const state = buildState({});
+    const converted = { players: { player1: { id: AI } } };
+    engineToAIStateMock.mockReturnValue(converted);
+    expect(getAIGameState(state)).toBe(converted);
+    expect(engineToAIStateMock).toHaveBeenCalledWith(state);
+  });
+});
+
+// ===========================================================================
+// AI-format accessors (operate on AIGameState directly)
+// ===========================================================================
+describe("AI-format accessors", () => {
+  const aiState = {
+    players: {
+      [AI]: {
+        id: AI,
+        hand: [
+          { cardInstanceId: "h-land", type: "Land" },
+          { cardInstanceId: "h-creep", type: "Creature" },
+        ],
+        battlefield: [
+          {
+            cardInstanceId: "b-ready",
+            type: "creature",
+            tapped: false,
+            summoningSickness: false,
+            power: 2,
+          },
+          {
+            cardInstanceId: "b-tapped",
+            type: "creature",
+            tapped: true,
+            summoningSickness: false,
+            power: 3,
+          },
+          {
+            cardInstanceId: "b-sick",
+            type: "creature",
+            tapped: false,
+            summoningSickness: true,
+            power: 5,
+          },
+          {
+            cardInstanceId: "b-zero",
+            type: "creature",
+            tapped: false,
+            summoningSickness: false,
+            power: 0,
+          },
+          { cardInstanceId: "b-land", type: "land", tapped: false },
+        ],
+      },
+    },
+  } as any;
+
+  it("getAvailableLandsAI returns land ids from the AI player's hand", () => {
+    expect(getAvailableLandsAI(aiState, AI)).toEqual(["h-land"]);
+  });
+
+  it("getAvailableLandsAI returns [] for an unknown player", () => {
+    expect(getAvailableLandsAI(aiState, "nobody")).toEqual([]);
+  });
+
+  it("getAvailableAttackersAI returns untapped, non-sick creatures with positive power", () => {
+    expect(getAvailableAttackersAI(aiState, AI)).toEqual(["b-ready"]);
+  });
+
+  it("getAvailableAttackersAI returns [] for an unknown player", () => {
+    expect(getAvailableAttackersAI(aiState, "nobody")).toEqual([]);
+  });
+
+  it("getAvailableBlockersAI returns untapped creatures (sickness/power ignored)", () => {
+    // getAvailableBlockersAI only excludes tapped creatures; it does NOT check
+    // power (unlike the attacker accessor) nor summoning sickness.
+    expect(getAvailableBlockersAI(aiState, AI).sort()).toEqual([
+      "b-ready",
+      "b-sick",
+      "b-zero",
+    ]);
+  });
+
+  it("getAvailableBlockersAI returns [] for an unknown player", () => {
+    expect(getAvailableBlockersAI(aiState, "nobody")).toEqual([]);
+  });
+});
+
+// ===========================================================================
+// evaluateLookahead — depth / action branches
+// ===========================================================================
+describe("evaluateLookahead", () => {
+  it("terminal depth (<=0) scores the current state without acting", async () => {
+    const state = buildState({});
+    const score = await evaluateLookahead(state, AI, 0);
+    expect(score).toBe(42);
+    expect(quickScoreMock).toHaveBeenCalled();
+    expect(castSpellMock).not.toHaveBeenCalled();
+    expect(playLandMock).not.toHaveBeenCalled();
+  });
+
+  it("positive depth but no action scores the current state", async () => {
+    const state = buildState({});
+    const score = await evaluateLookahead(state, AI, 2);
+    expect(score).toBe(42);
+    expect(quickScoreMock).toHaveBeenCalled();
+  });
+
+  it("returns -100 when the simulated action fails", async () => {
+    canPlayLandMock.mockReturnValue(false);
+    const state = buildState({});
+    const score = await evaluateLookahead(state, AI, 1, {
+      type: "play_land",
+      cardId: "l",
+    });
+    expect(score).toBe(-100);
+  });
+
+  it("at depth 1 evaluates the resulting state from the actor's view", async () => {
+    const state = buildState({});
+    const score = await evaluateLookahead(state, AI, 1, {
+      type: "pass_priority",
+    });
+    expect(score).toBe(42);
+    // quickScore called for the resulting state
+    expect(quickScoreMock).toHaveBeenCalled();
+  });
+
+  it("at depth > 1 blends our score with the opponent's potential response", async () => {
+    let calls = 0;
+    // Source computes opponentScore FIRST, then ourScore.
+    const opponentScore = 20;
+    const ourScore = 100;
+    const scores = [opponentScore, ourScore];
+    quickScoreMock.mockImplementation(() => scores[calls++]);
+    const state = buildState({ players: [AI, OPP] });
+    const score = await evaluateLookahead(state, AI, 2, {
+      type: "pass_priority",
+    });
+    // ourScore - (opponentScore * 0.5) / depth = 100 - (20 * 0.5) / 2 = 95
+    expect(score).toBe(95);
+  });
+});

--- a/src/ai/__tests__/ai-turn-loop.test.ts
+++ b/src/ai/__tests__/ai-turn-loop.test.ts
@@ -8,17 +8,198 @@
  * via AITurnConfig.
  */
 
-import { describe, it, expect } from "@jest/globals";
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 import {
   detectPlayerArchetype,
   detectOpponentArchetype,
+  runAITurn,
   type AITurnConfig,
 } from "../ai-turn-loop";
 import type { DeckCard } from "@/app/actions";
 import type {
   GameState as EngineGameState,
   CardInstance,
+  CardInstanceId,
+  PlayerId,
+  Turn,
 } from "@/lib/game-state/types";
+
+// ---------------------------------------------------------------------------
+// Issue #1092: runAITurn orchestration coverage.
+//
+// runAITurn sequences the AI's phases (untap -> upkeep -> draw -> main ->
+// combat -> main2 -> end -> cleanup) and is the single largest untested
+// branch cluster in the AI module. We exercise the REAL orchestration logic
+// while stubbing the rules-engine mutators and the combat decision tree so the
+// tests stay deterministic and fast. The real turn loop (phase ordering,
+// priority handling, action aggregation, termination) is the unit under test.
+// ---------------------------------------------------------------------------
+jest.mock("@/lib/game-state/mana");
+jest.mock("@/lib/game-state/spell-casting");
+jest.mock("@/lib/game-state/combat");
+jest.mock("@/lib/game-state/keyword-actions");
+jest.mock("@/lib/game-state/game-state");
+jest.mock("@/lib/game-state/turn-phases");
+jest.mock("@/lib/game-state/serialization");
+jest.mock("@/lib/game-rules");
+
+// `mock`-prefixed so the jest.mock factory may reference it (deferred read).
+let mockAttackPlan: { attacks: any[] } = { attacks: [] };
+jest.mock("../decision-making/combat-decision-tree", () => ({
+  CombatDecisionTree: jest.fn().mockImplementation(() => ({
+    generateAttackPlan: jest.fn(() => mockAttackPlan),
+  })),
+  deckArchetypeToOpponentArchetype: jest.fn(() => "midrange"),
+}));
+
+import { canPlayLand, playLand } from "@/lib/game-state/mana";
+import { canCastSpell, castSpell } from "@/lib/game-state/spell-casting";
+import { declareAttackers } from "@/lib/game-state/combat";
+import {
+  tapCardAction,
+  untapCardAction,
+  discardCards,
+} from "@/lib/game-state/keyword-actions";
+import { passPriority, drawCard } from "@/lib/game-state/game-state";
+import { advancePhase } from "@/lib/game-state/turn-phases";
+import { engineToAIState } from "@/lib/game-state/serialization";
+import { getMaxHandSize } from "@/lib/game-rules";
+
+const canPlayLandMock = canPlayLand as unknown as jest.Mock;
+const playLandMock = playLand as unknown as jest.Mock;
+const canCastSpellMock = canCastSpell as unknown as jest.Mock;
+const castSpellMock = castSpell as unknown as jest.Mock;
+const declareAttackersMock = declareAttackers as unknown as jest.Mock;
+const tapCardActionMock = tapCardAction as unknown as jest.Mock;
+const untapCardActionMock = untapCardAction as unknown as jest.Mock;
+const discardCardsMock = discardCards as unknown as jest.Mock;
+const passPriorityMock = passPriority as unknown as jest.Mock;
+const drawCardMock = drawCard as unknown as jest.Mock;
+const advancePhaseMock = advancePhase as unknown as jest.Mock;
+const engineToAIStateMock = engineToAIState as unknown as jest.Mock;
+const getMaxHandSizeMock = getMaxHandSize as unknown as jest.Mock;
+
+const AI: PlayerId = "player1";
+const OPP: PlayerId = "player2";
+
+function mkTurnCard(
+  id: CardInstanceId,
+  typeLine: string,
+  extra: Partial<CardInstance> = {},
+): CardInstance {
+  return {
+    id,
+    oracleId: id,
+    cardData: {
+      name: id,
+      type_line: typeLine,
+      cmc: 1,
+      mana_cost: "{1}",
+    } as any,
+    currentFaceIndex: 0,
+    isFaceDown: false,
+    controllerId: AI,
+    ownerId: AI,
+    isTapped: false,
+    isFlipped: false,
+    isTurnedFaceUp: false,
+    isPhasedOut: false,
+    hasSummoningSickness: false,
+    ...extra,
+  } as unknown as CardInstance;
+}
+
+function buildTurnState(opts: {
+  hand?: CardInstanceId[];
+  battlefield?: CardInstanceId[];
+  cards?: CardInstance[];
+  combatAttackers?: any[];
+}): EngineGameState {
+  const cards = new Map<string, CardInstance>();
+  for (const c of opts.cards ?? []) cards.set(c.id, c);
+
+  const zones = new Map<string, { cardIds: CardInstanceId[] }>();
+  zones.set(`${AI}-hand`, { cardIds: opts.hand ?? [] });
+  zones.set(`${AI}-battlefield`, { cardIds: opts.battlefield ?? [] });
+  zones.set(`${AI}-library`, { cardIds: [] });
+  zones.set(`${OPP}-battlefield`, { cardIds: [] }); // empty -> opponent 'unknown'
+
+  const players = new Map<PlayerId, unknown>();
+  players.set(AI, { id: AI });
+  players.set(OPP, { id: OPP });
+
+  const turn: Turn = {
+    activePlayerId: AI,
+    currentPhase: "untap" as any,
+    turnNumber: 3,
+    extraTurns: 0,
+    isFirstTurn: false,
+    startedAt: 0,
+  };
+
+  return {
+    cards,
+    zones,
+    players,
+    turn,
+    combat: {
+      inCombatPhase: false,
+      attackers: opts.combatAttackers ?? [],
+      blockers: new Map(),
+      remainingCombatPhases: 0,
+    } as any,
+    priorityPlayerId: AI,
+  } as unknown as EngineGameState;
+}
+
+/** Default config; delayMs:0 keeps real-timer tests fast (only upkeep's 500ms). */
+function baseConfig(overrides: Partial<AITurnConfig> = {}): AITurnConfig {
+  return {
+    difficulty: "medium",
+    delayMs: 0,
+    archetype: "midrange",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Engine stubs: succeed and echo the state so zones/cards persist across
+  // phases (the turn loop advances currentState from each phase's newState).
+  canPlayLandMock.mockReturnValue(true);
+  playLandMock.mockImplementation((state: any) => ({ success: true, state }));
+  canCastSpellMock.mockReturnValue({ canCast: true });
+  castSpellMock.mockImplementation((state: any) => ({ success: true, state }));
+  declareAttackersMock.mockImplementation((state: any) => ({
+    success: true,
+    state,
+    description: "",
+  }));
+  tapCardActionMock.mockImplementation((state: any) => ({
+    success: true,
+    state,
+    description: "",
+  }));
+  untapCardActionMock.mockImplementation((state: any) => ({
+    success: true,
+    state,
+    description: "",
+  }));
+  passPriorityMock.mockImplementation((state: any) => state);
+  drawCardMock.mockImplementation((state: any) => state);
+  discardCardsMock.mockImplementation((state: any) => ({
+    success: true,
+    state,
+    description: "",
+  }));
+  advancePhaseMock.mockImplementation((turn: any) => ({
+    ...turn,
+    currentPhase: "next",
+  }));
+  engineToAIStateMock.mockReturnValue({});
+  getMaxHandSizeMock.mockReturnValue(7);
+  mockAttackPlan = { attacks: [] };
+});
 
 function createCard(
   name: string,
@@ -326,5 +507,338 @@ describe("detectOpponentArchetype (issue #912 — live opponent detection)", () 
       battlefield: burnCards.slice(2),
     });
     expect(detectOpponentArchetype(midGameState, "player2")).toBe("aggro");
+  });
+});
+
+// ===========================================================================
+// runAITurn — full turn orchestration (issue #1092)
+// ===========================================================================
+describe("runAITurn — phase progression & termination", () => {
+  it("runs a full turn, advancing priority and terminating at cleanup", async () => {
+    const state = buildTurnState({ hand: [], battlefield: [] });
+    const result = await runAITurn(state, AI, baseConfig());
+
+    expect(result.success).toBe(true);
+    expect(result.phase).toBe("complete");
+    expect(result.finalState).toBeDefined();
+    // Priority was set to the AI player through every phase advance.
+    expect(advancePhaseMock).toHaveBeenCalled();
+    // A turn always terminates by passing priority in the end phase.
+    expect(passPriorityMock).toHaveBeenCalledWith(expect.anything(), AI);
+    expect(result.actionsTaken.some((a) => a.type === "pass_priority")).toBe(
+      true,
+    );
+  });
+
+  it("untaps every tapped permanent during the untap phase", async () => {
+    const tapped1 = mkTurnCard("t1", "Creature", { isTapped: true });
+    const tapped2 = mkTurnCard("t2", "Land", { isTapped: true });
+    const ready = mkTurnCard("r1", "Creature", { isTapped: false });
+    const state = buildTurnState({
+      hand: [],
+      battlefield: ["t1", "t2", "r1"],
+      cards: [tapped1, tapped2, ready],
+    });
+
+    const result = await runAITurn(state, AI, baseConfig());
+
+    const untaps = result.actionsTaken.filter((a) => a.type === "untap_card");
+    expect(untaps.map((a) => a.cardId).sort()).toEqual(["t1", "t2"]);
+    // The ready permanent is NOT untapped.
+    expect(untaps.find((a) => a.cardId === "r1")).toBeUndefined();
+    // untap_card is dispatched through the action executor -> keyword action.
+    expect(untapCardActionMock).toHaveBeenCalledWith(expect.anything(), "t1");
+    expect(untapCardActionMock).toHaveBeenCalledWith(expect.anything(), "t2");
+  });
+
+  it("draws a card during the draw phase and emits commentary", async () => {
+    const state = buildTurnState({ hand: [], battlefield: [] });
+    const commentary: string[] = [];
+    const result = await runAITurn(
+      state,
+      AI,
+      baseConfig({ onCommentary: (t) => commentary.push(t) }),
+    );
+
+    expect(drawCardMock).toHaveBeenCalledWith(expect.anything(), AI);
+    expect(commentary).toContain("Draws a card");
+    // The draw is recorded as a no-op action (the engine drew the card).
+    expect(
+      result.actionsTaken.some(
+        (a) => a.type === "no_action" && /Drew card/.test(a.reasoning ?? ""),
+      ),
+    ).toBe(true);
+  });
+
+  it("passes priority at end of turn and signals turn end", async () => {
+    const state = buildTurnState({ hand: [], battlefield: [] });
+    const commentary: string[] = [];
+    await runAITurn(
+      state,
+      AI,
+      baseConfig({ onCommentary: (t) => commentary.push(t) }),
+    );
+
+    expect(commentary).toContain("Ends turn");
+  });
+});
+
+// ===========================================================================
+// runAITurn — main phase: land + spell casting
+// ===========================================================================
+describe("runAITurn — main phase casting", () => {
+  it("plays a land from hand during the main phase", async () => {
+    const forest = mkTurnCard("forest", "Land");
+    const state = buildTurnState({
+      hand: ["forest"],
+      battlefield: [],
+      cards: [forest],
+    });
+    const commentary: string[] = [];
+    const result = await runAITurn(
+      state,
+      AI,
+      baseConfig({ onCommentary: (t) => commentary.push(t) }),
+    );
+
+    expect(playLandMock).toHaveBeenCalledWith(expect.anything(), AI, "forest");
+    expect(
+      result.actionsTaken.some(
+        (a) => a.type === "play_land" && a.cardId === "forest",
+      ),
+    ).toBe(true);
+    expect(commentary).toContain("Plays forest");
+  });
+
+  it("casts creatures and other spells from hand (medium difficulty)", async () => {
+    const bear = mkTurnCard("bear", "Creature", {
+      cardData: { name: "bear", type_line: "Creature", cmc: 2 } as any,
+    });
+    const bolt = mkTurnCard("bolt", "Instant", {
+      cardData: { name: "bolt", type_line: "Instant", cmc: 1 } as any,
+    });
+    const state = buildTurnState({
+      hand: ["bear", "bolt"],
+      battlefield: [],
+      cards: [bear, bolt],
+    });
+
+    // castCreatures skips a creature when Math.random() < randomnessFactor*0.3.
+    // A high roll never skips for any difficulty (max threshold is easy's 0.12).
+    const spy = jest.spyOn(Math, "random").mockReturnValue(0.9);
+    try {
+      const result = await runAITurn(state, AI, baseConfig());
+      expect(
+        result.actionsTaken.some(
+          (a) => a.type === "cast_spell" && a.cardId === "bear",
+        ),
+      ).toBe(true);
+      expect(
+        result.actionsTaken.some(
+          (a) => a.type === "cast_spell" && a.cardId === "bolt",
+        ),
+      ).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("handles an empty hand by taking no main-phase actions", async () => {
+    const state = buildTurnState({ hand: [], battlefield: [] });
+    const result = await runAITurn(state, AI, baseConfig());
+    const mainActions = result.actionsTaken.filter(
+      (a) => a.type === "play_land" || a.type === "cast_spell",
+    );
+    expect(mainActions).toEqual([]);
+    // Turn still completes successfully.
+    expect(result.success).toBe(true);
+  });
+});
+
+// ===========================================================================
+// runAITurn — difficulty-gated behavior (issue #1016 follow-up)
+// ===========================================================================
+describe("runAITurn — difficulty gates creature casting", () => {
+  // castCreatures skips a creature when Math.random() < randomnessFactor*0.3.
+  // With a fixed roll of 0.05 the thresholds differ by difficulty:
+  //   expert: 0.05*0.3 = 0.015  -> 0.05 < 0.015 is FALSE -> casts
+  //   easy:   0.40*0.3 = 0.120  -> 0.05 < 0.120 is TRUE  -> skips
+  const creatureState = () => {
+    const bear = mkTurnCard("bear", "Creature", {
+      cardData: { name: "bear", type_line: "Creature", cmc: 2 } as any,
+    });
+    return buildTurnState({ hand: ["bear"], battlefield: [], cards: [bear] });
+  };
+
+  it("expert difficulty casts the creature (roll under threshold)", async () => {
+    const spy = jest.spyOn(Math, "random").mockReturnValue(0.05);
+    try {
+      const result = await runAITurn(
+        creatureState(),
+        AI,
+        baseConfig({ difficulty: "expert" }),
+      );
+      const casts = result.actionsTaken.filter(
+        (a) => a.type === "cast_spell" && a.cardId === "bear",
+      );
+      expect(casts.length).toBeGreaterThan(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("easy difficulty skips the same creature on the identical roll", async () => {
+    const spy = jest.spyOn(Math, "random").mockReturnValue(0.05);
+    try {
+      const result = await runAITurn(
+        creatureState(),
+        AI,
+        baseConfig({ difficulty: "easy" }),
+      );
+      const casts = result.actionsTaken.filter(
+        (a) => a.type === "cast_spell" && a.cardId === "bear",
+      );
+      expect(casts).toEqual([]);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+// ===========================================================================
+// runAITurn — combat phase
+// ===========================================================================
+describe("runAITurn — combat phase", () => {
+  it("executes the combat decision tree's attack plan", async () => {
+    const bear = mkTurnCard("bear", "Creature");
+    const state = buildTurnState({
+      hand: [],
+      battlefield: ["bear"],
+      cards: [bear],
+    });
+    mockAttackPlan = {
+      attacks: [
+        {
+          shouldAttack: true,
+          creatureId: "bear",
+          target: OPP,
+          reasoning: "go face",
+        },
+      ],
+    };
+
+    const result = await runAITurn(state, AI, baseConfig());
+
+    expect(declareAttackersMock).toHaveBeenCalled();
+    const attacks = result.actionsTaken.filter((a) => a.type === "attack");
+    expect(attacks.some((a) => a.cardId === "bear")).toBe(true);
+  });
+
+  it("skips attacks the decision tree declines (shouldAttack/target none)", async () => {
+    const bear = mkTurnCard("bear", "Creature");
+    const state = buildTurnState({
+      hand: [],
+      battlefield: ["bear"],
+      cards: [bear],
+    });
+    mockAttackPlan = {
+      attacks: [
+        { shouldAttack: false, creatureId: "bear", target: OPP, reasoning: "" },
+        {
+          shouldAttack: true,
+          creatureId: "bear",
+          target: "none",
+          reasoning: "",
+        },
+      ],
+    };
+
+    const result = await runAITurn(state, AI, baseConfig());
+    expect(result.actionsTaken.filter((a) => a.type === "attack")).toEqual([]);
+    expect(declareAttackersMock).not.toHaveBeenCalled();
+  });
+
+  it("produces no attack actions when there are no attackers", async () => {
+    const state = buildTurnState({ hand: [], battlefield: [] });
+    mockAttackPlan = { attacks: [] };
+    const result = await runAITurn(state, AI, baseConfig());
+    expect(result.actionsTaken.filter((a) => a.type === "attack")).toEqual([]);
+  });
+});
+
+// ===========================================================================
+// runAITurn — cleanup phase (discard to max hand size)
+// ===========================================================================
+describe("runAITurn — cleanup phase", () => {
+  it("discards down to the max hand size when over the limit", async () => {
+    const hand = Array.from({ length: 9 }, (_, i) => `c${i}`);
+    const cards = hand.map((id) => mkTurnCard(id, "Instant"));
+    const state = buildTurnState({
+      hand,
+      battlefield: [],
+      cards,
+    });
+    getMaxHandSizeMock.mockReturnValue(7);
+
+    const commentary: string[] = [];
+    const result = await runAITurn(
+      state,
+      AI,
+      baseConfig({ onCommentary: (t) => commentary.push(t) }),
+    );
+
+    expect(discardCardsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      AI,
+      2,
+      true,
+    );
+    expect(
+      result.actionsTaken.some(
+        (a) =>
+          a.type === "no_action" && /Discarded 2 cards/.test(a.reasoning ?? ""),
+      ),
+    ).toBe(true);
+    expect(commentary.some((m) => /Discards 2 cards/.test(m))).toBe(true);
+  });
+
+  it("does not discard when at or below the max hand size", async () => {
+    const hand = ["a", "b"];
+    const cards = [mkTurnCard("a", "Instant"), mkTurnCard("b", "Instant")];
+    const state = buildTurnState({ hand, battlefield: [], cards });
+
+    await runAITurn(state, AI, baseConfig());
+    expect(discardCardsMock).not.toHaveBeenCalled();
+  });
+});
+
+// ===========================================================================
+// runAITurn — error handling (no legal actions / engine failure)
+// ===========================================================================
+describe("runAITurn — error & edge handling", () => {
+  it("returns a failure result when an engine call throws", async () => {
+    drawCardMock.mockImplementation(() => {
+      throw new Error("library empty");
+    });
+    const state = buildTurnState({ hand: [], battlefield: [] });
+
+    const result = await runAITurn(state, AI, baseConfig());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("library empty");
+    expect(result.finalState).toBeDefined();
+    // Some actions may have been taken before the failure.
+    expect(Array.isArray(result.actionsTaken)).toBe(true);
+  });
+
+  it("wraps a non-Error throw into a generic error message", async () => {
+    drawCardMock.mockImplementation(() => {
+      throw "kaboom";
+    });
+    const state = buildTurnState({ hand: [], battlefield: [] });
+
+    const result = await runAITurn(state, AI, baseConfig());
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Unknown error");
   });
 });

--- a/src/ai/ai-action-executor.ts
+++ b/src/ai/ai-action-executor.ts
@@ -8,29 +8,30 @@
  * conversion functions to work with the engine's GameState format.
  */
 
-import type { 
-  GameState as EngineGameState, 
-  PlayerId, 
+import type {
+  GameState as EngineGameState,
+  PlayerId,
   CardInstanceId,
   AIGameState,
-} from '@/lib/game-state/types';
-import { engineToAIState } from '@/lib/game-state/serialization';
-import type { AvailableResponse } from '@/ai/stack-interaction-ai';
-import { 
-  playLand as enginePlayLand, 
-  canPlayLand as engineCanPlayLand 
-} from '@/lib/game-state/mana';
-import { 
-  castSpell as engineCastSpell, 
-  canCastSpell as engineCanCastSpell 
-} from '@/lib/game-state/spell-casting';
-import { 
-  declareAttackers as engineDeclareAttackers 
-} from '@/lib/game-state/combat';
-import { tapCardAction, untapCardAction } from '@/lib/game-state/keyword-actions';
-import { passPriority } from '@/lib/game-state/game-state';
-import { quickScore } from './game-state-evaluator';
-import type { GameState } from './game-state-evaluator';
+} from "@/lib/game-state/types";
+import { engineToAIState } from "@/lib/game-state/serialization";
+import type { AvailableResponse } from "@/ai/stack-interaction-ai";
+import {
+  playLand as enginePlayLand,
+  canPlayLand as engineCanPlayLand,
+} from "@/lib/game-state/mana";
+import {
+  castSpell as engineCastSpell,
+  canCastSpell as engineCanCastSpell,
+} from "@/lib/game-state/spell-casting";
+import { declareAttackers as engineDeclareAttackers } from "@/lib/game-state/combat";
+import {
+  tapCardAction,
+  untapCardAction,
+} from "@/lib/game-state/keyword-actions";
+import { passPriority } from "@/lib/game-state/game-state";
+import { quickScore } from "./game-state-evaluator";
+import type { GameState } from "./game-state-evaluator";
 
 /**
  * AI Action types
@@ -51,17 +52,17 @@ export interface AIAction {
   mode?: string;
 }
 
-export type AIActionType = 
-  | 'play_land'
-  | 'cast_spell'
-  | 'attack'
-  | 'block'
-  | 'tap_card'
-  | 'untap_card'
-  | 'activate_ability'
-  | 'pass_priority'
-  | 'respond_to_stack'
-  | 'no_action';
+export type AIActionType =
+  | "play_land"
+  | "cast_spell"
+  | "attack"
+  | "block"
+  | "tap_card"
+  | "untap_card"
+  | "activate_ability"
+  | "pass_priority"
+  | "respond_to_stack"
+  | "no_action";
 
 /**
  * Result of executing an AI action
@@ -79,53 +80,63 @@ export interface AIActionResult {
 export async function executeAIAction(
   gameState: EngineGameState,
   action: AIAction,
-  aiPlayerId: PlayerId
+  aiPlayerId: PlayerId,
 ): Promise<AIActionResult> {
   try {
     switch (action.type) {
-      case 'play_land':
+      case "play_land":
         return executePlayLand(gameState, aiPlayerId, action.cardId!);
-      
-      case 'cast_spell':
+
+      case "cast_spell":
         return executeCastSpell(
-          gameState, 
-          aiPlayerId, 
-          action.cardId!, 
+          gameState,
+          aiPlayerId,
+          action.cardId!,
           action.targetIds || action.targetId,
           action.mode ? [action.mode] : [],
-          action.xValue || 0
+          action.xValue || 0,
         );
-      
-      case 'attack':
-        return executeAttack(gameState, aiPlayerId, action.cardId!, action.targetId);
-      
-      case 'block':
-        return executeBlock(gameState, aiPlayerId, action.cardId!, action.targetId!);
-      
-      case 'tap_card':
+
+      case "attack":
+        return executeAttack(
+          gameState,
+          aiPlayerId,
+          action.cardId!,
+          action.targetId,
+        );
+
+      case "block":
+        return executeBlock(
+          gameState,
+          aiPlayerId,
+          action.cardId!,
+          action.targetId!,
+        );
+
+      case "tap_card":
         return executeTapCard(gameState, action.cardId!);
-      
-      case 'untap_card':
+
+      case "untap_card":
         return executeUntapCard(gameState, action.cardId!);
-      
-      case 'pass_priority':
+
+      case "pass_priority":
         return executePassPriority(gameState, aiPlayerId);
-      
-      case 'no_action':
+
+      case "no_action":
         return { success: true, newState: gameState, action };
-      
+
       default:
-        return { 
-          success: false, 
+        return {
+          success: false,
           error: `Unknown action type: ${(action as any).type}`,
-          action 
+          action,
         };
     }
   } catch (error) {
-    return { 
-      success: false, 
-      error: error instanceof Error ? error.message : 'Unknown error',
-      action 
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+      action,
     };
   }
 }
@@ -136,30 +147,30 @@ export async function executeAIAction(
 function executePlayLand(
   gameState: EngineGameState,
   playerId: PlayerId,
-  cardId: CardInstanceId
+  cardId: CardInstanceId,
 ): AIActionResult {
   if (!engineCanPlayLand(gameState, playerId)) {
-    return { 
-      success: false, 
-      error: 'Cannot play land (already played or no priority)',
-      action: { type: 'play_land', cardId }
+    return {
+      success: false,
+      error: "Cannot play land (already played or no priority)",
+      action: { type: "play_land", cardId },
     };
   }
 
   const result = enginePlayLand(gameState, playerId, cardId);
-  
+
   if (result.success) {
-    return { 
-      success: true, 
+    return {
+      success: true,
       newState: result.state,
-      action: { type: 'play_land', cardId }
+      action: { type: "play_land", cardId },
     };
   }
 
-  return { 
-    success: false, 
-    error: result.error || 'Failed to play land',
-    action: { type: 'play_land', cardId }
+  return {
+    success: false,
+    error: result.error || "Failed to play land",
+    action: { type: "play_land", cardId },
   };
 }
 
@@ -173,44 +184,63 @@ function executeCastSpell(
   cardId: CardInstanceId,
   targetIdOrIds?: string | PlayerId | string[],
   chosenModes: string[] = [],
-  xValue: number = 0
+  xValue: number = 0,
 ): AIActionResult {
+  // canCastSpell returns { canCast: boolean; reason?: string } — guard on the
+  // boolean field, not the object (which is always truthy). Previously this
+  // checked `!canCast`, a dead branch that never short-circuited, so the AI
+  // always proceeded to castSpell even when it lacked mana/priority. (#1092)
   const canCast = engineCanCastSpell(gameState, playerId, cardId);
-  
-  if (!canCast) {
-    return { 
-      success: false, 
-      error: 'Cannot cast spell (no mana or no priority)',
-      action: { type: 'cast_spell', cardId, targetId: targetIdOrIds as string }
+
+  if (!canCast.canCast) {
+    return {
+      success: false,
+      error: "Cannot cast spell (no mana or no priority)",
+      action: { type: "cast_spell", cardId, targetId: targetIdOrIds as string },
     };
   }
 
   // Handle multi-target: array of targetIds
   let targets;
   if (Array.isArray(targetIdOrIds)) {
-    targets = targetIdOrIds.map((tid) => ({ 
-      type: 'card' as const, 
-      targetId: tid, 
-      isValid: true 
+    targets = targetIdOrIds.map((tid) => ({
+      type: "card" as const,
+      targetId: tid,
+      isValid: true,
     }));
   } else if (targetIdOrIds) {
-    targets = [{ type: 'card' as const, targetId: targetIdOrIds, isValid: true }];
+    targets = [
+      { type: "card" as const, targetId: targetIdOrIds, isValid: true },
+    ];
   }
 
-  const result = engineCastSpell(gameState, playerId, cardId, targets, chosenModes, xValue);
-  
+  const result = engineCastSpell(
+    gameState,
+    playerId,
+    cardId,
+    targets,
+    chosenModes,
+    xValue,
+  );
+
   if (result.success) {
-    return { 
-      success: true, 
+    return {
+      success: true,
       newState: result.state,
-      action: { type: 'cast_spell', cardId, targetId: targetIdOrIds as string, mode: chosenModes[0], xValue }
+      action: {
+        type: "cast_spell",
+        cardId,
+        targetId: targetIdOrIds as string,
+        mode: chosenModes[0],
+        xValue,
+      },
     };
   }
 
-  return { 
-    success: false, 
-    error: result.error || 'Failed to cast spell',
-    action: { type: 'cast_spell', cardId, targetId: targetIdOrIds as string }
+  return {
+    success: false,
+    error: result.error || "Failed to cast spell",
+    action: { type: "cast_spell", cardId, targetId: targetIdOrIds as string },
   };
 }
 
@@ -221,27 +251,27 @@ function executeAttack(
   gameState: EngineGameState,
   playerId: PlayerId,
   cardId: CardInstanceId,
-  defenderId?: string | PlayerId
+  defenderId?: string | PlayerId,
 ): AIActionResult {
   // Get current attackers from combat state
   const currentAttackers = gameState.combat.attackers || [];
-  
+
   // Find the creature
   const creature = gameState.cards.get(cardId);
   if (!creature) {
-    return { 
-      success: false, 
-      error: 'Creature not found',
-      action: { type: 'attack', cardId, targetId: defenderId }
+    return {
+      success: false,
+      error: "Creature not found",
+      action: { type: "attack", cardId, targetId: defenderId },
     };
   }
 
   // Check if creature can attack
   if (creature.isTapped || creature.hasSummoningSickness) {
-    return { 
-      success: false, 
-      error: 'Creature cannot attack (tapped or summoning sickness)',
-      action: { type: 'attack', cardId, targetId: defenderId }
+    return {
+      success: false,
+      error: "Creature cannot attack (tapped or summoning sickness)",
+      action: { type: "attack", cardId, targetId: defenderId },
     };
   }
 
@@ -250,27 +280,31 @@ function executeAttack(
     cardId,
     defenderId: defenderId || getOpponentPlayerId(gameState, playerId),
     isAttackingPlaneswalker: false,
-    damageToDeal: creature.cardData.power ? parseInt(creature.cardData.power) || 0 : 0,
-    hasFirstStrike: creature.cardData.keywords?.includes('first_strike') || false,
-    hasDoubleStrike: creature.cardData.keywords?.includes('double_strike') || false,
+    damageToDeal: creature.cardData.power
+      ? parseInt(creature.cardData.power) || 0
+      : 0,
+    hasFirstStrike:
+      creature.cardData.keywords?.includes("first_strike") || false,
+    hasDoubleStrike:
+      creature.cardData.keywords?.includes("double_strike") || false,
   };
 
   const updatedAttackers = [...currentAttackers, newAttacker];
-  
+
   const result = engineDeclareAttackers(gameState, updatedAttackers);
-  
+
   if (result.success) {
-    return { 
-      success: true, 
+    return {
+      success: true,
       newState: result.state,
-      action: { type: 'attack', cardId, targetId: defenderId }
+      action: { type: "attack", cardId, targetId: defenderId },
     };
   }
 
-  return { 
-    success: false, 
-    error: result.errors?.join(', ') || 'Failed to declare attackers',
-    action: { type: 'attack', cardId, targetId: defenderId }
+  return {
+    success: false,
+    error: result.errors?.join(", ") || "Failed to declare attackers",
+    action: { type: "attack", cardId, targetId: defenderId },
   };
 }
 
@@ -281,27 +315,27 @@ function executeBlock(
   gameState: EngineGameState,
   playerId: PlayerId,
   blockerId: CardInstanceId,
-  attackerId: string
+  attackerId: string,
 ): AIActionResult {
   // Get current blockers
   const currentBlockers = gameState.combat.blockers || new Map();
-  
+
   // Find the creature
   const creature = gameState.cards.get(blockerId);
   if (!creature) {
-    return { 
-      success: false, 
-      error: 'Creature not found',
-      action: { type: 'block', cardId: blockerId, targetId: attackerId }
+    return {
+      success: false,
+      error: "Creature not found",
+      action: { type: "block", cardId: blockerId, targetId: attackerId },
     };
   }
 
   // Check if creature can block
   if (creature.isTapped) {
-    return { 
-      success: false, 
-      error: 'Creature cannot block (tapped)',
-      action: { type: 'block', cardId: blockerId, targetId: attackerId }
+    return {
+      success: false,
+      error: "Creature cannot block (tapped)",
+      action: { type: "block", cardId: blockerId, targetId: attackerId },
     };
   }
 
@@ -310,21 +344,25 @@ function executeBlock(
   const newBlocker = {
     cardId: blockerId,
     attackerId,
-    damageToDeal: creature.cardData.toughness ? parseInt(creature.cardData.toughness) || 0 : 0,
+    damageToDeal: creature.cardData.toughness
+      ? parseInt(creature.cardData.toughness) || 0
+      : 0,
     blockerOrder: existingBlockers.length,
-    hasFirstStrike: creature.cardData.keywords?.includes('first_strike') || false,
-    hasDoubleStrike: creature.cardData.keywords?.includes('double_strike') || false,
+    hasFirstStrike:
+      creature.cardData.keywords?.includes("first_strike") || false,
+    hasDoubleStrike:
+      creature.cardData.keywords?.includes("double_strike") || false,
   };
 
   const updatedBlockers = new Map(currentBlockers);
   updatedBlockers.set(attackerId, [...existingBlockers, newBlocker]);
-  
+
   // Note: The actual blocking would need to be implemented in the combat module
   // For now, return success with the current state
-  return { 
-    success: true, 
+  return {
+    success: true,
     newState: gameState,
-    action: { type: 'block', cardId: blockerId, targetId: attackerId }
+    action: { type: "block", cardId: blockerId, targetId: attackerId },
   };
 }
 
@@ -333,22 +371,22 @@ function executeBlock(
  */
 function executeTapCard(
   gameState: EngineGameState,
-  cardId: CardInstanceId
+  cardId: CardInstanceId,
 ): AIActionResult {
   const result = tapCardAction(gameState, cardId);
-  
+
   if (result.success) {
-    return { 
-      success: true, 
+    return {
+      success: true,
       newState: result.state,
-      action: { type: 'tap_card', cardId }
+      action: { type: "tap_card", cardId },
     };
   }
 
-  return { 
-    success: false, 
-    error: result.error || 'Failed to tap card',
-    action: { type: 'tap_card', cardId }
+  return {
+    success: false,
+    error: result.error || "Failed to tap card",
+    action: { type: "tap_card", cardId },
   };
 }
 
@@ -357,22 +395,22 @@ function executeTapCard(
  */
 function executeUntapCard(
   gameState: EngineGameState,
-  cardId: CardInstanceId
+  cardId: CardInstanceId,
 ): AIActionResult {
   const result = untapCardAction(gameState, cardId);
-  
+
   if (result.success) {
-    return { 
-      success: true, 
+    return {
+      success: true,
       newState: result.state,
-      action: { type: 'untap_card', cardId }
+      action: { type: "untap_card", cardId },
     };
   }
 
-  return { 
-    success: false, 
-    error: result.error || 'Failed to untap card',
-    action: { type: 'untap_card', cardId }
+  return {
+    success: false,
+    error: result.error || "Failed to untap card",
+    action: { type: "untap_card", cardId },
   };
 }
 
@@ -381,23 +419,26 @@ function executeUntapCard(
  */
 function executePassPriority(
   gameState: EngineGameState,
-  playerId: PlayerId
+  playerId: PlayerId,
 ): AIActionResult {
   const newState = passPriority(gameState, playerId);
-  
-  return { 
-    success: true, 
+
+  return {
+    success: true,
     newState,
-    action: { type: 'pass_priority' }
+    action: { type: "pass_priority" },
   };
 }
 
 /**
  * Get opponent player ID (for 1v1)
  */
-function getOpponentPlayerId(gameState: EngineGameState, playerId: PlayerId): PlayerId {
+function getOpponentPlayerId(
+  gameState: EngineGameState,
+  playerId: PlayerId,
+): PlayerId {
   const playerIds = Array.from(gameState.players.keys());
-  return playerIds.find(id => id !== playerId) || playerId;
+  return playerIds.find((id) => id !== playerId) || playerId;
 }
 
 /**
@@ -405,16 +446,16 @@ function getOpponentPlayerId(gameState: EngineGameState, playerId: PlayerId): Pl
  */
 export function getAvailableLands(
   gameState: EngineGameState,
-  playerId: PlayerId
+  playerId: PlayerId,
 ): CardInstanceId[] {
   const handZone = gameState.zones.get(`${playerId}-hand`);
   if (!handZone) return [];
 
   const lands: CardInstanceId[] = [];
-  
+
   for (const cardId of handZone.cardIds) {
     const card = gameState.cards.get(cardId);
-    if (card && card.cardData.type_line.toLowerCase().includes('land')) {
+    if (card && card.cardData.type_line.toLowerCase().includes("land")) {
       lands.push(cardId);
     }
   }
@@ -427,19 +468,21 @@ export function getAvailableLands(
  */
 export function getAvailableAttackers(
   gameState: EngineGameState,
-  playerId: PlayerId
+  playerId: PlayerId,
 ): CardInstanceId[] {
   const battlefield = gameState.zones.get(`${playerId}-battlefield`);
   if (!battlefield) return [];
 
   const attackers: CardInstanceId[] = [];
-  
+
   for (const cardId of battlefield.cardIds) {
     const card = gameState.cards.get(cardId);
-    if (card && 
-        card.cardData.type_line.toLowerCase().includes('creature') &&
-        !card.isTapped &&
-        !card.hasSummoningSickness) {
+    if (
+      card &&
+      card.cardData.type_line.toLowerCase().includes("creature") &&
+      !card.isTapped &&
+      !card.hasSummoningSickness
+    ) {
       attackers.push(cardId);
     }
   }
@@ -452,18 +495,20 @@ export function getAvailableAttackers(
  */
 export function getAvailableBlockers(
   gameState: EngineGameState,
-  playerId: PlayerId
+  playerId: PlayerId,
 ): CardInstanceId[] {
   const battlefield = gameState.zones.get(`${playerId}-battlefield`);
   if (!battlefield) return [];
 
   const blockers: CardInstanceId[] = [];
-  
+
   for (const cardId of battlefield.cardIds) {
     const card = gameState.cards.get(cardId);
-    if (card && 
-        card.cardData.type_line.toLowerCase().includes('creature') &&
-        !card.isTapped) {
+    if (
+      card &&
+      card.cardData.type_line.toLowerCase().includes("creature") &&
+      !card.isTapped
+    ) {
       blockers.push(cardId);
     }
   }
@@ -476,31 +521,32 @@ export function getAvailableBlockers(
  */
 export function getAvailableResponses(
   gameState: EngineGameState,
-  playerId: PlayerId
+  playerId: PlayerId,
 ): AvailableResponse[] {
   const handZone = gameState.zones.get(`${playerId}-hand`);
   if (!handZone) return [];
 
   const responses: AvailableResponse[] = [];
-  
+
   for (const cardId of handZone.cardIds) {
     const card = gameState.cards.get(cardId);
     if (!card) continue;
 
-    const isInstant = card.cardData.type_line.toLowerCase().includes('instant');
-    const hasFlash = card.cardData.keywords?.includes('flash');
-    
+    const isInstant = card.cardData.type_line.toLowerCase().includes("instant");
+    const hasFlash = card.cardData.keywords?.includes("flash");
+
     if (isInstant || hasFlash) {
       responses.push({
         cardId,
         name: card.cardData.name,
-        type: isInstant ? 'instant' : 'flash',
+        type: isInstant ? "instant" : "flash",
         manaValue: card.cardData.cmc,
-        manaCost: parseManaCost(card.cardData.mana_cost || ''),
-        canCounter: card.cardData.oracle_text?.toLowerCase().includes('counter') || false,
+        manaCost: parseManaCost(card.cardData.mana_cost || ""),
+        canCounter:
+          card.cardData.oracle_text?.toLowerCase().includes("counter") || false,
         canTarget: [],
         effect: {
-          type: 'other',
+          type: "other",
           value: 5,
           targets: [],
         },
@@ -516,7 +562,7 @@ export function getAvailableResponses(
  */
 function parseManaCost(manaCost: string): { [color: string]: number } {
   const result: { [color: string]: number } = {};
-  
+
   // Simple parsing - count each color symbol
   const colorMatches = manaCost.matchAll(/[{]([WUBRG])(\d*)[}]/g);
   for (const match of colorMatches) {
@@ -524,11 +570,11 @@ function parseManaCost(manaCost: string): { [color: string]: number } {
     const count = match[2] ? parseInt(match[2]) : 1;
     result[color] = (result[color] || 0) + count;
   }
-  
+
   // Count generic mana
   const genericMatches = manaCost.matchAll(/[{](\d+)[}]/g);
   for (const match of genericMatches) {
-    result['generic'] = (result['generic'] || 0) + parseInt(match[1]);
+    result["generic"] = (result["generic"] || 0) + parseInt(match[1]);
   }
 
   return result;
@@ -545,42 +591,52 @@ export function getAIGameState(engineState: EngineGameState): AIGameState {
 /**
  * Get available lands from player's hand (using AI format)
  */
-export function getAvailableLandsAI(aiState: AIGameState, playerId: PlayerId): string[] {
+export function getAvailableLandsAI(
+  aiState: AIGameState,
+  playerId: PlayerId,
+): string[] {
   const player = aiState.players[playerId];
   if (!player) return [];
-  
+
   return player.hand
-    .filter(card => card.type.toLowerCase().includes('land'))
-    .map(card => card.cardInstanceId);
+    .filter((card) => card.type.toLowerCase().includes("land"))
+    .map((card) => card.cardInstanceId);
 }
 
 /**
  * Get available creatures for attacking (using AI format)
  */
-export function getAvailableAttackersAI(aiState: AIGameState, playerId: PlayerId): string[] {
+export function getAvailableAttackersAI(
+  aiState: AIGameState,
+  playerId: PlayerId,
+): string[] {
   const player = aiState.players[playerId];
   if (!player) return [];
-  
+
   return player.battlefield
-    .filter(perm => 
-      perm.type === 'creature' && 
-      !perm.tapped && 
-      !perm.summoningSickness &&
-      (perm.power || 0) > 0
+    .filter(
+      (perm) =>
+        perm.type === "creature" &&
+        !perm.tapped &&
+        !perm.summoningSickness &&
+        (perm.power || 0) > 0,
     )
-    .map(perm => perm.cardInstanceId);
+    .map((perm) => perm.cardInstanceId);
 }
 
 /**
  * Get available creatures for blocking (using AI format)
  */
-export function getAvailableBlockersAI(aiState: AIGameState, playerId: PlayerId): string[] {
+export function getAvailableBlockersAI(
+  aiState: AIGameState,
+  playerId: PlayerId,
+): string[] {
   const player = aiState.players[playerId];
   if (!player) return [];
-  
+
   return player.battlefield
-    .filter(perm => perm.type === 'creature' && !perm.tapped)
-    .map(perm => perm.cardInstanceId);
+    .filter((perm) => perm.type === "creature" && !perm.tapped)
+    .map((perm) => perm.cardInstanceId);
 }
 
 /**
@@ -592,24 +648,24 @@ export async function evaluateLookahead(
   gameState: EngineGameState,
   playerId: PlayerId,
   depth: number,
-  action?: AIAction
+  action?: AIAction,
 ): Promise<number> {
   // Base case: max depth reached
   if (depth <= 0) {
     const aiState = getAIGameState(gameState);
     // Use quick score for terminal evaluation
-    return quickScore(aiState as unknown as GameState, playerId, 'medium');
+    return quickScore(aiState as unknown as GameState, playerId, "medium");
   }
 
   // If no action provided, just evaluate current state
   if (!action) {
     const aiState = getAIGameState(gameState);
-    return quickScore(aiState as unknown as GameState, playerId, 'medium');
+    return quickScore(aiState as unknown as GameState, playerId, "medium");
   }
 
   // Execute the action to get new state (async)
   const result = await executeAIAction(gameState, action, playerId);
-  
+
   if (!result.success || !result.newState) {
     // Action failed, return negative value
     return -100;
@@ -617,7 +673,7 @@ export async function evaluateLookahead(
 
   // Get opponent ID (the one who would respond)
   const opponentId = getOpponentPlayerId(gameState, playerId);
-  
+
   // For depth > 1, simulate opponent's best response and recurse
   if (depth > 1) {
     // Get opponent's available actions (simplified - just evaluate their perspective)
@@ -625,16 +681,16 @@ export async function evaluateLookahead(
     const opponentScore = quickScore(
       getAIGameState(opponentState) as unknown as GameState,
       opponentId,
-      'medium'
+      "medium",
     );
-    
+
     // Our score after opponent's potential response
     const ourScore = quickScore(
       getAIGameState(result.newState) as unknown as GameState,
       playerId,
-      'medium'
+      "medium",
     );
-    
+
     // Combine: our immediate gain minus opponent's potential gain
     // This is simplified - real implementation would explore opponent actions
     return ourScore - (opponentScore * 0.5) / depth;
@@ -642,5 +698,5 @@ export async function evaluateLookahead(
 
   // For depth === 1, just evaluate the resulting state
   const aiState = getAIGameState(result.newState);
-  return quickScore(aiState as unknown as GameState, playerId, 'medium');
+  return quickScore(aiState as unknown as GameState, playerId, "medium");
 }


### PR DESCRIPTION
## Summary

Resolves #1092. Adds unit tests for the two largest untested AI modules and fixes a genuine dead-branch bug discovered along the way.

`src/ai/ai-action-executor.ts` and `src/ai/ai-turn-loop.ts` reported **0% branch coverage** in the measured report (the single largest concentrated coverage gap in the repo). They drive the AI opponent's per-turn decision execution and were a complete black box in CI.

## Coverage (jest --coverage)

| File | Branches before | Branches after | Funcs after | Lines after |
|---|---|---|---|---|
| `src/ai/ai-action-executor.ts` | **0%** | **87.83%** | 100% | 100% |
| `src/ai/ai-turn-loop.ts` | **11.67%*** | **81.02%** | 95% | 99.09% |

*The turn-loop file was nominally non-zero only because a pre-existing suite covered the `detectPlayerArchetype`/`detectOpponentArchetype` helpers; the actual turn orchestration (`runAITurn` + all 8 phase functions, lines 188–767) was **0%** and is now covered.

Both modules clear the issue's ≥70% branch target. Global coverage also rose (statements 37.66→40.06, branches 29.97→32.59), and the CI `coverageThreshold` gate (28/30/36/36) still passes.

## What's covered

**`ai-action-executor`** (`src/ai/__tests__/ai-action-executor.test.ts`, new)
- `executeAIAction` dispatch: every action type (play_land, cast_spell, attack, block, tap_card, untap_card, pass_priority, no_action) + unknown type + try/catch (Error & non-Error throws)
- Each helper's success **and** failure/validation paths (cannot play land, tapped/sick attacker, missing creature, failed engine calls, default error messages)
- Multi-target / modal / X-value spell forwarding
- Pure accessors with real fixtures: `getAvailableLands`, `getAvailableAttackers`, `getAvailableBlockers`, `getAvailableResponses` (incl. mana-cost parsing & canCounter flag), AI-format variants, `getAIGameState`
- `evaluateLookahead`: depth ≤ 0, no-action, action-failure (-100), depth 1, depth > 1 opponent blending

**`ai-turn-loop`** (`src/ai/__tests__/ai-turn-loop.test.ts`, extended)
- Full `runAITurn` progression: untap → upkeep → draw → main → combat → main2 → end → cleanup, priority hand-off, and clean termination at "complete"
- Phase behaviors: untap only tapped permanents, draw-for-turn + commentary, land drop, creature/spell casting, attack-plan execution, end-of-turn pass, discard-to-max-hand-size
- **Difficulty-gated behavior** (the gap #1016 left open): identical hand + identical `Math.random` roll → expert casts the creature, easy skips it (behavioral delta, not just config shape)
- Edge cases: empty hand, no attackers, declined attacks, cleanup below max hand size
- Error handling: engine throw → failure result (Error & non-Error)

Tests stub the heavyweight rules-engine mutators and the combat decision tree (kept deterministic via seeded `Math.random`) so they exercise the **real** dispatch/orchestration logic without invoking the full engine.

## Bug found & fixed

`executeCastSpell` had a dead-branch bug: `canCastSpell()` returns `{ canCast: boolean; reason?: string }`, but the guard checked `if (!canCast)` — an object is always truthy, so the "cannot cast (no mana/no priority)" short-circuit **never fired** and the AI always proceeded to `castSpell()`. Fixed to `if (!canCast.canCast)` with a regression test (`#1092 regression`) that asserts the failure path now executes. The `play_land` guard was already correct (`canPlayLand` returns a plain boolean).

## Verification
- `npx jest ai-action-executor ai-turn-loop` — pass (5286 tests, 0 failures)
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors
- `npm run test:coverage` — passes global threshold; target files at 87.83% / 81.02% branches
