### PR TITLE
feat(multiplayer): resolve #1088 — NAT-traversal diagnostics panel with ICE candidate reporting

### DIFF
--- a/src/app/(app)/multiplayer/page.tsx
+++ b/src/app/(app)/multiplayer/page.tsx
@@ -1,9 +1,25 @@
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
-import { Gamepad2, Users, Clock, Wifi, Shield, Share2, QrCode, MessageSquare } from "lucide-react";
+import {
+  Gamepad2,
+  Users,
+  Clock,
+  Wifi,
+  Shield,
+  Share2,
+  QrCode,
+  MessageSquare,
+} from "lucide-react";
 import Link from "next/link";
+import { P2PDiagnosticsPanel } from "@/components/p2p-diagnostics-panel";
 
 export default function MultiplayerPage() {
   return (
@@ -16,169 +32,196 @@ export default function MultiplayerPage() {
       </header>
       <main className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-1 space-y-6">
-            <Card>
-                <CardHeader>
-                    <CardTitle>Host a Game</CardTitle>
-                    <CardDescription>Create a P2P game and share connection code with your opponent</CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                    <Link href="/multiplayer/p2p-host">
-                        <Button className="w-full">
-                            <Wifi className="w-4 h-4 mr-2" />
-                            Create P2P Game
-                        </Button>
-                    </Link>
-                </CardContent>
-            </Card>
-            <Card>
-                <CardHeader>
-                    <CardTitle>Join a Game</CardTitle>
-                    <CardDescription>Enter a connection code to join your opponent's game</CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                    <Link href="/multiplayer/p2p-join">
-                        <Button variant="outline" className="w-full">
-                            <QrCode className="w-4 h-4 mr-2" />
-                            Scan QR Code
-                        </Button>
-                    </Link>
-                    <Link href="/multiplayer/p2p-join">
-                        <Button variant="outline" className="w-full">
-                            <Gamepad2 className="w-4 h-4 mr-2" />
-                            Enter Code Manually
-                        </Button>
-                    </Link>
-                </CardContent>
-            </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Host a Game</CardTitle>
+              <CardDescription>
+                Create a P2P game and share connection code with your opponent
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <Link href="/multiplayer/p2p-host">
+                <Button className="w-full">
+                  <Wifi className="w-4 h-4 mr-2" />
+                  Create P2P Game
+                </Button>
+              </Link>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Join a Game</CardTitle>
+              <CardDescription>
+                Enter a connection code to join your opponent's game
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <Link href="/multiplayer/p2p-join">
+                <Button variant="outline" className="w-full">
+                  <QrCode className="w-4 h-4 mr-2" />
+                  Scan QR Code
+                </Button>
+              </Link>
+              <Link href="/multiplayer/p2p-join">
+                <Button variant="outline" className="w-full">
+                  <Gamepad2 className="w-4 h-4 mr-2" />
+                  Enter Code Manually
+                </Button>
+              </Link>
+            </CardContent>
+          </Card>
         </div>
         <div className="lg:col-span-2">
-            <Card>
-                <CardHeader>
-                    <CardTitle>Peer-to-Peer Multiplayer</CardTitle>
-                    <CardDescription>Direct connections without any server</CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-6">
-                    <div className="grid gap-4 md:grid-cols-2">
-                        <div className="p-4 border rounded-lg bg-card">
-                            <div className="flex items-center gap-2 mb-2">
-                                <Shield className="w-5 h-5 text-green-500" />
-                                <h3 className="font-semibold">Serverless</h3>
-                            </div>
-                            <p className="text-sm text-muted-foreground">
-                                Direct P2P connection via WebRTC. No central server, no data collection.
-                            </p>
-                        </div>
-                        <div className="p-4 border rounded-lg bg-card">
-                            <div className="flex items-center gap-2 mb-2">
-                                <Share2 className="w-5 h-5 text-primary" />
-                                <h3 className="font-semibold">Easy Sharing</h3>
-                            </div>
-                            <p className="text-sm text-muted-foreground">
-                                Share connection codes via QR code, Discord, or any messaging app.
-                            </p>
-                        </div>
+          <Card>
+            <CardHeader>
+              <CardTitle>Peer-to-Peer Multiplayer</CardTitle>
+              <CardDescription>
+                Direct connections without any server
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="p-4 border rounded-lg bg-card">
+                  <div className="flex items-center gap-2 mb-2">
+                    <Shield className="w-5 h-5 text-green-500" />
+                    <h3 className="font-semibold">Serverless</h3>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    Direct P2P connection via WebRTC. No central server, no data
+                    collection.
+                  </p>
+                </div>
+                <div className="p-4 border rounded-lg bg-card">
+                  <div className="flex items-center gap-2 mb-2">
+                    <Share2 className="w-5 h-5 text-primary" />
+                    <h3 className="font-semibold">Easy Sharing</h3>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    Share connection codes via QR code, Discord, or any
+                    messaging app.
+                  </p>
+                </div>
+              </div>
+
+              <Separator />
+
+              <div>
+                <h3 className="font-semibold mb-4">How to Connect</h3>
+                <div className="space-y-4">
+                  <div className="flex gap-4">
+                    <div className="flex-shrink-0 w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center text-primary font-bold">
+                      1
                     </div>
-
-                    <Separator />
-
                     <div>
-                        <h3 className="font-semibold mb-4">How to Connect</h3>
-                        <div className="space-y-4">
-                            <div className="flex gap-4">
-                                <div className="flex-shrink-0 w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center text-primary font-bold">1</div>
-                                <div>
-                                    <h4 className="font-medium">Host Creates Game</h4>
-                                    <p className="text-sm text-muted-foreground">
-                                        Host creates a P2P game and generates a connection code
-                                    </p>
-                                </div>
-                            </div>
-                            <div className="flex gap-4">
-                                <div className="flex-shrink-0 w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center text-primary font-bold">2</div>
-                                <div>
-                                    <h4 className="font-medium">Share Connection Code</h4>
-                                    <p className="text-sm text-muted-foreground">
-                                        Host shares the QR code or connection string with opponent (Discord, text, etc.)
-                                    </p>
-                                </div>
-                            </div>
-                            <div className="flex gap-4">
-                                <div className="flex-shrink-0 w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center text-primary font-bold">3</div>
-                                <div>
-                                    <h4 className="font-medium">Opponent Joins</h4>
-                                    <p className="text-sm text-muted-foreground">
-                                        Opponent scans QR code or enters the connection code manually
-                                    </p>
-                                </div>
-                            </div>
-                            <div className="flex gap-4">
-                                <div className="flex-shrink-0 w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center text-primary font-bold">4</div>
-                                <div>
-                                    <h4 className="font-medium">Direct Connection</h4>
-                                    <p className="text-sm text-muted-foreground">
-                                        WebRTC establishes direct P2P connection for game play
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
+                      <h4 className="font-medium">Host Creates Game</h4>
+                      <p className="text-sm text-muted-foreground">
+                        Host creates a P2P game and generates a connection code
+                      </p>
                     </div>
+                  </div>
+                  <div className="flex gap-4">
+                    <div className="flex-shrink-0 w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center text-primary font-bold">
+                      2
+                    </div>
+                    <div>
+                      <h4 className="font-medium">Share Connection Code</h4>
+                      <p className="text-sm text-muted-foreground">
+                        Host shares the QR code or connection string with
+                        opponent (Discord, text, etc.)
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex gap-4">
+                    <div className="flex-shrink-0 w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center text-primary font-bold">
+                      3
+                    </div>
+                    <div>
+                      <h4 className="font-medium">Opponent Joins</h4>
+                      <p className="text-sm text-muted-foreground">
+                        Opponent scans QR code or enters the connection code
+                        manually
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex gap-4">
+                    <div className="flex-shrink-0 w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center text-primary font-bold">
+                      4
+                    </div>
+                    <div>
+                      <h4 className="font-medium">Direct Connection</h4>
+                      <p className="text-sm text-muted-foreground">
+                        WebRTC establishes direct P2P connection for game play
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
 
-                    <Separator />
+              <Separator />
 
-                    <div className="bg-muted/50 p-4 rounded-lg">
-                        <h4 className="font-semibold mb-2">Supported Formats</h4>
-                        <div className="flex flex-wrap gap-2">
-                            <Badge variant="outline">Commander</Badge>
-                            <Badge variant="outline">Modern</Badge>
-                            <Badge variant="outline">Standard</Badge>
-                            <Badge variant="outline">Pioneer</Badge>
-                            <Badge variant="outline">Legacy</Badge>
-                            <Badge variant="outline">Vintage</Badge>
-                            <Badge variant="outline">Pauper</Badge>
-                        </div>
-                    </div>
-                </CardContent>
-            </Card>
+              <div className="bg-muted/50 p-4 rounded-lg">
+                <h4 className="font-semibold mb-2">Supported Formats</h4>
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant="outline">Commander</Badge>
+                  <Badge variant="outline">Modern</Badge>
+                  <Badge variant="outline">Standard</Badge>
+                  <Badge variant="outline">Pioneer</Badge>
+                  <Badge variant="outline">Legacy</Badge>
+                  <Badge variant="outline">Vintage</Badge>
+                  <Badge variant="outline">Pauper</Badge>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
 
-            <Card className="mt-6">
-                <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                        <MessageSquare className="w-5 h-5" />
-                        Sharing Tips
-                    </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-3">
-                    <div className="flex items-start gap-3">
-                        <QrCode className="w-5 h-5 text-muted-foreground flex-shrink-0 mt-0.5" />
-                        <div>
-                            <h4 className="font-medium">QR Code</h4>
-                            <p className="text-sm text-muted-foreground">
-                                Best for in-person or screen sharing. Mobile users can scan directly.
-                            </p>
-                        </div>
-                    </div>
-                    <div className="flex items-start gap-3">
-                        <Share2 className="w-5 h-5 text-muted-foreground flex-shrink-0 mt-0.5" />
-                        <div>
-                            <h4 className="font-medium">Copy & Paste</h4>
-                            <p className="text-sm text-muted-foreground">
-                                Copy the connection string and paste it into Discord, email, or any messaging app.
-                            </p>
-                        </div>
-                    </div>
-                    <div className="flex items-start gap-3">
-                        <Users className="w-5 h-5 text-muted-foreground flex-shrink-0 mt-0.5" />
-                        <div>
-                            <h4 className="font-medium">Discord/Chat</h4>
-                            <p className="text-sm text-muted-foreground">
-                                The easiest way - send the code in any chat application.
-                            </p>
-                        </div>
-                    </div>
-                </CardContent>
-            </Card>
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <MessageSquare className="w-5 h-5" />
+                Sharing Tips
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="flex items-start gap-3">
+                <QrCode className="w-5 h-5 text-muted-foreground flex-shrink-0 mt-0.5" />
+                <div>
+                  <h4 className="font-medium">QR Code</h4>
+                  <p className="text-sm text-muted-foreground">
+                    Best for in-person or screen sharing. Mobile users can scan
+                    directly.
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-start gap-3">
+                <Share2 className="w-5 h-5 text-muted-foreground flex-shrink-0 mt-0.5" />
+                <div>
+                  <h4 className="font-medium">Copy & Paste</h4>
+                  <p className="text-sm text-muted-foreground">
+                    Copy the connection string and paste it into Discord, email,
+                    or any messaging app.
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-start gap-3">
+                <Users className="w-5 h-5 text-muted-foreground flex-shrink-0 mt-0.5" />
+                <div>
+                  <h4 className="font-medium">Discord/Chat</h4>
+                  <p className="text-sm text-muted-foreground">
+                    The easiest way - send the code in any chat application.
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
         </div>
       </main>
+
+      <section
+        className="mt-6"
+        aria-label="Peer-to-peer connection diagnostics"
+      >
+        <P2PDiagnosticsPanel />
+      </section>
     </div>
   );
 }

--- a/src/components/__tests__/p2p-diagnostics-panel.test.tsx
+++ b/src/components/__tests__/p2p-diagnostics-panel.test.tsx
@@ -1,0 +1,250 @@
+/**
+ * P2PDiagnosticsPanel tests.
+ * Issue #1088.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import { P2PDiagnosticsPanel } from "../p2p-diagnostics-panel";
+import type { ICEDiagnosticsSnapshot } from "@/lib/ice-diagnostics";
+
+function makeSnapshot(
+  overrides: Partial<ICEDiagnosticsSnapshot> = {},
+): ICEDiagnosticsSnapshot {
+  return {
+    timestamp: 1000,
+    iceConnectionState: "connected",
+    gatheringState: "complete",
+    phase: "connected",
+    candidateCounts: { host: 2, srflx: 1, prflx: 0, relay: 0, unknown: 0 },
+    candidates: [],
+    candidateErrors: [],
+    selectedPair: {
+      localType: "srflx",
+      remoteType: "host",
+      localAddress: "203.0.113.7",
+      remoteAddress: "192.168.1.9",
+      nominated: true,
+      currentRttMs: 42,
+      packetsSent: 100,
+      packetsReceived: 95,
+      packetsLost: 5,
+      bytesSent: 2048,
+      bytesReceived: 1800,
+    },
+    natType: "cone",
+    hasTurnConfigured: true,
+    gatheringStartedAt: 900,
+    gatheringCompleteAt: 1000,
+    gatheringDurationMs: 100,
+    connectedAt: 1100,
+    totalGathered: 3,
+    ...overrides,
+  };
+}
+
+/** Mock DiagnosticsSource that resolves a controlled snapshot. */
+function mockConnection(snapshot: ICEDiagnosticsSnapshot | null) {
+  let current = snapshot;
+  return {
+    set(next: ICEDiagnosticsSnapshot | null) {
+      current = next;
+    },
+    source: {
+      async getDiagnostics() {
+        return current;
+      },
+    },
+  };
+}
+
+describe("P2PDiagnosticsPanel", () => {
+  const originalRTCP = (window as { RTCPeerConnection?: unknown })
+    .RTCPeerConnection;
+
+  beforeEach(() => {
+    (window as any).RTCPeerConnection = function MockPC() {};
+  });
+
+  afterEach(() => {
+    (window as { RTCPeerConnection?: unknown }).RTCPeerConnection =
+      originalRTCP;
+  });
+
+  it("renders a collapsed panel and expands on toggle", async () => {
+    const user = userEvent.setup();
+    render(
+      <P2PDiagnosticsPanel
+        connection={mockConnection(makeSnapshot()).source}
+      />,
+    );
+
+    // Header always present.
+    expect(screen.getByText(/Connection Diagnostics/i)).toBeInTheDocument();
+
+    // Collapsed: readout not yet shown.
+    expect(
+      screen.queryByTestId("p2p-diag-candidate-grid"),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByText(/Connection Diagnostics/i));
+
+    expect(
+      await screen.findByTestId("p2p-diag-candidate-grid"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an unsupported state when WebRTC is unavailable", async () => {
+    (window as { RTCPeerConnection?: unknown }).RTCPeerConnection = undefined;
+    const user = userEvent.setup();
+    render(<P2PDiagnosticsPanel />);
+    await user.click(screen.getByText(/Connection Diagnostics/i));
+    expect(
+      await screen.findByTestId("p2p-diag-unsupported"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders candidate type counts and a cone NAT badge", async () => {
+    const user = userEvent.setup();
+    render(
+      <P2PDiagnosticsPanel
+        defaultOpen
+        connection={mockConnection(makeSnapshot()).source}
+      />,
+    );
+    expect(await screen.findByTestId("p2p-diag-count-host")).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId("p2p-diag-count-srflx")).toHaveTextContent("1");
+    expect(screen.getByTestId("p2p-diag-count-relay")).toHaveTextContent("0");
+    expect(screen.getByTestId("p2p-diag-nat-badge")).toHaveTextContent(/Cone/i);
+    expect(screen.getByTestId("p2p-diag-phase-badge")).toHaveTextContent(
+      "Connected",
+    );
+  });
+
+  it("renders RTT and packet loss from the selected pair", async () => {
+    const user = userEvent.setup();
+    render(
+      <P2PDiagnosticsPanel
+        defaultOpen
+        connection={mockConnection(makeSnapshot()).source}
+      />,
+    );
+    expect(await screen.findByTestId("p2p-diag-rtt")).toHaveTextContent(
+      "42 ms",
+    );
+    // 5 lost / 100 sent = 5.0%
+    expect(screen.getByTestId("p2p-diag-loss")).toHaveTextContent("5.0%");
+  });
+
+  it("surfaces a TURN-required hint for a restrictive NAT without TURN", async () => {
+    const user = userEvent.setup();
+    render(
+      <P2PDiagnosticsPanel
+        defaultOpen
+        connection={
+          mockConnection(
+            makeSnapshot({
+              natType: "restrictive",
+              hasTurnConfigured: false,
+              candidateCounts: {
+                host: 3,
+                srflx: 0,
+                prflx: 0,
+                relay: 0,
+                unknown: 0,
+              },
+              totalGathered: 3,
+              selectedPair: null,
+            }),
+          ).source
+        }
+      />,
+    );
+    expect(
+      await screen.findByTestId("p2p-diag-turn-required"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("p2p-diag-nat-badge")).toHaveTextContent(
+      /Restrictive/i,
+    );
+  });
+
+  it("does not show the TURN-required hint when TURN is configured", async () => {
+    const user = userEvent.setup();
+    render(
+      <P2PDiagnosticsPanel
+        defaultOpen
+        connection={
+          mockConnection(
+            makeSnapshot({
+              natType: "turn-dependent",
+              hasTurnConfigured: true,
+              candidateCounts: {
+                host: 1,
+                srflx: 0,
+                prflx: 0,
+                relay: 1,
+                unknown: 0,
+              },
+              totalGathered: 2,
+            }),
+          ).source
+        }
+      />,
+    );
+    expect(await screen.findByTestId("p2p-diag-nat-badge")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("p2p-diag-turn-required"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows candidate error entries when present", async () => {
+    const user = userEvent.setup();
+    render(
+      <P2PDiagnosticsPanel
+        defaultOpen
+        connection={
+          mockConnection(
+            makeSnapshot({
+              candidateErrors: [
+                {
+                  url: "stun:stun.l.google.com:19302",
+                  errorCode: 701,
+                  errorText: "STUN host unreachable",
+                  timestamp: 5,
+                },
+              ],
+            }),
+          ).source
+        }
+      />,
+    );
+    expect(await screen.findByTestId("p2p-diag-error-list")).toHaveTextContent(
+      /701/,
+    );
+    expect(screen.getByTestId("p2p-diag-errors")).toHaveTextContent("1");
+  });
+
+  it("renders an idle prompt and a Test button when no connection is given", async () => {
+    const user = userEvent.setup();
+    render(<P2PDiagnosticsPanel defaultOpen />);
+    expect(await screen.findByTestId("p2p-diag-idle")).toBeInTheDocument();
+    expect(screen.getByTestId("p2p-diag-run-test")).toBeInTheDocument();
+  });
+
+  it("renders an error alert when the live source throws", async () => {
+    const failing = {
+      async getDiagnostics(): Promise<ICEDiagnosticsSnapshot | null> {
+        throw new Error("nope");
+      },
+    };
+    render(<P2PDiagnosticsPanel defaultOpen connection={failing} />);
+    expect(await screen.findByTestId("p2p-diag-error")).toHaveTextContent(
+      /nope/,
+    );
+  });
+});

--- a/src/components/p2p-diagnostics-panel.tsx
+++ b/src/components/p2p-diagnostics-panel.tsx
@@ -1,0 +1,454 @@
+/**
+ * P2PDiagnosticsPanel
+ *
+ * Toggleable, accessible NAT-traversal / ICE diagnostics surface for the
+ * multiplayer area. Issue #1088.
+ *
+ * Two observation modes:
+ *   1. **Live** — pass a `connection` (anything with a `getDiagnostics()`
+ *      method, e.g. a `WebRTCConnection`). The panel polls it on an interval.
+ *   2. **Self-test probe** — when no connection is supplied, a "Run connection
+ *      test" button spins up an ephemeral RTCPeerConnection (using the app's
+ *      ICE config) to classify the local NAT. This never touches game traffic.
+ *
+ * Reported data: gathered ICE candidate types (host/srflx/prflx/relay counts),
+ * the selected candidate pair with RTT/packet-loss, the ICE connection
+ * state/phase, an effective NAT-type heuristic, gathering timing, and candidate
+ * errors. A restrictive NAT with no TURN configured surfaces an actionable
+ * "TURN required" hint.
+ *
+ * The heavy logic lives in `@/lib/ice-diagnostics` (+ `useP2PDiagnostics`);
+ * this component is presentational + light interaction only.
+ */
+
+"use client";
+
+import { useCallback, useState } from "react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+import {
+  Activity,
+  ChevronDown,
+  Loader2,
+  RefreshCw,
+  ShieldAlert,
+  ShieldCheck,
+  TriangleAlert,
+} from "lucide-react";
+
+import { getGlobalICEManager } from "@/lib/ice-config";
+import {
+  CANDIDATE_TYPE_ORDER,
+  NAT_TYPE_META,
+  runDiagnosticsProbe,
+  type CandidateType,
+  type ICEDiagnosticsSnapshot,
+  type NATType,
+} from "@/lib/ice-diagnostics";
+import {
+  useP2PDiagnostics,
+  type DiagnosticsSource,
+} from "@/hooks/use-p2p-diagnostics";
+
+export interface P2PDiagnosticsPanelProps {
+  /**
+   * Optional live connection to observe. When omitted the panel runs a
+   * self-contained NAT probe on demand.
+   */
+  connection?: DiagnosticsSource | null;
+  /** Collapsed/expanded on first render. Defaults to collapsed. */
+  defaultOpen?: boolean;
+  /** Poll cadence (ms) for the live connection. Defaults to the hook default. */
+  pollIntervalMs?: number;
+  className?: string;
+}
+
+const CANDIDATE_LABEL: Record<CandidateType, string> = {
+  host: "Host",
+  srflx: "Server-reflexive",
+  prflx: "Peer-reflexive",
+  relay: "Relay (TURN)",
+  unknown: "Unknown",
+};
+
+const PHASE_VARIANT: Record<
+  string,
+  {
+    label: string;
+    variant: "default" | "secondary" | "destructive" | "outline";
+  }
+> = {
+  connected: { label: "Connected", variant: "default" },
+  completed: { label: "Completed", variant: "default" },
+  connecting: { label: "Connecting", variant: "secondary" },
+  gathering: { label: "Gathering", variant: "secondary" },
+  new: { label: "New", variant: "outline" },
+  disconnected: { label: "Disconnected", variant: "outline" },
+  failed: { label: "Failed", variant: "destructive" },
+  closed: { label: "Closed", variant: "outline" },
+};
+
+function formatMs(ms: number | null | undefined): string {
+  if (ms == null || !Number.isFinite(ms)) return "—";
+  if (ms < 1) return "<1 ms";
+  return `${Math.round(ms)} ms`;
+}
+
+function formatBytes(bytes: number | null | undefined): string {
+  if (bytes == null || !Number.isFinite(bytes)) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function natBadgeVariant(
+  nat: NATType,
+): "default" | "secondary" | "destructive" | "outline" {
+  switch (nat) {
+    case "cone":
+      return "default";
+    case "turn-dependent":
+      return "secondary";
+    case "restrictive":
+      return "destructive";
+    default:
+      return "outline";
+  }
+}
+
+function StatRow({
+  label,
+  value,
+  testId,
+}: {
+  label: string;
+  value: React.ReactNode;
+  testId?: string;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2 py-1">
+      <dt className="text-sm text-muted-foreground">{label}</dt>
+      <dd className="text-sm font-medium tabular-nums" data-testid={testId}>
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+/**
+ * Pure presentation of a diagnostics snapshot. Extracted so it can be reused by
+ * both the live path and the probe path and unit-tested with mock snapshots.
+ */
+function DiagnosticsReadout({
+  snapshot,
+}: {
+  snapshot: ICEDiagnosticsSnapshot;
+}) {
+  const phase = PHASE_VARIANT[snapshot.phase] ?? {
+    label: snapshot.phase,
+    variant: "outline" as const,
+  };
+  const nat = NAT_TYPE_META[snapshot.natType];
+  const needsTurn =
+    snapshot.natType === "restrictive" && !snapshot.hasTurnConfigured;
+  const pair = snapshot.selectedPair;
+  const lossPct =
+    pair && pair.packetsSent != null && pair.packetsSent > 0
+      ? ((pair.packetsLost ?? 0) / pair.packetsSent) * 100
+      : null;
+
+  return (
+    <div className="space-y-4">
+      {/* Status row */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant={phase.variant} data-testid="p2p-diag-phase-badge">
+          {phase.label}
+        </Badge>
+        <Badge
+          variant={natBadgeVariant(snapshot.natType)}
+          data-testid="p2p-diag-nat-badge"
+        >
+          <ShieldAlert className="mr-1 h-3 w-3" aria-hidden="true" />
+          {nat.label}
+        </Badge>
+        {snapshot.hasTurnConfigured ? (
+          <Badge variant="outline" className="gap-1">
+            <ShieldCheck className="h-3 w-3" aria-hidden="true" />
+            TURN configured
+          </Badge>
+        ) : null}
+      </div>
+
+      {/* TURN-required actionable hint */}
+      {needsTurn ? (
+        <Alert variant="destructive" data-testid="p2p-diag-turn-required">
+          <TriangleAlert className="h-4 w-4" aria-hidden="true" />
+          <AlertTitle>TURN server required</AlertTitle>
+          <AlertDescription>
+            Only local (host) candidates were gathered, which means this network
+            uses a restrictive/symmetric NAT that blocks direct peer-to-peer
+            connections. Add a TURN relay server in your network settings to
+            connect. See issue #983 for configuration guidance.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      <p className="text-sm text-muted-foreground">{nat.description}</p>
+
+      <Separator />
+
+      {/* Candidate types */}
+      <section>
+        <h4 className="mb-2 text-sm font-semibold">
+          Gathered candidates
+          <span className="ml-2 font-normal text-muted-foreground">
+            ({snapshot.totalGathered})
+          </span>
+        </h4>
+        <dl
+          className="grid grid-cols-2 gap-x-4 sm:grid-cols-3"
+          data-testid="p2p-diag-candidate-grid"
+        >
+          {CANDIDATE_TYPE_ORDER.map((type) => (
+            <StatRow
+              key={type}
+              label={CANDIDATE_LABEL[type]}
+              value={snapshot.candidateCounts[type] ?? 0}
+              testId={`p2p-diag-count-${type}`}
+            />
+          ))}
+        </dl>
+      </section>
+
+      <Separator />
+
+      {/* Selected pair + quality */}
+      <section>
+        <h4 className="mb-2 text-sm font-semibold">Active connection</h4>
+        <dl className="grid grid-cols-2 gap-x-4">
+          <StatRow
+            label="Local type"
+            value={pair?.localType ?? "—"}
+            testId="p2p-diag-local-type"
+          />
+          <StatRow
+            label="Remote type"
+            value={pair?.remoteType ?? "—"}
+            testId="p2p-diag-remote-type"
+          />
+          <StatRow
+            label="Round-trip time"
+            value={formatMs(pair?.currentRttMs)}
+            testId="p2p-diag-rtt"
+          />
+          <StatRow
+            label="Packet loss"
+            value={
+              lossPct != null
+                ? `${lossPct.toFixed(1)}%`
+                : (pair?.packetsLost ?? "—")
+            }
+            testId="p2p-diag-loss"
+          />
+          <StatRow label="Sent" value={formatBytes(pair?.bytesSent)} />
+          <StatRow label="Received" value={formatBytes(pair?.bytesReceived)} />
+        </dl>
+      </section>
+
+      <Separator />
+
+      {/* Gathering timing + errors */}
+      <section>
+        <h4 className="mb-2 text-sm font-semibold">Gathering</h4>
+        <dl className="grid grid-cols-2 gap-x-4">
+          <StatRow
+            label="Gathering time"
+            value={formatMs(snapshot.gatheringDurationMs)}
+            testId="p2p-diag-gather-time"
+          />
+          <StatRow
+            label="Candidate errors"
+            value={snapshot.candidateErrors.length}
+            testId="p2p-diag-errors"
+          />
+        </dl>
+        {snapshot.candidateErrors.length > 0 ? (
+          <ul
+            className="mt-2 space-y-1 text-xs text-muted-foreground"
+            data-testid="p2p-diag-error-list"
+          >
+            {snapshot.candidateErrors.slice(0, 5).map((err, idx) => (
+              <li key={`${err.timestamp}-${idx}`}>
+                <span className="font-medium text-destructive">
+                  {err.errorCode != null ? `Error ${err.errorCode}` : "Error"}
+                </span>
+                {err.url ? ` · ${err.url}` : ""}
+                {err.errorText ? ` · ${err.errorText}` : ""}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </section>
+    </div>
+  );
+}
+
+export function P2PDiagnosticsPanel({
+  connection,
+  defaultOpen = false,
+  pollIntervalMs,
+  className,
+}: P2PDiagnosticsPanelProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  const live = useP2PDiagnostics({
+    connection: connection ?? null,
+    pollIntervalMs,
+  });
+
+  // Probe state (used only when no live connection is supplied).
+  const [probeSnapshot, setProbeSnapshot] =
+    useState<ICEDiagnosticsSnapshot | null>(null);
+  const [probeRunning, setProbeRunning] = useState(false);
+  const [probeError, setProbeError] = useState<Error | null>(null);
+
+  const liveMode = connection != null;
+  const supported = live.supported;
+
+  const runProbe = useCallback(async () => {
+    setProbeRunning(true);
+    setProbeError(null);
+    try {
+      const rtcConfig = getGlobalICEManager().getRTCConfiguration();
+      const { snapshot } = await runDiagnosticsProbe(rtcConfig);
+      setProbeSnapshot(snapshot);
+    } catch (err) {
+      setProbeError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setProbeRunning(false);
+    }
+  }, []);
+
+  const activeSnapshot = liveMode ? live.snapshot : probeSnapshot;
+  const loading = liveMode ? live.loading : probeRunning;
+  const error = liveMode ? live.error : probeError;
+
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className={cn(
+        "rounded-lg border bg-card text-card-foreground",
+        className,
+      )}
+      data-testid="p2p-diagnostics-panel"
+    >
+      <div className="flex items-center justify-between gap-2 p-3">
+        <CollapsibleTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="flex-1 justify-start"
+            aria-expanded={open}
+            aria-controls="p2p-diagnostics-content"
+          >
+            <Activity className="h-4 w-4" aria-hidden="true" />
+            Connection Diagnostics
+            <ChevronDown
+              className={cn(
+                "ml-auto h-4 w-4 transition-transform",
+                open && "rotate-180",
+              )}
+              aria-hidden="true"
+            />
+          </Button>
+        </CollapsibleTrigger>
+        {supported && liveMode ? (
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => live.refresh()}
+            disabled={loading}
+            aria-label="Refresh diagnostics"
+            data-testid="p2p-diag-refresh"
+          >
+            <RefreshCw
+              className={cn("h-4 w-4", loading && "animate-spin")}
+              aria-hidden="true"
+            />
+          </Button>
+        ) : null}
+        {!liveMode && supported ? (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void runProbe()}
+            disabled={probeRunning}
+            data-testid="p2p-diag-run-test"
+          >
+            {probeRunning ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <RefreshCw className="h-4 w-4" aria-hidden="true" />
+            )}
+            Test
+          </Button>
+        ) : null}
+      </div>
+
+      <CollapsibleContent id="p2p-diagnostics-content">
+        <div
+          className="space-y-3 px-3 pb-3"
+          role="region"
+          aria-label="P2P connection diagnostics"
+          aria-live="polite"
+        >
+          {!supported ? (
+            <Alert variant="warning" data-testid="p2p-diag-unsupported">
+              <TriangleAlert className="h-4 w-4" aria-hidden="true" />
+              <AlertTitle>Diagnostics unavailable</AlertTitle>
+              <AlertDescription>
+                This environment does not support WebRTC (RTCPeerConnection).
+                Diagnostics require a browser or a Tauri webview with WebRTC
+                enabled.
+              </AlertDescription>
+            </Alert>
+          ) : null}
+
+          {error ? (
+            <Alert variant="destructive" data-testid="p2p-diag-error">
+              <TriangleAlert className="h-4 w-4" aria-hidden="true" />
+              <AlertTitle>Could not read diagnostics</AlertTitle>
+              <AlertDescription>{error.message}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          {supported && !error && !activeSnapshot ? (
+            <p
+              className="text-sm text-muted-foreground"
+              data-testid="p2p-diag-idle"
+            >
+              {liveMode
+                ? "Waiting for a peer connection…"
+                : "Run a connection test to detect your NAT type and gather ICE candidates."}
+            </p>
+          ) : null}
+
+          {supported && activeSnapshot ? (
+            <DiagnosticsReadout snapshot={activeSnapshot} />
+          ) : null}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+export default P2PDiagnosticsPanel;

--- a/src/hooks/__tests__/use-p2p-diagnostics.test.ts
+++ b/src/hooks/__tests__/use-p2p-diagnostics.test.ts
@@ -1,0 +1,171 @@
+/**
+ * useP2PDiagnostics hook tests.
+ * Issue #1088.
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+
+import { useP2PDiagnostics } from "../use-p2p-diagnostics";
+import type { ICEDiagnosticsSnapshot } from "@/lib/ice-diagnostics";
+
+function makeSnapshot(
+  overrides: Partial<ICEDiagnosticsSnapshot> = {},
+): ICEDiagnosticsSnapshot {
+  return {
+    timestamp: 1000,
+    iceConnectionState: "connected",
+    gatheringState: "complete",
+    phase: "connected",
+    candidateCounts: { host: 1, srflx: 1, prflx: 0, relay: 0, unknown: 0 },
+    candidates: [],
+    candidateErrors: [],
+    selectedPair: null,
+    natType: "cone",
+    hasTurnConfigured: true,
+    gatheringStartedAt: 900,
+    gatheringCompleteAt: 1000,
+    gatheringDurationMs: 100,
+    connectedAt: 1100,
+    totalGathered: 2,
+    ...overrides,
+  };
+}
+
+/** Minimal diagnostics source that returns a controlled snapshot. */
+function makeSource(snapshot: ICEDiagnosticsSnapshot | null) {
+  let latest = snapshot;
+  const calls = { count: 0 };
+  return {
+    calls,
+    source: {
+      async getDiagnostics() {
+        calls.count++;
+        return latest;
+      },
+    },
+    set(next: ICEDiagnosticsSnapshot | null) {
+      latest = next;
+    },
+  };
+}
+
+/** Resolve after `ms` so real timers can drive the poll interval. */
+const after = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("useP2PDiagnostics", () => {
+  const originalRTCP = (window as { RTCPeerConnection?: unknown })
+    .RTCPeerConnection;
+
+  beforeEach(() => {
+    // The hook is guarded on WebRTC availability.
+
+    (window as any).RTCPeerConnection = function MockPC() {};
+  });
+
+  afterEach(() => {
+    (window as { RTCPeerConnection?: unknown }).RTCPeerConnection =
+      originalRTCP;
+  });
+
+  it("reports supported=true when WebRTC is present", () => {
+    const { result } = renderHook(() =>
+      useP2PDiagnostics({ connection: null }),
+    );
+    expect(result.current.supported).toBe(true);
+  });
+
+  it("returns a null snapshot when no connection is provided", () => {
+    const { result } = renderHook(() =>
+      useP2PDiagnostics({ connection: null }),
+    );
+    expect(result.current.snapshot).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("fetches the snapshot on mount and after each poll interval", async () => {
+    const snap = makeSnapshot();
+    const { source, calls } = makeSource(snap);
+    const { result } = renderHook(() =>
+      useP2PDiagnostics({
+        connection: source,
+        pollIntervalMs: 60,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.snapshot).not.toBeNull();
+    });
+    expect(result.current.snapshot?.natType).toBe("cone");
+    expect(calls.count).toBeGreaterThanOrEqual(1);
+
+    // Advance past one poll interval; another fetch occurs.
+    await after(90);
+    await waitFor(() => {
+      expect(calls.count).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it("manual refresh triggers a new fetch", async () => {
+    const snap = makeSnapshot();
+    const { source, calls } = makeSource(snap);
+    const { result } = renderHook(() =>
+      useP2PDiagnostics({ connection: source, pollIntervalMs: 60000 }),
+    );
+
+    await waitFor(() => expect(result.current.snapshot).not.toBeNull());
+    const before = calls.count;
+    result.current.refresh();
+    await waitFor(() => expect(calls.count).toBeGreaterThan(before));
+  });
+
+  it("surfaces errors from getDiagnostics without throwing", async () => {
+    const failing = {
+      async getDiagnostics(): Promise<ICEDiagnosticsSnapshot | null> {
+        throw new Error("boom");
+      },
+    };
+    const { result } = renderHook(() =>
+      useP2PDiagnostics({ connection: failing, pollIntervalMs: 60000 }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+      expect(result.current.error?.message).toBe("boom");
+    });
+    expect(result.current.snapshot).toBeNull();
+  });
+
+  it("does not poll when disabled", async () => {
+    const snap = makeSnapshot();
+    const { source, calls } = makeSource(snap);
+    renderHook(() =>
+      useP2PDiagnostics({
+        connection: source,
+        enabled: false,
+        pollIntervalMs: 30,
+      }),
+    );
+    expect(calls.count).toBe(0);
+    await after(60);
+    expect(calls.count).toBe(0);
+  });
+
+  it("reflects updated snapshot values on subsequent polls", async () => {
+    const snap = makeSnapshot();
+    const { source, calls, set } = makeSource(snap);
+    const { result } = renderHook(() =>
+      useP2PDiagnostics({ connection: source, pollIntervalMs: 40 }),
+    );
+
+    await waitFor(() => expect(result.current.snapshot?.totalGathered).toBe(2));
+
+    // Change the source's snapshot and wait for the next poll.
+    set(makeSnapshot({ totalGathered: 9, natType: "restrictive" }));
+    await after(60);
+    await waitFor(() => {
+      expect(result.current.snapshot?.totalGathered).toBe(9);
+      expect(result.current.snapshot?.natType).toBe("restrictive");
+    });
+    expect(calls.count).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/hooks/use-p2p-diagnostics.ts
+++ b/src/hooks/use-p2p-diagnostics.ts
@@ -1,0 +1,115 @@
+/**
+ * useP2PDiagnostics — React hook that surfaces live ICE / NAT-traversal
+ * diagnostics for the diagnostics panel.
+ * Issue #1088: NAT-traversal diagnostics panel with ICE candidate reporting.
+ *
+ * The hook polls a connection's `getDiagnostics()` snapshot on an interval and
+ * exposes a manual `refresh`. It is guarded for SSR and for environments
+ * without WebRTC (older Tauri webviews). It never mutates the connection.
+ */
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  isICEDiagnosticsSupported,
+  type ICEDiagnosticsSnapshot,
+} from "@/lib/ice-diagnostics";
+
+/**
+ * Structural type for anything that can produce a diagnostics snapshot
+ * (e.g. `WebRTCConnection`). Kept loose so the hook is decoupled from the
+ * concrete connection class and trivially mockable in tests.
+ */
+export interface DiagnosticsSource {
+  getDiagnostics(): Promise<ICEDiagnosticsSnapshot | null>;
+}
+
+export interface UseP2PDiagnosticsOptions {
+  /** The connection to observe, or null when none is active. */
+  connection: DiagnosticsSource | null;
+  /** Start/stop polling. When false the hook keeps the last snapshot. */
+  enabled?: boolean;
+  /** Polling cadence in ms. Defaults to 2000. */
+  pollIntervalMs?: number;
+}
+
+export interface UseP2PDiagnosticsResult {
+  snapshot: ICEDiagnosticsSnapshot | null;
+  loading: boolean;
+  error: Error | null;
+  supported: boolean;
+  refresh: () => void;
+}
+
+/**
+ * Default polling interval. ICE state changes are comparatively slow, so 2s
+ * balances responsiveness against `getStats()` cost.
+ */
+const DEFAULT_POLL_MS = 2000;
+
+export function useP2PDiagnostics(
+  options: UseP2PDiagnosticsOptions,
+): UseP2PDiagnosticsResult {
+  const {
+    connection,
+    enabled = true,
+    pollIntervalMs = DEFAULT_POLL_MS,
+  } = options;
+
+  const supported = isICEDiagnosticsSupported();
+  const [snapshot, setSnapshot] = useState<ICEDiagnosticsSnapshot | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Track the latest connection + a "refresh nonce" so polling and manual
+  // refresh share one async path without racing stale closures.
+  const connectionRef = useRef<DiagnosticsSource | null>(connection);
+  connectionRef.current = connection;
+  const refreshNonce = useRef(0);
+  const [nonce, setNonce] = useState(0);
+
+  const refresh = useCallback(() => {
+    refreshNonce.current += 1;
+    setNonce(refreshNonce.current);
+  }, []);
+
+  useEffect(() => {
+    if (!supported || !enabled || !connection) {
+      setLoading(false);
+      // Drop the snapshot when the connection goes away.
+      if (!connection) setSnapshot(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    const fetchSnapshot = async () => {
+      const source = connectionRef.current;
+      if (!source) return;
+      try {
+        const next = await source.getDiagnostics();
+        if (cancelled) return;
+        setSnapshot(next);
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void fetchSnapshot();
+
+    const interval = setInterval(fetchSnapshot, pollIntervalMs);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+    // `nonce` changes on manual refresh; connection/enabled/cadence drive setup.
+  }, [connection, enabled, pollIntervalMs, supported, nonce]);
+
+  return { snapshot, loading, error, supported, refresh };
+}

--- a/src/lib/__tests__/ice-diagnostics.test.ts
+++ b/src/lib/__tests__/ice-diagnostics.test.ts
@@ -1,0 +1,444 @@
+/**
+ * ICE / NAT-traversal diagnostics — data-layer unit tests.
+ * Issue #1088: NAT-type classifier + getStats aggregation coverage.
+ *
+ * These tests mock RTCPeerConnection events / RTCStatsReport as plain data and
+ * assert the pure classification + aggregation logic. No browser WebRTC stack.
+ */
+
+import {
+  classifyCandidateType,
+  classifyNATType,
+  deriveICEPhase,
+  extractSelectedCandidatePair,
+  buildDiagnosticsSnapshot,
+  inferIPFamily,
+  toCandidateRecord,
+  isICEDiagnosticsSupported,
+  ICEDiagnosticsCollector,
+  MAX_STORED_CANDIDATES,
+  type CandidateCounts,
+  type ICEDiagnosticsSnapshot,
+} from "../ice-diagnostics";
+
+const HOST_CAND =
+  "candidate:842163049 1 udp 1677729535 192.168.1.5 53427 typ host generation 0 ufrag 5p+J";
+const SRFLX_CAND =
+  "candidate:842163049 1 udp 1677729535 203.0.113.7 53427 typ srflx raddr 192.168.1.5 rport 53427 generation 0";
+const RELAY_CAND =
+  "candidate:842163049 1 tcp 1518280447 198.51.100.3 443 typ relay tcptype passive generation 0";
+const PRFLX_CAND =
+  "candidate:842163049 1 udp 1677729535 203.0.113.99 41255 typ prflx generation 0";
+const IPV6_HOST_CAND =
+  "candidate:842163049 1 udp 1677729535 2001:db8::1 53427 typ host generation 0";
+
+function emptyCounts(): CandidateCounts {
+  return { host: 0, srflx: 0, prflx: 0, relay: 0, unknown: 0 };
+}
+
+describe("classifyCandidateType", () => {
+  it.each([
+    ["host", HOST_CAND],
+    ["srflx", SRFLX_CAND],
+    ["relay", RELAY_CAND],
+    ["prflx", PRFLX_CAND],
+  ])("classifies a raw %s candidate SDP line", (expected, sdp) => {
+    expect(classifyCandidateType(sdp)).toBe(expected);
+  });
+
+  it("prefers a structured .type property when present", () => {
+    expect(classifyCandidateType({ type: "srflx" })).toBe("srflx");
+    expect(classifyCandidateType({ type: "relay" })).toBe("relay");
+  });
+
+  it("falls back to SDP parsing when .type is invalid", () => {
+    expect(classifyCandidateType({ type: "bogus", candidate: HOST_CAND })).toBe(
+      "host",
+    );
+  });
+
+  it("returns unknown for malformed / empty / null candidates", () => {
+    expect(classifyCandidateType(null)).toBe("unknown");
+    expect(classifyCandidateType(undefined)).toBe("unknown");
+    expect(classifyCandidateType("candidate:garbage no typ here")).toBe(
+      "unknown",
+    );
+    expect(classifyCandidateType({})).toBe("unknown");
+    expect(classifyCandidateType({ candidate: null })).toBe("unknown");
+  });
+});
+
+describe("inferIPFamily", () => {
+  it("detects IPv4", () => {
+    expect(inferIPFamily("192.168.1.5")).toBe("ipv4");
+    expect(inferIPFamily("10.0.0.1")).toBe("ipv4");
+  });
+  it("detects IPv6 (including bracketed)", () => {
+    expect(inferIPFamily("2001:db8::1")).toBe("ipv6");
+    expect(inferIPFamily("[2001:db8::1]")).toBe("ipv6");
+  });
+  it("returns unknown for empty / non-IP", () => {
+    expect(inferIPFamily(null)).toBe("unknown");
+    expect(inferIPFamily("")).toBe("unknown");
+    expect(inferIPFamily("localhost")).toBe("unknown");
+  });
+});
+
+describe("toCandidateRecord", () => {
+  it("normalizes a host candidate record", () => {
+    const rec = toCandidateRecord(HOST_CAND, 1000);
+    expect(rec).not.toBeNull();
+    expect(rec?.type).toBe("host");
+    expect(rec?.address).toBe("192.168.1.5");
+    expect(rec?.protocol).toBe("udp");
+    expect(rec?.ipFamily).toBe("ipv4");
+    expect(rec?.timestamp).toBe(1000);
+  });
+
+  it("normalizes a relay candidate with TCP", () => {
+    const rec = toCandidateRecord(RELAY_CAND)!;
+    expect(rec.type).toBe("relay");
+    expect(rec.protocol).toBe("tcp");
+    expect(rec.address).toBe("198.51.100.3");
+  });
+
+  it("classifies IPv6 host family", () => {
+    const rec = toCandidateRecord(IPV6_HOST_CAND)!;
+    expect(rec.ipFamily).toBe("ipv6");
+  });
+
+  it("returns null for the end-of-gathering null candidate", () => {
+    expect(toCandidateRecord(null)).toBeNull();
+    expect(toCandidateRecord({ candidate: null })).toBeNull();
+  });
+});
+
+describe("classifyNATType", () => {
+  it("returns restrictive for host-only candidates", () => {
+    expect(classifyNATType({ ...emptyCounts(), host: 3 })).toBe("restrictive");
+  });
+
+  it("returns cone when srflx candidates are present", () => {
+    expect(classifyNATType({ ...emptyCounts(), host: 2, srflx: 1 })).toBe(
+      "cone",
+    );
+  });
+
+  it("returns cone when only prflx is present", () => {
+    expect(classifyNATType({ ...emptyCounts(), prflx: 1 })).toBe("cone");
+  });
+
+  it("returns turn-dependent when a relay candidate is gathered", () => {
+    expect(classifyNATType({ ...emptyCounts(), host: 2, relay: 1 })).toBe(
+      "turn-dependent",
+    );
+  });
+
+  it("returns turn-dependent when the selected pair uses relay", () => {
+    expect(
+      classifyNATType(
+        { ...emptyCounts(), host: 2, srflx: 1 },
+        {
+          localType: "relay",
+          remoteType: "host",
+          localAddress: null,
+          remoteAddress: null,
+          nominated: true,
+          currentRttMs: null,
+          packetsSent: null,
+          packetsReceived: null,
+          packetsLost: null,
+          bytesSent: null,
+          bytesReceived: null,
+        },
+      ),
+    ).toBe("turn-dependent");
+  });
+
+  it("returns unknown when nothing was gathered", () => {
+    expect(classifyNATType(emptyCounts())).toBe("unknown");
+  });
+});
+
+describe("deriveICEPhase", () => {
+  it("maps ICE connection states to phases", () => {
+    expect(deriveICEPhase(null, "connected")).toBe("connected");
+    expect(deriveICEPhase(null, "completed")).toBe("completed");
+    expect(deriveICEPhase(null, "failed")).toBe("failed");
+    expect(deriveICEPhase(null, "disconnected")).toBe("disconnected");
+    expect(deriveICEPhase(null, "closed")).toBe("closed");
+    expect(deriveICEPhase(null, "checking")).toBe("connecting");
+  });
+
+  it("surfaces 'gathering' before checks begin", () => {
+    expect(deriveICEPhase("gathering", "new")).toBe("gathering");
+    expect(deriveICEPhase("complete", "new")).toBe("connecting");
+  });
+
+  it("defaults to new with no signal", () => {
+    expect(deriveICEPhase(null, null)).toBe("new");
+    expect(deriveICEPhase("new", "new")).toBe("new");
+  });
+});
+
+describe("extractSelectedCandidatePair", () => {
+  function buildReport(
+    entries: Array<[string, Record<string, unknown>]>,
+  ): Map<string, unknown> {
+    return new Map(entries);
+  }
+
+  it("extracts the nominated pair with types, addresses, RTT and counts", () => {
+    const report = buildReport([
+      [
+        "L1",
+        {
+          type: "local-candidate",
+          candidateType: "srflx",
+          address: "203.0.113.7",
+        },
+      ],
+      [
+        "R1",
+        { type: "remote-candidate", candidateType: "host", ip: "192.168.1.9" },
+      ],
+      [
+        "P1",
+        {
+          type: "candidate-pair",
+          localCandidateId: "L1",
+          remoteCandidateId: "R1",
+          nominated: true,
+          state: "succeeded",
+          currentRoundTripTime: 0.05,
+          packetsSent: 100,
+          packetsReceived: 95,
+          packetsLost: 5,
+          bytesSent: 1000,
+          bytesReceived: 900,
+        },
+      ],
+    ]);
+
+    const pair = extractSelectedCandidatePair(report);
+    expect(pair).not.toBeNull();
+    expect(pair?.localType).toBe("srflx");
+    expect(pair?.remoteType).toBe("host");
+    expect(pair?.localAddress).toBe("203.0.113.7");
+    expect(pair?.remoteAddress).toBe("192.168.1.9");
+    expect(pair?.nominated).toBe(true);
+    expect(pair?.currentRttMs).toBe(50);
+    expect(pair?.packetsSent).toBe(100);
+    expect(pair?.packetsLost).toBe(5);
+  });
+
+  it("prefers a nominated pair over a merely succeeded one", () => {
+    const report = buildReport([
+      ["L1", { type: "local-candidate", candidateType: "host" }],
+      ["R1", { type: "remote-candidate", candidateType: "host" }],
+      [
+        "P-succ",
+        {
+          type: "candidate-pair",
+          localCandidateId: "L1",
+          remoteCandidateId: "R1",
+          state: "succeeded",
+        },
+      ],
+      [
+        "P-nom",
+        {
+          type: "candidate-pair",
+          localCandidateId: "L1",
+          remoteCandidateId: "R1",
+          nominated: true,
+          state: "in-progress",
+        },
+      ],
+    ]);
+    expect(extractSelectedCandidatePair(report)?.nominated).toBe(true);
+  });
+
+  it("falls back to a succeeded pair when none is nominated", () => {
+    const report = buildReport([
+      ["L1", { type: "local-candidate", candidateType: "host" }],
+      ["R1", { type: "remote-candidate", candidateType: "host" }],
+      [
+        "P",
+        {
+          type: "candidate-pair",
+          localCandidateId: "L1",
+          remoteCandidateId: "R1",
+          state: "succeeded",
+        },
+      ],
+    ]);
+    const pair = extractSelectedCandidatePair(report);
+    expect(pair).not.toBeNull();
+    expect(pair?.nominated).toBe(false);
+  });
+
+  it("returns null when no candidate pair is usable", () => {
+    const report = buildReport([
+      ["L1", { type: "local-candidate", candidateType: "host" }],
+      [
+        "P",
+        {
+          type: "candidate-pair",
+          localCandidateId: "L1",
+          state: "waiting", // score 0
+        },
+      ],
+    ]);
+    expect(extractSelectedCandidatePair(report)).toBeNull();
+  });
+
+  it("returns null for an empty / non-Map report", () => {
+    expect(extractSelectedCandidatePair(null)).toBeNull();
+    expect(extractSelectedCandidatePair(undefined)).toBeNull();
+    expect(extractSelectedCandidatePair({} as never)).toBeNull();
+  });
+});
+
+describe("ICEDiagnosticsCollector", () => {
+  it("counts candidate types as they are recorded", () => {
+    const c = new ICEDiagnosticsCollector();
+    c.recordCandidate(HOST_CAND);
+    c.recordCandidate(HOST_CAND);
+    c.recordCandidate(SRFLX_CAND);
+    c.recordCandidate(RELAY_CAND);
+
+    const counts = c.getCandidateCounts();
+    expect(counts.host).toBe(2);
+    expect(counts.srflx).toBe(1);
+    expect(counts.relay).toBe(1);
+    expect(counts.unknown).toBe(0);
+  });
+
+  it("ignores the end-of-gathering null candidate", () => {
+    const c = new ICEDiagnosticsCollector();
+    c.recordCandidate(null);
+    c.recordCandidate({ candidate: null });
+    expect(c.getCandidateCounts().host).toBe(0);
+    expect(c.getSnapshot().totalGathered).toBe(0);
+  });
+
+  it("records candidate errors", () => {
+    const c = new ICEDiagnosticsCollector();
+    c.recordCandidateError({
+      url: "stun:stun.l.google.com:19302",
+      errorCode: 701,
+      errorText: "STUN host unreachable",
+    });
+    const snap = c.getSnapshot();
+    expect(snap.candidateErrors).toHaveLength(1);
+    expect(snap.candidateErrors[0]?.errorCode).toBe(701);
+    expect(snap.candidateErrors[0]?.url).toContain("stun.l.google.com");
+  });
+
+  it("tracks gathering timing and connection timestamp", () => {
+    const c = new ICEDiagnosticsCollector();
+    c.recordGatheringState("gathering");
+    c.recordState("checking", "gathering");
+    c.recordState("connected", "complete");
+    const snap = c.getSnapshot();
+    expect(snap.gatheringStartedAt).not.toBeNull();
+    expect(snap.gatheringCompleteAt).not.toBeNull();
+    expect(snap.connectedAt).not.toBeNull();
+    expect(snap.phase).toBe("connected");
+  });
+
+  it("caps stored candidates at MAX_STORED_CANDIDATES", () => {
+    const c = new ICEDiagnosticsCollector();
+    for (let i = 0; i < MAX_STORED_CANDIDATES + 10; i++) {
+      c.recordCandidate(HOST_CAND);
+    }
+    const snap = c.getSnapshot();
+    expect(snap.candidates.length).toBe(MAX_STORED_CANDIDATES);
+    // counts still reflect the true total
+    expect(snap.candidateCounts.host).toBe(MAX_STORED_CANDIDATES + 10);
+    expect(snap.totalGathered).toBe(MAX_STORED_CANDIDATES + 10);
+  });
+
+  it("merges a stats report into the snapshot selected pair", () => {
+    const c = new ICEDiagnosticsCollector();
+    c.recordCandidate(SRFLX_CAND);
+    const report = new Map<string, unknown>([
+      ["L1", { type: "local-candidate", candidateType: "srflx" }],
+      ["R1", { type: "remote-candidate", candidateType: "host" }],
+      [
+        "P1",
+        {
+          type: "candidate-pair",
+          localCandidateId: "L1",
+          remoteCandidateId: "R1",
+          nominated: true,
+          currentRoundTripTime: 0.023,
+        },
+      ],
+    ]);
+    const snap = c.getSnapshot(report);
+    expect(snap.selectedPair).not.toBeNull();
+    expect(snap.selectedPair?.currentRttMs).toBe(23);
+  });
+
+  it("reset() clears all collected data", () => {
+    const c = new ICEDiagnosticsCollector();
+    c.recordCandidate(HOST_CAND);
+    c.recordState("connected", "complete");
+    c.reset();
+    const snap = c.getSnapshot();
+    expect(snap.totalGathered).toBe(0);
+    expect(snap.connectedAt).toBeNull();
+    expect(snap.phase).toBe("new");
+  });
+});
+
+describe("buildDiagnosticsSnapshot", () => {
+  it("derives natType and totalGathered from inputs", () => {
+    const snap: ICEDiagnosticsSnapshot = buildDiagnosticsSnapshot({
+      candidateCounts: { ...emptyCounts(), host: 2, srflx: 1 },
+      candidates: [],
+      candidateErrors: [],
+      iceConnectionState: "connected",
+      gatheringState: "complete",
+      hasTurnConfigured: true,
+      gatheringStartedAt: 1000,
+      gatheringCompleteAt: 1500,
+      connectedAt: 1600,
+      statsReport: null,
+    });
+    expect(snap.natType).toBe("cone");
+    expect(snap.totalGathered).toBe(3);
+    expect(snap.gatheringDurationMs).toBe(500);
+    expect(snap.phase).toBe("connected");
+    expect(snap.hasTurnConfigured).toBe(true);
+    // snapshot copies counts so callers can't mutate internal state
+    expect(snap.candidateCounts).toEqual({
+      host: 2,
+      srflx: 1,
+      prflx: 0,
+      relay: 0,
+      unknown: 0,
+    });
+  });
+});
+
+describe("isICEDiagnosticsSupported", () => {
+  const original = (window as { RTCPeerConnection?: unknown })
+    .RTCPeerConnection;
+
+  afterEach(() => {
+    (window as { RTCPeerConnection?: unknown }).RTCPeerConnection = original;
+  });
+
+  it("returns false when RTCPeerConnection is absent", () => {
+    (window as { RTCPeerConnection?: unknown }).RTCPeerConnection = undefined;
+    expect(isICEDiagnosticsSupported()).toBe(false);
+  });
+
+  it("returns true when RTCPeerConnection is available", () => {
+    (window as any).RTCPeerConnection = function MockPC() {};
+    expect(isICEDiagnosticsSupported()).toBe(true);
+  });
+});

--- a/src/lib/__tests__/webrtc-p2p.test.ts
+++ b/src/lib/__tests__/webrtc-p2p.test.ts
@@ -361,3 +361,123 @@ describe("WebRTCConnection reconnection (issue #915)", () => {
     expect(conn.isConnected()).toBe(false);
   });
 });
+
+// =============================================================================
+// Issue #1088: getDiagnostics() — ICE candidate / NAT-traversal observability
+// =============================================================================
+
+/**
+ * RTCPeerConnection mock that supports addEventListener (so the diagnostics
+ * collector actually subscribes) and emits candidate/state events on demand.
+ */
+let lastDiagPC: DiagnosticsPC | null = null;
+
+class DiagnosticsPC {
+  connectionState: RTCPeerConnectionState = "new";
+  iceConnectionState: RTCIceConnectionState = "new";
+  iceGatheringState: RTCIceGatheringState = "new";
+  localDescription: RTCSessionDescriptionInit | null = null;
+  private listeners: Record<string, Array<(event: unknown) => void>> = {};
+
+  constructor() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    lastDiagPC = this;
+  }
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    (this.listeners[type] ??= []).push(listener);
+  }
+  removeEventListener(type: string, listener: (event: unknown) => void): void {
+    this.listeners[type] = (this.listeners[type] ?? []).filter(
+      (l) => l !== listener,
+    );
+  }
+  emit(type: string, event: unknown): void {
+    for (const l of this.listeners[type] ?? []) l(event);
+  }
+  async createOffer(): Promise<RTCSessionDescriptionInit> {
+    return { type: "offer", sdp: "sdp" };
+  }
+  async setLocalDescription(d: RTCSessionDescriptionInit): Promise<void> {
+    this.localDescription = d;
+  }
+  createDataChannel(): unknown {
+    return { close: () => {} };
+  }
+  async getStats(): Promise<Map<string, unknown>> {
+    return new Map();
+  }
+  close(): void {
+    this.connectionState = "closed";
+  }
+}
+
+describe("WebRTCConnection.getDiagnostics() (issue #1088)", () => {
+  const ORIGINAL_RTCP = global.RTCPeerConnection;
+
+  beforeEach(() => {
+    (global as { RTCPeerConnection?: unknown }).RTCPeerConnection =
+      DiagnosticsPC as unknown as typeof RTCPeerConnection;
+    lastDiagPC = null;
+  });
+
+  afterEach(() => {
+    (global as { RTCPeerConnection?: unknown }).RTCPeerConnection =
+      ORIGINAL_RTCP;
+  });
+
+  it("returns null before a peer connection exists", async () => {
+    const conn = new WebRTCConnection({
+      playerId: "p1",
+      playerName: "P1",
+      isHost: true,
+      enableICEMonitoring: false,
+    });
+    expect(await conn.getDiagnostics()).toBeNull();
+  });
+
+  it("reports candidate types, ICE state and NAT type via the collector", async () => {
+    const conn = new WebRTCConnection({
+      playerId: "p1",
+      playerName: "P1",
+      isHost: true,
+      enableICEMonitoring: false,
+    });
+    await conn.initialize();
+    const pc = lastDiagPC as DiagnosticsPC;
+
+    // Simulate ICE gathering producing a host + srflx candidate.
+    pc.emit("icegatheringstatechange", {});
+    // First set the gathering state on the mock, then re-emit so the collector
+    // reads the updated value.
+    pc.iceGatheringState = "gathering";
+    pc.emit("icegatheringstatechange", {});
+    pc.emit("icecandidate", {
+      candidate: {
+        candidate: "candidate:1 1 udp 1 192.168.1.5 5000 typ host generation 0",
+      },
+    });
+    pc.emit("icecandidate", {
+      candidate: {
+        candidate:
+          "candidate:2 1 udp 2 203.0.113.7 5001 typ srflx generation 0",
+      },
+    });
+    pc.iceGatheringState = "complete";
+    pc.emit("icegatheringstatechange", {});
+    pc.iceConnectionState = "connected";
+    pc.emit("iceconnectionstatechange", {});
+
+    const diag = await conn.getDiagnostics();
+    expect(diag).not.toBeNull();
+    expect(diag?.candidateCounts.host).toBe(1);
+    expect(diag?.candidateCounts.srflx).toBe(1);
+    expect(diag?.natType).toBe("cone");
+    expect(diag?.iceConnectionState).toBe("connected");
+    expect(diag?.phase).toBe("connected");
+    expect(diag?.totalGathered).toBe(2);
+
+    conn.close();
+    // Detaching must not throw and the connection is gone.
+    expect(await conn.getDiagnostics()).toBeNull();
+  });
+});

--- a/src/lib/ice-diagnostics.ts
+++ b/src/lib/ice-diagnostics.ts
@@ -1,0 +1,834 @@
+/**
+ * ICE / NAT-traversal diagnostics — runtime observability for P2P connections.
+ * Issue #1088: Add NAT-traversal diagnostics panel with ICE candidate reporting.
+ *
+ * This module is a *pure data layer*: it classifies ICE candidate types, derives
+ * an effective NAT-type heuristic, aggregates the selected candidate pair from
+ * `getStats()`, and collects live ICE events from an `RTCPeerConnection`. The UI
+ * (panel + hook) consumes the resulting {@link ICEDiagnosticsSnapshot}.
+ *
+ * Design notes:
+ *  - All classification/aggregation is framework-agnostic and synchronous, so it
+ *    can be unit-tested without a real browser WebRTC stack (mock RTCStatsReport
+ *    as a plain `Map`, feed candidate SDP strings, assert counts/NAT type).
+ *  - The {@link ICEDiagnosticsCollector} attaches to an `RTCPeerConnection` via
+ *    `addEventListener` so it never clobbers existing `onicecandidate` /
+ *    `oniceconnectionstatechange` handlers wired by the connection manager. It
+ *    only observes; it never drives the connection.
+ */
+
+/**
+ * The candidate `typ` values defined by RFC 8445 / WebRTC.
+ *
+ * - `host`       — a directly reachable local interface address
+ * - `srflx`      — server-reflexive address (STUN-mapped public address)
+ * - `prflx`      — peer-reflexive address (learned during connectivity checks)
+ * - `relay`      — a TURN relayed address (relay)
+ * - `unknown`    — could not be classified (malformed/empty candidate)
+ */
+export type CandidateType = "host" | "srflx" | "prflx" | "relay" | "unknown";
+
+/**
+ * A single high-level phase derived from the ICE gathering + connection state
+ * machines, for compact display in the diagnostics panel.
+ */
+export type ICEPhase =
+  | "new"
+  | "gathering"
+  | "connecting"
+  | "connected"
+  | "completed"
+  | "disconnected"
+  | "failed"
+  | "closed";
+
+/**
+ * Effective NAT-type heuristic derived from the gathered candidate mix.
+ *
+ * - `restrictive`    — only host candidates ⇒ the NAT is dropping server-reflexive
+ *                      mappings (symmetric/restrictive NAT). Direct P2P almost
+ *                      always fails; a TURN relay is required.
+ * - `cone`           — host + srflx (and/or prflx) candidates ⇒ a NAT that can
+ *                      be traversed directly (cone/endpoint-independent mapping).
+ * - `turn-dependent` — a relay candidate is in use ⇒ connectivity depends on a
+ *                      reachable TURN server.
+ * - `unknown`        — no candidates yet (still gathering) or empty.
+ */
+export type NATType = "restrictive" | "cone" | "turn-dependent" | "unknown";
+
+/** IP address family inferred from a candidate address. */
+export type IPFamily = "ipv4" | "ipv6" | "unknown";
+
+/**
+ * A normalized, classified ICE candidate record.
+ *
+ * `address`/`candidate` are retained for developer self-diagnosis; the panel
+ * may redact them for screenshots. They never leave the client.
+ */
+export interface CandidateRecord {
+  type: CandidateType;
+  address: string | null;
+  protocol: string | null;
+  ipFamily: IPFamily;
+  /** Raw candidate SDP line (e.g. `candidate:... typ host`). */
+  candidate: string;
+  /** For srflx/relay candidates, the STUN/TURN URL that produced it, if known. */
+  url: string | null;
+  /** Epoch ms when the candidate was observed. */
+  timestamp: number;
+}
+
+/** A failed candidate-gathering attempt (e.g. STUN/TURN unreachable). */
+export interface ICECandidateError {
+  url: string | null;
+  errorCode: number | null;
+  errorText: string | null;
+  timestamp: number;
+}
+
+/** The active selected candidate pair + link quality, from `getStats()`. */
+export interface SelectedCandidatePair {
+  localType: CandidateType | null;
+  remoteType: CandidateType | null;
+  localAddress: string | null;
+  remoteAddress: string | null;
+  nominated: boolean;
+  /** Round-trip time in milliseconds (from `currentRoundTripTime`, in seconds). */
+  currentRttMs: number | null;
+  packetsSent: number | null;
+  packetsReceived: number | null;
+  packetsLost: number | null;
+  bytesSent: number | null;
+  bytesReceived: number | null;
+}
+
+/** Per-type gathered-candidate counts. */
+export type CandidateCounts = Record<CandidateType, number>;
+
+/**
+ * Aggregated, immutable diagnostics snapshot consumed by the panel/hook.
+ */
+export interface ICEDiagnosticsSnapshot {
+  /** Epoch ms when the snapshot was produced. */
+  timestamp: number;
+  iceConnectionState: RTCIceConnectionState | null;
+  gatheringState: RTCIceGatheringState | null;
+  phase: ICEPhase;
+  candidateCounts: CandidateCounts;
+  /** Most recent candidates (capped to {@link MAX_STORED_CANDIDATES}). */
+  candidates: CandidateRecord[];
+  candidateErrors: ICECandidateError[];
+  selectedPair: SelectedCandidatePair | null;
+  natType: NATType;
+  /** Whether a TURN relay is configured for this connection. */
+  hasTurnConfigured: boolean;
+  gatheringStartedAt: number | null;
+  gatheringCompleteAt: number | null;
+  gatheringDurationMs: number | null;
+  /** Epoch ms when the connection first reached a connected/completed state. */
+  connectedAt: number | null;
+  /** Total candidates gathered (sum across all types). */
+  totalGathered: number;
+}
+
+/** Maximum candidate records retained in memory for the panel. */
+export const MAX_STORED_CANDIDATES = 32;
+/** Maximum candidate-error records retained in memory for the panel. */
+export const MAX_STORED_ERRORS = 16;
+
+/** Ordered candidate types for stable display. */
+export const CANDIDATE_TYPE_ORDER: readonly CandidateType[] = [
+  "host",
+  "srflx",
+  "prflx",
+  "relay",
+  "unknown",
+] as const;
+
+/**
+ * A human-readable label + explainer for each NAT type, used by the panel.
+ */
+export const NAT_TYPE_META: Record<
+  NATType,
+  { label: string; description: string }
+> = {
+  restrictive: {
+    label: "Restrictive NAT",
+    description:
+      "Only local (host) candidates were gathered. The network is likely a " +
+      "symmetric/restrictive NAT that blocks direct peer-to-peer connections.",
+  },
+  cone: {
+    label: "Cone / traversable NAT",
+    description:
+      "Server-reflexive (STUN) candidates were gathered. The NAT can be " +
+      "traversed directly without a relay.",
+  },
+  "turn-dependent": {
+    label: "TURN-dependent",
+    description:
+      "A relay candidate is in use. Connectivity depends on a reachable TURN " +
+      "server.",
+  },
+  unknown: {
+    label: "Detecting…",
+    description:
+      "Not enough candidates gathered yet to classify the NAT. Diagnostics " +
+      "will update as candidates arrive.",
+  },
+};
+
+const EMPTY_COUNTS: CandidateCounts = {
+  host: 0,
+  srflx: 0,
+  prflx: 0,
+  relay: 0,
+  unknown: 0,
+};
+
+/**
+ * Normalize an arbitrary candidate input (an `RTCIceCandidate`, an init object,
+ * or a raw SDP string) into its raw candidate string. Returns `null` when the
+ * input carries no candidate SDP (e.g. the end-of-gathering `null` candidate).
+ */
+export function getRawCandidateString(candidate: unknown): string | null {
+  if (candidate == null) return null;
+  if (typeof candidate === "string") return candidate;
+  if (typeof candidate !== "object") return null;
+  const obj = candidate as Record<string, unknown>;
+  if (typeof obj.candidate === "string") return obj.candidate;
+  return null;
+}
+
+const CANDIDATE_TYPE_RE = /\btyp\s+(host|srflx|prflx|relay)\b/i;
+const PROTOCOL_RE = /(?:^|\s)candidate:\S+\s+\S+\s+(udp|tcp)\s/i;
+
+/**
+ * Extract the address (IP/host) from a candidate SDP line.
+ *
+ * The candidate line format is:
+ *   `candidate:<foundation> <component> <protocol> <priority> <addr> <port> typ <type> ...`
+ * The address is the 5th whitespace-delimited token after `candidate:`.
+ */
+function extractAddress(raw: string): string | null {
+  const body = raw.startsWith("candidate:")
+    ? raw.slice("candidate:".length)
+    : raw;
+  const tokens = body.trim().split(/\s+/);
+  // tokens: foundation component protocol priority address port ...
+  const address = tokens[4];
+  return address && address !== "0.0.0.0" ? address : null;
+}
+
+/**
+ * Infer the IP address family from an address string.
+ */
+export function inferIPFamily(address: string | null | undefined): IPFamily {
+  if (!address) return "unknown";
+  // IPv6 addresses contain ':' (and may be wrapped in brackets, which we strip).
+  const cleaned = address.replace(/^\[|\]$/g, "");
+  if (cleaned.includes(":")) return "ipv6";
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(cleaned)) return "ipv4";
+  return "unknown";
+}
+
+/**
+ * Classify a candidate into its {@link CandidateType} by parsing the candidate
+ * SDP line. Accepts an `RTCIceCandidate`, an init-like object (with a
+ * `candidate` string), or a raw SDP string.
+ *
+ * Prefers a structured `.type` property when present (set by some WebRTC
+ * implementations), falling back to regex extraction of the `typ` token.
+ */
+export function classifyCandidateType(candidate: unknown): CandidateType {
+  if (candidate && typeof candidate === "object") {
+    const obj = candidate as Record<string, unknown>;
+    if (
+      typeof obj.type === "string" &&
+      obj.type &&
+      CANDIDATE_TYPE_ORDER.includes(obj.type as CandidateType)
+    ) {
+      return obj.type as CandidateType;
+    }
+  }
+  const raw = getRawCandidateString(candidate);
+  if (!raw) return "unknown";
+  const match = CANDIDATE_TYPE_RE.exec(raw);
+  if (!match) return "unknown";
+  return match[1].toLowerCase() as CandidateType;
+}
+
+/**
+ * Build a normalized {@link CandidateRecord} from a candidate event payload.
+ */
+export function toCandidateRecord(
+  candidate: unknown,
+  timestamp: number = Date.now(),
+): CandidateRecord | null {
+  const raw = getRawCandidateString(candidate);
+  if (!raw) return null;
+  const type = classifyCandidateType(candidate);
+  const address = extractAddress(raw);
+  const protocolMatch = PROTOCOL_RE.exec(raw);
+  return {
+    type,
+    address,
+    protocol: protocolMatch ? protocolMatch[1].toLowerCase() : null,
+    ipFamily: inferIPFamily(address),
+    candidate: raw,
+    // STUN/TURN URLs are not part of the candidate SDP line; they surface on
+    // `icecandidateerror` events and RTCStats `url` fields, so this stays null
+    // for raw candidates and is populated elsewhere when known.
+    url: null,
+    timestamp,
+  };
+}
+
+/**
+ * Derive the effective NAT type from the gathered candidate counts and the
+ * selected candidate pair (when known).
+ *
+ * Precedence (issue #1088):
+ *  1. relay candidate present / selected pair uses relay → `turn-dependent`
+ *  2. srflx or prflx candidate present                    → `cone`
+ *  3. only host candidates                                → `restrictive`
+ *  4. nothing gathered yet                                → `unknown`
+ */
+export function classifyNATType(
+  counts: CandidateCounts,
+  selectedPair: SelectedCandidatePair | null = null,
+): NATType {
+  if (
+    counts.relay > 0 ||
+    selectedPair?.localType === "relay" ||
+    selectedPair?.remoteType === "relay"
+  ) {
+    return "turn-dependent";
+  }
+  if (counts.srflx > 0 || counts.prflx > 0) {
+    return "cone";
+  }
+  if (counts.host > 0) {
+    return "restrictive";
+  }
+  return "unknown";
+}
+
+/**
+ * Derive a compact {@link ICEPhase} from the two ICE state machines.
+ *
+ * Gathering is surfaced while candidates are being collected (even before ICE
+ * checks begin), then the connection-state machine takes precedence.
+ */
+export function deriveICEPhase(
+  gatheringState: RTCIceGatheringState | null | undefined,
+  iceConnectionState: RTCIceConnectionState | null | undefined,
+): ICEPhase {
+  switch (iceConnectionState) {
+    case "connected":
+      return "connected";
+    case "completed":
+      return "completed";
+    case "failed":
+      return "failed";
+    case "disconnected":
+      return "disconnected";
+    case "closed":
+      return "closed";
+    case "checking":
+      return "connecting";
+    default:
+      break;
+  }
+  if (gatheringState === "gathering") return "gathering";
+  if (gatheringState === "complete") return "connecting";
+  return "new";
+}
+
+/**
+ * Minimal structural view over an `RTCStatsReport` (which extends `Map`).
+ * Modeled loosely so tests can pass a plain `Map<string, unknown>`.
+ */
+type StatsEntry = {
+  type?: string;
+  [key: string]: unknown;
+};
+type StatsReportLike = Map<string, StatsEntry> | RTCStatsReport;
+
+/**
+ * Normalize a candidate-type value from an RTCStats candidate entry into a
+ * known {@link CandidateType}.
+ */
+function normalizeStatType(value: unknown): CandidateType | null {
+  if (typeof value !== "string" || !value) return null;
+  const lower = value.toLowerCase();
+  return CANDIDATE_TYPE_ORDER.includes(lower as CandidateType)
+    ? (lower as CandidateType)
+    : null;
+}
+
+/**
+ * Read the address field from a candidate stats entry. Browsers expose it as
+ * `address` (legacy) or `ip` (newer); accept either.
+ */
+function readStatAddress(entry: StatsEntry): string | null {
+  const addr = entry.address ?? entry.ip;
+  return typeof addr === "string" && addr ? addr : null;
+}
+
+/**
+ * Extract the active (nominated/succeeded) candidate pair and its link quality
+ * from a `getStats()` report.
+ *
+ * Selection preference: a `nominated` pair wins; otherwise a `succeeded` pair;
+ * otherwise (older browsers) an entry flagged `selected`.
+ *
+ * This is a pure function over a Map-like report, so it is unit-tested by
+ * passing a hand-built `Map`.
+ */
+export function extractSelectedCandidatePair(
+  report: StatsReportLike | null | undefined,
+): SelectedCandidatePair | null {
+  if (
+    !report ||
+    typeof (report as Map<string, unknown>).forEach !== "function"
+  ) {
+    return null;
+  }
+
+  const candidateById = new Map<string, StatsEntry>();
+  const pairs: Array<StatsEntry & { id: string }> = [];
+
+  (report as Map<string, StatsEntry>).forEach((value, id) => {
+    if (!value || typeof value !== "object") return;
+    const entry = value as StatsEntry;
+    const type = typeof entry.type === "string" ? entry.type : "";
+    if (
+      type === "local-candidate" ||
+      type === "remote-candidate" ||
+      type === "candidate" // legacy
+    ) {
+      candidateById.set(id, entry);
+    } else if (type === "candidate-pair" || type === "pair") {
+      pairs.push({ ...entry, id });
+    }
+  });
+
+  if (pairs.length === 0) return null;
+
+  const score = (pair: StatsEntry): number => {
+    if (pair.nominated === true) return 3;
+    if (pair.state === "succeeded") return 2;
+    if (pair.selected === true) return 1;
+    return 0;
+  };
+
+  const best = pairs.reduce<{ pair: StatsEntry; s: number } | null>(
+    (acc, pair) => {
+      const s = score(pair);
+      if (!acc || s > acc.s) return { pair, s };
+      return acc;
+    },
+    null,
+  );
+
+  if (!best || best.s === 0) return null;
+  const pair = best.pair;
+
+  const local = pair.localCandidateId
+    ? candidateById.get(pair.localCandidateId as string)
+    : undefined;
+  const remote = pair.remoteCandidateId
+    ? candidateById.get(pair.remoteCandidateId as string)
+    : undefined;
+
+  const rttSeconds = pair.currentRoundTripTime;
+  const packetsLost =
+    typeof pair.packetsLost === "number" ? pair.packetsLost : null;
+
+  return {
+    localType: local ? normalizeStatType(local.candidateType) : null,
+    remoteType: remote ? normalizeStatType(remote.candidateType) : null,
+    localAddress: local ? readStatAddress(local) : null,
+    remoteAddress: remote ? readStatAddress(remote) : null,
+    nominated: pair.nominated === true,
+    currentRttMs:
+      typeof rttSeconds === "number" && Number.isFinite(rttSeconds)
+        ? Math.round(rttSeconds * 1000)
+        : null,
+    packetsSent: numOrNull(pair.packetsSent),
+    packetsReceived: numOrNull(pair.packetsReceived),
+    packetsLost,
+    bytesSent: numOrNull(pair.bytesSent),
+    bytesReceived: numOrNull(pair.bytesReceived),
+  };
+}
+
+function numOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Build an immutable {@link ICEDiagnosticsSnapshot} from a collector + a fresh
+ * stats report + connection metadata.
+ */
+export function buildDiagnosticsSnapshot(args: {
+  candidateCounts: CandidateCounts;
+  candidates: CandidateRecord[];
+  candidateErrors: ICECandidateError[];
+  iceConnectionState: RTCIceConnectionState | null;
+  gatheringState: RTCIceGatheringState | null;
+  hasTurnConfigured: boolean;
+  gatheringStartedAt: number | null;
+  gatheringCompleteAt: number | null;
+  connectedAt: number | null;
+  statsReport?: StatsReportLike | null;
+}): ICEDiagnosticsSnapshot {
+  const selectedPair = extractSelectedCandidatePair(args.statsReport ?? null);
+  const natType = classifyNATType(args.candidateCounts, selectedPair);
+  const totalGathered =
+    args.candidateCounts.host +
+    args.candidateCounts.srflx +
+    args.candidateCounts.prflx +
+    args.candidateCounts.relay +
+    args.candidateCounts.unknown;
+
+  const gatheringDurationMs =
+    args.gatheringStartedAt != null && args.gatheringCompleteAt != null
+      ? Math.max(0, args.gatheringCompleteAt - args.gatheringStartedAt)
+      : null;
+
+  return {
+    timestamp: Date.now(),
+    iceConnectionState: args.iceConnectionState,
+    gatheringState: args.gatheringState,
+    phase: deriveICEPhase(args.gatheringState, args.iceConnectionState),
+    candidateCounts: { ...args.candidateCounts },
+    candidates: args.candidates.slice(),
+    candidateErrors: args.candidateErrors.slice(),
+    selectedPair,
+    natType,
+    hasTurnConfigured: args.hasTurnConfigured,
+    gatheringStartedAt: args.gatheringStartedAt,
+    gatheringCompleteAt: args.gatheringCompleteAt,
+    gatheringDurationMs,
+    connectedAt: args.connectedAt,
+    totalGathered,
+  };
+}
+
+/**
+ * Collects live ICE events from an `RTCPeerConnection` and aggregates them into
+ * diagnostics snapshots. Observability-only: it never mutates connection state.
+ *
+ * It listens via `addEventListener` (when available) so it coexists with the
+ * connection manager's `on*` handlers. If `addEventListener` is absent (e.g. a
+ * minimal mock), {@link attach} is a no-op and the collector can still be fed
+ * manually via {@link recordCandidate} / {@link recordState} for testing.
+ */
+export class ICEDiagnosticsCollector {
+  private candidateCounts: CandidateCounts = { ...EMPTY_COUNTS };
+  private candidates: CandidateRecord[] = [];
+  private candidateErrors: ICECandidateError[] = [];
+  private iceConnectionState: RTCIceConnectionState | null = null;
+  private gatheringState: RTCIceGatheringState | null = null;
+  private gatheringStartedAt: number | null = null;
+  private gatheringCompleteAt: number | null = null;
+  private connectedAt: number | null = null;
+  private hasTurnConfigured = false;
+  private connection: RTCPeerConnection | null = null;
+  private readonly handlers: Array<[string, (event: unknown) => void]> = [];
+
+  /**
+   * Attach to a peer connection. Detaches any previous attachment first.
+   */
+  attach(connection: RTCPeerConnection, hasTurnConfigured = false): void {
+    this.detach();
+    this.connection = connection;
+    this.hasTurnConfigured = hasTurnConfigured;
+
+    // Seed current states from the (possibly already-active) connection.
+    this.iceConnectionState =
+      (connection.iceConnectionState as RTCIceConnectionState | null) ?? null;
+    this.gatheringState =
+      (connection.iceGatheringState as RTCIceGatheringState | null) ?? null;
+    if (this.gatheringState === "gathering") {
+      this.gatheringStartedAt = this.gatheringStartedAt ?? Date.now();
+    }
+
+    const onCandidate = (event: unknown) => {
+      const candidate = (event as { candidate?: unknown } | null)?.candidate;
+      this.recordCandidate(candidate);
+    };
+    const onCandidateError = (event: unknown) => {
+      this.recordCandidateError(event);
+    };
+    const onIceState = () => {
+      if (!this.connection) return;
+      this.recordState(
+        this.connection.iceConnectionState,
+        this.connection.iceGatheringState,
+      );
+    };
+    const onGatheringState = () => {
+      if (!this.connection) return;
+      this.recordGatheringState(this.connection.iceGatheringState);
+    };
+
+    // addEventListener may be absent on minimal mocks; guard for safety.
+    if (typeof connection.addEventListener === "function") {
+      connection.addEventListener("icecandidate", onCandidate as EventListener);
+      connection.addEventListener(
+        "icecandidateerror",
+        onCandidateError as EventListener,
+      );
+      connection.addEventListener(
+        "iceconnectionstatechange",
+        onIceState as EventListener,
+      );
+      connection.addEventListener(
+        "icegatheringstatechange",
+        onGatheringState as EventListener,
+      );
+      // Store the raw handlers (typed against `unknown`) so they remain
+      // assignable to the handlers array; they are cast to EventListener only
+      // at the DOM call sites above.
+      this.handlers.push(
+        ["icecandidate", onCandidate],
+        ["icecandidateerror", onCandidateError],
+        ["iceconnectionstatechange", onIceState],
+        ["icegatheringstatechange", onGatheringState],
+      );
+    }
+  }
+
+  /** Detach all listeners from the current connection. */
+  detach(): void {
+    const conn = this.connection;
+    if (conn && typeof conn.removeEventListener === "function") {
+      for (const [type, handler] of this.handlers) {
+        try {
+          conn.removeEventListener(type, handler);
+        } catch {
+          // Some mocks throw on unknown event types; ignore.
+        }
+      }
+    }
+    this.handlers.length = 0;
+    this.connection = null;
+  }
+
+  /** Reset all collected data (e.g. on reconnection / ICE restart). */
+  reset(): void {
+    this.candidateCounts = { ...EMPTY_COUNTS };
+    this.candidates = [];
+    this.candidateErrors = [];
+    this.iceConnectionState = null;
+    this.gatheringState = null;
+    this.gatheringStartedAt = null;
+    this.gatheringCompleteAt = null;
+    this.connectedAt = null;
+  }
+
+  /** Record a single gathered candidate (from `icecandidate` event or manual). */
+  recordCandidate(candidate: unknown): void {
+    const record = toCandidateRecord(candidate);
+    if (!record) return;
+    this.candidateCounts[record.type] = this.candidateCounts[record.type] + 1;
+    this.candidates.push(record);
+    if (this.candidates.length > MAX_STORED_CANDIDATES) {
+      this.candidates.splice(0, this.candidates.length - MAX_STORED_CANDIDATES);
+    }
+  }
+
+  /** Record a candidate-gathering error (from `icecandidateerror` event). */
+  recordCandidateError(event: unknown): void {
+    const e = event as {
+      url?: unknown;
+      errorCode?: unknown;
+      errorText?: unknown;
+    } | null;
+    this.candidateErrors.push({
+      url: typeof e?.url === "string" ? e.url : null,
+      errorCode: typeof e?.errorCode === "number" ? e.errorCode : null,
+      errorText: typeof e?.errorText === "string" ? e.errorText : null,
+      timestamp: Date.now(),
+    });
+    if (this.candidateErrors.length > MAX_STORED_ERRORS) {
+      this.candidateErrors.splice(
+        0,
+        this.candidateErrors.length - MAX_STORED_ERRORS,
+      );
+    }
+  }
+
+  /** Record the ICE connection + gathering states (transitions). */
+  recordState(
+    iceConnectionState: RTCIceConnectionState | null | undefined,
+    gatheringState: RTCIceGatheringState | null | undefined,
+  ): void {
+    this.iceConnectionState = iceConnectionState ?? null;
+    this.recordGatheringState(gatheringState);
+    if (
+      (iceConnectionState === "connected" ||
+        iceConnectionState === "completed") &&
+      this.connectedAt == null
+    ) {
+      this.connectedAt = Date.now();
+    }
+  }
+
+  /** Record an ICE gathering-state transition (starts/stop gathering timing). */
+  recordGatheringState(state: RTCIceGatheringState | null | undefined): void {
+    this.gatheringState = state ?? null;
+    if (state === "gathering" && this.gatheringStartedAt == null) {
+      this.gatheringStartedAt = Date.now();
+      this.gatheringCompleteAt = null;
+    } else if (state === "complete" && this.gatheringCompleteAt == null) {
+      this.gatheringCompleteAt = Date.now();
+      if (this.gatheringStartedAt == null) {
+        this.gatheringStartedAt = this.gatheringCompleteAt;
+      }
+    }
+  }
+
+  /** Current candidate counts. */
+  getCandidateCounts(): CandidateCounts {
+    return { ...this.candidateCounts };
+  }
+
+  /**
+   * Build a snapshot, optionally merging a fresh `getStats()` report for the
+   * selected candidate pair and link quality.
+   */
+  getSnapshot(statsReport?: StatsReportLike | null): ICEDiagnosticsSnapshot {
+    return buildDiagnosticsSnapshot({
+      candidateCounts: this.candidateCounts,
+      candidates: this.candidates,
+      candidateErrors: this.candidateErrors,
+      iceConnectionState: this.iceConnectionState,
+      gatheringState: this.gatheringState,
+      hasTurnConfigured: this.hasTurnConfigured,
+      gatheringStartedAt: this.gatheringStartedAt,
+      gatheringCompleteAt: this.gatheringCompleteAt,
+      connectedAt: this.connectedAt,
+      statsReport: statsReport ?? null,
+    });
+  }
+}
+
+/**
+ * Returns true when the current runtime can perform WebRTC diagnostics.
+ * Guards against SSR (no `window`), non-browser runtimes, and environments
+ * without `RTCPeerConnection` (older Tauri webviews / restricted contexts).
+ */
+export function isICEDiagnosticsSupported(): boolean {
+  if (typeof window === "undefined") return false;
+  return (
+    typeof (window as { RTCPeerConnection?: unknown }).RTCPeerConnection ===
+    "function"
+  );
+}
+
+/**
+ * Result of running a self-contained NAT-traversal probe (an ephemeral
+ * RTCPeerConnection that gathers candidates using the app's ICE config without
+ * affecting game traffic). Used by the panel's "Run connection test" affordance.
+ */
+export interface ICEDiagnosticsProbeResult {
+  snapshot: ICEDiagnosticsSnapshot;
+}
+
+/**
+ * Run a self-contained, ephemeral ICE gathering probe to classify the local
+ * NAT type. Creates a throwaway `RTCPeerConnection` with the supplied RTC
+ * configuration, triggers candidate gathering via an offer + data channel, waits
+ * for gathering to complete (or `timeoutMs`), then closes the connection.
+ *
+ * This does NOT affect any active game connection. Throws if WebRTC is
+ * unavailable — callers should guard with {@link isICEDiagnosticsSupported}.
+ */
+export async function runDiagnosticsProbe(
+  rtcConfig: RTCConfiguration,
+  timeoutMs = 5000,
+): Promise<ICEDiagnosticsProbeResult> {
+  if (
+    typeof window === "undefined" ||
+    typeof window.RTCPeerConnection !== "function"
+  ) {
+    throw new Error("WebRTC is not available in this environment");
+  }
+  const collector = new ICEDiagnosticsCollector();
+  const hasTurnConfigured =
+    Array.isArray(rtcConfig.iceServers) &&
+    rtcConfig.iceServers.some((server) => {
+      const urls = server.urls;
+      const list = Array.isArray(urls) ? urls : urls ? [urls] : [];
+      return list.some((u) => typeof u === "string" && /^turns?:/i.test(u));
+    });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pc: RTCPeerConnection = new (window as any).RTCPeerConnection(
+    rtcConfig,
+  );
+  collector.attach(pc, hasTurnConfigured);
+
+  let settled = false;
+  const cleanup = () => {
+    if (settled) return;
+    settled = true;
+    try {
+      pc.close();
+    } catch {
+      // ignore
+    }
+    collector.detach();
+  };
+
+  try {
+    // A data channel is required for 'icegatheringstatechange' to reach
+    // 'complete' on some browsers ( Chromium triggers gathering off an offer).
+    pc.createDataChannel("diagnostics");
+    const offer = await pc.createOffer({
+      offerToReceiveAudio: false,
+    } as RTCOfferOptions);
+    await pc.setLocalDescription(offer);
+
+    await new Promise<void>((resolve) => {
+      const check = () => {
+        if (pc.iceGatheringState === "complete") {
+          resolve();
+        }
+      };
+      check();
+      if (settled) return;
+      const onState = () => check();
+      if (typeof pc.addEventListener === "function") {
+        pc.addEventListener(
+          "icegatheringstatechange",
+          onState as EventListener,
+        );
+      }
+      setTimeout(() => {
+        if (typeof pc.removeEventListener === "function") {
+          pc.removeEventListener(
+            "icegatheringstatechange",
+            onState as EventListener,
+          );
+        }
+        resolve();
+      }, timeoutMs);
+    });
+
+    let statsReport: RTCStatsReport | null = null;
+    try {
+      statsReport = await pc.getStats();
+    } catch {
+      statsReport = null;
+    }
+    const snapshot = collector.getSnapshot(statsReport);
+    return { snapshot };
+  } finally {
+    cleanup();
+  }
+}

--- a/src/lib/webrtc-p2p.ts
+++ b/src/lib/webrtc-p2p.ts
@@ -30,15 +30,16 @@ import {
   type ICEConfigOptions,
   getGlobalICEManager,
 } from "./ice-config";
+import {
+  ICEDiagnosticsCollector,
+  type ICEDiagnosticsSnapshot,
+} from "./ice-diagnostics";
 import { redactSensitive } from "./p2p-log-redact";
 import {
   MAX_MESSAGE_SIZE_BYTES,
   withinStructuralLimits,
 } from "./p2p-json-validation";
-import {
-  P2PRateLimiter,
-  type P2PRateLimitOptions,
-} from "./p2p-rate-limiter";
+import { P2PRateLimiter, type P2PRateLimitOptions } from "./p2p-rate-limiter";
 
 /**
  * WebRTC configuration with STUN/TURN servers
@@ -248,7 +249,7 @@ function computeChecksum(state: ReturnType<typeof engineToAIState>): string {
   let hash = 0;
   for (let i = 0; i < data.length; i++) {
     const char = data.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
+    hash = (hash << 5) - hash + char;
     hash = hash & hash;
   }
   return Math.abs(hash).toString(16).padStart(8, "0");
@@ -284,6 +285,12 @@ export class WebRTCConnection {
   private iceManager: ICEConfigurationManager;
   private iceMonitor: ICEConnectionMonitor | null = null;
   private iceCandidateFilter: ICECandidateFilter;
+  /**
+   * Observability-only ICE diagnostics collector (issue #1088). Listens to the
+   * peer connection's ICE events via addEventListener so it never disturbs the
+   * existing on* handlers that drive the connection.
+   */
+  private iceDiagnostics: ICEDiagnosticsCollector;
   private enableICEMonitoring: boolean;
   private fallbackToRelay: boolean;
   private pendingCandidates: RTCIceCandidateInit[] = [];
@@ -332,6 +339,9 @@ export class WebRTCConnection {
       allowLinkLocal: false,
     });
 
+    // Initialize ICE diagnostics collector (issue #1088 — NAT-traversal panel).
+    this.iceDiagnostics = new ICEDiagnosticsCollector();
+
     // Set default event handlers
 
     const defaultEvents: P2PEvents = {
@@ -368,6 +378,14 @@ export class WebRTCConnection {
       this.updateConnectionState("connecting");
 
       this.peerConnection = new RTCPeerConnection(this.rtcConfig);
+
+      // Attach ICE diagnostics collector (observability-only; #1088). Done
+      // after the on* handlers below so it never overwrites them — it listens
+      // via addEventListener and only records candidate/state events.
+      this.iceDiagnostics.attach(
+        this.peerConnection,
+        this.iceManager.hasTurnServers(),
+      );
 
       // Set up ICE candidate handling with filtering
       this.peerConnection.onicecandidate = (event) => {
@@ -452,6 +470,11 @@ export class WebRTCConnection {
 
       // Create new peer connection with relay config
       this.peerConnection = new RTCPeerConnection(relayConfig);
+
+      // Re-attach ICE diagnostics collector for the relayed connection (#1088).
+      // Relay mode is TURN-dependent by definition.
+      this.iceDiagnostics.reset();
+      this.iceDiagnostics.attach(this.peerConnection, true);
 
       // Re-attach event handlers
       this.peerConnection.onicecandidate = (event) => {
@@ -633,11 +656,11 @@ export class WebRTCConnection {
     if (!this.dataChannel) return;
 
     this.dataChannel.onopen = () => {
-       this.updateConnectionState("connected");
-       if (!this.externalPing) {
-         this.startPingInterval();
-       }
-     };
+      this.updateConnectionState("connected");
+      if (!this.externalPing) {
+        this.startPingInterval();
+      }
+    };
 
     this.dataChannel.onclose = () => {
       this.handleDisconnection();
@@ -645,10 +668,7 @@ export class WebRTCConnection {
 
     this.dataChannel.onerror = (event) => {
       // #982: redact — error events may include diagnostic data channel info.
-      console.error(
-        "[WebRTC] Data channel error:",
-        redactSensitive(event),
-      );
+      console.error("[WebRTC] Data channel error:", redactSensitive(event));
 
       let errorToReport: Error;
 
@@ -1247,7 +1267,8 @@ export class WebRTCConnection {
     const aiState = engineToAIState(gameState);
 
     const syncState: PeerSyncState = {
-      lastVersion: (gameState.turn as unknown as { turnNumber?: number }).turnNumber ?? 0,
+      lastVersion:
+        (gameState.turn as unknown as { turnNumber?: number }).turnNumber ?? 0,
       lastChecksum: computeChecksum(aiState),
       lastState: aiState,
       lastSerializedState: JSON.stringify(serializedState),
@@ -1277,7 +1298,7 @@ export class WebRTCConnection {
   private sendDeltaSync(
     gameState: GameState,
     peerId: string,
-    lastSyncedAI: ReturnType<typeof engineToAIState> | null
+    lastSyncedAI: ReturnType<typeof engineToAIState> | null,
   ): void {
     const delta = computeStateDelta(gameState, lastSyncedAI);
     const deltaSize = estimateDeltaSize(delta);
@@ -1421,6 +1442,9 @@ export class WebRTCConnection {
       this.iceMonitor = null;
     }
 
+    // Detach ICE diagnostics listeners (#1088).
+    this.iceDiagnostics.detach();
+
     if (this.dataChannel) {
       this.dataChannel.close();
       this.dataChannel = null;
@@ -1459,6 +1483,20 @@ export class WebRTCConnection {
    */
   getICEConnectionState(): RTCIceConnectionState | null {
     return this.peerConnection?.iceConnectionState || null;
+  }
+
+  /**
+   * Build an aggregated ICE / NAT-traversal diagnostics snapshot for the panel
+   * (issue #1088). Merges the live candidate/state history collected from ICE
+   * events with a fresh `getStats()` report for the selected candidate pair and
+   * link quality. Observability-only — never mutates the connection.
+   *
+   * Returns `null` when no peer connection is active.
+   */
+  async getDiagnostics(): Promise<ICEDiagnosticsSnapshot | null> {
+    if (!this.peerConnection) return null;
+    const stats = await this.getICEStats();
+    return this.iceDiagnostics.getSnapshot(stats);
   }
 
   /**


### PR DESCRIPTION
## Summary

Resolves #1088 — adds a user/dev-facing **NAT-traversal diagnostics panel** that surfaces live ICE candidate gathering, the selected candidate pair, ICE connection state/phase, and an effective NAT-type heuristic, so a silent P2P failure becomes an actionable "you need a TURN server".

When a P2P connection fails there is currently no visibility into *why*. This PR makes ICE candidate gathering observable and turns a restrictive-NAT failure into a self-serve diagnostic.

## What's reported

- **Gathered ICE candidate types** — counts for `host` / `srflx` (server-reflexive) / `prflx` (peer-reflexive) / `relay` (TURN).
- **Selected candidate pair** — local/remote candidate type + addresses, RTT, packet-loss %, bytes sent/received (from `RTCPeerConnection.getStats()`).
- **ICE connection state / phase** — derived from both state machines: `new → gathering → connecting → connected/completed` (or `disconnected/failed/closed`).
- **Effective NAT-type heuristic** — `restrictive` (host-only ⇒ symmetric NAT), `cone` (srflx/prflx ⇒ traversable), `turn-dependent` (relay in use), or `unknown`.
- **Gathering timing** — duration from `icegatheringstatechange` `gathering → complete`.
- **Candidate errors** — `icecandidateerror` entries (STUN/TURN URL + error code/text).
- **Actionable hint** — a `TURN server required` alert renders when only host candidates are gathered **and** no TURN server is configured (links to the #983 guidance).

## Design

- **`src/lib/ice-diagnostics.ts`** (new) — the pure data layer:
  - `classifyCandidateType()` parses `typ host|srflx|prflx|relay` from candidate SDP (falls back to structured `.type`).
  - `classifyNATType()` derives the NAT heuristic from candidate counts + selected pair.
  - `extractSelectedCandidatePair()` aggregates the nominated/succeeded pair + quality from a `getStats()` report (pure function over a Map-like report).
  - `ICEDiagnosticsCollector` attaches to an `RTCPeerConnection` **via `addEventListener`** so it never clobbers the connection manager's existing `on*` handlers — observability-only, it never drives the connection.
  - `runDiagnosticsProbe()` runs a self-contained ephemeral gathering probe (separate throwaway `RTCPeerConnection` using the app's ICE config) to classify the local NAT without affecting game traffic.
- **`src/hooks/use-p2p-diagnostics.ts`** (new) — polls `connection.getDiagnostics()` on an interval, exposes manual `refresh`, and guards for SSR / non-WebRTC runtimes (older Tauri webviews).
- **`src/components/p2p-diagnostics-panel.tsx`** (new) — toggleable (Radix `Collapsible`), accessible panel. Two modes: **live** (pass a `connection`) or **self-test probe** ("Run connection test" button). Reuses existing UI primitives (Badge, Alert, Button, Separator).
- **`src/lib/webrtc-p2p.ts`** — minimal observability wiring: the `WebRTCConnection` now owns an `ICEDiagnosticsCollector` (attached in `initialize()` + re-attached on relay fallback, detached in `close()`), and exposes `getDiagnostics(): Promise<ICEDiagnosticsSnapshot | null>`. **No change to connection logic.**
- **`src/app/(app)/multiplayer/page.tsx`** — mounts the panel as a non-intrusive, collapsed-by-default diagnostics affordance in the multiplayer area.

## Non-intrusive

The panel is collapsed by default and only observes. The collector never mutates connection state; it coexists with the existing `onicecandidate` / `oniceconnectionstatechange` handlers that drive the connection.

## Acceptance criteria

- [x] ICE candidate gathering is observable: candidate types (`host`/`srflx`/`relay`/`prflx`), counts, and the selected candidate pair are reported
- [x] ICE connection state/phase is shown (`gathering → connecting → connected/failed`)
- [x] A diagnostics panel UI surfaces this info (dev/user-facing), accessible and clearly labeled
- [x] The panel is non-intrusive (toggleable/collapsed-by-default)
- [x] Unit tests cover the diagnostics data collection/classification (candidate types, state transitions, NAT classifier, stats aggregation)

## Tests

- `src/lib/__tests__/ice-diagnostics.test.ts` (38 tests) — candidate classification, IP family, NAT heuristic, ICE phase derivation, `extractSelectedCandidatePair` (nominated/succeeded precedence, RTT/loss extraction), collector counting/capping/reset, snapshot building, support guard.
- `src/lib/__tests__/webrtc-p2p.test.ts` (+3 tests) — `getDiagnostics()` returns `null` before init and reports candidate types / NAT type / phase through the full `WebRTCConnection` path (mock RTCPeerConnection with `addEventListener`).
- `src/hooks/__tests__/use-p2p-diagnostics.test.ts` (7 tests) — polling, manual refresh, error surfacing, disabled mode, live updates.
- `src/components/__tests__/p2p-diagnostics-panel.test.tsx` (9 tests) — toggle, unsupported state, candidate counts, RTT/loss, restrictive-NAT TURN hint (+ absence when TURN configured), candidate errors, idle/probe mode, error alert.

## Verification

- `npx jest webrtc ice p2p-diagnostics use-p2p` → **283 passed**
- `npx tsc --noEmit` → clean
- `npm run lint` → 0 errors (only pre-existing warnings)

Resolves #1088