### PR TITLE
feat(multiplayer): 3+ player mesh topology foundation (refs #1087 — partial)

### DIFF
--- a/src/lib/__tests__/anti-replay-tracker.test.ts
+++ b/src/lib/__tests__/anti-replay-tracker.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for the reusable per-sender anti-replay tracker.
+ * Issue #1087: extracted as a shared primitive so the mesh and the 1:1
+ * connection share one identical replay-protection policy.
+ */
+
+import { AntiReplayTracker } from "../anti-replay-tracker";
+
+describe("AntiReplayTracker", () => {
+  let tracker: AntiReplayTracker;
+
+  beforeEach(() => {
+    tracker = new AntiReplayTracker();
+  });
+
+  describe("first message from a sender", () => {
+    it("accepts seq 0 from a brand-new sender (not a replay)", () => {
+      expect(tracker.isReplay("peer-a", 0)).toBe(false);
+    });
+
+    it("reports null for an unseen sender before any message", () => {
+      expect(tracker.getLastApplied("peer-a")).toBeNull();
+    });
+  });
+
+  describe("in-order acceptance + monotonic high-water mark", () => {
+    it("advances the high-water mark as seqs increase", () => {
+      for (let s = 0; s < 5; s++) {
+        expect(tracker.isReplay("peer-a", s)).toBe(false);
+        tracker.markApplied("peer-a", s);
+      }
+      expect(tracker.getLastApplied("peer-a")).toBe(4);
+    });
+
+    it("accepts a seq gap (the check is <=, not contiguous)", () => {
+      tracker.markApplied("peer-a", 1);
+      expect(tracker.isReplay("peer-a", 5)).toBe(false);
+      tracker.markApplied("peer-a", 5);
+      expect(tracker.getLastApplied("peer-a")).toBe(5);
+    });
+  });
+
+  describe("duplicate rejection", () => {
+    it("flags an identical seq as a replay after it was applied", () => {
+      tracker.markApplied("peer-a", 3);
+      expect(tracker.isReplay("peer-a", 3)).toBe(true);
+    });
+
+    it("does not regress the high-water mark when re-marking an old seq", () => {
+      tracker.markApplied("peer-a", 7);
+      tracker.markApplied("peer-a", 2); // stale — ignored
+      expect(tracker.getLastApplied("peer-a")).toBe(7);
+    });
+  });
+
+  describe("stale / out-of-order rejection", () => {
+    it("flags an older seq as a replay", () => {
+      tracker.markApplied("peer-a", 10);
+      expect(tracker.isReplay("peer-a", 9)).toBe(true);
+      expect(tracker.isReplay("peer-a", 10)).toBe(true);
+    });
+
+    it("flags a straggler that arrives after a higher seq was applied", () => {
+      tracker.markApplied("peer-a", 5);
+      expect(tracker.isReplay("peer-a", 4)).toBe(true);
+    });
+  });
+
+  describe("per-sender isolation (scales to N senders)", () => {
+    it("tracks each sender independently — both can start at seq 0", () => {
+      expect(tracker.isReplay("alice", 0)).toBe(false);
+      tracker.markApplied("alice", 0);
+      // Bob is unaffected by Alice's stream.
+      expect(tracker.isReplay("bob", 0)).toBe(false);
+      tracker.markApplied("bob", 0);
+
+      expect(tracker.getLastApplied("alice")).toBe(0);
+      expect(tracker.getLastApplied("bob")).toBe(0);
+      expect(tracker.trackedSenderCount).toBe(2);
+
+      // Alice replaying her own seq 0 is still caught.
+      expect(tracker.isReplay("alice", 0)).toBe(true);
+    });
+
+    it("tracks many senders without cross-contamination", () => {
+      for (let i = 0; i < 6; i++) {
+        const id = `peer-${i}`;
+        expect(tracker.isReplay(id, 0)).toBe(false);
+        tracker.markApplied(id, 0);
+        tracker.markApplied(id, 1);
+      }
+      expect(tracker.trackedSenderCount).toBe(6);
+      // A replay from any one sender is caught.
+      expect(tracker.isReplay("peer-3", 1)).toBe(true);
+      // While a new sender is still accepted.
+      expect(tracker.isReplay("peer-new", 0)).toBe(false);
+    });
+  });
+
+  describe("advanceTo (full-sync reconciliation, #946/#1091)", () => {
+    it("jumps the high-water mark forward without a message", () => {
+      tracker.markApplied("host", 4);
+      tracker.advanceTo("host", 50);
+      expect(tracker.getLastApplied("host")).toBe(50);
+      // Everything up to 50 is now a replay.
+      expect(tracker.isReplay("host", 50)).toBe(true);
+      expect(tracker.isReplay("host", 49)).toBe(true);
+      expect(tracker.isReplay("host", 51)).toBe(false);
+    });
+
+    it("uses max so a duplicate snapshot delivery is still a replay", () => {
+      tracker.advanceTo("host", 20);
+      tracker.advanceTo("host", 20); // idempotent
+      expect(tracker.getLastApplied("host")).toBe(20);
+      expect(tracker.isReplay("host", 20)).toBe(true);
+    });
+
+    it("ignores invalid (negative / NaN) seqs", () => {
+      tracker.advanceTo("host", 5);
+      tracker.advanceTo("host", -1);
+      tracker.advanceTo("host", Number.NaN);
+      expect(tracker.getLastApplied("host")).toBe(5);
+    });
+  });
+
+  describe("resetSender / clear", () => {
+    it("resetSender makes the sender look brand-new again", () => {
+      tracker.markApplied("peer-a", 9);
+      tracker.resetSender("peer-a");
+      expect(tracker.getLastApplied("peer-a")).toBeNull();
+      expect(tracker.isReplay("peer-a", 0)).toBe(false);
+    });
+
+    it("clear wipes every sender", () => {
+      tracker.markApplied("a", 1);
+      tracker.markApplied("b", 2);
+      tracker.clear();
+      expect(tracker.trackedSenderCount).toBe(0);
+      expect(tracker.getLastApplied("a")).toBeNull();
+    });
+  });
+
+  describe("realistic interleaved stream (3 senders)", () => {
+    it("drops replays and accepts fresh seqs across interleaved senders", () => {
+      type Msg = { sender: string; seq: number };
+      // Interleaved arrivals from three peers.
+      const stream: Msg[] = [
+        { sender: "a", seq: 0 },
+        { sender: "b", seq: 0 },
+        { sender: "c", seq: 0 },
+        { sender: "a", seq: 1 },
+        { sender: "b", seq: 1 },
+        { sender: "a", seq: 1 }, // replay of a:1
+        { sender: "c", seq: 0 }, // replay of c:0
+        { sender: "c", seq: 1 },
+        { sender: "b", seq: 0 }, // stale replay of b:0
+      ];
+      const accepted: Msg[] = [];
+      for (const m of stream) {
+        if (!tracker.isReplay(m.sender, m.seq)) {
+          tracker.markApplied(m.sender, m.seq);
+          accepted.push(m);
+        }
+      }
+      expect(accepted).toEqual([
+        { sender: "a", seq: 0 },
+        { sender: "b", seq: 0 },
+        { sender: "c", seq: 0 },
+        { sender: "a", seq: 1 },
+        { sender: "b", seq: 1 },
+        { sender: "c", seq: 1 },
+      ]);
+    });
+  });
+});

--- a/src/lib/__tests__/lobby-multiplayer-capacity.test.ts
+++ b/src/lib/__tests__/lobby-multiplayer-capacity.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Lobby capacity regression coverage for 3+ player games.
+ * Issue #1087: the lobby layer must admit 3+ peers (the mesh foundation
+ * routes their GameMessages; this locks in the lobby-side capacity +
+ * stable-identity behaviour the mesh depends on).
+ *
+ * Self-contained (its own dependency mocks) so it does not disturb the
+ * existing lobby-manager test suite.
+ */
+
+jest.mock("../public-lobby-browser", () => ({
+  publicLobbyBrowser: {
+    registerPublicGame: jest.fn(),
+    updatePublicGame: jest.fn(),
+    unregisterPublicGame: jest.fn(),
+  },
+}));
+
+jest.mock("../game-code-generator", () => ({
+  generateGameCode: jest.fn(() => "ABC123"),
+  generateLobbyId: jest.fn(() => "lobby-123"),
+  generatePlayerId: jest.fn(() => "player-123"),
+}));
+
+jest.mock("../format-validator", () => ({
+  validateDeckForLobby: jest.fn(() => ({ valid: true, errors: [] })),
+}));
+
+jest.mock("../game-mode", () => ({
+  getGameModeForPlayerCount: jest.fn(() => "ffa"),
+  getGameModeConfig: jest.fn(() => ({
+    name: "Free-for-All",
+    isTeamMode: false,
+    minPlayers: 2,
+    maxPlayers: 4,
+  })),
+}));
+
+import { lobbyManager } from "../lobby-manager";
+import { generatePlayerId } from "../game-code-generator";
+import type { GameFormat, PlayerCount } from "../multiplayer-types";
+
+const baseSettings = {
+  isPublic: false,
+  allowSpectators: false,
+  timerEnabled: false,
+};
+
+describe("Lobby capacity for 3+ players (issue #1087 mesh foundation)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    lobbyManager.closeLobby();
+  });
+
+  afterEach(() => {
+    // Restore the module-level mock default so nothing leaks.
+    jest.mocked(generatePlayerId).mockReturnValue("player-123");
+    lobbyManager.closeLobby();
+  });
+
+  it("admits up to maxPlayers (4) peers, each with a stable distinct id", () => {
+    let counter = 0;
+    jest.mocked(generatePlayerId).mockImplementation(() => `pid-${counter++}`);
+
+    const lobby = lobbyManager.createLobby(
+      {
+        name: "Commander Pod",
+        format: "commander" as GameFormat,
+        maxPlayers: "4" as PlayerCount,
+        settings: baseSettings,
+      },
+      "Host",
+    );
+
+    const p2 = lobbyManager.addPlayer("Alice");
+    const p3 = lobbyManager.addPlayer("Bob");
+    const p4 = lobbyManager.addPlayer("Carol");
+    // Capacity is enforced: host + 3 = 4; the 5th is rejected (null), and
+    // addPlayer returns null WITHOUT minting a new id.
+    const overCapacity = lobbyManager.addPlayer("Dave");
+
+    expect([p2, p3, p4].every(Boolean)).toBe(true);
+    expect(overCapacity).toBeNull();
+    expect(lobby.players).toHaveLength(4);
+    // Every player has a stable, distinct identity.
+    const ids = lobby.players.map((p) => p.id);
+    expect(new Set(ids).size).toBe(4);
+  });
+
+  it("a 3-player lobby admits exactly two non-host peers", () => {
+    let counter = 0;
+    jest.mocked(generatePlayerId).mockImplementation(() => `id-${counter++}`);
+
+    const lobby = lobbyManager.createLobby(
+      {
+        name: "Trio",
+        format: "standard" as GameFormat,
+        maxPlayers: "3" as PlayerCount,
+        settings: baseSettings,
+      },
+      "Host",
+    );
+
+    expect(lobbyManager.addPlayer("A")).not.toBeNull();
+    expect(lobbyManager.addPlayer("B")).not.toBeNull();
+    expect(lobbyManager.addPlayer("C")).toBeNull();
+
+    expect(lobby.players).toHaveLength(3);
+  });
+});

--- a/src/lib/__tests__/mesh-game-connection.test.ts
+++ b/src/lib/__tests__/mesh-game-connection.test.ts
@@ -1,0 +1,722 @@
+/**
+ * Tests for the game-message-level multi-peer mesh.
+ * Issue #1087: "[Multiplayer] Support 3+ player mesh topology in the P2P
+ * connection layer".
+ *
+ * Covers: 3+ peer join, broadcast delivery to all, targeted send, peer
+ * leave/disconnect, per-sender anti-replay across multiple senders (#1091),
+ * host-side action validation from any peer (#1089), per-link rate limiting
+ * (#1111), host-migration rewiring, and the trust pipeline (malformed /
+ * oversize / missing-seq rejection).
+ */
+
+import {
+  MeshGameConnection,
+  createMeshGameConnection,
+  type PeerLink,
+  type MeshGameConnectionEvents,
+} from "../mesh-game-connection";
+import type { GameMessage } from "../p2p-game-connection";
+
+/** The event handle: each callback is a jest.Mock so call sites can assert. */
+interface MockEvents {
+  onMessage: jest.Mock;
+  onGameAction: jest.Mock;
+  onChat: jest.Mock;
+  onPeerJoined: jest.Mock;
+  onPeerLeft: jest.Mock;
+  onError: jest.Mock;
+}
+
+/** A controllable stand-in for a peer's data-channel-backed transport link. */
+class MockLink implements PeerLink {
+  peerId: string;
+  open: boolean;
+  closed = false;
+  sent: string[] = [];
+
+  constructor(peerId: string, open = true) {
+    this.peerId = peerId;
+    this.open = open;
+  }
+
+  send(raw: string): boolean {
+    if (!this.open) return false;
+    this.sent.push(raw);
+    return true;
+  }
+
+  isOpen(): boolean {
+    return this.open;
+  }
+
+  close(): void {
+    this.closed = true;
+    this.open = false;
+  }
+
+  /** Parsed messages this link received, in order. */
+  messages(): GameMessage[] {
+    return this.sent.map((s) => JSON.parse(s) as GameMessage);
+  }
+}
+
+/** Build a wire-string GameMessage for inbound injection. */
+const inbound = (
+  senderId: string,
+  seq: number,
+  overrides: Partial<GameMessage> & { type?: GameMessage["type"] } = {},
+): string => {
+  const msg: GameMessage = {
+    type: "game-action",
+    senderId,
+    timestamp: Date.now(),
+    seq,
+    data: { action: "pass_priority", data: {} },
+    ...overrides,
+  };
+  return JSON.stringify(msg);
+};
+
+const newMesh = (
+  overrides: Partial<ConstructorParameters<typeof MeshGameConnection>[0]> & {
+    events?: Partial<MeshGameConnectionEvents>;
+  } = {},
+): { mesh: MeshGameConnection; events: MockEvents } => {
+  const events: MockEvents = {
+    onMessage: jest.fn(),
+    onGameAction: jest.fn(),
+    onChat: jest.fn(),
+    onPeerJoined: jest.fn(),
+    onPeerLeft: jest.fn(),
+    onError: jest.fn(),
+  };
+  // Apply caller event overrides onto the shared handle so the returned
+  // `events` object is exactly what the mesh uses (same references).
+  if (overrides.events) {
+    Object.assign(events, overrides.events);
+  }
+  const { events: _omit, ...rest } = overrides;
+  const mesh = new MeshGameConnection({
+    localPlayerId: "host",
+    localPlayerName: "Host",
+    hostId: "host",
+    isHost: true,
+    events,
+    ...rest,
+  });
+  return { mesh, events };
+};
+
+describe("MeshGameConnection — construction & host role", () => {
+  it("requires localPlayerId and hostId", () => {
+    expect(
+      () =>
+        new MeshGameConnection({
+          localPlayerId: "",
+          localPlayerName: "x",
+          hostId: "h",
+          isHost: true,
+        }),
+    ).toThrow();
+    expect(
+      () =>
+        new MeshGameConnection({
+          localPlayerId: "x",
+          localPlayerName: "x",
+          hostId: "",
+          isHost: true,
+        }),
+    ).toThrow();
+  });
+
+  it("reports host id + host flag", () => {
+    const { mesh } = newMesh();
+    expect(mesh.isHost()).toBe(true);
+    expect(mesh.getHostId()).toBe("host");
+  });
+
+  it("createMeshGameConnection factory returns a working instance", () => {
+    const mesh = createMeshGameConnection({
+      localPlayerId: "p1",
+      localPlayerName: "P1",
+      hostId: "p1",
+      isHost: true,
+    });
+    expect(mesh.getPeerCount()).toBe(0);
+  });
+});
+
+describe("MeshGameConnection — peer membership (3+ players)", () => {
+  it("adds three peers and reports them", () => {
+    const { mesh, events } = newMesh();
+    expect(mesh.addPeerLink(new MockLink("p1"))).toBe(true);
+    expect(mesh.addPeerLink(new MockLink("p2"))).toBe(true);
+    expect(mesh.addPeerLink(new MockLink("p3"))).toBe(true);
+
+    expect(mesh.getPeerCount()).toBe(3);
+    expect(mesh.getPeerIds().sort()).toEqual(["p1", "p2", "p3"]);
+    expect(mesh.hasPeer("p2")).toBe(true);
+    // onPeerJoined fired once per new peer.
+    expect(events.onPeerJoined).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects adding the local player as a peer", () => {
+    const { mesh } = newMesh();
+    expect(mesh.addPeerLink(new MockLink("host"))).toBe(false);
+    expect(mesh.getPeerCount()).toBe(0);
+  });
+
+  it("rejects adding an empty peer id", () => {
+    const { mesh } = newMesh();
+    expect(mesh.addPeerLink(new MockLink(""))).toBe(false);
+  });
+
+  it("replacing a peer link closes the old link and keeps the count flat", () => {
+    const { mesh, events } = newMesh();
+    const first = new MockLink("p1");
+    mesh.addPeerLink(first);
+    const second = new MockLink("p1");
+    // Replace returns false (not a NEW peer) but the old link is closed.
+    expect(mesh.addPeerLink(second)).toBe(false);
+    expect(first.closed).toBe(true);
+    expect(mesh.getPeerCount()).toBe(1);
+    // Only one onPeerJoined (the original add).
+    expect(events.onPeerJoined).toHaveBeenCalledTimes(1);
+  });
+
+  it("removing a peer closes its link, drops it from the mesh, emits onPeerLeft", () => {
+    const { mesh, events } = newMesh();
+    const link = new MockLink("p1");
+    mesh.addPeerLink(link);
+    expect(mesh.removePeerLink("p1")).toBe(true);
+
+    expect(link.closed).toBe(true);
+    expect(mesh.hasPeer("p1")).toBe(false);
+    expect(events.onPeerLeft).toHaveBeenCalledWith("p1");
+  });
+
+  it("removePeerLink is a no-op for an unknown peer", () => {
+    const { mesh } = newMesh();
+    expect(mesh.removePeerLink("ghost")).toBe(false);
+  });
+});
+
+describe("MeshGameConnection — broadcast delivery to all peers", () => {
+  it("delivers a broadcast to every open link (3 players)", () => {
+    const { mesh } = newMesh();
+    const a = new MockLink("a");
+    const b = new MockLink("b");
+    const c = new MockLink("c");
+    mesh.addPeerLink(a);
+    mesh.addPeerLink(b);
+    mesh.addPeerLink(c);
+
+    const delivered = mesh.broadcastGameAction("pass_priority", {});
+
+    expect(delivered).toBe(3);
+    expect(a.messages()).toHaveLength(1);
+    expect(b.messages()).toHaveLength(1);
+    expect(c.messages()).toHaveLength(1);
+    // Same authoritative message reached every peer.
+    for (const link of [a, b, c]) {
+      const m = link.messages()[0];
+      expect(m.type).toBe("game-action");
+      expect(m.senderId).toBe("host");
+      expect(m.data).toEqual({ action: "pass_priority", data: {} });
+    }
+  });
+
+  it("stamps one shared monotonic seq per broadcast across all peers", () => {
+    const { mesh } = newMesh();
+    const a = new MockLink("a");
+    const b = new MockLink("b");
+    mesh.addPeerLink(a);
+    mesh.addPeerLink(b);
+
+    mesh.broadcastGameAction("act1", {});
+    mesh.broadcastGameAction("act2", {});
+
+    // First broadcast → seq 0 to both; second broadcast → seq 1 to both.
+    expect(a.messages()[0].seq).toBe(0);
+    expect(b.messages()[0].seq).toBe(0);
+    expect(a.messages()[1].seq).toBe(1);
+    expect(b.messages()[1].seq).toBe(1);
+    expect(mesh.getOutgoingSeq()).toBe(2);
+  });
+
+  it("skips closed links and returns only the count reached", () => {
+    const { mesh } = newMesh();
+    const open = new MockLink("open");
+    const closed = new MockLink("closed", false);
+    mesh.addPeerLink(open);
+    mesh.addPeerLink(closed);
+
+    expect(mesh.broadcastGameAction("x", {})).toBe(1);
+    expect(open.messages()).toHaveLength(1);
+    expect(closed.sent).toHaveLength(0);
+  });
+
+  it("broadcasts chat with the local sender name", () => {
+    const { mesh } = newMesh({
+      localPlayerId: "me",
+      localPlayerName: "Me",
+      hostId: "me",
+    });
+    const a = new MockLink("a");
+    mesh.addPeerLink(a);
+
+    mesh.broadcastChat("hello world");
+    expect(a.messages()[0]).toEqual(
+      expect.objectContaining({
+        type: "chat",
+        senderId: "me",
+        data: { senderName: "Me", text: "hello world" },
+      }),
+    );
+  });
+
+  it("broadcast to an empty mesh reaches nobody (0)", () => {
+    const { mesh } = newMesh();
+    expect(mesh.broadcastGameAction("x", {})).toBe(0);
+  });
+});
+
+describe("MeshGameConnection — targeted send (send-to-one)", () => {
+  it("delivers only to the targeted peer", () => {
+    const { mesh } = newMesh();
+    const a = new MockLink("a");
+    const b = new MockLink("b");
+    const c = new MockLink("c");
+    mesh.addPeerLink(a);
+    mesh.addPeerLink(b);
+    mesh.addPeerLink(c);
+
+    expect(mesh.sendToPeer("b", { type: "chat", data: { text: "psst" } })).toBe(
+      true,
+    );
+    expect(b.messages()).toHaveLength(1);
+    expect(a.sent).toHaveLength(0);
+    expect(c.sent).toHaveLength(0);
+  });
+
+  it("returns false for an unknown peer", () => {
+    const { mesh } = newMesh();
+    expect(mesh.sendToPeer("ghost", { type: "chat", data: {} })).toBe(false);
+  });
+
+  it("returns false when the target link is closed", () => {
+    const { mesh } = newMesh();
+    const dead = new MockLink("dead", false);
+    mesh.addPeerLink(dead);
+    expect(mesh.sendToPeer("dead", { type: "chat", data: {} })).toBe(false);
+  });
+});
+
+describe("MeshGameConnection — host-authoritative routing", () => {
+  it("a non-host routes its game-action to the host only", () => {
+    const { mesh } = newMesh({
+      localPlayerId: "p2",
+      localPlayerName: "P2",
+      hostId: "host",
+      isHost: false,
+    });
+    const host = new MockLink("host");
+    const other = new MockLink("p3");
+    mesh.addPeerLink(host);
+    mesh.addPeerLink(other);
+
+    expect(mesh.sendGameActionToHost("cast_spell", { target: "x" })).toBe(true);
+    expect(host.messages()).toHaveLength(1);
+    expect(other.sent).toHaveLength(0);
+    expect(host.messages()[0].type).toBe("game-action");
+  });
+
+  it("a host sending to itself is a no-op (returns false)", () => {
+    const { mesh } = newMesh(); // local == host
+    mesh.addPeerLink(new MockLink("p2"));
+    expect(mesh.sendGameActionToHost("cast", {})).toBe(false);
+  });
+});
+
+describe("MeshGameConnection — inbound trust pipeline", () => {
+  it("forwards a well-formed game-action to onMessage + onGameAction", () => {
+    const { mesh, events } = newMesh();
+    mesh.addPeerLink(new MockLink("p1"));
+
+    mesh.handleIncoming(inbound("p1", 0), "p1");
+
+    expect(events.onMessage).toHaveBeenCalledTimes(1);
+    expect(events.onMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "game-action", senderId: "p1", seq: 0 }),
+      "p1",
+    );
+    expect(events.onGameAction).toHaveBeenCalledWith("pass_priority", {}, "p1");
+  });
+
+  it("forwards chat to onChat with sender + text", () => {
+    const { mesh, events } = newMesh();
+    mesh.addPeerLink(new MockLink("p1"));
+    mesh.handleIncoming(
+      inbound("p1", 0, {
+        type: "chat",
+        data: { senderName: "P1", text: "hi" },
+      }),
+      "p1",
+    );
+    expect(events.onChat).toHaveBeenCalledWith("p1", "P1", "hi");
+  });
+
+  it("rejects malformed JSON without forwarding", () => {
+    const { mesh, events } = newMesh();
+    mesh.addPeerLink(new MockLink("p1"));
+    expect(() => mesh.handleIncoming("{ not json", "p1")).not.toThrow();
+    expect(events.onMessage).not.toHaveBeenCalled();
+  });
+
+  it("rejects valid JSON of the wrong shape", () => {
+    const { mesh, events } = newMesh();
+    mesh.addPeerLink(new MockLink("p1"));
+    mesh.handleIncoming(JSON.stringify({ type: "evil", senderId: "x" }), "p1");
+    mesh.handleIncoming(JSON.stringify({ foo: "bar" }), "p1");
+    expect(events.onMessage).not.toHaveBeenCalled();
+  });
+
+  it("rejects a well-shaped message missing the required seq field", () => {
+    const { mesh, events } = newMesh();
+    mesh.addPeerLink(new MockLink("p1"));
+    mesh.handleIncoming(
+      JSON.stringify({
+        type: "game-action",
+        senderId: "p1",
+        timestamp: 1,
+        data: { action: "pass" },
+      }),
+      "p1",
+    );
+    expect(events.onMessage).not.toHaveBeenCalled();
+  });
+
+  it("rejects an oversize message before forwarding", () => {
+    const { mesh, events } = newMesh();
+    mesh.addPeerLink(new MockLink("p1"));
+    const huge = "x".repeat(300 * 1024);
+    mesh.handleIncoming(
+      inbound("p1", 0, { data: { action: "pass", junk: huge } }),
+      "p1",
+    );
+    expect(events.onMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not break the mesh when a handler throws", () => {
+    const { mesh } = newMesh({
+      events: {
+        onMessage: () => {
+          throw new Error("boom");
+        },
+      },
+    });
+    mesh.addPeerLink(new MockLink("p1"));
+    // The thrown handler error is caught — mesh stays usable.
+    expect(() => mesh.handleIncoming(inbound("p1", 0), "p1")).not.toThrow();
+    // A subsequent well-formed message still parses (mesh alive).
+    mesh.handleIncoming(inbound("p1", 1), "p1");
+  });
+});
+
+describe("MeshGameConnection — per-sender anti-replay across N senders (#1091)", () => {
+  it("accepts an increasing stream from one sender and tracks the high-water mark", () => {
+    const { mesh, events } = newMesh();
+    mesh.addPeerLink(new MockLink("p1"));
+    for (let s = 0; s < 4; s++) {
+      mesh.handleIncoming(inbound("p1", s), "p1");
+    }
+    expect(mesh.getLastAppliedSeq("p1")).toBe(3);
+    expect(events.onMessage).toHaveBeenCalledTimes(4);
+  });
+
+  it("drops a duplicate seq (same payload identity) from one sender", () => {
+    const { mesh, events } = newMesh();
+    mesh.addPeerLink(new MockLink("p1"));
+    mesh.handleIncoming(inbound("p1", 5), "p1");
+    mesh.handleIncoming(inbound("p1", 5), "p1"); // duplicate
+    expect(events.onMessage).toHaveBeenCalledTimes(1);
+    expect(mesh.getLastAppliedSeq("p1")).toBe(5);
+  });
+
+  it("drops a stale (older) seq that straggles in", () => {
+    const { mesh, events } = newMesh();
+    mesh.addPeerLink(new MockLink("p1"));
+    mesh.handleIncoming(inbound("p1", 10), "p1");
+    mesh.handleIncoming(inbound("p1", 9), "p1"); // stale
+    expect(events.onMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks three senders independently — each may start at seq 0", () => {
+    const { mesh, events } = newMesh();
+    mesh.addPeerLink(new MockLink("a"));
+    mesh.addPeerLink(new MockLink("b"));
+    mesh.addPeerLink(new MockLink("c"));
+
+    mesh.handleIncoming(inbound("a", 0), "a");
+    mesh.handleIncoming(inbound("b", 0), "b");
+    mesh.handleIncoming(inbound("c", 0), "c");
+    mesh.handleIncoming(inbound("a", 1), "a");
+    mesh.handleIncoming(inbound("a", 0), "a"); // replay of a:0 → dropped
+    mesh.handleIncoming(inbound("c", 0), "c"); // replay of c:0 → dropped
+
+    expect(events.onMessage).toHaveBeenCalledTimes(4);
+    expect(mesh.getLastAppliedSeq("a")).toBe(1);
+    expect(mesh.getLastAppliedSeq("b")).toBe(0);
+    expect(mesh.getLastAppliedSeq("c")).toBe(0);
+  });
+
+  it("advanceIncomingSeq jumps the high-water mark (full-sync reconciliation)", () => {
+    const { mesh, events } = newMesh();
+    mesh.addPeerLink(new MockLink("p1"));
+    mesh.handleIncoming(inbound("p1", 2), "p1");
+    mesh.advanceIncomingSeq("p1", 100);
+    // Everything <= 100 is now a replay.
+    mesh.handleIncoming(inbound("p1", 50), "p1");
+    mesh.handleIncoming(inbound("p1", 100), "p1");
+    expect(events.onMessage).toHaveBeenCalledTimes(1);
+    mesh.handleIncoming(inbound("p1", 101), "p1");
+    expect(events.onMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("resetIncomingSeq lets a sender start fresh", () => {
+    const { mesh, events } = newMesh();
+    mesh.addPeerLink(new MockLink("p1"));
+    mesh.handleIncoming(inbound("p1", 9), "p1");
+    mesh.resetIncomingSeq("p1");
+    expect(mesh.getLastAppliedSeq("p1")).toBeNull();
+    mesh.handleIncoming(inbound("p1", 0), "p1"); // accepted again
+    expect(events.onMessage).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("MeshGameConnection — host-side action validation (#1089)", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("the host forwards a LEGAL action from any peer", () => {
+    const validator = jest.fn(() => ({ isValid: true }));
+    const { mesh, events } = newMesh({
+      validatePeerActions: true,
+      validatePeerAction: validator,
+    });
+    mesh.addPeerLink(new MockLink("p1"));
+    mesh.handleIncoming(inbound("p1", 0), "p1");
+    expect(events.onMessage).toHaveBeenCalledTimes(1);
+    expect(validator).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "pass_priority" }),
+      "p1",
+    );
+  });
+
+  it("the host REJECTS an illegal action and does NOT forward it", () => {
+    const validator = jest.fn(() => ({ isValid: false, reason: "Illegal" }));
+    const { mesh, events } = newMesh({
+      validatePeerActions: true,
+      validatePeerAction: validator,
+    });
+    const link = new MockLink("p1");
+    mesh.addPeerLink(link);
+
+    mesh.handleIncoming(inbound("p1", 0), "p1");
+
+    expect(events.onMessage).not.toHaveBeenCalled();
+    expect(events.onGameAction).not.toHaveBeenCalled();
+    // A typed error was sent back over the sender's link.
+    const err = link.messages()[0];
+    expect(err.type).toBe("error");
+    expect(err.data).toEqual(
+      expect.objectContaining({
+        code: "action_rejected",
+        action: "pass_priority",
+        reason: "Illegal",
+        rejectedSeq: 0,
+      }),
+    );
+  });
+
+  it("the rejection uses a default reason when the validator omits one", () => {
+    const { mesh } = newMesh({
+      validatePeerActions: true,
+      validatePeerAction: jest.fn(() => ({ isValid: false })),
+    });
+    const link = new MockLink("p1");
+    mesh.addPeerLink(link);
+    mesh.handleIncoming(inbound("p1", 0), "p1");
+    expect((link.messages()[0].data as { reason: string }).reason).toBe(
+      "Action rejected by host",
+    );
+  });
+
+  it("fail-closed: gate enabled without a validator rejects the action", () => {
+    const { mesh, events } = newMesh({ validatePeerActions: true });
+    const link = new MockLink("p1");
+    mesh.addPeerLink(link);
+    mesh.handleIncoming(inbound("p1", 0), "p1");
+    expect(events.onMessage).not.toHaveBeenCalled();
+    expect((link.messages()[0].data as { reason: string }).reason).toBe(
+      "No action validator configured",
+    );
+  });
+
+  it("opt-in: a NON-host does not validate actions even if a validator is set", () => {
+    const validator = jest.fn(() => ({ isValid: true }));
+    const { mesh, events } = newMesh({
+      localPlayerId: "p2",
+      hostId: "host",
+      isHost: false,
+      validatePeerActions: true,
+      validatePeerAction: validator,
+    });
+    mesh.addPeerLink(new MockLink("host"));
+    mesh.handleIncoming(inbound("host", 0), "host");
+    // Non-host forwards without consulting the validator.
+    expect(events.onMessage).toHaveBeenCalledTimes(1);
+    expect(validator).not.toHaveBeenCalled();
+  });
+
+  it("a throwing validator is treated as a rejection (never applied)", () => {
+    const { mesh, events } = newMesh({
+      validatePeerActions: true,
+      validatePeerAction: () => {
+        throw new Error("validator crashed");
+      },
+    });
+    mesh.addPeerLink(new MockLink("p1"));
+    mesh.handleIncoming(inbound("p1", 0), "p1");
+    expect(events.onMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not corrupt state: a later legal action still applies", () => {
+    const validator = jest.fn((a) =>
+      a.action === "evil"
+        ? { isValid: false, reason: "Illegal" }
+        : { isValid: true },
+    );
+    const { mesh, events } = newMesh({
+      validatePeerActions: true,
+      validatePeerAction: validator,
+    });
+    mesh.addPeerLink(new MockLink("p1"));
+    mesh.handleIncoming(inbound("p1", 0, { data: { action: "evil" } }), "p1");
+    mesh.handleIncoming(
+      inbound("p1", 1, { data: { action: "pass_priority" } }),
+      "p1",
+    );
+    expect(events.onMessage).toHaveBeenCalledTimes(1);
+    expect(events.onMessage.mock.calls[0][0].seq).toBe(1);
+  });
+});
+
+describe("MeshGameConnection — per-link rate limiting (#1111)", () => {
+  it("drops messages from a flooding peer without affecting other peers", () => {
+    const { mesh, events } = newMesh({
+      rateLimit: { maxMessages: 2, windowMs: 60_000 },
+    });
+    mesh.addPeerLink(new MockLink("flooder"));
+    mesh.addPeerLink(new MockLink("nice"));
+
+    // Flooder blasts 3 messages (limit is 2) — 3rd dropped.
+    mesh.handleIncoming(inbound("flooder", 0), "flooder");
+    mesh.handleIncoming(inbound("flooder", 1), "flooder");
+    mesh.handleIncoming(inbound("flooder", 2), "flooder");
+    // Nice peer is unaffected by the flooder's budget.
+    mesh.handleIncoming(inbound("nice", 0), "nice");
+
+    const forwardedSenders = events.onMessage.mock.calls.map(
+      (c: unknown[]) => (c[0] as GameMessage).senderId,
+    );
+    expect(forwardedSenders).toEqual(["flooder", "flooder", "nice"]);
+  });
+});
+
+describe("MeshGameConnection — host-migration rewiring (#946)", () => {
+  it("setHostId updates the host and routes sendGameActionToHost to the new host", () => {
+    const { mesh } = newMesh({
+      localPlayerId: "p2",
+      localPlayerName: "P2",
+      hostId: "oldhost",
+      isHost: false,
+    });
+    const oldHost = new MockLink("oldhost");
+    const newHost = new MockLink("newhost");
+    mesh.addPeerLink(oldHost);
+    mesh.addPeerLink(newHost);
+
+    mesh.sendGameActionToHost("act", {}); // → oldhost
+    expect(oldHost.messages()).toHaveLength(1);
+
+    mesh.setHostId("newhost"); // migration
+    expect(mesh.getHostId()).toBe("newhost");
+    expect(mesh.isHost()).toBe(false);
+
+    mesh.sendGameActionToHost("act", {}); // → newhost
+    expect(newHost.messages()).toHaveLength(1);
+    expect(oldHost.messages()).toHaveLength(1); // unchanged
+  });
+
+  it("setHostId promotes the local client to host when it is the successor", () => {
+    const { mesh } = newMesh({
+      localPlayerId: "p2",
+      hostId: "oldhost",
+      isHost: false,
+    });
+    mesh.setHostId("p2");
+    expect(mesh.isHost()).toBe(true);
+    // Now host: sendGameActionToHost is a no-op.
+    expect(mesh.sendGameActionToHost("act", {})).toBe(false);
+  });
+
+  it("adoptOutgoingSeq continues the counter for the successor", () => {
+    const { mesh } = newMesh();
+    // A peer link is required: broadcast short-circuits on an empty mesh and
+    // would not stamp an outgoing seq.
+    mesh.addPeerLink(new MockLink("a"));
+    mesh.broadcastGameAction("a", {}); // seq 0
+    mesh.broadcastGameAction("b", {}); // seq 1
+    expect(mesh.getOutgoingSeq()).toBe(2);
+    mesh.adoptOutgoingSeq(50); // adopt previous host's high-water mark
+    mesh.broadcastGameAction("c", {});
+    expect(mesh.getOutgoingSeq()).toBe(51);
+  });
+
+  it("adoptOutgoingSeq never regresses the counter", () => {
+    const { mesh } = newMesh();
+    mesh.adoptOutgoingSeq(100);
+    mesh.adoptOutgoingSeq(5); // ignored
+    expect(mesh.getOutgoingSeq()).toBe(100);
+  });
+});
+
+describe("MeshGameConnection — teardown", () => {
+  it("close() closes every link and clears anti-replay state", () => {
+    const { mesh } = newMesh();
+    const a = new MockLink("a");
+    const b = new MockLink("b");
+    mesh.addPeerLink(a);
+    mesh.addPeerLink(b);
+    mesh.handleIncoming(inbound("a", 0), "a"); // seed anti-replay
+
+    mesh.close();
+
+    expect(a.closed).toBe(true);
+    expect(b.closed).toBe(true);
+    expect(mesh.getPeerCount()).toBe(0);
+    expect(mesh.getLastAppliedSeq("a")).toBeNull();
+  });
+
+  it("close() is idempotent", () => {
+    const { mesh } = newMesh();
+    mesh.addPeerLink(new MockLink("a"));
+    expect(() => {
+      mesh.close();
+      mesh.close();
+    }).not.toThrow();
+  });
+});

--- a/src/lib/anti-replay-tracker.ts
+++ b/src/lib/anti-replay-tracker.ts
@@ -1,0 +1,95 @@
+/**
+ * Per-sender anti-replay high-water-mark tracker.
+ *
+ * Extracted as a reusable primitive (issue #1087) so the multi-peer mesh
+ * ({@link MeshGameConnection}) and the legacy 1:1 connection
+ * (`P2PGameConnection`) can share one identical replay-protection policy
+ * without duplicating the logic. `GameMessage`s carry a monotonic per-sender
+ * `seq` (issue #1091); the receiver tracks the highest `seq` it has applied
+ * per `senderId` and rejects any message whose `seq` is `<=` that high-water
+ * mark. This drops duplicates (reconnect re-delivery, #943) and replays
+ * (host-migration rebroadcast, #946) before they can corrupt game state.
+ *
+ * The tracker is pure in-memory state — no transport, no clocks, no
+ * allocation beyond the per-sender map entries — so it composes trivially
+ * under any number of concurrent senders.
+ */
+export class AntiReplayTracker {
+  /**
+   * Highest sequence number applied per sender id. `undefined` (absent key)
+   * means "no message observed from this sender yet".
+   */
+  private readonly highWaterMarks: Map<string, number> = new Map();
+
+  /**
+   * Returns `true` when `seq` has already been applied (or is older than the
+   * last applied) for `senderId`, i.e. the message is a duplicate/replay that
+   * must be dropped. A sender unseen until now is always accepted.
+   *
+   * Precondition: `seq` is a non-negative integer (callers validate shape
+   * before reaching here).
+   */
+  isReplay(senderId: string, seq: number): boolean {
+    const last = this.highWaterMarks.get(senderId);
+    if (last === undefined) {
+      return false;
+    }
+    return seq <= last;
+  }
+
+  /**
+   * Record the high-water mark for `senderId` as `max(current, seq)`. Called
+   * on every accepted message so the stream stays monotonic.
+   */
+  markApplied(senderId: string, seq: number): void {
+    const last = this.highWaterMarks.get(senderId) ?? -1;
+    if (seq > last) {
+      this.highWaterMarks.set(senderId, seq);
+    }
+  }
+
+  /**
+   * Advance the high-water mark for `senderId` to at least `seq` WITHOUT
+   * accepting a message. Used when a full `game-state-sync` reconciliation
+   * snapshot (e.g. post host-migration #946) carries `lastSeq`: the receiver
+   * jumps its tracker forward so any queued / re-emitted action with
+   * `seq <= lastSeq` is rejected as a replay. `max` is used so a duplicate
+   * delivery of the snapshot itself is still rejected by {@link isReplay}.
+   */
+  advanceTo(senderId: string, seq: number): void {
+    if (!Number.isFinite(seq) || seq < 0) {
+      return;
+    }
+    const last = this.highWaterMarks.get(senderId) ?? -1;
+    if (seq > last) {
+      this.highWaterMarks.set(senderId, seq);
+    }
+  }
+
+  /**
+   * Highest seq applied from `senderId`, or `null` if no message has been seen
+   * from that sender. Exposed for diagnostics and tests.
+   */
+  getLastApplied(senderId: string): number | null {
+    const v = this.highWaterMarks.get(senderId);
+    return v === undefined ? null : v;
+  }
+
+  /**
+   * Reset the high-water mark for a sender (e.g. when starting a fresh session
+   * or recovering from a known-clean state). Idempotent.
+   */
+  resetSender(senderId: string): void {
+    this.highWaterMarks.delete(senderId);
+  }
+
+  /** Number of senders currently tracked. */
+  get trackedSenderCount(): number {
+    return this.highWaterMarks.size;
+  }
+
+  /** Drop all per-sender tracking (e.g. on session teardown). */
+  clear(): void {
+    this.highWaterMarks.clear();
+  }
+}

--- a/src/lib/mesh-game-connection.ts
+++ b/src/lib/mesh-game-connection.ts
@@ -1,0 +1,690 @@
+/**
+ * Mesh Game Connection — game-message-level full-mesh routing for 3+ players.
+ *
+ * Issue #1087: "[Multiplayer] Support 3+ player mesh topology in the P2P
+ * connection layer".
+ *
+ * ----------------------------------------------------------------------------
+ * WHY THIS MODULE EXISTS
+ * ----------------------------------------------------------------------------
+ * The transport layer already had multi-peer plumbing (the
+ * `WebRTCConnectionPool` / `MeshTopologyManager` added under issue #1021), but
+ * it operates on the low-level `P2PMessage` type which carries none of the
+ * game-layer guarantees. Meanwhile the game-message layer that DOES carry
+ * those guarantees — `P2PGameConnection` with its monotonic `seq`
+ * anti-replay (#1091), host-side rules-engine validation (#1089), rate
+ * limiting (#1111) and structural message limits — held a single
+ * `peerConnection` + `dataChannel` + `remotePlayerId`: strictly 1 host ↔ 1
+ * peer. So Commander / 2HG pods (>2 players) were unreachable even though the
+ * lobby, host-migration and anti-replay code were all written for N peers.
+ *
+ * `MeshGameConnection` closes that gap. It is a **game-message-level** mesh:
+ * it maintains N peer links and routes `GameMessage`s across them (broadcast +
+ * targeted), while reusing — not duplicating — the existing trust pipeline:
+ *
+ *   - shape validation via the shared {@link isGameMessage} guard,
+ *   - structural/size limits via {@link safeParseJson},
+ *   - per-sender anti-replay via {@link AntiReplayTracker} (the same
+ *     high-water-mark policy as `P2PGameConnection`, now a shared primitive),
+ *   - per-link rate limiting via {@link P2PRateLimiter} (one independent
+ *     counter per peer, matching #1111's intent),
+ *   - authoritative-host action validation via {@link PeerActionValidator}
+ *     (the #1089 gate), applied on the host regardless of which peer sent the
+ *     action.
+ *
+ * ----------------------------------------------------------------------------
+ * TOPOLOGY DECISION: FULL MESH (each peer ↔ each peer)
+ * ----------------------------------------------------------------------------
+ * The local node holds one {@link PeerLink} per remote peer and `broadcast`
+ * fans a message out to every open link. This is deliberately a *superset* of
+ * both the legacy 1:1 link (the N=2 degenerate case) and a host-centered star:
+ * the host still owns game-state authority through the validation gate, but it
+ * ALSO holds direct links to every peer so a host drop can be detected and
+ * rewired by the existing `HostMigrationManager` (#946) without re-discovery.
+ * Full mesh was chosen because (a) the issue title specifies mesh, (b) being a
+ * superset it cannot regress the shipped 1:1 path or the star-authority model,
+ * and (c) host-migration's `remainingPeers` roster already assumes every peer
+ * knows every other peer.
+ *
+ * ----------------------------------------------------------------------------
+ * COMPOSITION BOUNDARY (what this module deliberately does NOT do)
+ * ----------------------------------------------------------------------------
+ * `MeshGameConnection` is **transport-agnostic**: it owns `PeerLink` send
+ * handles, never `RTCPeerConnection`s. ICE gathering, NAT traversal, the
+ * #943 per-link ICE-restart reconnection, and the actual data-channel
+ * handshake all continue to live in `WebRTCConnection` / the connection pool.
+ * A production caller wires each peer's open data channel into a `PeerLink`;
+ * the mesh then handles routing, anti-replay, rate limiting and host
+ * validation uniformly across all of them. This keeps the trust pipeline in
+ * exactly one place and avoids regressing the shipped transport. Wiring the
+ * mesh into the live signaling runtime / UI (currently 1:1 via
+ * `useP2PConnection`) and exercising host-migration + per-link reconnection
+ * end-to-end at N>2 is tracked as follow-up work — see the PR description.
+ */
+import {
+  isGameMessage,
+  type GameMessage,
+  type GameMessageType,
+  type PeerActionValidator,
+  type PeerActionValidationResult,
+  type PeerGameActionPayload,
+} from "./p2p-game-connection";
+import { safeParseJson } from "./p2p-json-validation";
+import { P2PRateLimiter, type P2PRateLimitOptions } from "./p2p-rate-limiter";
+import { redactSensitive } from "./p2p-log-redact";
+import { AntiReplayTracker } from "./anti-replay-tracker";
+
+/**
+ * A handle the mesh uses to push bytes to one remote peer and query its
+ * liveness. In production this is backed by an open `RTCDataChannel` (or a
+ * pooled `WebRTCConnection`); in tests it is a mock. Abstracting it here is
+ * what lets the mesh compose with the existing transport instead of owning
+ * `RTCPeerConnection`s itself.
+ */
+export interface PeerLink {
+  /** Stable identity of the remote peer this link reaches. */
+  peerId: string;
+  /** Serialize + push a raw message string to the remote peer. */
+  send(raw: string): boolean;
+  /** Whether the underlying transport is currently usable. */
+  isOpen(): boolean;
+  /** Close the underlying transport (idempotent). */
+  close(): void;
+}
+
+/**
+ * Events emitted by {@link MeshGameConnection}. Each inbound event is tagged
+ * with the `fromPeerId` that delivered it so callers can attribute state.
+ */
+export interface MeshGameConnectionEvents {
+  /** A well-formed, non-replay, host-validated message was accepted. */
+  onMessage: (message: GameMessage, fromPeerId: string) => void;
+  /** A `game-action` cleared the host validation gate (host-side convenience). */
+  onGameAction: (action: string, data: unknown, senderId: string) => void;
+  /** A `chat` message was accepted. */
+  onChat: (senderId: string, senderName: string, text: string) => void;
+  /** A new peer link was registered (peer joined / connected). */
+  onPeerJoined: (peerId: string) => void;
+  /** A peer link was removed (peer left / disconnected). */
+  onPeerLeft: (peerId: string) => void;
+  /** Recoverable trust-pipeline rejection (malformed/replay/illegal/rate). */
+  onError: (error: Error, fromPeerId: string) => void;
+}
+
+/** A message payload the caller wants to put on the wire (seq/timestamp stamped by the mesh). */
+export interface OutgoingGamePayload {
+  type: GameMessageType;
+  data: unknown;
+}
+
+/** Options for constructing a {@link MeshGameConnection}. */
+export interface MeshGameConnectionOptions {
+  /** Stable identity of the local player. */
+  localPlayerId: string;
+  /** Display name of the local player (used for chat emission). */
+  localPlayerName: string;
+  /**
+   * Identity of the authoritative host (game-state authority). Non-host peers
+   * route their `game-action`s here via {@link MeshGameConnection.sendGameActionToHost}.
+   * Updated on host migration via {@link MeshGameConnection.setHostId}.
+   */
+  hostId: string;
+  /** Whether the local client is the authoritative host. */
+  isHost: boolean;
+  /** Lifecycle events. `onMessage` defaults to a no-op. */
+  events?: Partial<MeshGameConnectionEvents>;
+  /**
+   * Authoritative-host action validation gate (issue #1089). When true (host
+   * only), incoming `game-action`s are validated by {@link validatePeerAction}
+   * against the host's authoritative state before being emitted.
+   */
+  validatePeerActions?: boolean;
+  /** Rules-engine legality check for peer game-actions (host-only, #1089). */
+  validatePeerAction?: PeerActionValidator;
+  /** Per-link rate limit for inbound messages (one counter per peer, #1111). */
+  rateLimit?: Partial<P2PRateLimitOptions>;
+}
+
+/** Default reason stamped on a host rejection when the validator omits one. */
+const DEFAULT_REJECTION_REASON = "Action rejected by host";
+
+/**
+ * Multi-peer game-message mesh.
+ *
+ * See the module header for the full topology / composition rationale. This
+ * class is intentionally free of any `RTCPeerConnection` reference: it routes
+ * already-serialized `GameMessage`s across registered {@link PeerLink}s and
+ * runs the shared trust pipeline on everything that arrives.
+ */
+export class MeshGameConnection {
+  private readonly localPlayerId: string;
+  private readonly localPlayerName: string;
+  private hostId: string;
+  private isHostFlag: boolean;
+
+  /** Registered peer links keyed by peer id (the mesh). */
+  private readonly links: Map<string, PeerLink> = new Map();
+  /** One independent rate limiter per peer link (issue #1111, per-connection). */
+  private readonly rateLimiters: Map<string, P2PRateLimiter> = new Map();
+  private readonly rateLimitOptions: Partial<P2PRateLimitOptions>;
+
+  /**
+   * Monotonic outgoing sequence counter shared across all sends. The local
+   * node is a single sender, so every receiver tracks one monotonic stream for
+   * `senderId = localPlayerId` — one counter keeps it gap-free everywhere.
+   * Issue #1091.
+   */
+  private outgoingSeq = 0;
+
+  /** Per-sender inbound anti-replay high-water marks. Issue #1091. */
+  private readonly antiReplay: AntiReplayTracker = new AntiReplayTracker();
+
+  private readonly validatePeerActions: boolean;
+  private readonly validatePeerAction: PeerActionValidator | null;
+  private readonly events: MeshGameConnectionEvents;
+
+  constructor(options: MeshGameConnectionOptions) {
+    if (!options.localPlayerId) {
+      throw new Error("MeshGameConnectionOptions.localPlayerId is required");
+    }
+    if (!options.hostId) {
+      throw new Error("MeshGameConnectionOptions.hostId is required");
+    }
+    this.localPlayerId = options.localPlayerId;
+    this.localPlayerName = options.localPlayerName;
+    this.hostId = options.hostId;
+    this.isHostFlag = options.isHost;
+    this.rateLimitOptions = options.rateLimit ?? {};
+    this.validatePeerActions = options.validatePeerActions === true;
+    this.validatePeerAction = options.validatePeerAction ?? null;
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const noop = (): void => {};
+    const defaults: MeshGameConnectionEvents = {
+      onMessage: noop,
+      onGameAction: noop,
+      onChat: noop,
+      onPeerJoined: noop,
+      onPeerLeft: noop,
+      onError: noop,
+    };
+    this.events = options.events
+      ? { ...defaults, ...options.events }
+      : defaults;
+  }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Topology / peer membership
+  // ────────────────────────────────────────────────────────────────────────
+
+  /** Whether the local client currently holds the authoritative-host role. */
+  isHost(): boolean {
+    return this.isHostFlag;
+  }
+
+  /** Current authoritative host id (updated on migration). */
+  getHostId(): string {
+    return this.hostId;
+  }
+
+  /**
+   * Update the authoritative host. Used by the host-migration layer (#946) to
+   * rewire routing after a host drop. Toggles the local host flag when the
+   * local client is the new host.
+   */
+  setHostId(newHostId: string): void {
+    if (!newHostId) return;
+    this.hostId = newHostId;
+    this.isHostFlag = newHostId === this.localPlayerId;
+  }
+
+  /**
+   * Register a transport link to a peer (idempotent). Re-registering for an
+   * existing peer id closes the previous link first so a transport never leaks.
+   * The local player can never be added as a peer. Returns true when a NEW
+   * peer was added (false on replace/self).
+   */
+  addPeerLink(link: PeerLink): boolean {
+    if (!link.peerId || link.peerId === this.localPlayerId) {
+      return false;
+    }
+    const isReplace = this.links.has(link.peerId);
+    if (isReplace) {
+      this.links.get(link.peerId)!.close();
+    }
+    this.links.set(link.peerId, link);
+    // A fresh limiter on (re)connect so a prior flood window doesn't persist.
+    this.rateLimiters.set(
+      link.peerId,
+      new P2PRateLimiter(this.rateLimitOptions),
+    );
+    if (!isReplace) {
+      this.events.onPeerJoined(link.peerId);
+    }
+    return !isReplace;
+  }
+
+  /**
+   * Remove a peer link (disconnect / leave). Closes the underlying transport,
+   * drops its rate limiter, and emits {@link MeshGameConnectionEvents.onPeerLeft}.
+   * The per-sender anti-replay state is intentionally RETAINED so a
+   * reconnecting peer that re-delivers stale messages is still rejected; use
+   * {@link resetIncomingSeq} for an explicit clean slate. No-op if unknown.
+   */
+  removePeerLink(peerId: string): boolean {
+    const link = this.links.get(peerId);
+    if (!link) return false;
+    link.close();
+    this.links.delete(peerId);
+    this.rateLimiters.delete(peerId);
+    this.events.onPeerLeft(peerId);
+    return true;
+  }
+
+  /** Whether a link to `peerId` is currently registered. */
+  hasPeer(peerId: string): boolean {
+    return this.links.has(peerId);
+  }
+
+  /** Peer ids with a registered link (excluding the local player). */
+  getPeerIds(): string[] {
+    return Array.from(this.links.keys());
+  }
+
+  /** Number of registered peer links. */
+  getPeerCount(): number {
+    return this.links.size;
+  }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Outbound routing
+  // ────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Allocate the next outgoing sequence number. Centralised so every send
+   * path shares one monotonic counter (issue #1091).
+   */
+  private nextOutgoingSeq(): number {
+    return this.outgoingSeq++;
+  }
+
+  /** Build a fully-stamped, serialized `GameMessage` ready for the wire. */
+  private serializeOutgoing(payload: OutgoingGamePayload): string {
+    const message: GameMessage = {
+      type: payload.type,
+      senderId: this.localPlayerId,
+      timestamp: Date.now(),
+      seq: this.nextOutgoingSeq(),
+      data: payload.data,
+    };
+    return JSON.stringify(message);
+  }
+
+  /**
+   * Broadcast a message to every OPEN peer link. Returns the number of peers
+   * the message was delivered to (closed links are skipped, not counted).
+   */
+  broadcast(payload: OutgoingGamePayload): number {
+    if (this.links.size === 0) return 0;
+    const raw = this.serializeOutgoing(payload);
+    let sent = 0;
+    for (const link of this.links.values()) {
+      if (this.sendRawOnLink(link, raw)) sent++;
+    }
+    return sent;
+  }
+
+  /**
+   * Send a message to a single targeted peer. Returns true if delivered to an
+   * open link, false if the peer is unknown or its link is closed.
+   */
+  sendToPeer(peerId: string, payload: OutgoingGamePayload): boolean {
+    const link = this.links.get(peerId);
+    if (!link) return false;
+    return this.sendRawOnLink(link, this.serializeOutgoing(payload));
+  }
+
+  /** Push a pre-serialized string onto a link, swallowing transport errors. */
+  private sendRawOnLink(link: PeerLink, raw: string): boolean {
+    if (!link.isOpen()) return false;
+    try {
+      return link.send(raw);
+    } catch (error) {
+      // #982: redact — transport errors may reference the payload/SDP.
+      console.error(
+        "[MeshGameConnection] Failed to send to peer:",
+        redactSensitive(error),
+      );
+      return false;
+    }
+  }
+
+  /** Broadcast a `game-action` to all peers (host distributing authoritative state). */
+  broadcastGameAction(action: string, data: unknown): number {
+    return this.broadcast({ type: "game-action", data: { action, data } });
+  }
+
+  /** Broadcast a `chat` message to all peers. */
+  broadcastChat(text: string): number {
+    return this.broadcast({
+      type: "chat",
+      data: { senderName: this.localPlayerName, text },
+    });
+  }
+
+  /**
+   * Route a `game-action` to the authoritative HOST for validation+application
+   * (non-host path in the authoritative-host model). If the local client IS
+   * the host this is a no-op return (the host applies its own actions locally).
+   * Returns true if the action was sent to an open host link.
+   */
+  sendGameActionToHost(action: string, data: unknown): boolean {
+    if (this.isHostFlag) return false;
+    return this.sendToPeer(this.hostId, {
+      type: "game-action",
+      data: { action, data },
+    });
+  }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Inbound trust pipeline (compose with shared primitives)
+  // ────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Get (creating if necessary) the per-link rate limiter for `peerId`. A
+   * limiter is created lazily so an inbound message that arrives just before
+   * its link is registered is still protected rather than dropped.
+   */
+  private ensureLimiter(peerId: string): P2PRateLimiter {
+    let limiter = this.rateLimiters.get(peerId);
+    if (!limiter) {
+      limiter = new P2PRateLimiter(this.rateLimitOptions);
+      this.rateLimiters.set(peerId, limiter);
+    }
+    return limiter;
+  }
+
+  /**
+   * Handle a raw inbound message that arrived over `fromPeerId`'s link.
+   *
+   * Enforces, in order, the SAME pipeline as `P2PGameConnection.handleMessage`
+   * so the trust boundary is identical at N=2 and N>2:
+   *   1. Per-link rate limit — a flooding peer is dropped before any parsing
+   *      (issue #1111). Each peer has its own counter so one flooder cannot
+   *      starve the others.
+   *   2. Safe parse + structural limits (size/depth/key-count) via
+   *      {@link safeParseJson}.
+   *   3. Shape validation via the shared {@link isGameMessage} guard
+   *      (including the required `seq`, #1091).
+   *   4. Anti-replay: a message with `seq <=` the highest seq already applied
+   *      from this `senderId` is dropped BEFORE it can touch game state (#1091).
+   *   5. Host-side rules-engine legality (#1089): on the authoritative host, a
+   *      `game-action` is validated against the host's own state; illegal
+   *      actions are rejected (peer notified via a typed `error` message
+   *      targeted back over the sender's link) BEFORE being emitted.
+   *
+   * Malformed, oversize, rate-limited, replayed or illegal messages are
+   * rejected gracefully without breaking the mesh or any other peer's link.
+   */
+  handleIncoming(raw: string, fromPeerId: string): void {
+    try {
+      // 1. Per-link rate limit first — never do parse/validation work for a
+      //    flooding peer.
+      if (!this.ensureLimiter(fromPeerId).tryAcquire()) {
+        console.warn(
+          "[MeshGameConnection] Rate limit exceeded; dropping peer message",
+          redactSensitive({ fromPeerId }),
+        );
+        return;
+      }
+
+      // 2 + 3. Safe parse + structural limits + shape validation.
+      const message = safeParseJson<GameMessage>(raw, isGameMessage);
+      if (!message) {
+        console.error(
+          "[MeshGameConnection] Rejected malformed peer message",
+          redactSensitive({ fromPeerId }),
+        );
+        return;
+      }
+
+      // 4. Anti-replay (per senderId, scales to N senders). Issue #1091.
+      if (this.antiReplay.isReplay(message.senderId, message.seq)) {
+        console.warn(
+          "[MeshGameConnection] Dropping duplicate/replay message",
+          redactSensitive({ senderId: message.senderId, seq: message.seq }),
+        );
+        return;
+      }
+      this.antiReplay.markApplied(message.senderId, message.seq);
+
+      // 5. Host-side rules-engine legality for game-actions. Issue #1089.
+      //    Auto-gated to the authoritative host: a non-host forwards actions
+      //    untouched (the host is the only one with authoritative state), and
+      //    a peer promoted by host migration (#946) begins validating
+      //    automatically once isHostFlag flips on.
+      if (
+        message.type === "game-action" &&
+        this.validatePeerActions &&
+        this.isHostFlag
+      ) {
+        const result = this.validatePeerGameAction(message);
+        if (!result.isValid) {
+          this.sendActionRejection(message, fromPeerId, result.reason);
+          return;
+        }
+      }
+
+      this.dispatch(message, fromPeerId);
+    } catch (error) {
+      // Defensive: a handler bug must not tear down the mesh.
+      console.error(
+        "[MeshGameConnection] Failed to handle message:",
+        redactSensitive(error),
+      );
+      this.events.onError(
+        error instanceof Error
+          ? error
+          : new Error("Failed to handle mesh message"),
+        fromPeerId,
+      );
+    }
+  }
+
+  /**
+   * Fan an accepted message out to the typed event surface. Mirrors the
+   * `P2PGameConnection` per-type dispatch so downstream consumers are
+   * identical whether they sit on the 1:1 or the mesh connection.
+   */
+  private dispatch(message: GameMessage, fromPeerId: string): void {
+    this.events.onMessage(message, fromPeerId);
+    switch (message.type) {
+      case "game-action": {
+        const payload = message.data as { action?: unknown; data?: unknown };
+        if (typeof payload.action === "string") {
+          this.events.onGameAction(
+            payload.action,
+            payload.data,
+            message.senderId,
+          );
+        }
+        break;
+      }
+      case "chat": {
+        const payload = message.data as {
+          senderName?: unknown;
+          text?: unknown;
+        };
+        if (typeof payload.text === "string") {
+          this.events.onChat(
+            message.senderId,
+            typeof payload.senderName === "string" ? payload.senderName : "",
+            payload.text,
+          );
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Validate a peer-originated `game-action` against the rules engine using the
+   * host's authoritative state (via {@link validatePeerAction}). Fail-closed:
+   * anything that cannot be confirmed legal is treated as illegal so it can
+   * never be applied to host state. Issue #1089.
+   */
+  private validatePeerGameAction(
+    message: GameMessage,
+  ): PeerActionValidationResult {
+    const payload = message.data;
+    if (
+      typeof payload !== "object" ||
+      payload === null ||
+      typeof (payload as { action?: unknown }).action !== "string"
+    ) {
+      return { isValid: false, reason: "Malformed game action" };
+    }
+    if (!this.validatePeerAction) {
+      // Gate enabled without a validator — fail-closed.
+      return { isValid: false, reason: "No action validator configured" };
+    }
+    const peerAction = payload as PeerGameActionPayload;
+    try {
+      const result = this.validatePeerAction(peerAction, message.senderId);
+      if (
+        result &&
+        typeof result === "object" &&
+        typeof result.isValid === "boolean"
+      ) {
+        return result;
+      }
+      return { isValid: false, reason: "Invalid validator result" };
+    } catch (error) {
+      return {
+        isValid: false,
+        reason:
+          error instanceof Error ? error.message : "Action validation error",
+      };
+    }
+  }
+
+  /**
+   * Notify the originating peer that its `game-action` was rejected by the
+   * authoritative host. Targets the sender's link specifically (in a full mesh
+   * the sender is a direct neighbor). Reuses the exact `error` message shape
+   * from `P2PGameConnection.sendActionRejection` so peers interpret rejections
+   * identically across 1:1 and mesh connections. Issue #1089.
+   */
+  private sendActionRejection(
+    message: GameMessage,
+    fromPeerId: string,
+    reason: string | undefined,
+  ): void {
+    const payload = message.data as { action?: unknown };
+    const rejection: GameMessage = {
+      type: "error",
+      senderId: this.localPlayerId,
+      timestamp: Date.now(),
+      seq: this.nextOutgoingSeq(),
+      data: {
+        code: "action_rejected",
+        action:
+          typeof payload?.action === "string" ? payload.action : undefined,
+        reason: reason ?? DEFAULT_REJECTION_REASON,
+        // Echo the rejected message's seq so the peer can correlate.
+        rejectedSeq: message.seq,
+      },
+    };
+    // Prefer the message's declared sender; fall back to the delivering link.
+    const targetId = this.links.has(message.senderId)
+      ? message.senderId
+      : fromPeerId;
+    const link = this.links.get(targetId);
+    if (!link) {
+      // Originating peer already gone (left mid-rejection) — nothing to send.
+      return;
+    }
+    this.sendRawOnLink(link, JSON.stringify(rejection));
+  }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Anti-replay / migration helpers (issue #1091, #946)
+  // ────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Highest seq applied from `senderId`, or `null` if none observed. Exposed
+   * for diagnostics, host-migration handoff, and tests. Issue #1091.
+   */
+  getLastAppliedSeq(senderId: string): number | null {
+    return this.antiReplay.getLastApplied(senderId);
+  }
+
+  /**
+   * Advance the per-sender anti-replay high-water mark (e.g. from a full
+   * `game-state-sync` reconciliation snapshot carrying `lastSeq`). Issue #1091.
+   */
+  advanceIncomingSeq(senderId: string, seq: number): void {
+    this.antiReplay.advanceTo(senderId, seq);
+  }
+
+  /** Reset the anti-replay high-water mark for a sender. Issue #1091. */
+  resetIncomingSeq(senderId: string): void {
+    this.antiReplay.resetSender(senderId);
+  }
+
+  /**
+   * The highest outgoing seq stamped so far. A newly-promoted host ships this
+   * as `lastSeq` in the post-migration reconciliation snapshot (#946/#1091).
+   */
+  getOutgoingSeq(): number {
+    return this.outgoingSeq;
+  }
+
+  /**
+   * Advance the outgoing seq counter to at least `seq` (no-op if already past
+   * it). A newly-promoted host calls this after host migration so its
+   * post-migration messages continue monotonically from the previous host's
+   * high-water mark. Issue #1091.
+   */
+  adoptOutgoingSeq(seq: number): void {
+    if (Number.isFinite(seq) && seq >= 0 && seq > this.outgoingSeq) {
+      this.outgoingSeq = seq;
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Teardown
+  // ────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Tear down the mesh: close every peer link, drop all rate limiters, and
+   * clear anti-replay state so a fresh session is not poisoned by stale
+   * high-water marks. Idempotent.
+   */
+  close(): void {
+    for (const link of this.links.values()) {
+      try {
+        link.close();
+      } catch (error) {
+        console.error(
+          "[MeshGameConnection] Error closing peer link:",
+          redactSensitive(error),
+        );
+      }
+    }
+    this.links.clear();
+    this.rateLimiters.clear();
+    this.antiReplay.clear();
+  }
+}
+
+/**
+ * Convenience factory mirroring `createP2PGameConnection`.
+ */
+export function createMeshGameConnection(
+  options: MeshGameConnectionOptions,
+): MeshGameConnection {
+  return new MeshGameConnection(options);
+}


### PR DESCRIPTION
## Refs #1087 (partial — foundation only; full N-player gameplay tracked as follow-up) — 3+ player mesh topology foundation

> Scope note: This is a **scoped, feasibility-first foundation**, exactly as the
> issue requested ("Introduce a `PeerMesh`/`MultiPeerConnectionManager`… keep the
> current single-peer path as the degenerate N=2 case"). It delivers the
> **connection + lobby foundation** with full test coverage. Live runtime wiring
> (N-pair signaling, UI, runtime host-migration/reconnection at N>2) is outlined
> under **Follow-ups**. I did **not** rewrite the shipped 1:1 game or duplicate
> the trust pipeline.

### The gap this closes
The transport layer already had multi-peer plumbing (`WebRTCConnectionPool` /
`MeshTopologyManager`, #1021), but it operates on the low-level `P2PMessage`
type. The **game-message layer** that carries the real guarantees —
`P2PGameConnection` with monotonic `seq` anti-replay (#1091), host-side
rules-engine validation (#1089), rate limiting (#1111) and structural limits —
held a single `peerConnection` + `dataChannel` + `remotePlayerId`: strictly
1:1. So Commander / 2HG pods (>2 players) were unreachable even though the
lobby, host-migration and anti-replay code were all written for N peers. This
PR adds the missing **game-message-level mesh**.

## What's delivered (the foundation)
- **`AntiReplayTracker`** (`src/lib/anti-replay-tracker.ts`) — the per-sender
  high-water-mark policy from #1091, extracted into a reusable primitive so the
  mesh and the 1:1 connection share one identical replay-protection logic
  instead of duplicating it.
- **`MeshGameConnection`** (`src/lib/mesh-game-connection.ts`) — an N-peer
  game-message mesh that:
  - holds N transport-agnostic **`PeerLink`** send handles (`Map<peerId, PeerLink>`) — it never owns an `RTCPeerConnection`, so it **composes** with the existing pool / `WebRTCConnection` (ICE, NAT, #943 reconnection all stay where they are);
  - **broadcast** (send-to-all) + **targeted send** (`sendToPeer`), each stamping one shared monotonic outgoing `seq`;
  - runs the **identical trust pipeline** as `P2PGameConnection.handleMessage` on every inbound message: per-link rate limit (#1111) → `safeParseJson` structural limits → shared `isGameMessage` shape guard → per-sender anti-replay (#1091) → host-side action validation (#1089);
  - **host-authoritative routing**: non-host peers route `game-action`s to the host (`sendGameActionToHost`); the host validates against its own state and broadcasts authoritative results;
  - **host-migration rewiring** helpers (`setHostId`, `adoptOutgoingSeq`, `advanceIncomingSeq`) that line up with the existing `HostMigrationManager` (#946) and the post-migration reconciliation-snapshot policy.
- **Lobby 3+/4-player capacity regression** (`lobby-multiplayer-capacity.test.ts`) — locks in stable distinct player identities for 3- and 4-player pods (already supported by `lobby-manager`; now guarded against regression).
- **80 new unit tests** (full suite **5522 green**): peer join (3+), broadcast delivery to all, targeted send, leave/disconnect, per-sender anti-replay across N senders, host validation from any peer (incl. fail-closed + throwing-validator), per-link rate limiting isolating a flooding peer, host-migration rewiring, and teardown.

## Topology decision: **full mesh** (each peer ↔ each peer)
The local node holds one `PeerLink` per remote peer and `broadcast` fans out to
every open link. This is deliberately a **superset** of both the legacy 1:1 link
(the N=2 degenerate case) and a host-centered star: the host still owns
game-state authority through the validation gate, but it *also* holds direct
links to every peer so a host drop can be detected and rewired by the existing
`HostMigrationManager` without re-discovery. Chosen because (a) the issue title
specifies mesh, (b) as a superset it cannot regress the shipped 1:1 path or the
star-authority model, (c) host-migration's `remainingPeers` roster already
assumes every peer knows every other peer.

## How it composes with #1091 / size limits / #1089 (no duplication)
`MeshGameConnection` **imports and reuses** the existing primitives — it does
not reimplement any of them:
- `isGameMessage` (shape guard incl. required `seq`), `safeParseJson` (size/depth/key-count limits), `P2PRateLimiter` (one independent counter **per peer link**, matching #1111's intent), `redactSensitive` (log hygiene), `PeerActionValidator` / `PeerGameActionPayload` (#1089 gate), and the new shared `AntiReplayTracker` (the #1091 policy).
- The `error` rejection message uses the **exact same wire shape** as `P2PGameConnection.sendActionRejection` so peers interpret rejections identically across 1:1 and mesh connections.
- The 1:1 `P2PGameConnection` is **untouched** — the mesh is purely additive.

## Acceptance-criteria checklist
| Issue criterion | Status |
| --- | --- |
| Multi-peer manager maintaining N `RTCPeerConnection`s (the mesh); send/receive to/from every peer | ✅ `MeshGameConnection` (holds N `PeerLink`s over the existing pooled `RTCPeerConnection`s; broadcast + targeted send/receive) |
| Lobby supports 3+ players joining; each gets a stable identity | ✅ (pre-existing `lobby-manager` + new capacity regression test) |
| Message broadcast + targeted send across the mesh | ✅ `broadcast` / `sendToPeer` (+ `broadcastGameAction`/`broadcastChat`/`sendGameActionToHost`) |
| Anti-replay (#1091) + host validation (#1089) compose across multiple peers | ✅ verified — per-sender tracker scales to N; validation auto-gates to host; 64 dedicated tests |
| Host/coordinator (authoritative-host) works with N peers | ✅ host-authoritative routing + validation in the mesh layer |
| Comprehensive mesh unit tests | ✅ 80 new tests |
| 3-player game created via lobby; all three receive broadcast game-actions (end-to-end) | ⏳ deferred — foundation layer + unit-level broadcast-to-all proven; **live lobby→mesh signaling/UI wiring is follow-up** |
| Host migration rewires the mesh at runtime when host drops (N>2) | ⏳ deferred — rewiring API + helpers present; **runtime integration with `HostMigrationManager` is follow-up** |
| Per-peer reconnection (#943) runs independently per link | ⏳ deferred — the mesh is transport-agnostic and composes with the per-link reconnection already in `WebRTCConnection`; **runtime exercise is follow-up** |

## Verification (all green)
- `npm run typecheck` (`tsc --noEmit`) ✅
- `npm run lint` ✅ (0 errors; my files are warning-free)
- `npm test` ✅ — **263 suites / 5522 tests passed**, 0 failures (80 new)
- `npm run build` (`next build`) ✅

## Follow-ups (explicitly out of scope for this foundation PR)
1. **Runtime wiring**: connect `MeshGameConnection` to the live signaling flow in `useP2PConnection` — register a `PeerLink` per peer as each data channel opens, so a real 3-player lobby game broadcasts to all three (closes the first deferred criterion).
2. **Host migration at N>2**: drive `MeshGameConnection.setHostId`/`adoptOutgoingSeq` from `HostMigrationManager` on a host drop and exercise the full rewire end-to-end.
3. **Per-link reconnection**: exercise the existing #943 ICE-restart per `WebRTCConnection` link through the mesh at N>2 (the composition seam is already in place).
4. **N-player gameplay rules/UI**: multiplayer combat targeting, turn order for >2 players, etc. (separate, larger effort).

---

🤖 This PR was generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands) working in scoped/feasibility-first mode.

