### PR TITLE
perf(deck-builder): resolve #1081 — virtualize the deck-builder deck list

### DIFF
--- a/src/app/(app)/deck-builder/_components/__tests__/deck-list.test.tsx
+++ b/src/app/(app)/deck-builder/_components/__tests__/deck-list.test.tsx
@@ -1,14 +1,20 @@
 /**
- * @fileoverview Accessibility tests for DeckList
+ * @fileoverview Accessibility + virtualization tests for DeckList
  *
- * Verifies deck-list card controls are keyboard-accessible (issue #933):
+ * Accessibility (#933):
  *   1. The remove/decrease control is always visible (not hover-only).
  *   2. Every interactive control exposes an accessible name via aria-label.
  *   3. Quantity steppers (+/-) are rendered as real buttons that invoke the
  *      correct handlers.
+ *
+ * Virtualization (#1081):
+ *   4. Only a bounded window of rows (+ overscan) is mounted regardless of
+ *      deck size.
+ *   5. Every card stays reachable by scrolling (nothing is dropped).
+ *   6. Stepper interactions keep working through the virtualizer.
  */
 
-import { describe, it, expect, jest } from "@jest/globals";
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
@@ -23,10 +29,6 @@ jest.mock("@/components/ui/card", () => ({
 
 jest.mock("@/components/ui/input", () => ({
   Input: (props: any) => <input {...props} />,
-}));
-
-jest.mock("@/components/ui/scroll-area", () => ({
-  ScrollArea: ({ children }: any) => <div>{children}</div>,
 }));
 
 jest.mock("@/components/ui/separator", () => ({
@@ -44,18 +46,22 @@ jest.mock("@/components/ui/button", () => ({
 jest.mock("lucide-react", () => ({
   Minus: () => <svg data-testid="minus-icon" />,
   Plus: () => <svg data-testid="plus-icon" />,
+  MinusCircle: () => <svg data-testid="minus-circle-icon" />,
+  AlertTriangle: () => <svg data-testid="alert-triangle-icon" />,
+  ShieldAlert: () => <svg data-testid="shield-alert-icon" />,
 }));
 
 import { DeckList } from "@/app/(app)/deck-builder/_components/deck-list";
+import type { DeckCard } from "@/app/actions";
 
 const bolt = {
   id: "bolt-1",
   name: "Lightning Bolt",
   count: 3,
   type_line: "Instant",
-} as any;
+} as DeckCard;
 
-const deck = [bolt] as any;
+const deck = [bolt];
 
 const renderList = (overrides: any = {}) =>
   render(
@@ -68,6 +74,91 @@ const renderList = (overrides: any = {}) =>
       {...overrides}
     />,
   );
+
+/**
+ * jsdom reports 0 for every layout property by default, which makes
+ * @tanstack/react-virtual think the viewport is empty and mount nothing.
+ * Give the scroll viewport a non-zero size, virtual rows a measurable
+ * height, and provide the ResizeObserver the library relies on. Mirrors the
+ * setup in virtual-card-list.test.tsx / virtualized-battlefield.test.tsx.
+ */
+const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+let originalClientHeight: PropertyDescriptor | undefined;
+let originalOffsetHeight: PropertyDescriptor | undefined;
+
+function rect(height: number): DOMRect {
+  return {
+    width: 600,
+    height,
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    bottom: height,
+    right: 600,
+    toJSON() {},
+  } as DOMRect;
+}
+
+beforeEach(() => {
+  originalClientHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "clientHeight",
+  );
+  originalOffsetHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "offsetHeight",
+  );
+
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get() {
+      return 400;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    get() {
+      return 400;
+    },
+  });
+
+  // Virtual rows (data-index) report a measurable height; the scroll
+  // container (role=list) reports the viewport height.
+  Element.prototype.getBoundingClientRect = function getBoundingClientRect() {
+    if (this.hasAttribute && this.hasAttribute("data-index")) {
+      return rect(40);
+    }
+    if (this.getAttribute && this.getAttribute("role") === "list") {
+      return rect(400);
+    }
+    return originalGetBoundingClientRect.call(this);
+  };
+
+  (global as { ResizeObserver?: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+afterEach(() => {
+  if (originalClientHeight) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      "clientHeight",
+      originalClientHeight,
+    );
+  }
+  if (originalOffsetHeight) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      "offsetHeight",
+      originalOffsetHeight,
+    );
+  }
+  Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+});
 
 describe("DeckList — card control accessibility (#933)", () => {
   it("renders the empty-state message when the deck is empty", () => {
@@ -131,5 +222,92 @@ describe("DeckList — card control accessibility (#933)", () => {
     fireEvent.click(screen.getByTestId("increase-quantity-bolt-1"));
     expect(onAddCard).toHaveBeenCalledTimes(1);
     expect(onAddCard).toHaveBeenCalledWith(bolt);
+  });
+});
+
+describe("DeckList — virtualization (#1081)", () => {
+  /** Build a constructed-sized deck spread across several categories. */
+  function makeDeck(n: number): DeckCard[] {
+    const types = [
+      "Creature",
+      "Instant",
+      "Sorcery",
+      "Artifact",
+      "Land",
+    ];
+    return Array.from({ length: n }, (_, i) => ({
+      id: `card-${i}`,
+      name: `Card ${i}`,
+      count: 1,
+      type_line: types[i % types.length],
+    })) as DeckCard[];
+  }
+
+  it("mounts only a bounded window of rows, not the whole deck", () => {
+    const bigDeck = makeDeck(150);
+    render(
+      <DeckList
+        deck={bigDeck}
+        deckName="Big"
+        onDeckNameChange={jest.fn()}
+        onRemoveCard={jest.fn()}
+        onAddCard={jest.fn()}
+      />,
+    );
+
+    const mounted = screen.getAllByTestId(/^deck-item-card-\d+$/);
+    // A virtualized window must mount only a small fraction of 150 cards.
+    expect(mounted.length).toBeGreaterThan(0);
+    expect(mounted.length).toBeLessThan(60);
+  });
+
+  it("makes every card reachable as the user scrolls", () => {
+    const bigDeck = makeDeck(150);
+    render(
+      <DeckList
+        deck={bigDeck}
+        deckName="Big"
+        onDeckNameChange={jest.fn()}
+        onRemoveCard={jest.fn()}
+        onAddCard={jest.fn()}
+      />,
+    );
+
+    // Initially the first card is mounted and a far card is not.
+    expect(screen.getByTestId("deck-item-card-0")).toBeTruthy();
+    expect(screen.queryByTestId("deck-item-card-140")).toBeNull();
+
+    const scroller = screen.getByTestId("deck-list-scroll");
+    fireEvent.scroll(scroller, { target: { scrollTop: 5600 } });
+
+    // After scrolling near the bottom, early cards are unmounted and late
+    // cards have entered the window — proving reachability via virtualization.
+    expect(screen.queryByTestId("deck-item-card-0")).toBeNull();
+    const mountedIndices = screen
+      .getAllByTestId(/^deck-item-card-\d+$/)
+      .map((el) => Number(el.getAttribute("data-testid")!.replace("deck-item-card-", "")));
+    expect(Math.max(...mountedIndices)).toBeGreaterThan(80);
+  });
+
+  it("keeps stepper interactions working through the virtualizer", () => {
+    const onAddCard = jest.fn();
+    const onRemoveCard = jest.fn();
+    const bigDeck = makeDeck(150);
+    render(
+      <DeckList
+        deck={bigDeck}
+        deckName="Big"
+        onDeckNameChange={jest.fn()}
+        onRemoveCard={onRemoveCard}
+        onAddCard={onAddCard}
+      />,
+    );
+
+    // The first card is in the initial window; its steppers must fire.
+    fireEvent.click(screen.getByTestId("decrease-quantity-card-0"));
+    expect(onRemoveCard).toHaveBeenCalledWith("card-0");
+    fireEvent.click(screen.getByTestId("increase-quantity-card-0"));
+    expect(onAddCard).toHaveBeenCalledTimes(1);
+    expect(onAddCard).toHaveBeenCalledWith(expect.objectContaining({ id: "card-0" }));
   });
 });

--- a/src/app/(app)/deck-builder/_components/deck-list.tsx
+++ b/src/app/(app)/deck-builder/_components/deck-list.tsx
@@ -1,16 +1,17 @@
 "use client";
 
+import * as React from "react";
+import { useMemo, useState, memo } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { DeckCard } from "@/app/actions";
 import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
 import { Minus, Plus, MinusCircle, AlertTriangle, ShieldAlert } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
-import { useMemo, useState } from "react";
 import {
   getCardColorIdentityStatus,
   getColorIdentityFixSuggestions,
@@ -81,6 +82,117 @@ function describeViolation(violation: ColorIdentityViolation, commanderIdentity:
   return `Has ${violatedNames} but Commander is ${commanderLabel} only`;
 }
 
+type CardIdentityStatus = ReturnType<typeof getCardColorIdentityStatus>;
+
+interface DeckCardRowProps {
+  card: DeckCard;
+  status?: CardIdentityStatus;
+  legality?: CardLegalityResult;
+  commanderColorIdentity?: string[];
+  onRemoveCard: (cardId: string) => void;
+  onAddCard: (card: DeckCard) => void;
+}
+
+/**
+ * A single deck row (name + quantity stepper + badges).
+ *
+ * Extracted and memoized so the continuous re-renders triggered by every
+ * deck edit (add/remove/count change) skip rows whose props did not change —
+ * the same pattern the windowed battlefield strip (#1082) uses for its
+ * `BattlefieldCard`. The markup is byte-for-byte the previous inline row so
+ * existing tests, test-ids and aria-labels are preserved.
+ */
+const DeckCardRow = memo(function DeckCardRow({
+  card,
+  status,
+  legality,
+  commanderColorIdentity,
+  onRemoveCard,
+  onAddCard,
+}: DeckCardRowProps) {
+  const isViolation = status?.severity === "violation";
+  const isWarning = status?.severity === "warning";
+  return (
+    <div
+      className={cn(
+        "group flex items-center justify-between text-sm p-1 rounded-md hover:bg-secondary border-l-2",
+        isViolation && "border-l-destructive bg-destructive/5",
+        isWarning && "border-l-amber-500 bg-amber-500/5",
+        !isViolation && !isWarning && "border-l-transparent",
+      )}
+      data-testid={`deck-item-${card.name.toLowerCase().replace(/\s+/g, "-")}`}
+      title={
+        status && status.severity !== "valid" && commanderColorIdentity
+          ? describeViolation(
+              {
+                name: status.name,
+                colorIdentity: status.colorIdentity,
+                violatedColors: status.violatedColors,
+                severity: status.severity,
+              },
+              commanderColorIdentity,
+            )
+          : undefined
+      }
+    >
+      <span className="flex items-center">
+        {card.count}x {card.name}
+        {card.color_identity && card.color_identity.length > 0 && (
+          <ColorIdentityBadge identity={card.color_identity} />
+        )}
+        {legality && (
+          <LegalityBadge
+            status={legality.status}
+            className="text-[10px] px-1.5 py-0"
+          />
+        )}
+        {isViolation && (
+          <ShieldAlert className="size-3.5 ml-1.5 text-destructive" data-testid="violation-icon" />
+        )}
+        {isWarning && (
+          <AlertTriangle className="size-3.5 ml-1.5 text-amber-500" data-testid="warning-icon" />
+        )}
+      </span>
+      <div className="flex items-center gap-1">
+        <Button variant="ghost" size="icon" className="size-6" aria-label={`Decrease quantity of ${card.name}`} onClick={() => onRemoveCard(card.id)} data-testid={`decrease-quantity-${card.id}`}>
+          <Minus className="size-4" />
+        </Button>
+        <span className="w-5 text-center tabular-nums" aria-label={`Quantity ${card.count}`}>{card.count}</span>
+        <Button variant="ghost" size="icon" className="size-6" aria-label={`Increase quantity of ${card.name}`} onClick={() => onAddCard(card)} data-testid={`increase-quantity-${card.id}`}>
+          <Plus className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+});
+
+/**
+ * A single flat entry in the windowed deck list. The previous render grouped
+ * cards under per-category <ul> blocks; for virtualization the whole list is
+ * flattened into one ordered sequence of rows so a single virtualizer can
+ * window it. Category headers, the color-identity fix toggle and the fix
+ * suggestions are all first-class rows so there is no preceding static
+ * content to throw off the windowing math.
+ */
+type DeckRow =
+  | { kind: "fix-toggle" }
+  | { kind: "fix-suggestions" }
+  | { kind: "category-header"; category: string; count: number }
+  | { kind: "card"; card: DeckCard };
+
+function deckRowKey(row: DeckRow): string {
+  switch (row.kind) {
+    case "fix-toggle":
+      return "deck-fix-toggle";
+    case "fix-suggestions":
+      return "deck-fix-suggestions";
+    case "category-header":
+      return `deck-category-${row.category}`;
+    case "card":
+      return `deck-card-${row.card.id}`;
+  }
+}
+
 export function DeckList({
   deck,
   deckName,
@@ -95,7 +207,7 @@ export function DeckList({
 
   // Pre-compute a per-card color-identity status lookup keyed by card id.
   const statusById = useMemo(() => {
-    const map = new Map<string, ReturnType<typeof getCardColorIdentityStatus>>();
+    const map = new Map<string, CardIdentityStatus>();
     if (!commanderColorIdentity) return map;
     deck.forEach((card) => {
       map.set(card.id, getCardColorIdentityStatus(card, commanderColorIdentity));
@@ -141,6 +253,48 @@ export function DeckList({
     return map;
   }, [deck]);
 
+  // Flatten the grouped deck (plus the optional color-identity fix blocks)
+  // into one ordered row list the virtualizer can window. Cards stay sorted
+  // alphabetically within each category, exactly as before (#1081).
+  const rows = useMemo<DeckRow[]>(() => {
+    const out: DeckRow[] = [];
+    if (commanderColorIdentity) {
+      out.push({ kind: "fix-toggle" });
+      if (fixMode && hasViolations) {
+        out.push({ kind: "fix-suggestions" });
+      }
+    }
+    for (const category of categoryOrder) {
+      const categoryCards = categorizedDeck[category];
+      if (!categoryCards) continue;
+      const sorted = [...categoryCards].sort((a, b) => a.name.localeCompare(b.name));
+      const categoryCount = sorted.reduce((sum, card) => sum + card.count, 0);
+      out.push({ kind: "category-header", category, count: categoryCount });
+      for (const card of sorted) {
+        out.push({ kind: "card", card });
+      }
+    }
+    return out;
+    // categoryOrder is a module-stable constant; eslint excludes it below.
+  }, [commanderColorIdentity, fixMode, hasViolations, categorizedDeck]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+
+  // Single-column virtualizer, same primitive (`@tanstack/react-virtual`)
+  // and the same dynamic-measurement / overscan pattern already adopted by
+  // `VirtualCardList` (#945) and `VirtualizedBattlefield` (#1082). Row
+  // heights are measured at runtime so the existing markup (badges, wrapping
+  // names) is preserved regardless of row kind.
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 40,
+    overscan: 8,
+    gap: 4,
+  });
+
+  const virtualItems = rowVirtualizer.getVirtualItems();
+
   return (
     <Card className="flex flex-col h-full">
       <CardHeader>
@@ -163,168 +317,143 @@ export function DeckList({
       </CardHeader>
       <Separator />
       <CardContent className="p-0 flex-grow">
-        <ScrollArea className="h-[calc(100vh-20rem)]">
-          <div className="p-4 space-y-4">
-            {deck.length === 0 ? (
-                <div className="text-center text-muted-foreground py-10">
-                    Your deck is empty.
-                </div>
-            ) : (
-              <>
-                {/* Color Identity Fix mode toggle */}
-                {commanderColorIdentity && (
-                  <div className="flex items-center justify-between rounded-md border bg-muted/40 px-3 py-2">
-                    <div className="flex items-center gap-2">
-                      <Switch
-                        id="color-fix-mode"
-                        checked={fixMode}
-                        onCheckedChange={setFixMode}
-                        disabled={!hasViolations}
-                        aria-label="Toggle color identity fix mode"
-                        data-testid="color-fix-mode-switch"
-                      />
-                      <Label htmlFor="color-fix-mode" className="text-sm cursor-pointer">
-                        Color Identity Fix
-                      </Label>
-                      {hasViolations ? (
-                        <Badge variant="destructive" className="text-[10px] px-1.5 py-0" data-testid="color-violation-count">
-                          {fixSuggestions.length}
-                        </Badge>
-                      ) : (
-                        <span className="text-xs text-muted-foreground">No violations</span>
+        {deck.length === 0 ? (
+          <div className="text-center text-muted-foreground py-10">
+            Your deck is empty.
+          </div>
+        ) : (
+          <div
+            ref={scrollRef}
+            className="h-[calc(100vh-20rem)] overflow-y-auto overflow-x-hidden outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            role="list"
+            aria-label="Deck cards"
+            tabIndex={0}
+            data-testid="deck-list-scroll"
+          >
+            <div className="p-4">
+              <div
+                style={{
+                  height: `${rowVirtualizer.getTotalSize()}px`,
+                  width: "100%",
+                  position: "relative",
+                }}
+              >
+                {virtualItems.map((virtualRow) => {
+                  const row = rows[virtualRow.index];
+                  if (!row) return null;
+                  return (
+                    <div
+                      key={deckRowKey(row)}
+                      data-index={virtualRow.index}
+                      ref={rowVirtualizer.measureElement}
+                      role="listitem"
+                      style={{
+                        position: "absolute",
+                        top: 0,
+                        left: 0,
+                        width: "100%",
+                        transform: `translateY(${virtualRow.start}px)`,
+                      }}
+                    >
+                      {row.kind === "fix-toggle" && (
+                        <div className="flex items-center justify-between rounded-md border bg-muted/40 px-3 py-2">
+                          <div className="flex items-center gap-2">
+                            <Switch
+                              id="color-fix-mode"
+                              checked={fixMode}
+                              onCheckedChange={setFixMode}
+                              disabled={!hasViolations}
+                              aria-label="Toggle color identity fix mode"
+                              data-testid="color-fix-mode-switch"
+                            />
+                            <Label htmlFor="color-fix-mode" className="text-sm cursor-pointer">
+                              Color Identity Fix
+                            </Label>
+                            {hasViolations ? (
+                              <Badge variant="destructive" className="text-[10px] px-1.5 py-0" data-testid="color-violation-count">
+                                {fixSuggestions.length}
+                              </Badge>
+                            ) : (
+                              <span className="text-xs text-muted-foreground">No violations</span>
+                            )}
+                          </div>
+                        </div>
+                      )}
+
+                      {row.kind === "fix-suggestions" && (
+                        <div
+                          className="rounded-md border border-destructive/40 bg-destructive/5 p-3 space-y-2"
+                          data-testid="color-fix-suggestions"
+                        >
+                          <div className="flex items-center gap-1.5 text-sm font-semibold text-destructive">
+                            <ShieldAlert className="size-4" />
+                            Remove to comply
+                          </div>
+                          <ul className="space-y-1">
+                            {fixSuggestions.map((suggestion) => {
+                              const cardId = idByName.get(suggestion.name);
+                              const isHardViolation = suggestion.severity === "violation";
+                              return (
+                                <li
+                                  key={suggestion.name}
+                                  className="flex items-center justify-between text-sm p-1 rounded-md hover:bg-secondary"
+                                  data-testid={`color-fix-item-${suggestion.name.toLowerCase().replace(/\s+/g, '-')}`}
+                                >
+                                  <span className="flex items-center gap-1.5">
+                                    {isHardViolation ? (
+                                      <ShieldAlert className="size-3.5 text-destructive" />
+                                    ) : (
+                                      <AlertTriangle className="size-3.5 text-amber-500" />
+                                    )}
+                                    <span>{suggestion.name}</span>
+                                    <ColorIdentityBadge identity={suggestion.colorIdentity} />
+                                  </span>
+                                  <div className="flex items-center gap-2">
+                                    <span className="text-xs text-muted-foreground hidden sm:inline">
+                                      {describeViolation(suggestion, commanderColorIdentity!)}
+                                    </span>
+                                    {cardId && (
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="size-6"
+                                        onClick={() => onRemoveCard(cardId)}
+                                        aria-label={`Remove ${suggestion.name}`}
+                                      >
+                                        <MinusCircle className="size-4 text-destructive" />
+                                      </Button>
+                                    )}
+                                  </div>
+                                </li>
+                              );
+                            })}
+                          </ul>
+                        </div>
+                      )}
+
+                      {row.kind === "category-header" && (
+                        <h4 className="font-semibold text-muted-foreground text-sm pt-3 pb-1">
+                          {row.category} ({row.count})
+                        </h4>
+                      )}
+
+                      {row.kind === "card" && (
+                        <DeckCardRow
+                          card={row.card}
+                          status={statusById.get(row.card.id)}
+                          legality={cardLegality?.get(row.card.id)}
+                          commanderColorIdentity={commanderColorIdentity}
+                          onRemoveCard={onRemoveCard}
+                          onAddCard={onAddCard}
+                        />
                       )}
                     </div>
-                  </div>
-                )}
-
-                {/* Color Identity Fix suggestions */}
-                {fixMode && hasViolations && (
-                  <div
-                    className="rounded-md border border-destructive/40 bg-destructive/5 p-3 space-y-2"
-                    data-testid="color-fix-suggestions"
-                  >
-                    <div className="flex items-center gap-1.5 text-sm font-semibold text-destructive">
-                      <ShieldAlert className="size-4" />
-                      Remove to comply
-                    </div>
-                    <ul className="space-y-1">
-                      {fixSuggestions.map((suggestion) => {
-                        const cardId = idByName.get(suggestion.name);
-                        const isHardViolation = suggestion.severity === "violation";
-                        return (
-                          <li
-                            key={suggestion.name}
-                            className="flex items-center justify-between text-sm p-1 rounded-md hover:bg-secondary"
-                            data-testid={`color-fix-item-${suggestion.name.toLowerCase().replace(/\s+/g, '-')}`}
-                          >
-                            <span className="flex items-center gap-1.5">
-                              {isHardViolation ? (
-                                <ShieldAlert className="size-3.5 text-destructive" />
-                              ) : (
-                                <AlertTriangle className="size-3.5 text-amber-500" />
-                              )}
-                              <span>{suggestion.name}</span>
-                              <ColorIdentityBadge identity={suggestion.colorIdentity} />
-                            </span>
-                            <div className="flex items-center gap-2">
-                              <span className="text-xs text-muted-foreground hidden sm:inline">
-                                {describeViolation(suggestion, commanderColorIdentity!)}
-                              </span>
-                              {cardId && (
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  className="size-6"
-                                  onClick={() => onRemoveCard(cardId)}
-                                  aria-label={`Remove ${suggestion.name}`}
-                                >
-                                  <MinusCircle className="size-4 text-destructive" />
-                                </Button>
-                              )}
-                            </div>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  </div>
-                )}
-
-                {categoryOrder.map(category => {
-                    if (categorizedDeck[category]) {
-                        const categoryCount = categorizedDeck[category].reduce((sum: number, card: DeckCard) => sum + card.count, 0);
-                        return (
-                            <div key={category}>
-                                <h4 className="font-semibold text-muted-foreground mb-2">{category} ({categoryCount})</h4>
-                                <ul className="space-y-1">
-                                    {categorizedDeck[category].sort((a: DeckCard, b: DeckCard) => a.name.localeCompare(b.name)).map(card => {
-                                      const status = statusById.get(card.id);
-                                      const isViolation = status?.severity === "violation";
-                                      const isWarning = status?.severity === "warning";
-                                      const legality = cardLegality?.get(card.id);
-                                      return (
-                                        <li
-                                          key={card.id}
-                                          className={cn(
-                                            "group flex items-center justify-between text-sm p-1 rounded-md hover:bg-secondary border-l-2",
-                                            isViolation && "border-l-destructive bg-destructive/5",
-                                            isWarning && "border-l-amber-500 bg-amber-500/5",
-                                            !isViolation && !isWarning && "border-l-transparent",
-                                          )}
-                                          data-testid={`deck-item-${card.name.toLowerCase().replace(/\s+/g, '-')}`}
-                                          title={
-                                            status && status.severity !== "valid"
-                                              ? describeViolation(
-                                                  {
-                                                    name: status.name,
-                                                    colorIdentity: status.colorIdentity,
-                                                    violatedColors: status.violatedColors,
-                                                    severity: status.severity,
-                                                  },
-                                                  commanderColorIdentity!,
-                                                )
-                                              : undefined
-                                          }
-                                        >
-                                            <span className="flex items-center">
-                                                {card.count}x {card.name}
-                                                {card.color_identity && card.color_identity.length > 0 && (
-                                                  <ColorIdentityBadge identity={card.color_identity} />
-                                                )}
-                                                {legality && (
-                                                  <LegalityBadge
-                                                    status={legality.status}
-                                                    className="text-[10px] px-1.5 py-0"
-                                                  />
-                                                )}
-                                                {isViolation && (
-                                                  <ShieldAlert className="size-3.5 ml-1.5 text-destructive" data-testid="violation-icon" />
-                                                )}
-                                                {isWarning && (
-                                                  <AlertTriangle className="size-3.5 ml-1.5 text-amber-500" data-testid="warning-icon" />
-                                                )}
-                                            </span>
-                                            <div className="flex items-center gap-1">
-                                                <Button variant="ghost" size="icon" className="size-6" aria-label={`Decrease quantity of ${card.name}`} onClick={() => onRemoveCard(card.id)} data-testid={`decrease-quantity-${card.id}`}>
-                                                    <Minus className="size-4" />
-                                                </Button>
-                                                <span className="w-5 text-center tabular-nums" aria-label={`Quantity ${card.count}`}>{card.count}</span>
-                                                <Button variant="ghost" size="icon" className="size-6" aria-label={`Increase quantity of ${card.name}`} onClick={() => onAddCard(card)} data-testid={`increase-quantity-${card.id}`}>
-                                                    <Plus className="size-4" />
-                                                </Button>
-                                            </div>
-                                        </li>
-                                      );
-                                    })}
-                                </ul>
-                            </div>
-                        )
-                    }
-                    return null;
+                  );
                 })}
-              </>
-            )}
+              </div>
+            </div>
           </div>
-        </ScrollArea>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary

Virtualizes the deck-builder deck list so only the visible rows (+ overscan) mount, regardless of deck size. Previously the list rendered one row component per card via a flat `.map()`, causing slow first paint and scroll jank on constructed (75+ card) and Cube/Limited decks — and it re-rendered in full on every add/remove edit.

Resolves #1081.

## Approach

- Reuses `@tanstack/react-virtual` (already a dependency) and the **same dynamic-measurement / overscan pattern** adopted by the collection grid (`VirtualCardList`, #945) and the recently-merged game-board battlefield strip (`VirtualizedBattlefield`, #1082). Like the battlefield PR, the deck list uses `useVirtualizer` **directly** with a purpose-built layout rather than the `CollectionCard`-typed `VirtualCardList`, because the deck list is grouped (category headers) and mixes non-card rows.
- The previously nested `category → <ul> → <li>` map is **flattened into a single ordered row list** the virtualizer can window: optional color-identity fix toggle + suggestions (leading rows, commander-format only), then per-category header rows followed by their alphabetically-sorted card rows. Flattening keeps the grouped visual layout while avoiding the "preceding static content throws off windowing" pitfall — every scrollable element is a first-class virtual row.
- The single card row was extracted into a memoized `DeckCardRow` (`React.memo`), mirroring the `BattlefieldCard` memo pattern, so per-edit re-renders skip rows whose props didn't change.
- Row heights are measured at runtime (`measureElement`) so the existing markup (badges, wrapping card names) is preserved exactly. The `ScrollArea` was replaced by an equivalently-sized scroll container (`h-[calc(100vh-20rem)]`, `p-4`).

## Interactions preserved (no behavior change)

- Quantity steppers `+`/`-` (test-ids `increase-quantity-*` / `decrease-quantity-*`, aria-labels, `onAddCard`/`onRemoveCard` handlers).
- Color-identity fix mode: toggle switch, violation count badge, and per-suggestion remove buttons.
- Per-card legality + color-identity/violation/warning badges and `title` tooltips.
- Stable, content-based item keys (`deck-card-<id>`, `deck-category-<name>`, …) so reconciliation stays correct across edits.
- Empty-deck state and the `DeckListProps` contract are unchanged — the host page needed no edits.

## Verification

- `npx tsc --noEmit` — clean for the changed files (the only remaining errors are a pre-existing, environmental `next-intl` resolution issue in untouched files; `next-intl` is a declared dep that isn't installed in this worktree's `node_modules`).
- `eslint` on both changed files — passes (0 warnings).
- `jest deck-list deck-builder virtualized` — **267 suites / 5542 tests pass, 0 failures**.
- New/updated tests in `deck-list.test.tsx`:
  - Existing #933 accessibility tests retained and passing (jsdom virtualizer mocks added so rows mount in the test environment).
  - **Windowing test**: a 150-card deck mounts only a bounded window of rows (< 60), proving constant-time mounting.
  - **Reachability test**: scrolling the container unmounts early cards and reveals far cards (nothing is dropped).
  - **Interaction-through-virtualizer test**: steppers fire the correct handlers for a card in the initial window.

## Files changed

- `src/app/(app)/deck-builder/_components/deck-list.tsx` — virtualized the deck list (`useVirtualizer`, flat row list, memoized `DeckCardRow`).
- `src/app/(app)/deck-builder/_components/__tests__/deck-list.test.tsx` — added jsdom virtualizer setup + windowing/reachability/interaction tests; retained all existing a11y tests.
