### PR TITLE
fix(game-board): resolve #1082 — window the game-board permanent list for large board states

### DIFF
--- a/src/components/__tests__/virtualized-battlefield.test.tsx
+++ b/src/components/__tests__/virtualized-battlefield.test.tsx
@@ -1,0 +1,244 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import {
+  VirtualizedBattlefield,
+  BattlefieldCard,
+} from "../virtualized-battlefield";
+import type { CardState, ZoneType } from "@/types/game";
+
+/**
+ * Build N minimal battlefield permanents. Cast through `unknown` to avoid
+ * constructing a full ScryfallCard (mirrors the pattern in
+ * virtual-card-list.test.tsx). Only the fields the component reads
+ * (`id`, `card.name`, `card.image_uris`, `tapped`) are populated.
+ */
+function makePermanents(n: number, tappedFrom = -1): CardState[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `perm-${i}`,
+    card: {
+      id: `card-${i}`,
+      name: `Permanent ${i}`,
+      image_uris: { normal: `https://example.com/img-${i}.jpg` },
+    },
+    tapped: i >= tappedFrom ? true : undefined,
+  })) as unknown as CardState[];
+}
+
+/**
+ * A jsdom-sized DOMRect. jsdom reports 0 for every layout property by
+ * default, which makes @tanstack/react-virtual think the viewport is empty
+ * and mount nothing — so the tests must give it real numbers.
+ */
+function rect(width: number, height: number): DOMRect {
+  return {
+    width,
+    height,
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    bottom: height,
+    right: width,
+    toJSON() {},
+  } as DOMRect;
+}
+
+describe("VirtualizedBattlefield", () => {
+  const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+  let originalClientWidth: PropertyDescriptor | undefined;
+  let originalOffsetWidth: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalClientWidth = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientWidth",
+    );
+    originalOffsetWidth = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "offsetWidth",
+    );
+
+    // Give the horizontal scroll viewport a narrow width so only a few cards
+    // fit, forcing windowing of the rest.
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      get() {
+        return 300;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      configurable: true,
+      get() {
+        return 300;
+      },
+    });
+
+    // Virtual items (data-index) report the estimated card width; the scroll
+    // container (role=list) reports the viewport width.
+    Element.prototype.getBoundingClientRect = function getBoundingClientRect() {
+      if (this.hasAttribute && this.hasAttribute("data-index")) {
+        return rect(56, 80);
+      }
+      if (this.getAttribute && this.getAttribute("role") === "list") {
+        return rect(300, 96);
+      }
+      return originalGetBoundingClientRect.call(this);
+    };
+
+    // jsdom lacks ResizeObserver, which @tanstack/react-virtual relies on.
+    (global as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  });
+
+  afterEach(() => {
+    if (originalClientWidth) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        "clientWidth",
+        originalClientWidth,
+      );
+    }
+    if (originalOffsetWidth) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        "offsetWidth",
+        originalOffsetWidth,
+      );
+    }
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  });
+
+  it("mounts only a bounded window of permanents, not the whole board", () => {
+    const cards = makePermanents(100);
+    render(
+      <VirtualizedBattlefield
+        cards={cards}
+        zone="battlefield"
+        onCardClick={jest.fn()}
+      />,
+    );
+
+    const mounted = screen.getAllByTestId(/^battlefield-card-/);
+    // Windowing: some permanents render, but far fewer than the full 100.
+    expect(mounted.length).toBeGreaterThan(0);
+    expect(mounted.length).toBeLessThan(100);
+    // Overscan keeps the window comfortably bounded for a 300px viewport.
+    expect(mounted.length).toBeLessThanOrEqual(40);
+  });
+
+  it("renders zero permanent nodes for an empty board without crashing", () => {
+    render(
+      <VirtualizedBattlefield
+        cards={[]}
+        zone="battlefield"
+        onCardClick={jest.fn()}
+      />,
+    );
+    expect(screen.queryAllByTestId(/^battlefield-card-/)).toHaveLength(0);
+  });
+
+  it("preserves per-permanent click targeting on visible (mounted) items", () => {
+    const cards = makePermanents(100);
+    const onCardClick = jest.fn();
+    render(
+      <VirtualizedBattlefield
+        cards={cards}
+        zone="battlefield"
+        onCardClick={onCardClick}
+      />,
+    );
+
+    const mounted = screen.getAllByTestId(/^battlefield-card-/);
+    expect(mounted.length).toBeGreaterThan(0);
+
+    // The first mounted permanent is the first card (scroll starts at 0).
+    fireEvent.click(mounted[0]);
+    expect(onCardClick).toHaveBeenCalledTimes(1);
+    expect(onCardClick).toHaveBeenCalledWith("perm-0", "battlefield");
+  });
+
+  it("uses a stable, unique key per permanent so targeting identity is correct", () => {
+    // Duplicate names must not collide: keys are derived from card.id.
+    const cards = [
+      { id: "a1", card: { name: " Goblin" } },
+      { id: "a2", card: { name: "Goblin" } },
+    ] as unknown as CardState[];
+    const onCardClick = jest.fn();
+    const { container } = render(
+      <VirtualizedBattlefield
+        cards={cards}
+        zone="battlefield"
+        onCardClick={onCardClick}
+      />,
+    );
+    // Two distinct listitems mounted for two distinct ids.
+    expect(container.querySelectorAll('[role="listitem"]')).toHaveLength(2);
+  });
+});
+
+describe("BattlefieldCard", () => {
+  it("renders the image when image_uris.normal is present", () => {
+    const card = {
+      id: "p1",
+      card: {
+        name: "Lightning Bolt",
+        image_uris: { normal: "https://example.com/bolt.jpg" },
+      },
+    } as unknown as CardState;
+    render(
+      <BattlefieldCard
+        card={card}
+        zone={"battlefield" as ZoneType}
+        onCardClick={jest.fn()}
+      />,
+    );
+    const node = screen.getByTestId("battlefield-card-lightning-bolt");
+    expect(node).toBeTruthy();
+    expect(node.querySelector("img")).toBeTruthy();
+  });
+
+  it("renders a name fallback when no image is available", () => {
+    const card = {
+      id: "p2",
+      card: { name: "Fallback Token" },
+    } as unknown as CardState;
+    render(
+      <BattlefieldCard
+        card={card}
+        zone={"battlefield" as ZoneType}
+        onCardClick={jest.fn()}
+      />,
+    );
+    const node = screen.getByTestId("battlefield-card-fallback-token");
+    expect(node.textContent).toContain("Fallback Token");
+    expect(node.querySelector("img")).toBeNull();
+  });
+
+  it("shows the TAPPED indicator and fires onCardClick with the right zone", () => {
+    const onCardClick = jest.fn();
+    const card = {
+      id: "p3",
+      card: {
+        name: "Tapped Guy",
+        image_uris: { normal: "https://example.com/x.jpg" },
+      },
+      tapped: true,
+    } as unknown as CardState;
+    render(
+      <BattlefieldCard
+        card={card}
+        zone={"battlefield" as ZoneType}
+        onCardClick={onCardClick}
+      />,
+    );
+    const node = screen.getByTestId("battlefield-card-tapped-guy");
+    expect(node.textContent).toContain("TAPPED");
+
+    fireEvent.click(node);
+    expect(onCardClick).toHaveBeenCalledWith("p3", "battlefield");
+  });
+});

--- a/src/components/game-board.tsx
+++ b/src/components/game-board.tsx
@@ -28,7 +28,6 @@ import {
   CardState,
 } from "@/types/game";
 import { HandDisplay } from "@/components/hand-display";
-import Image from "next/image";
 import {
   DamageOverlay,
   useDamageEvents,
@@ -50,10 +49,16 @@ import {
 } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { MobileGameLayout } from "@/components/mobile-game-layout";
+import {
+  BattlefieldCard,
+  VirtualizedBattlefield,
+} from "@/components/virtualized-battlefield";
 
 // Performance optimization constants
-const VIRTUALIZATION_THRESHOLD = 20;
-const MAX_VISIBLE_GAME_BOARD_CARDS = 14;
+// Only the visible window of battlefield permanents is mounted once a board
+// exceeds this size; below it every permanent renders directly (no overhead).
+// See #1082 — windowing the game-board permanent list for large board states.
+const BATTLEFIELD_WINDOWING_THRESHOLD = 20;
 
 interface GameBoardProps {
   players: PlayerState[];
@@ -128,20 +133,14 @@ const ZoneDisplay = memo(function ZoneDisplay({
     onZoneClick?.(zone, playerId);
   }, [onZoneClick, zone, playerId]);
 
-  // Virtualize game board when there are many cards (performance optimization)
-  const displayCards = useMemo(() => {
-    if (zone === "battlefield" && count > VIRTUALIZATION_THRESHOLD) {
-      return cards.slice(0, MAX_VISIBLE_GAME_BOARD_CARDS);
-    }
-    return zone === "battlefield" ? cards.slice(0, 7) : cards;
-  }, [zone, count, cards]);
-
-  const remainingCount = useMemo(() => {
-    if (zone === "battlefield" && count > VIRTUALIZATION_THRESHOLD) {
-      return count - MAX_VISIBLE_GAME_BOARD_CARDS;
-    }
-    return 0;
-  }, [zone, count]);
+  // Window the battlefield once the board is large enough to matter (#1082).
+  // Below the threshold every permanent renders directly; above it the
+  // `VirtualizedBattlefield` mounts only the visible window (+ overscan) and
+  // reveals the rest via horizontal scroll. This also replaces the previous
+  // approach that silently sliced off overflow permanents (making them
+  // untargetable); every permanent is now reachable by scroll.
+  const isWindowedBattlefield =
+    zone === "battlefield" && count > BATTLEFIELD_WINDOWING_THRESHOLD;
 
   const zoneIcons: Record<ZoneType, React.ReactNode> = useMemo(
     () => ({
@@ -180,47 +179,23 @@ const ZoneDisplay = memo(function ZoneDisplay({
             {count > 0 && (
               <div className="absolute inset-0 flex items-center justify-center gap-1 flex-wrap p-1">
                 {zone === "battlefield" &&
-                  displayCards.map((card: ZoneCard, idx: number) => (
-                    <div
-                      key={card.id || idx}
-                      data-testid={`battlefield-card-${card.card.name.toLowerCase().replace(/\s+/g, "-")}`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onCardClick?.(card.id, zone);
-                      }}
-                      className="relative w-10 h-14 sm:w-12 sm:h-16 md:w-14 md:h-20 rounded overflow-hidden border border-primary/30 hover:scale-[3] hover:z-50 hover:shadow-2xl transition-all duration-300 cursor-pointer group"
-                      title={card.card.name}
-                    >
-                      {card.card.image_uris?.normal ? (
-                        <Image
-                          src={card.card.image_uris.normal}
-                          alt={card.card.name}
-                          fill
-                          sizes="80px"
-                          className="object-cover rounded"
-                          loading="lazy"
-                        />
-                      ) : (
-                        <div className="w-full h-full bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center">
-                          <span className="text-[8px] text-center leading-tight px-0.5 line-clamp-2">
-                            {card.card.name}
-                          </span>
-                        </div>
-                      )}
-                      {card.tapped && (
-                        <div className="absolute inset-0 bg-black/20 flex items-center justify-center">
-                          <span className="text-[8px] text-white font-bold rotate-45">
-                            TAPPED
-                          </span>
-                        </div>
-                      )}
-                    </div>
+                  (isWindowedBattlefield ? (
+                    <VirtualizedBattlefield
+                      cards={cards}
+                      zone={zone}
+                      onCardClick={onCardClick}
+                      className="absolute inset-0 p-1"
+                    />
+                  ) : (
+                    cards.map((card: ZoneCard, idx: number) => (
+                      <BattlefieldCard
+                        key={card.id || idx}
+                        card={card}
+                        zone={zone}
+                        onCardClick={onCardClick}
+                      />
+                    ))
                   ))}
-                {zone === "battlefield" && remainingCount > 0 && (
-                  <div className="absolute bottom-1 right-1 bg-primary/80 text-primary-foreground text-xs px-1.5 py-0.5 rounded">
-                    +{remainingCount} more
-                  </div>
-                )}
                 {zone !== "battlefield" && (
                   <div className="flex items-center gap-1">
                     {zoneIcons[zone]}
@@ -277,7 +252,9 @@ const PlayerInfo = memo(function PlayerInfo({
   );
 
   return (
-    <div className={`flex items-center gap-1.5 ${isVertical ? "flex-col" : ""}`}>
+    <div
+      className={`flex items-center gap-1.5 ${isVertical ? "flex-col" : ""}`}
+    >
       <div className="flex items-center gap-1">
         <div className="flex items-center gap-1 text-xs">
           <User className="h-3 w-3" />
@@ -475,7 +452,9 @@ function PlayerArea({
         <div
           className={`grid ${isBottom ? "grid-rows-[1fr_auto_auto]" : "grid-rows-[auto_auto_1fr]"} gap-1.5 flex-1 min-h-0`}
         >
-          <div className={`${isBottom ? "row-start-3 z-10 overflow-visible" : "z-0"}`}>
+          <div
+            className={`${isBottom ? "row-start-3 z-10 overflow-visible" : "z-0"}`}
+          >
             {isBottom ? (
               <div
                 className="bg-primary/5 border border-primary/20 rounded-md p-1.5 overflow-visible"

--- a/src/components/virtualized-battlefield.tsx
+++ b/src/components/virtualized-battlefield.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import * as React from "react";
+import { memo, useCallback } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import Image from "next/image";
+import type { CardState, ZoneType } from "@/types/game";
+import { cn } from "@/lib/utils";
+
+interface BattlefieldCardProps {
+  card: CardState;
+  zone: ZoneType;
+  onCardClick?: (cardId: string, zone: ZoneType) => void;
+}
+
+/**
+ * A single battlefield permanent thumbnail.
+ *
+ * Extracted so the exact same markup is reused by both the small-board
+ * (non-virtualized) render path and the windowed `VirtualizedBattlefield`.
+ * Memoized so re-renders triggered by game-state deltas (#1024 delta-sync)
+ * skip cards whose props did not change.
+ */
+export const BattlefieldCard = memo(function BattlefieldCard({
+  card,
+  zone,
+  onCardClick,
+}: BattlefieldCardProps) {
+  const testId = `battlefield-card-${card.card.name.toLowerCase().replace(/\s+/g, "-")}`;
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      onCardClick?.(card.id, zone);
+    },
+    [onCardClick, card.id, zone],
+  );
+
+  return (
+    <div
+      data-testid={testId}
+      onClick={handleClick}
+      className="relative w-10 h-14 sm:w-12 sm:h-16 md:w-14 md:h-20 rounded overflow-hidden border border-primary/30 hover:scale-[3] hover:z-50 hover:shadow-2xl transition-all duration-300 cursor-pointer group shrink-0"
+      title={card.card.name}
+    >
+      {card.card.image_uris?.normal ? (
+        <Image
+          src={card.card.image_uris.normal}
+          alt={card.card.name}
+          fill
+          sizes="80px"
+          className="object-cover rounded"
+          loading="lazy"
+        />
+      ) : (
+        <div className="w-full h-full bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center">
+          <span className="text-[8px] text-center leading-tight px-0.5 line-clamp-2">
+            {card.card.name}
+          </span>
+        </div>
+      )}
+      {card.tapped && (
+        <div className="absolute inset-0 bg-black/20 flex items-center justify-center">
+          <span className="text-[8px] text-white font-bold rotate-45">
+            TAPPED
+          </span>
+        </div>
+      )}
+    </div>
+  );
+});
+
+export interface VirtualizedBattlefieldProps {
+  cards: CardState[];
+  zone: ZoneType;
+  onCardClick?: (cardId: string, zone: ZoneType) => void;
+  /** Class applied to the scroll container (e.g. absolute fill / height). */
+  className?: string;
+  /** Estimated card width in px (cards are ~40-56px wide). */
+  estimateSize?: number;
+  /** Horizontal gap between cards in px (mirrors Tailwind `gap-1` = 4px). */
+  gap?: number;
+  /** Number of cards rendered outside the visible window on each side. */
+  overscan?: number;
+}
+
+/**
+ * Horizontally-windowed battlefield permanent strip.
+ *
+ * The game board is the single most re-render-heavy surface in the app, and
+ * Commander / token-heavy boards can carry dozens of permanents. Mounting all
+ * of them every render tanks performance (#1082). Only the visible window of
+ * permanents (plus `overscan`) is mounted to the DOM; the rest are reachable
+ * by horizontal scroll. Built on `@tanstack/react-virtual` (already a project
+ * dependency, same primitive used by `VirtualCardList` / `VirtualizedCardGrid`)
+ * in horizontal mode, which suits the single-row battlefield strip layout.
+ *
+ * Because every permanent lives at a stable virtual index keyed by `card.id`,
+ * combat targeting / ability menus resolve to the correct card whether or not
+ * it is currently mounted — scrolling reveals it rather than missing it.
+ */
+export function VirtualizedBattlefield({
+  cards,
+  zone,
+  onCardClick,
+  className,
+  estimateSize = 56,
+  gap = 4,
+  overscan = 6,
+}: VirtualizedBattlefieldProps) {
+  const parentRef = React.useRef<HTMLDivElement>(null);
+
+  const rowVirtualizer = useVirtualizer({
+    count: cards.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => estimateSize,
+    overscan,
+    gap,
+    horizontal: true,
+  });
+
+  const virtualItems = rowVirtualizer.getVirtualItems();
+
+  return (
+    <div
+      ref={parentRef}
+      className={cn(
+        "overflow-x-auto overflow-y-hidden outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+      role="list"
+      aria-label={`Battlefield (${cards.length} permanents)`}
+      tabIndex={0}
+    >
+      <div
+        style={{
+          width: `${rowVirtualizer.getTotalSize()}px`,
+          height: "100%",
+          position: "relative",
+        }}
+      >
+        {virtualItems.map((virtualItem) => {
+          const card = cards[virtualItem.index];
+          if (!card) return null;
+          return (
+            <div
+              key={card.id ?? virtualItem.key}
+              data-index={virtualItem.index}
+              role="listitem"
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                height: "100%",
+                transform: `translateX(${virtualItem.start}px)`,
+                display: "flex",
+                alignItems: "center",
+              }}
+            >
+              <BattlefieldCard
+                card={card}
+                zone={zone}
+                onCardClick={onCardClick}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Resolves #1082 (Lane: Performance, Phase 33). The battlefield is the single most re-render-heavy surface in the app (it re-renders on every game-state delta from #1024). With Commander games / token-heavy boards / AI-vs-AI stress tests, dozens of permanents were mounted every render, causing jank.

The previous code also had a latent bug: it silently `slice()`d the battlefield to the first 7–14 permanents and showed a “+N more” badge, which **dropped overflow permanents entirely** — they were unmountable and untargetable. This PR fixes both.

## Approach

**Windowing via `@tanstack/react-virtual` (horizontal), gated behind a threshold** — matching the primitive already used by `VirtualCardList` and `VirtualizedCardGrid` (already a project dependency, so **no new dependency**).

- **`src/components/virtualized-battlefield.tsx`** (new):
  - `BattlefieldCard` — the single permanent thumbnail (image / name fallback / TAPPED overlay / hover-scale), extracted and `memo`-ized so it is shared by both render paths and skips unchanged cards on delta-sync re-renders.
  - `VirtualizedBattlefield` — a horizontally-scrollable strip using `useVirtualizer({ horizontal: true })`. Only the visible window (+ `overscan = 6`) is mounted to the DOM; the rest are revealed by horizontal scroll. This suits the real layout: the battlefield zone is a single-row strip (`h-24` ≈ 96 px → effectively one visible row of ~40–56 px thumbnails).
  - Keys are derived from the stable `card.id`, so combat targeting / ability menus resolve to the correct permanent whether or not it is currently mounted — scrolling reveals it rather than missing it.
- **`src/components/game-board.tsx`**:
  - Replaced the broken `displayCards`/`remainingCount` slice (and the “+N more” badge) with a threshold gate.
  - `count <= 20` → render **every** permanent directly via the shared `BattlefieldCard` (no slicing — also fixes the silent card-drop for 8–20 permanent boards; no virtualization overhead on small boards).
  - `count > 20` → render `<VirtualizedBattlefield>` (windowed + scrollable; all permanents reachable).
  - The per-card markup is identical (same classes, same `data-testid`, same `onCardClick`), so the visual layout and interactions are preserved.
  - Removed the now-unused `next/image` import.

### Why horizontal strip and not a 2D grid virtualizer?
The battlefield zone renders as a ~96 px tall strip of small thumbnails — only one row is ever visible. The repo’s `VirtualizedCardGrid` targets tall scrollable 2D grids (180 px items), which is a poor fit for this single-row strip. A horizontal `useVirtualizer` is the minimal, correct windowing for the actual layout and avoids materially changing the visuals.

## Render-count reasoning (large board)

For a 50+ permanent board in a 300 px viewport with 56 px cards + 4 px gap:
- visible window ≈ 5–6 cards + `overscan` 6 on each side ≈ **~17 cards mounted**, vs. **all 50+** before.
- For a 100-permanent stress board: still ~17 mounted (constant wrt board size) instead of 100. The virtualizer’s mounted count is bounded by viewport/`estimateSize` + 2·`overscan`, independent of `cards.length`.

## Acceptance criteria

- [x] Permanent zones window off-screen items past a configurable threshold (`BATTLEFIELD_WINDOWING_THRESHOLD = 20`)
- [x] Combat targeting and ability menus still reach every permanent (stable `card.id` keys; off-screen items reachable via scroll instead of being dropped)
- [x] Re-render cost on a 40+ permanent board drops measurably — mounted nodes bounded by viewport + overscan, not by board size (documented above)
- [x] Tests added; coverage maintained — `src/components/__tests__/virtualized-battlefield.test.tsx` (7 tests)
- [x] Small boards (≤ 20) unchanged path; no regression to normal rendering
- [x] Interactions preserved: clicking a visible permanent still fires `onCardClick(cardId, "battlefield")`; tap overlay/select still work

## Test coverage (`src/components/__tests__/virtualized-battlefield.test.tsx`)

- ✅ with 100 permanents, far fewer than 100 (≤ 40) mount to the DOM
- ✅ empty board renders nothing without crashing
- ✅ clicking a visible permanent calls `onCardClick` with the correct id + zone (targeting preserved)
- ✅ duplicate card names do not collide (keys derived from `card.id`)
- ✅ `BattlefieldCard`: image rendered when present; name fallback when absent; TAPPED indicator + click→zone

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (672 pre-existing warnings repo-wide, none in changed files)
- `npx jest src/components` — **92 passed / 92** (no regressions); new suite **7 passed / 7**

## Files changed

- `src/components/virtualized-battlefield.tsx` (new) — `BattlefieldCard` + `VirtualizedBattlefield` (horizontal windowing)
- `src/components/game-board.tsx` — threshold-gated windowing; fixes silent permanent-drop bug; reuse shared card
- `src/components/__tests__/virtualized-battlefield.test.tsx` (new) — windowing + interaction tests

Resolves #1082