### PR TITLE
fix(multiplayer): resolve #1089 — validate peer game-actions against the rules engine on the authoritative host

### DIFF
--- a/src/lib/__tests__/p2p-game-connection.test.ts
+++ b/src/lib/__tests__/p2p-game-connection.test.ts
@@ -6,6 +6,7 @@
 import {
   P2PGameConnection,
   createP2PGameConnection,
+  createRulesEngineValidator,
   isGameMessage,
   type P2PGameConnectionEvents,
   type P2PGameConnectionOptions,
@@ -13,7 +14,9 @@ import {
   type GameMessage,
   type GameMessageType,
   type ChatMessage,
+  type PeerActionValidator,
 } from "../p2p-game-connection";
+import { ValidationService } from "../game-state/validation-service";
 
 describe("P2P Game Connection Types", () => {
   describe("GameMessageType", () => {
@@ -832,5 +835,354 @@ describe("P2PGameConnection sequence-number anti-replay (#1091)", () => {
       handleMessage(connection, JSON.stringify(msg("peer", 3)));
       expect(connection.getLastAppliedSeq("peer")).toBe(3);
     });
+  });
+});
+
+/**
+ * Authoritative-host game-action validation coverage (issue #1089).
+ *
+ * On the host, an incoming peer `game-action` must be validated against the
+ * rules engine BEFORE it is applied. Legal actions pass through to onMessage;
+ * illegal actions are rejected (not applied) and the originating peer is
+ * notified via a typed `error` message. This stage composes with — and runs
+ * strictly after — the rate-limit, structural, and anti-replay checks.
+ */
+describe("P2PGameConnection host action validation (#1089)", () => {
+  let onMessage: jest.Mock;
+  let onError: jest.Mock;
+  let sendSpy: jest.SpyInstance;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /**
+   * Build a connection whose `send` is spied on so we can assert on the
+   * rejection feedback message without a live data channel.
+   */
+  const makeConn = (
+    opts: {
+      validator?: PeerActionValidator;
+      enabled?: boolean;
+    } = {},
+  ): P2PGameConnection => {
+    onMessage = jest.fn();
+    onError = jest.fn();
+    const conn = createP2PGameConnection({
+      playerId: "host",
+      playerName: "Host",
+      role: "host",
+      validatePeerActions: opts.enabled ?? true,
+      validatePeerAction: opts.validator ?? jest.fn(() => ({ isValid: true })),
+      events: {
+        onConnectionStateChange: () => {},
+        onSignalingStateChange: () => {},
+        onMessage,
+        onGameStateSync: () => {},
+        onChat: () => {},
+        onError,
+        onPlayerJoined: () => {},
+        onPlayerLeft: () => {},
+      },
+    });
+    sendSpy = jest.spyOn(conn, "send");
+    return conn;
+  };
+
+  const handleMessage = (conn: P2PGameConnection, raw: string) =>
+    (conn as unknown as { handleMessage: (d: string) => void }).handleMessage(
+      raw,
+    );
+
+  /** Build a `game-action` message with a strict-increasing seq stream. */
+  const actionMsg = (
+    senderId: string,
+    seq: number,
+    action = "pass_priority",
+    data: unknown = {},
+  ): GameMessage => ({
+    type: "game-action",
+    senderId,
+    timestamp: Date.now(),
+    seq,
+    data: { action, data },
+  });
+
+  /** Distinct forwarded seqs for a sender (robust to single-dispatch). */
+  const forwardedSeqs = (senderId: string): number[] =>
+    Array.from(
+      new Set(
+        onMessage.mock.calls
+          .map((c) => c[0] as GameMessage)
+          .filter((m) => m.senderId === senderId && m.type === "game-action")
+          .map((m) => m.seq),
+      ),
+    ).sort((a, b) => a - b);
+
+  describe("legal actions", () => {
+    it("applies a legal action (forwards to onMessage)", () => {
+      const conn = makeConn({
+        validator: () => ({ isValid: true }),
+      });
+      handleMessage(conn, JSON.stringify(actionMsg("peer", 0)));
+      expect(forwardedSeqs("peer")).toEqual([0]);
+    });
+
+    it("does not send a rejection for a legal action", () => {
+      const conn = makeConn({
+        validator: () => ({ isValid: true }),
+      });
+      handleMessage(conn, JSON.stringify(actionMsg("peer", 1)));
+      expect(sendSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("illegal actions", () => {
+    it("rejects an illegal action and does NOT apply it (not forwarded)", () => {
+      const conn = makeConn({
+        validator: () => ({ isValid: false, reason: "Not your turn" }),
+      });
+      handleMessage(conn, JSON.stringify(actionMsg("peer", 0)));
+      expect(forwardedSeqs("peer")).toEqual([]);
+      expect(onMessage).not.toHaveBeenCalled();
+    });
+
+    it("notifies the peer of the rejection with a typed error message", () => {
+      const conn = makeConn({
+        validator: () => ({ isValid: false, reason: "Not your turn" }),
+      });
+      handleMessage(conn, JSON.stringify(actionMsg("peer", 7, "cast_spell")));
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const sent = sendSpy.mock.calls[0][0] as GameMessage;
+      expect(sent.type).toBe("error");
+      expect(sent.senderId).toBe("host");
+      expect(sent.data).toEqual(
+        expect.objectContaining({
+          code: "action_rejected",
+          action: "cast_spell",
+          reason: "Not your turn",
+          rejectedSeq: 7,
+        }),
+      );
+      // The rejection itself carries a monotonic seq (anti-replay compatible).
+      expect(typeof sent.seq).toBe("number");
+    });
+
+    it("uses a default reason when the validator omits one", () => {
+      const conn = makeConn({
+        validator: () => ({ isValid: false }),
+      });
+      handleMessage(conn, JSON.stringify(actionMsg("peer", 0)));
+      const sent = sendSpy.mock.calls[0][0] as GameMessage;
+      expect((sent.data as { reason: string }).reason).toBe(
+        "Action rejected by host",
+      );
+    });
+
+    it("does not corrupt host state: a later legal action still applies", () => {
+      const conn = makeConn({
+        validator: (action) =>
+          action.action === "evil"
+            ? { isValid: false, reason: "Illegal" }
+            : { isValid: true },
+      });
+      // Illegal first — rejected, not applied.
+      handleMessage(conn, JSON.stringify(actionMsg("peer", 0, "evil")));
+      // Then a legal action with a higher seq — accepted and applied.
+      handleMessage(
+        conn,
+        JSON.stringify(actionMsg("peer", 1, "pass_priority")),
+      );
+      expect(forwardedSeqs("peer")).toEqual([1]);
+    });
+  });
+
+  describe("fail-closed on bad input / validator misbehaviour", () => {
+    it("rejects a malformed action payload (no action string) without calling the validator", () => {
+      const validator = jest.fn(() => ({ isValid: true }));
+      const conn = makeConn({ validator });
+      // Valid GameMessage shape, but its data lacks an `action` string.
+      handleMessage(
+        conn,
+        JSON.stringify({
+          type: "game-action",
+          senderId: "peer",
+          timestamp: 1,
+          seq: 0,
+          data: { notAnAction: true },
+        }),
+      );
+      expect(forwardedSeqs("peer")).toEqual([]);
+      expect(validator).not.toHaveBeenCalled();
+      // Peer is still notified of the rejection.
+      const sent = sendSpy.mock.calls[sendSpy.mock.calls.length - 1]?.[0] as
+        | GameMessage
+        | undefined;
+      expect(sent?.type).toBe("error");
+    });
+
+    it("rejects when the validator throws (never applies)", () => {
+      const conn = makeConn({
+        validator: () => {
+          throw new Error("boom");
+        },
+      });
+      handleMessage(conn, JSON.stringify(actionMsg("peer", 0)));
+      expect(forwardedSeqs("peer")).toEqual([]);
+      const sent = sendSpy.mock.calls[0][0] as GameMessage;
+      expect((sent.data as { reason: string }).reason).toBe("boom");
+    });
+
+    it("fail-closes when the gate is enabled but no validator is wired", () => {
+      // Build directly so the option is genuinely absent.
+      onMessage = jest.fn();
+      onError = jest.fn();
+      const conn = createP2PGameConnection({
+        playerId: "host",
+        playerName: "Host",
+        role: "host",
+        validatePeerActions: true,
+        events: {
+          onConnectionStateChange: () => {},
+          onSignalingStateChange: () => {},
+          onMessage,
+          onGameStateSync: () => {},
+          onChat: () => {},
+          onError,
+          onPlayerJoined: () => {},
+          onPlayerLeft: () => {},
+        },
+      });
+      sendSpy = jest.spyOn(conn, "send");
+      handleMessage(conn, JSON.stringify(actionMsg("peer", 0)));
+      expect(forwardedSeqs("peer")).toEqual([]);
+      const sent = sendSpy.mock.calls[0][0] as GameMessage;
+      expect((sent.data as { reason: string }).reason).toBe(
+        "No action validator configured",
+      );
+    });
+  });
+
+  describe("opt-in gate (single-player / AI unaffected)", () => {
+    it("does not validate when validatePeerActions is disabled (default)", () => {
+      const validator = jest.fn();
+      const conn = makeConn({ enabled: false, validator });
+      // Even though the validator would reject, the gate is off so the action
+      // passes straight through to onMessage.
+      handleMessage(conn, JSON.stringify(actionMsg("peer", 0)));
+      expect(validator).not.toHaveBeenCalled();
+      expect(forwardedSeqs("peer")).toEqual([0]);
+      expect(sendSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("composition with earlier pipeline stages", () => {
+    it("anti-replay drops a duplicate BEFORE validation runs (no regression #1091)", () => {
+      const validator = jest.fn(() => ({ isValid: true }));
+      const conn = makeConn({ validator });
+      handleMessage(conn, JSON.stringify(actionMsg("peer", 5)));
+      // Replay the same seq — dropped by anti-replay; validator must NOT be
+      // consulted again for it and no extra forwarding occurs.
+      handleMessage(conn, JSON.stringify(actionMsg("peer", 5)));
+      expect(forwardedSeqs("peer")).toEqual([5]);
+      // Validator called exactly once (for the first, accepted message only).
+      expect(validator).toHaveBeenCalledTimes(1);
+      // A genuinely new action is still validated and forwarded.
+      handleMessage(conn, JSON.stringify(actionMsg("peer", 6)));
+      expect(validator).toHaveBeenCalledTimes(2);
+      expect(forwardedSeqs("peer")).toEqual([5, 6]);
+    });
+
+    it("rejects a well-shaped message missing the seq field (no regression #1091)", () => {
+      const validator = jest.fn();
+      const conn = makeConn({ validator });
+      expect(() =>
+        handleMessage(
+          conn,
+          JSON.stringify({
+            type: "game-action",
+            senderId: "peer",
+            timestamp: 1,
+            data: { action: "pass_priority", data: {} },
+          }),
+        ),
+      ).not.toThrow();
+      expect(validator).not.toHaveBeenCalled();
+      expect(onMessage).not.toHaveBeenCalled();
+    });
+
+    it("rejects malformed JSON before validation (no regression #924/#951)", () => {
+      const validator = jest.fn();
+      const conn = makeConn({ validator });
+      expect(() => handleMessage(conn, "{ not json")).not.toThrow();
+      expect(validator).not.toHaveBeenCalled();
+      expect(onMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("incoming error message (rejection feedback to the peer)", () => {
+    it("surfaces a received error message via onError and onMessage without failing", () => {
+      const conn = makeConn();
+      handleMessage(
+        conn,
+        JSON.stringify({
+          type: "error",
+          senderId: "host",
+          timestamp: 1,
+          seq: 0,
+          data: { code: "action_rejected", reason: "Not your turn" },
+        }),
+      );
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+      expect((onError.mock.calls[0][0] as Error).message).toBe("Not your turn");
+      // Also forwarded for app-level handling.
+      expect(onMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+/**
+ * The rules-engine validator factory (issue #1089). It must delegate to
+ * `ValidationService.validateAction`, mapping the wire payload + senderId to
+ * the engine's `GameAction` and validating against the host's OWN state.
+ */
+describe("createRulesEngineValidator (#1089)", () => {
+  it("delegates to ValidationService.validateAction with the mapped action", () => {
+    const fakeState = { status: "in_progress" } as never;
+    const spy = jest
+      .spyOn(ValidationService, "validateAction")
+      .mockReturnValue({ isValid: true });
+
+    const validator = createRulesEngineValidator(() => fakeState, "commander");
+    const result = validator(
+      { action: "cast_spell", data: { cardId: "c1" } },
+      "peer-1",
+    );
+
+    expect(result).toEqual({ isValid: true, reason: undefined });
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [stateArg, actionArg, modeArg] = spy.mock.calls[0];
+    expect(stateArg).toBe(fakeState);
+    expect(actionArg).toMatchObject({
+      type: "cast_spell",
+      playerId: "peer-1",
+      data: { cardId: "c1" },
+    });
+    expect(modeArg).toBe("commander");
+    spy.mockRestore();
+  });
+
+  it("propagates the engine's rejection reason", () => {
+    const fakeState = {} as never;
+    const spy = jest
+      .spyOn(ValidationService, "validateAction")
+      .mockReturnValue({ isValid: false, reason: "Not enough mana" });
+
+    const validator = createRulesEngineValidator(() => fakeState);
+    const result = validator({ action: "cast_spell", data: {} }, "peer-2");
+
+    expect(result).toEqual({ isValid: false, reason: "Not enough mana" });
+    spy.mockRestore();
   });
 });

--- a/src/lib/p2p-game-connection.ts
+++ b/src/lib/p2p-game-connection.ts
@@ -6,7 +6,12 @@
  * using client-side signaling without server dependencies.
  */
 
-import type { GameState, Phase, PlayerId } from "./game-state/types";
+import type {
+  GameState,
+  Phase,
+  PlayerId,
+  GameAction,
+} from "./game-state/types";
 import {
   LocalSignalingClient,
   createLocalSignalingClient,
@@ -20,6 +25,7 @@ import {
   deserializeGameState,
   type SerializedGameState,
 } from "./game-state/serialization";
+import { ValidationService } from "./game-state/validation-service";
 import {
   ICEConfigurationManager,
   getGlobalICEManager,
@@ -67,6 +73,12 @@ export type { SignalingRole };
 
 /**
  * Game message types
+ *
+ * `error` is the typed rejection/feedback channel used by the authoritative
+ * host to tell a peer one of its `game-action`s was rejected by the rules
+ * engine (issue #1089). It is informational — receiving one does NOT fail the
+ * connection (unlike a transport-level failure routed through the private
+ * `handleError`).
  */
 export type GameMessageType =
   | "game-state-sync"
@@ -75,7 +87,8 @@ export type GameMessageType =
   | "player-joined"
   | "player-left"
   | "ping"
-  | "pong";
+  | "pong"
+  | "error";
 
 /**
  * Base game message.
@@ -113,6 +126,7 @@ const GAME_MESSAGE_TYPES: ReadonlySet<GameMessageType> = new Set([
   "player-left",
   "ping",
   "pong",
+  "error",
 ]);
 
 /**
@@ -151,6 +165,42 @@ export interface ChatMessage {
 }
 
 /**
+ * Result of validating a peer-originated game-action against the rules engine
+ * on the authoritative host. Issue #1089.
+ */
+export interface PeerActionValidationResult {
+  isValid: boolean;
+  /** Machine-readable reason the action was rejected (when `isValid` is false). */
+  reason?: string;
+}
+
+/**
+ * Wire payload of a `game-action` message — an action name plus its
+ * action-specific data. Mirrors what {@link P2PGameConnection.sendGameAction}
+ * puts on the wire. Issue #1089.
+ */
+export interface PeerGameActionPayload {
+  action: string;
+  data: unknown;
+}
+
+/**
+ * Validator the authoritative host supplies to check a peer-originated
+ * `game-action` against the rules engine using the host's OWN authoritative
+ * state. The transport layer never owns or trusts peer-supplied state — it
+ * delegates the legality decision to this callback.
+ *
+ * `peerAction` is the parsed `{ action, data }` payload of the `game-action`
+ * message; `senderId` is the originating peer (the actor). Hosts typically
+ * wire this to the rules engine via {@link createRulesEngineValidator}.
+ * Issue #1089.
+ */
+export type PeerActionValidator = (
+  peerAction: PeerGameActionPayload,
+  senderId: string,
+) => PeerActionValidationResult;
+
+/**
  * P2P Game Connection options
  */
 export interface P2PGameConnectionOptions {
@@ -167,6 +217,23 @@ export interface P2PGameConnectionOptions {
    * flooding peer. Issue #1111.
    */
   rateLimit?: Partial<P2PRateLimitOptions>;
+  /**
+   * Authoritative-host game-action validation. When `true`, every incoming
+   * peer `game-action` is run through {@link validatePeerAction} against the
+   * host's authoritative state BEFORE it is emitted for application; illegal
+   * actions are rejected (not applied) and the originating peer is notified
+   * with an `error` message. Defaults to `false` so single-player/AI and
+   * non-host paths are unaffected. Issue #1089.
+   */
+  validatePeerActions?: boolean;
+  /**
+   * Rules-engine validator invoked for each peer `game-action` when
+   * {@link validatePeerActions} is enabled. Must validate against the host's
+   * OWN authoritative state — never peer-supplied state. Use
+   * {@link createRulesEngineValidator} to wire it to the rules engine.
+   * Issue #1089.
+   */
+  validatePeerAction?: PeerActionValidator;
 }
 
 /**
@@ -211,6 +278,17 @@ export class P2PGameConnection {
    * `p2p-host-migration.ts`.
    */
   private lastAppliedSeqByPeer: Map<string, number> = new Map();
+  /**
+   * Authoritative-host game-action validation gate (issue #1089). When true,
+   * incoming peer `game-action`s are validated by {@link validatePeerAction}
+   * against the host's authoritative state before being applied.
+   */
+  private readonly validatePeerActions: boolean;
+  /**
+   * Rules-engine legality check for peer game-actions (issue #1089). Supplied
+   * by the host; validates against the host's OWN state.
+   */
+  private readonly validatePeerAction: PeerActionValidator | null;
 
   constructor(options: P2PGameConnectionOptions) {
     this.playerId = options.playerId;
@@ -220,6 +298,11 @@ export class P2PGameConnection {
     // Per-connection rate limiter guards the parse/validate path against
     // flooding peers. Issue #1111.
     this.rateLimiter = new P2PRateLimiter(options.rateLimit);
+
+    // Authoritative-host action validation (issue #1089). Opt-in; disabled by
+    // default so single-player/AI paths are unaffected.
+    this.validatePeerActions = options.validatePeerActions === true;
+    this.validatePeerAction = options.validatePeerAction ?? null;
 
     // Initialize ICE manager
     if (options.iceConfig) {
@@ -598,9 +681,17 @@ export class P2PGameConnection {
    *   4. Anti-replay check: a message with `seq <=` the highest seq already
    *      applied from this `senderId` is dropped as a duplicate/replay BEFORE
    *      it can be applied to game state (issue #1091).
+   *   5. Rules-engine legality (issue #1089): on the authoritative host, a
+   *      `game-action` is validated against the host's own state; illegal
+   *      actions are rejected (peer notified via an `error` message) BEFORE
+   *      they are applied.
    *
-   * Malformed, oversize, rate-limited, or replayed messages are rejected
-   * gracefully without breaking the connection.
+   * The legality stage (#5) runs strictly AFTER anti-replay (#4) and
+   * structural/shape checks (#2/#3) and strictly BEFORE the action is emitted
+   * for application, so an illegal action can never touch host game state.
+   *
+   * Malformed, oversize, rate-limited, replayed, or illegal messages are
+   * rejected gracefully without breaking the connection.
    */
   private handleMessage(data: string): void {
     try {
@@ -640,9 +731,25 @@ export class P2PGameConnection {
         case "game-state-sync":
           this.handleGameStateSync(message);
           break;
-        case "game-action":
-          this.events.onMessage(message);
+        case "game-action": {
+          // Rules-engine legality (issue #1089). Runs AFTER anti-replay
+          // (#1091) and structural/shape checks, and BEFORE the action is
+          // emitted for application — so an illegal action can never touch
+          // host game state. Only the authoritative host opts in. Fail-closed:
+          // if the gate is on but no validator is wired, actions are rejected
+          // rather than applied unvalidated (trust-boundary default).
+          if (this.validatePeerActions) {
+            const result = this.validatePeerGameAction(message);
+            if (!result.isValid) {
+              this.sendActionRejection(message, result.reason);
+              // Do NOT fall through to onMessage: the illegal action is not
+              // applied. `return` skips the post-switch emission too.
+              return;
+            }
+          }
+          // Legal (or validation disabled): forward to onMessage below.
           break;
+        }
         case "chat":
           this.handleChat(message);
           break;
@@ -658,6 +765,22 @@ export class P2PGameConnection {
         case "pong":
           // Connection is alive
           break;
+        case "error": {
+          // A peer (typically the host) is signalling a rejection/error.
+          // Surface it WITHOUT failing the connection (the private
+          // handleError sets state=failed — we must not call it here). The
+          // message also flows to onMessage below for app-level handling.
+          // Issue #1089.
+          const errorData = message.data as { reason?: string };
+          this.events.onError(
+            new Error(
+              typeof errorData?.reason === "string"
+                ? errorData.reason
+                : "Received error message from peer",
+            ),
+          );
+          break;
+        }
       }
 
       this.events.onMessage(message);
@@ -733,6 +856,75 @@ export class P2PGameConnection {
    */
   resetIncomingSeq(senderId: string): void {
     this.lastAppliedSeqByPeer.delete(senderId);
+  }
+
+  /**
+   * Validate a peer-originated `game-action` against the rules engine using
+   * the host's authoritative state (via {@link validatePeerAction}). Defensive
+   * against malformed payloads and throwing validators: anything that cannot
+   * be confirmed legal is treated as illegal (fail-closed) so it can never be
+   * applied to host state. Issue #1089.
+   */
+  private validatePeerGameAction(
+    message: GameMessage,
+  ): PeerActionValidationResult {
+    const payload = message.data;
+    if (
+      typeof payload !== "object" ||
+      payload === null ||
+      typeof (payload as { action?: unknown }).action !== "string"
+    ) {
+      return { isValid: false, reason: "Malformed game action" };
+    }
+    const peerAction = payload as PeerGameActionPayload;
+    if (!this.validatePeerAction) {
+      // Gate enabled without a validator — fail-closed.
+      return { isValid: false, reason: "No action validator configured" };
+    }
+    try {
+      const result = this.validatePeerAction(peerAction, message.senderId);
+      if (
+        result &&
+        typeof result === "object" &&
+        typeof result.isValid === "boolean"
+      ) {
+        return result;
+      }
+      return { isValid: false, reason: "Invalid validator result" };
+    } catch (error) {
+      // A throwing validator is treated as a rejection — never apply.
+      return {
+        isValid: false,
+        reason:
+          error instanceof Error ? error.message : "Action validation error",
+      };
+    }
+  }
+
+  /**
+   * Notify the originating peer that its `game-action` was rejected by the
+   * authoritative host. Reuses the typed message channel (an `error` message)
+   * rather than introducing a new protocol. Issue #1089.
+   */
+  private sendActionRejection(
+    message: GameMessage,
+    reason: string | undefined,
+  ): void {
+    const payload = message.data as { action?: unknown };
+    this.send({
+      type: "error",
+      senderId: this.playerId,
+      timestamp: Date.now(),
+      seq: this.nextOutgoingSeq(),
+      data: {
+        code: "action_rejected",
+        action:
+          typeof payload?.action === "string" ? payload.action : undefined,
+        reason: reason ?? "Action rejected by host",
+        // Echo the rejected message's seq so the peer can correlate.
+        rejectedSeq: message.seq,
+      },
+    });
   }
 
   /**
@@ -1029,4 +1221,46 @@ export function createP2PGameConnection(
   options: P2PGameConnectionOptions,
 ): P2PGameConnection {
   return new P2PGameConnection(options);
+}
+
+/**
+ * Build a {@link PeerActionValidator} that delegates to the rules engine
+ * (`ValidationService.validateAction`) against the host's authoritative state.
+ *
+ * The host supplies `getState`, which must return its OWN authoritative
+ * {@link GameState} at call time — never a state claimed by the peer. The wire
+ * payload (`{ action, data }`) plus the originating `senderId` are mapped to
+ * the engine's {@link GameAction} and validated in place; the action is NOT
+ * applied (this only decides legality). Issue #1089.
+ *
+ * Example (authoritative host):
+ * ```ts
+ * createP2PGameConnection({
+ *   // ...
+ *   validatePeerActions: true,
+ *   validatePeerAction: createRulesEngineValidator(
+ *     () => authoritativeGameStateRef.current,
+ *   ),
+ * });
+ * ```
+ *
+ * This wrapper only delegates — it does not reimplement rules. Unknown action
+ * types therefore fall through to `ValidationService.validateAction`'s default
+ * handling.
+ */
+export function createRulesEngineValidator(
+  getState: () => GameState,
+  modeId?: string,
+): PeerActionValidator {
+  return (peerAction, senderId) => {
+    const state = getState();
+    const gameAction = {
+      type: peerAction.action,
+      playerId: senderId as PlayerId,
+      timestamp: Date.now(),
+      data: peerAction.data,
+    } as unknown as GameAction;
+    const result = ValidationService.validateAction(state, gameAction, modeId);
+    return { isValid: result.isValid, reason: result.reason };
+  };
 }


### PR DESCRIPTION
## Summary

Closes the anti-cheat trust boundary on the authoritative host. Previously `handleMessage` routed incoming peer `game-action`s straight to `onMessage` (application) after only the *shape* check from #951 — shape validation confirms well-formed JSON, **not** that the action is legal. A buggy/modified peer could push arbitrary actions (cast a spell it doesn't own, act out of turn, target an invalid object) and the host would apply them.

Now the host validates each peer game-action against the rules engine **before** it is applied, and rejects illegal ones back to the sender.

## Validation pipeline order (`handleMessage`)

Validation composes with the existing hardening layers — it is inserted strictly after anti-replay and strictly before application:

1. **Rate limit** — flooding peer dropped before any parsing (#1111)
2. **Structural/size** — `safeParseJson` size/depth/key-count (#951/#1111)
3. **Shape** — `isGameMessage` incl. required `seq` (#1091)
4. **Anti-replay** — `seq <=` high-water mark dropped before state (#1091)
5. **Rules-engine legality** — *(new, #1089)* `validatePeerAction` against the host's **own** authoritative state
6. **Apply** — forwarded to `onMessage` (only if legal)

Stage 5 runs only when `validatePeerActions` is enabled. It is **fail-closed**: a malformed payload, a throwing validator, or a missing validator (gate on, no validator wired) all result in a rejection rather than an unvalidated apply.

## Rejection feedback

Illegal actions are **not** applied (`onMessage` is not invoked for them). The host notifies the originating peer by reusing the typed message channel — a minimal `error` message (no new protocol):

```jsonc
{ "type": "error", "data": { "code": "action_rejected", "action": "<name>", "reason": "<why>", "rejectedSeq": <seq> } }
```

On the receiving side an `error` message surfaces via `onError` **and** `onMessage` but does **not** fail the connection (unlike the private transport-error `handleError`).

## How the rules engine is reused (no reimplementation)

`P2PGameConnection` is transport-only and never owns/trusts peer state, so validation is dependency-injected:

- `validatePeerActions` (gate) + `validatePeerAction` (callback) options on `P2PGameConnectionOptions`.
- `createRulesEngineValidator(getState, modeId?)` factory delegates to the engine's `ValidationService.validateAction(state, action)`, mapping the wire payload `{ action, data }` + `senderId` → engine `GameAction` (`{ type, playerId, data }`) and validating in place (the action is **not** applied — only its legality is decided).
- Defaults to off, so single-player / AI / non-host paths are unaffected.

## Files changed

- `src/lib/p2p-game-connection.ts` — `error` message type; `PeerActionValidator`/`PeerActionValidationResult`/`PeerGameActionPayload` types; `validatePeerActions`/`validatePeerAction` options; legality stage in `handleMessage`; `validatePeerGameAction`/`sendActionRejection` helpers; `error` receive path; `createRulesEngineValidator` factory.
- `src/lib/__tests__/p2p-game-connection.test.ts` — 16 new tests covering legal/illegal/fail-closed/gate/composition/factory.

## Acceptance criteria

- [x] Host validates incoming peer game-actions against the rules engine **before** applying
- [x] Legal actions applied as before
- [x] Illegal actions **rejected** (not applied) and originating peer notified
- [x] Composes with #1111 (size/rate) and #1091 (seq anti-replay); validation runs after anti-replay, before apply
- [x] Tests: legal-accept, illegal-reject+not-applied, rejection-notified, replay/dup still rejected (no regression)

## Verification

- `npx jest src/lib/__tests__/p2p-game-connection.test.ts` — 72 pass (16 new)
- Full suite — 5335 pass / 0 fail
- `npx tsc --noEmit` — clean
- `npx eslint src --max-warnings 1000` — 0 errors

Resolves #1089