### PR TITLE
test(e2e): resolve #1159 — stabilize flaky game-flow 'selecting a card in hand' under CI load

### DIFF
--- a/e2e/game-flow.spec.ts
+++ b/e2e/game-flow.spec.ts
@@ -81,12 +81,22 @@ test.describe("Game Flow E2E", () => {
     await page.keyboard.press("ArrowDown");
     await page.keyboard.press("Enter");
 
-    // Start game
+    // Start game — wait until a deck is selected and the button is genuinely
+    // actionable before clicking (mirrors the stable sibling test above).
+    // Clicking before the board setup is ready is what races under CI load.
     const startButton = page.locator('button:has-text("Start Game vs AI")');
+    await expect(startButton).toBeEnabled({ timeout: 10000 });
     await startButton.click();
 
-    // Handle the Mulligan dialog
+    // Wait for navigation to the game board before proceeding — mirrors the
+    // stable sibling test. Without this readiness gate the test races ahead
+    // of board load under CI load (#1159).
+    await expect(page).toHaveURL(/.*\/game\/.*/, { timeout: 15000 });
+
+    // Handle the Mulligan dialog — wait for the button to be visible and
+    // interactive so the opening hand is actually dealt before we interact.
     const keepHandButton = page.getByRole("button", { name: "Keep Hand" });
+    await expect(keepHandButton).toBeVisible();
     await keepHandButton.click();
     await expect(keepHandButton).toBeHidden();
 
@@ -108,14 +118,25 @@ test.describe("Game Flow E2E", () => {
         console.warn("Overlay backdrop did not hide");
       });
 
-    // Locate cards in hand (they use checkboxes for selection)
-    const handCards = page.getByRole("checkbox");
-    await expect(handCards.first()).toBeVisible({ timeout: 10000 });
+    // Locate cards in hand. Only the current player's cards expose
+    // role="checkbox" (opponents render card backs), so this locator is
+    // unambiguous — bind it once and reuse it for a stable interaction.
+    const firstCard = page.getByRole("checkbox").first();
 
-    // Select the first card - Use click() because it's a custom button-based checkbox
-    await handCards.first().click();
+    // Readiness gate: wait until the opening hand has actually been dealt and
+    // the card is visible AND interactive (enabled == selectable) before
+    // interacting. This is the state-based wait that resolves the #1159 race
+    // where the click landed before the hand was settled under CI load.
+    await expect(firstCard).toBeVisible({ timeout: 10000 });
+    await expect(firstCard).toBeEnabled();
 
-    // Verify it is checked (custom component uses aria-pressed="true" for selection state)
-    await expect(handCards.first()).toHaveAttribute("aria-pressed", "true");
+    // Select the card. click() auto-waits for actionability (visible, stable,
+    // enabled, receives pointer events) — no manual timing.
+    await firstCard.click();
+
+    // Verify it is selected. This is a web-first (auto-retrying) assertion:
+    // Playwright re-checks aria-pressed up to the expect timeout rather than
+    // doing a one-shot check — the state-based wait for the selection state.
+    await expect(firstCard).toHaveAttribute("aria-pressed", "true");
   });
 });


### PR DESCRIPTION
Resolves #1159

## Root cause

The `game-flow.spec.ts` test **"should allow selecting a card in hand"** (line 74) was racing the game-board setup. It skipped the state-based readiness gates that its stable sibling test ("should start a game and pass priority") relies on:

| Step | Stable sibling test | Flaky test (before) |
| --- | --- | --- |
| Start button | `expect(startButton).toBeEnabled({timeout:10000})` then click | clicked immediately |
| Board navigation | `expect(page).toHaveURL(/\/game\//, {timeout:15000})` | **missing** |
| Keep Hand dialog | `expect(keepHandButton).toBeVisible()` then click | clicked immediately |
| Hand card | — | `toBeVisible` only, then click + one-shot-style assert |

Under CI load (slower machine, 4 workers), the board navigation and opening-hand deal take longer. Without the `toHaveURL` / `toBeEnabled` / `toBeVisible` gates the test clicked **Start → Keep Hand → card** before the board was settled, so the card-selection click didn't reliably land on an interactive card and the auto-retrying `aria-pressed` assertion exhausted its window → intermittent timeout. It passed locally and on rerun because timing happened to align.

The component (`src/components/hand-display.tsx`) is correct — `selectedCardIds` is a stable `useState` and the controlled selection flow is consistent — so **no component change was needed**; the fix is entirely in the test.

## Fix (test-only)

Hardened the flaky test with state-based Playwright auto-waiting (no `setTimeout` / arbitrary timing):

- `expect(startButton).toBeEnabled({timeout:10000})` before clicking Start.
- `expect(page).toHaveURL(/.*\/game\/.*/, {timeout:15000})` — wait for board navigation (the key missing gate).
- `expect(keepHandButton).toBeVisible()` before clicking Keep Hand.
- Bind the hand card locator once; gate the interaction on `toBeVisible({timeout:10000})` **and** `toBeEnabled()` (enabled == selectable) so the click only fires on a ready, interactive card.
- Keep the final `expect(firstCard).toHaveAttribute("aria-pressed", "true")` — a web-first, auto-retrying assertion — as the state-based wait for the selection state.

This mirrors the proven-stable sibling test and addresses the race at its source rather than masking it with timeouts.

## Verification

Local run, `chromium` project (firefox/webkit binaries unavailable in this env — fix is browser-agnostic):

```
# Flaky test, 5 consecutive runs
npx playwright test --project=chromium -g "should allow selecting a card in hand" --repeat-each=5
PASS (5) FAIL (0)

# Both game-flow tests, 5 consecutive runs each (no regression to sibling)
npx playwright test --project=chromium -g "should (start a game and pass priority|allow selecting a card in hand)" --repeat-each=5
PASS (10) FAIL (0)
```

- `npx tsc --noEmit` → 0 errors
- `npm run lint` → 0 errors (pre-existing warnings in `src/` only; changed file is in `e2e/`)

## Files changed
- `e2e/game-flow.spec.ts` — hardened "should allow selecting a card in hand" with state-based readiness/auto-wait gates (+32/−11)

## Summary by Sourcery

Tests:
- Harden the 'should allow selecting a card in hand' Playwright test with URL, visibility, and enabled checks before interacting with Start, Keep Hand, and the first hand card to eliminate timing races in CI.