### PR TITLE
perf(ai): resolve #1080 — offload trigger-chain evaluation to the AI Web Worker

### DIFF
--- a/src/ai/__tests__/stack-interaction-ai.test.ts
+++ b/src/ai/__tests__/stack-interaction-ai.test.ts
@@ -4,7 +4,7 @@
  * Comprehensive tests for the Stack Interaction AI system.
  */
 
-import { describe, test, expect, beforeEach } from '@jest/globals';
+import { describe, test, expect, beforeEach } from "@jest/globals";
 
 import {
   StackInteractionAI,
@@ -14,26 +14,26 @@ import {
   evaluateStackResponse,
   decideCounterspell,
   manageResponseResources,
-} from '../stack-interaction-ai';
-import { GameState, PlayerState } from '../game-state-evaluator';
+} from "../stack-interaction-ai";
+import { GameState, PlayerState } from "../game-state-evaluator";
 
-describe('StackInteractionAI', () => {
+describe("StackInteractionAI", () => {
   let gameState: GameState;
   let playerId: string;
 
   beforeEach(() => {
-    playerId = 'player1';
+    playerId = "player1";
     gameState = createTestGameState();
   });
 
-  describe('Basic Response Evaluation', () => {
-    test('should pass on low-threat actions', () => {
+  describe("Basic Response Evaluation", () => {
+    test("should pass on low-threat actions", () => {
       const stackAction: StackAction = {
-        id: 'stack_1',
-        cardId: 'small_creature',
-        name: 'Gray Ogre',
-        controller: 'player2',
-        type: 'spell',
+        id: "stack_1",
+        cardId: "small_creature",
+        name: "Gray Ogre",
+        controller: "player2",
+        type: "spell",
         manaValue: 3,
         isInstantSpeed: false,
         timestamp: Date.now(),
@@ -47,40 +47,40 @@ describe('StackInteractionAI', () => {
         availableResponses: [],
         opponentsRemaining: [],
         isMyTurn: false,
-        phase: 'precombat_main',
-        step: 'main',
+        phase: "precombat_main",
+        step: "main",
         respondingToOpponent: true,
       };
 
-      const ai = new StackInteractionAI(gameState, playerId, 'medium');
+      const ai = new StackInteractionAI(gameState, playerId, "medium");
       const decision = ai.evaluateResponse(context);
 
       expect(decision.shouldRespond).toBe(false);
-      expect(decision.action).toBe('pass');
+      expect(decision.action).toBe("pass");
     });
 
-    test('should respond to high-threat actions', () => {
+    test("should respond to high-threat actions", () => {
       const stackAction: StackAction = {
-        id: 'stack_1',
-        cardId: 'threatening_spell',
-        name: 'Exsanguinate',
-        controller: 'player2',
-        type: 'spell',
+        id: "stack_1",
+        cardId: "threatening_spell",
+        name: "Exsanguinate",
+        controller: "player2",
+        type: "spell",
         manaValue: 6,
         isInstantSpeed: false,
         timestamp: Date.now(),
       };
 
       const response: AvailableResponse = {
-        cardId: 'counter',
-        name: 'Counterspell',
-        type: 'instant',
+        cardId: "counter",
+        name: "Counterspell",
+        type: "instant",
         manaValue: 2,
         manaCost: { blue: 2 },
         canCounter: true,
-        canTarget: ['spell'],
+        canTarget: ["spell"],
         effect: {
-          type: 'counter',
+          type: "counter",
           value: 8,
           targets: [stackAction.id],
         },
@@ -94,42 +94,42 @@ describe('StackInteractionAI', () => {
         availableResponses: [response],
         opponentsRemaining: [],
         isMyTurn: false,
-        phase: 'precombat_main',
-        step: 'main',
+        phase: "precombat_main",
+        step: "main",
         respondingToOpponent: true,
       };
 
-      const ai = new StackInteractionAI(gameState, playerId, 'medium');
+      const ai = new StackInteractionAI(gameState, playerId, "medium");
       const decision = ai.evaluateResponse(context);
 
       expect(decision.shouldRespond).toBe(true);
-      expect(decision.action).toBe('respond');
+      expect(decision.action).toBe("respond");
     });
   });
 
-  describe('Counterspell Decisions', () => {
-    test('should counter high-threat spells', () => {
+  describe("Counterspell Decisions", () => {
+    test("should counter high-threat spells", () => {
       const stackAction: StackAction = {
-        id: 'stack_1',
-        cardId: 'threat',
-        name: 'Primeval Titan',
-        controller: 'player2',
-        type: 'spell',
+        id: "stack_1",
+        cardId: "threat",
+        name: "Primeval Titan",
+        controller: "player2",
+        type: "spell",
         manaValue: 6,
         isInstantSpeed: false,
         timestamp: Date.now(),
       };
 
       const counterspell: AvailableResponse = {
-        cardId: 'counter',
-        name: 'Cancel',
-        type: 'instant',
+        cardId: "counter",
+        name: "Cancel",
+        type: "instant",
         manaValue: 3,
         manaCost: { blue: 2, colorless: 1 },
         canCounter: true,
-        canTarget: ['spell'],
+        canTarget: ["spell"],
         effect: {
-          type: 'counter',
+          type: "counter",
           value: 7,
           targets: [stackAction.id],
         },
@@ -143,40 +143,40 @@ describe('StackInteractionAI', () => {
         availableResponses: [counterspell],
         opponentsRemaining: [],
         isMyTurn: false,
-        phase: 'precombat_main',
-        step: 'main',
+        phase: "precombat_main",
+        step: "main",
         respondingToOpponent: true,
       };
 
-      const ai = new StackInteractionAI(gameState, playerId, 'medium');
+      const ai = new StackInteractionAI(gameState, playerId, "medium");
       const decision = ai.decideCounterspell(context, counterspell);
 
       expect(decision.shouldRespond).toBe(true);
       expect(decision.responseCardId).toBe(counterspell.cardId);
     });
 
-    test('should not counter low-value spells', () => {
+    test("should not counter low-value spells", () => {
       const stackAction: StackAction = {
-        id: 'stack_1',
-        cardId: 'minor_spell',
-        name: 'Elvish Mystic',
-        controller: 'player2',
-        type: 'spell',
+        id: "stack_1",
+        cardId: "minor_spell",
+        name: "Elvish Mystic",
+        controller: "player2",
+        type: "spell",
         manaValue: 1,
         isInstantSpeed: false,
         timestamp: Date.now(),
       };
 
       const counterspell: AvailableResponse = {
-        cardId: 'counter',
-        name: 'Counterspell',
-        type: 'instant',
+        cardId: "counter",
+        name: "Counterspell",
+        type: "instant",
         manaValue: 2,
         manaCost: { blue: 2 },
         canCounter: true,
-        canTarget: ['spell'],
+        canTarget: ["spell"],
         effect: {
-          type: 'counter',
+          type: "counter",
           value: 2,
           targets: [stackAction.id],
         },
@@ -190,44 +190,44 @@ describe('StackInteractionAI', () => {
         availableResponses: [counterspell],
         opponentsRemaining: [],
         isMyTurn: false,
-        phase: 'precombat_main',
-        step: 'main',
+        phase: "precombat_main",
+        step: "main",
         respondingToOpponent: true,
       };
 
-      const ai = new StackInteractionAI(gameState, playerId, 'medium');
+      const ai = new StackInteractionAI(gameState, playerId, "medium");
       const decision = ai.decideCounterspell(context, counterspell);
 
       expect(decision.shouldRespond).toBe(false);
-      expect(decision.action).toBe('pass');
+      expect(decision.action).toBe("pass");
     });
 
-    test('should counter lethal threats regardless of cost', () => {
-      gameState.players['player1'].life = 3;
+    test("should counter lethal threats regardless of cost", () => {
+      gameState.players["player1"].life = 3;
 
       const stackAction: StackAction = {
-        id: 'stack_1',
-        cardId: 'lethal',
-        name: 'Lightning Bolt',
-        controller: 'player2',
-        type: 'spell',
+        id: "stack_1",
+        cardId: "lethal",
+        name: "Lightning Bolt",
+        controller: "player2",
+        type: "spell",
         manaValue: 1,
-        colors: ['red'],
-        targets: [{ playerId: 'player1' }],
+        colors: ["red"],
+        targets: [{ playerId: "player1" }],
         isInstantSpeed: true,
         timestamp: Date.now(),
       };
 
       const counterspell: AvailableResponse = {
-        cardId: 'counter',
-        name: 'Force of Will',
-        type: 'instant',
+        cardId: "counter",
+        name: "Force of Will",
+        type: "instant",
         manaValue: 0, // Alternative cost
         manaCost: { blue: 0 },
         canCounter: true,
-        canTarget: ['spell'],
+        canTarget: ["spell"],
         effect: {
-          type: 'counter',
+          type: "counter",
           value: 10, // Preventing lethal
           targets: [stackAction.id],
         },
@@ -241,12 +241,12 @@ describe('StackInteractionAI', () => {
         availableResponses: [counterspell],
         opponentsRemaining: [],
         isMyTurn: false,
-        phase: 'postcombat_main',
-        step: 'main',
+        phase: "postcombat_main",
+        step: "main",
         respondingToOpponent: true,
       };
 
-      const ai = new StackInteractionAI(gameState, playerId, 'medium');
+      const ai = new StackInteractionAI(gameState, playerId, "medium");
       const decision = ai.decideCounterspell(context, counterspell);
 
       expect(decision.shouldRespond).toBe(true);
@@ -254,29 +254,29 @@ describe('StackInteractionAI', () => {
     });
   });
 
-  describe('Resource Management', () => {
-    test('should hold mana for opponent turn', () => {
+  describe("Resource Management", () => {
+    test("should hold mana for opponent turn", () => {
       const stackAction: StackAction = {
-        id: 'stack_1',
-        cardId: 'minor_spell',
-        name: 'Candlestick',
-        controller: 'player1',
-        type: 'spell',
+        id: "stack_1",
+        cardId: "minor_spell",
+        name: "Candlestick",
+        controller: "player1",
+        type: "spell",
         manaValue: 1,
         isInstantSpeed: false,
         timestamp: Date.now(),
       };
 
       const instantResponse: AvailableResponse = {
-        cardId: 'instant',
-        name: 'Shock',
-        type: 'instant',
+        cardId: "instant",
+        name: "Shock",
+        type: "instant",
         manaValue: 1,
         manaCost: { red: 1 },
         canCounter: false,
         canTarget: [],
         effect: {
-          type: 'damage',
+          type: "damage",
           value: 4,
           targets: [],
         },
@@ -288,27 +288,27 @@ describe('StackInteractionAI', () => {
         actionsAbove: [],
         availableMana: { red: 2, blue: 1, colorless: 1 },
         availableResponses: [instantResponse],
-        opponentsRemaining: ['player2'],
+        opponentsRemaining: ["player2"],
         isMyTurn: true,
-        phase: 'precombat_main',
-        step: 'main',
+        phase: "precombat_main",
+        step: "main",
         respondingToOpponent: false,
       };
 
-      const ai = new StackInteractionAI(gameState, playerId, 'medium');
+      const ai = new StackInteractionAI(gameState, playerId, "medium");
       const decision = ai.manageResources(context);
 
-      expect(decision.holdFor).toBe('opponent_turn');
+      expect(decision.holdFor).toBe("opponent_turn");
       expect(decision.manaToReserve).toBeDefined();
     });
 
-    test('should use mana now when no better opportunity', () => {
+    test("should use mana now when no better opportunity", () => {
       const stackAction: StackAction = {
-        id: 'stack_1',
-        cardId: 'instant_use',
-        name: 'Sorcery',
-        controller: 'player1',
-        type: 'spell',
+        id: "stack_1",
+        cardId: "instant_use",
+        name: "Sorcery",
+        controller: "player1",
+        type: "spell",
         manaValue: 2,
         isInstantSpeed: false,
         timestamp: Date.now(),
@@ -322,27 +322,27 @@ describe('StackInteractionAI', () => {
         availableResponses: [], // No instant-speed options
         opponentsRemaining: [],
         isMyTurn: true,
-        phase: 'precombat_main',
-        step: 'main',
+        phase: "precombat_main",
+        step: "main",
         respondingToOpponent: false,
       };
 
-      const ai = new StackInteractionAI(gameState, playerId, 'medium');
+      const ai = new StackInteractionAI(gameState, playerId, "medium");
       const decision = ai.manageResources(context);
 
       expect(decision.useNow).toBe(true);
-      expect(decision.holdFor).toBe('nothing');
+      expect(decision.holdFor).toBe("nothing");
     });
   });
 
-  describe('Priority Decisions', () => {
-    test('should pass priority on low-threat actions', () => {
+  describe("Priority Decisions", () => {
+    test("should pass priority on low-threat actions", () => {
       const stackAction: StackAction = {
-        id: 'stack_1',
-        cardId: 'minor_spell',
-        name: 'Giant Growth',
-        controller: 'player2',
-        type: 'spell',
+        id: "stack_1",
+        cardId: "minor_spell",
+        name: "Giant Growth",
+        controller: "player2",
+        type: "spell",
         manaValue: 1,
         isInstantSpeed: true,
         timestamp: Date.now(),
@@ -356,30 +356,30 @@ describe('StackInteractionAI', () => {
         availableResponses: [],
         opponentsRemaining: [],
         isMyTurn: false,
-        phase: 'combat',
-        step: 'combat_damage',
+        phase: "combat",
+        step: "combat_damage",
         respondingToOpponent: true,
       };
 
-      const ai = new StackInteractionAI(gameState, playerId, 'medium');
+      const ai = new StackInteractionAI(gameState, playerId, "medium");
       const decision = ai.decidePriorityPass(context);
 
       expect(decision.shouldPass).toBe(true);
-      expect(decision.riskLevel).toBe('low');
+      expect(decision.riskLevel).toBe("low");
     });
 
-    test('should not pass priority on high-threat actions', () => {
-      gameState.players['player1'].life = 5;
+    test("should not pass priority on high-threat actions", () => {
+      gameState.players["player1"].life = 5;
 
       const stackAction: StackAction = {
-        id: 'stack_1',
-        cardId: 'threat',
-        name: 'Fireball',
-        controller: 'player2',
-        type: 'spell',
+        id: "stack_1",
+        cardId: "threat",
+        name: "Fireball",
+        controller: "player2",
+        type: "spell",
         manaValue: 5,
-        colors: ['red'],
-        targets: [{ playerId: 'player1' }],
+        colors: ["red"],
+        targets: [{ playerId: "player1" }],
         isInstantSpeed: true,
         timestamp: Date.now(),
       };
@@ -391,15 +391,15 @@ describe('StackInteractionAI', () => {
         availableMana: { blue: 2, colorless: 1 },
         availableResponses: [
           {
-            cardId: 'counter',
-            name: 'Counterspell',
-            type: 'instant',
+            cardId: "counter",
+            name: "Counterspell",
+            type: "instant",
             manaValue: 2,
             manaCost: { blue: 2 },
             canCounter: true,
-            canTarget: ['spell'],
+            canTarget: ["spell"],
             effect: {
-              type: 'counter',
+              type: "counter",
               value: 10,
               targets: [stackAction.id],
             },
@@ -407,27 +407,27 @@ describe('StackInteractionAI', () => {
         ],
         opponentsRemaining: [],
         isMyTurn: false,
-        phase: 'postcombat_main',
-        step: 'main',
+        phase: "postcombat_main",
+        step: "main",
         respondingToOpponent: true,
       };
 
-      const ai = new StackInteractionAI(gameState, playerId, 'medium');
+      const ai = new StackInteractionAI(gameState, playerId, "medium");
       const decision = ai.decidePriorityPass(context);
 
       expect(decision.shouldPass).toBe(false);
-      expect(decision.riskLevel).toBe('high');
+      expect(decision.riskLevel).toBe("high");
     });
   });
 
-  describe('Stack Ordering', () => {
-    test('should optimize order of multiple responses', () => {
+  describe("Stack Ordering", () => {
+    test("should optimize order of multiple responses", () => {
       const stackAction: StackAction = {
-        id: 'stack_1',
-        cardId: 'target',
-        name: 'Creature',
-        controller: 'player2',
-        type: 'spell',
+        id: "stack_1",
+        cardId: "target",
+        name: "Creature",
+        controller: "player2",
+        type: "spell",
         manaValue: 3,
         isInstantSpeed: false,
         timestamp: Date.now(),
@@ -435,29 +435,29 @@ describe('StackInteractionAI', () => {
 
       const responses: AvailableResponse[] = [
         {
-          cardId: 'response_1',
-          name: 'Counterspell',
-          type: 'instant',
+          cardId: "response_1",
+          name: "Counterspell",
+          type: "instant",
           manaValue: 2,
           manaCost: { blue: 2 },
           canCounter: true,
-          canTarget: ['spell'],
+          canTarget: ["spell"],
           effect: {
-            type: 'counter',
+            type: "counter",
             value: 6,
             targets: [stackAction.id],
           },
         },
         {
-          cardId: 'response_2',
-          name: 'Draw Spell',
-          type: 'instant',
+          cardId: "response_2",
+          name: "Draw Spell",
+          type: "instant",
           manaValue: 2,
           manaCost: { blue: 1, colorless: 1 },
           canCounter: false,
           canTarget: [],
           effect: {
-            type: 'draw',
+            type: "draw",
             value: 5,
             targets: [],
           },
@@ -472,12 +472,12 @@ describe('StackInteractionAI', () => {
         availableResponses: responses,
         opponentsRemaining: [],
         isMyTurn: false,
-        phase: 'precombat_main',
-        step: 'main',
+        phase: "precombat_main",
+        step: "main",
         respondingToOpponent: true,
       };
 
-      const ai = new StackInteractionAI(gameState, playerId, 'medium');
+      const ai = new StackInteractionAI(gameState, playerId, "medium");
       const decision = ai.optimizeResponseOrder(context, responses);
 
       expect(decision.orderedActions).toBeDefined();
@@ -486,29 +486,29 @@ describe('StackInteractionAI', () => {
     });
   });
 
-  describe('Difficulty Level Differences', () => {
-    test('easy difficulty should be more aggressive', () => {
+  describe("Difficulty Level Differences", () => {
+    test("easy difficulty should be more aggressive", () => {
       const stackAction: StackAction = {
-        id: 'stack_1',
-        cardId: 'medium_threat',
-        name: 'Hill Giant',
-        controller: 'player2',
-        type: 'spell',
+        id: "stack_1",
+        cardId: "medium_threat",
+        name: "Hill Giant",
+        controller: "player2",
+        type: "spell",
         manaValue: 3,
         isInstantSpeed: false,
         timestamp: Date.now(),
       };
 
       const counterspell: AvailableResponse = {
-        cardId: 'counter',
-        name: 'Cancel',
-        type: 'instant',
+        cardId: "counter",
+        name: "Cancel",
+        type: "instant",
         manaValue: 3,
         manaCost: { blue: 2, colorless: 1 },
         canCounter: true,
-        canTarget: ['spell'],
+        canTarget: ["spell"],
         effect: {
-          type: 'counter',
+          type: "counter",
           value: 4,
           targets: [stackAction.id],
         },
@@ -522,15 +522,15 @@ describe('StackInteractionAI', () => {
         availableResponses: [counterspell],
         opponentsRemaining: [],
         isMyTurn: false,
-        phase: 'precombat_main',
-        step: 'main',
+        phase: "precombat_main",
+        step: "main",
         respondingToOpponent: true,
       };
 
-      const easyAI = new StackInteractionAI(gameState, playerId, 'easy');
+      const easyAI = new StackInteractionAI(gameState, playerId, "easy");
       const easyDecision = easyAI.decideCounterspell(context, counterspell);
 
-      const hardAI = new StackInteractionAI(gameState, playerId, 'hard');
+      const hardAI = new StackInteractionAI(gameState, playerId, "hard");
       const hardDecision = hardAI.decideCounterspell(context, counterspell);
 
       // Easy might counter, hard might save it
@@ -540,14 +540,14 @@ describe('StackInteractionAI', () => {
     });
   });
 
-  describe('Convenience Functions', () => {
-    test('evaluateStackResponse should work', () => {
+  describe("Convenience Functions", () => {
+    test("evaluateStackResponse should work", () => {
       const stackAction: StackAction = {
-        id: 'stack_1',
-        cardId: 'test_spell',
-        name: 'Test Spell',
-        controller: 'player2',
-        type: 'spell',
+        id: "stack_1",
+        cardId: "test_spell",
+        name: "Test Spell",
+        controller: "player2",
+        type: "spell",
         manaValue: 2,
         isInstantSpeed: false,
         timestamp: Date.now(),
@@ -561,39 +561,44 @@ describe('StackInteractionAI', () => {
         availableResponses: [],
         opponentsRemaining: [],
         isMyTurn: false,
-        phase: 'precombat_main',
-        step: 'main',
+        phase: "precombat_main",
+        step: "main",
         respondingToOpponent: true,
       };
 
-      const decision = evaluateStackResponse(gameState, playerId, context, 'medium');
+      const decision = evaluateStackResponse(
+        gameState,
+        playerId,
+        context,
+        "medium",
+      );
 
       expect(decision).toBeDefined();
       expect(decision.shouldRespond).toBeDefined();
     });
 
-    test('decideCounterspell should work', () => {
+    test("decideCounterspell should work", () => {
       const stackAction: StackAction = {
-        id: 'stack_1',
-        cardId: 'test_spell',
-        name: 'Test Spell',
-        controller: 'player2',
-        type: 'spell',
+        id: "stack_1",
+        cardId: "test_spell",
+        name: "Test Spell",
+        controller: "player2",
+        type: "spell",
         manaValue: 2,
         isInstantSpeed: false,
         timestamp: Date.now(),
       };
 
       const counterspell: AvailableResponse = {
-        cardId: 'counter',
-        name: 'Counterspell',
-        type: 'instant',
+        cardId: "counter",
+        name: "Counterspell",
+        type: "instant",
         manaValue: 2,
         manaCost: { blue: 2 },
         canCounter: true,
-        canTarget: ['spell'],
+        canTarget: ["spell"],
         effect: {
-          type: 'counter',
+          type: "counter",
           value: 5,
           targets: [stackAction.id],
         },
@@ -607,24 +612,30 @@ describe('StackInteractionAI', () => {
         availableResponses: [counterspell],
         opponentsRemaining: [],
         isMyTurn: false,
-        phase: 'precombat_main',
-        step: 'main',
+        phase: "precombat_main",
+        step: "main",
         respondingToOpponent: true,
       };
 
-      const decision = decideCounterspell(gameState, playerId, context, counterspell, 'medium');
+      const decision = decideCounterspell(
+        gameState,
+        playerId,
+        context,
+        counterspell,
+        "medium",
+      );
 
       expect(decision).toBeDefined();
       expect(decision.shouldRespond).toBeDefined();
     });
 
-    test('manageResponseResources should work', () => {
+    test("manageResponseResources should work", () => {
       const stackAction: StackAction = {
-        id: 'stack_1',
-        cardId: 'test_spell',
-        name: 'Test Spell',
-        controller: 'player1',
-        type: 'spell',
+        id: "stack_1",
+        cardId: "test_spell",
+        name: "Test Spell",
+        controller: "player1",
+        type: "spell",
         manaValue: 1,
         isInstantSpeed: false,
         timestamp: Date.now(),
@@ -636,18 +647,100 @@ describe('StackInteractionAI', () => {
         actionsAbove: [],
         availableMana: { blue: 2, colorless: 1 },
         availableResponses: [],
-        opponentsRemaining: ['player2'],
+        opponentsRemaining: ["player2"],
         isMyTurn: true,
-        phase: 'precombat_main',
-        step: 'main',
+        phase: "precombat_main",
+        step: "main",
         respondingToOpponent: false,
       };
 
-      const decision = manageResponseResources(gameState, playerId, context, 'medium');
+      const decision = manageResponseResources(
+        gameState,
+        playerId,
+        context,
+        "medium",
+      );
 
       expect(decision).toBeDefined();
       expect(decision.useNow).toBeDefined();
       expect(decision.holdFor).toBeDefined();
+    });
+  });
+
+  describe("Trigger Chain Evaluation (offloaded via the AI Web Worker, #1080)", () => {
+    test("evaluateTriggerChains is async and returns the full post-processed result", async () => {
+      // A resolving spell that can produce ETB/cascade triggers downstream.
+      const stackAction: StackAction = {
+        id: "stack_chain",
+        cardId: "cascade_spell",
+        name: "Bloodbraid Cascade",
+        controller: "player2",
+        type: "spell",
+        manaValue: 4,
+        isInstantSpeed: false,
+        timestamp: Date.now(),
+      };
+
+      const context: StackContext = {
+        currentAction: stackAction,
+        stackSize: 1,
+        actionsAbove: [],
+        availableMana: { blue: 2, colorless: 1 },
+        availableResponses: [],
+        opponentsRemaining: ["player2"],
+        isMyTurn: false,
+        phase: "precombat_main",
+        step: "main",
+        respondingToOpponent: true,
+      };
+
+      const ai = new StackInteractionAI(gameState, playerId, "medium");
+
+      // Now async: awaits the AI Web Worker (or its main-thread fallback).
+      const result = await ai.evaluateTriggerChains(context);
+
+      expect(result).toBeDefined();
+      expect(typeof result.summary).toBe("string");
+      expect(result.chains).toBeInstanceOf(Array);
+      expect(result.cascadeThreatBonus).toBeGreaterThanOrEqual(0);
+      expect(result.cascadeThreatBonus).toBeLessThanOrEqual(0.5);
+      expect(typeof result.shouldCounterToPrevent).toBe("boolean");
+      // highestValueChain, when present, is one of the evaluated chains.
+      if (result.highestValueChain) {
+        expect(result.chains).toContainEqual(result.highestValueChain);
+      }
+    });
+
+    test("assessActionThreatWithTriggers is async and clamps to [0,1]", async () => {
+      const stackAction: StackAction = {
+        id: "stack_threat",
+        cardId: "threat",
+        name: "Exsanguinate",
+        controller: "player2",
+        type: "spell",
+        manaValue: 6,
+        isInstantSpeed: false,
+        timestamp: Date.now(),
+      };
+
+      const context: StackContext = {
+        currentAction: stackAction,
+        stackSize: 1,
+        actionsAbove: [],
+        availableMana: { blue: 2, colorless: 1 },
+        availableResponses: [],
+        opponentsRemaining: ["player2"],
+        isMyTurn: false,
+        phase: "precombat_main",
+        step: "main",
+        respondingToOpponent: true,
+      };
+
+      const ai = new StackInteractionAI(gameState, playerId, "medium");
+      const threat = await ai.assessActionThreatWithTriggers(context);
+
+      expect(threat).toBeGreaterThanOrEqual(0);
+      expect(threat).toBeLessThanOrEqual(1);
     });
   });
 });
@@ -657,41 +750,56 @@ describe('StackInteractionAI', () => {
  */
 function createTestGameState(): GameState {
   const player1: PlayerState = {
-    id: 'player1',
+    id: "player1",
     life: 20,
     poisonCounters: 0,
     commanderDamage: {},
     hand: [
-      { cardInstanceId: 'card1', name: 'Counterspell', type: 'Instant', manaValue: 2 },
-      { cardInstanceId: 'card2', name: 'Instant', type: 'Instant', manaValue: 1 },
-      { cardInstanceId: 'card3', name: 'Creature', type: 'Creature', manaValue: 3 },
+      {
+        cardInstanceId: "card1",
+        name: "Counterspell",
+        type: "Instant",
+        manaValue: 2,
+      },
+      {
+        cardInstanceId: "card2",
+        name: "Instant",
+        type: "Instant",
+        manaValue: 1,
+      },
+      {
+        cardInstanceId: "card3",
+        name: "Creature",
+        type: "Creature",
+        manaValue: 3,
+      },
     ],
     graveyard: [],
     exile: [],
     library: 50,
     battlefield: [
       {
-        id: 'land1',
-        cardInstanceId: 'land1',
-        name: 'Island',
-        type: 'land',
-        controller: 'player1',
+        id: "land1",
+        cardInstanceId: "land1",
+        name: "Island",
+        type: "land",
+        controller: "player1",
         tapped: false,
       },
       {
-        id: 'land2',
-        cardInstanceId: 'land2',
-        name: 'Island',
-        type: 'land',
-        controller: 'player1',
+        id: "land2",
+        cardInstanceId: "land2",
+        name: "Island",
+        type: "land",
+        controller: "player1",
         tapped: false,
       },
       {
-        id: 'land3',
-        cardInstanceId: 'land3',
-        name: 'Island',
-        type: 'land',
-        controller: 'player1',
+        id: "land3",
+        cardInstanceId: "land3",
+        name: "Island",
+        type: "land",
+        controller: "player1",
         tapped: false,
       },
     ],
@@ -699,32 +807,42 @@ function createTestGameState(): GameState {
   };
 
   const player2: PlayerState = {
-    id: 'player2',
+    id: "player2",
     life: 20,
     poisonCounters: 0,
     commanderDamage: {},
     hand: [
-      { cardInstanceId: 'opp1', name: 'Creature', type: 'Creature', manaValue: 3 },
-      { cardInstanceId: 'opp2', name: 'Sorcery', type: 'Sorcery', manaValue: 2 },
+      {
+        cardInstanceId: "opp1",
+        name: "Creature",
+        type: "Creature",
+        manaValue: 3,
+      },
+      {
+        cardInstanceId: "opp2",
+        name: "Sorcery",
+        type: "Sorcery",
+        manaValue: 2,
+      },
     ],
     graveyard: [],
     exile: [],
     library: 50,
     battlefield: [
       {
-        id: 'opp_land1',
-        cardInstanceId: 'opp_land1',
-        name: 'Mountain',
-        type: 'land',
-        controller: 'player2',
+        id: "opp_land1",
+        cardInstanceId: "opp_land1",
+        name: "Mountain",
+        type: "land",
+        controller: "player2",
         tapped: false,
       },
       {
-        id: 'opp_land2',
-        cardInstanceId: 'opp_land2',
-        name: 'Mountain',
-        type: 'land',
-        controller: 'player2',
+        id: "opp_land2",
+        cardInstanceId: "opp_land2",
+        name: "Mountain",
+        type: "land",
+        controller: "player2",
         tapped: false,
       },
     ],
@@ -738,10 +856,10 @@ function createTestGameState(): GameState {
     },
     turnInfo: {
       currentTurn: 3,
-      currentPlayer: 'player2',
-      phase: 'precombat_main',
-      step: 'main',
-      priority: 'player1',
+      currentPlayer: "player2",
+      phase: "precombat_main",
+      step: "main",
+      priority: "player1",
     },
     stack: [],
   };

--- a/src/ai/stack-interaction-ai.ts
+++ b/src/ai/stack-interaction-ai.ts
@@ -38,7 +38,6 @@ import {
   DetailedEvaluation,
 } from "./game-state-evaluator";
 import {
-  evaluateTriggerChain,
   shouldCounterToPreventTriggers,
   getHighestValueChain,
   getTriggerChainSummary,
@@ -48,6 +47,10 @@ import type {
   BoardPermanent,
   CascadeContext,
 } from "./trigger-chain-evaluator";
+// Trigger-chain evaluation is offloaded to the AI Web Worker to keep AI turns
+// off the main thread (#1080). The bridge falls back to identical main-thread
+// computation if the worker is unavailable.
+import { evaluateTriggerChainAsync } from "./worker/trigger-chain-worker-bridge";
 import { callAIProxy } from "@/lib/ai-proxy-client";
 import { AIProvider } from "./providers/types";
 import {
@@ -1447,13 +1450,16 @@ export class StackInteractionAI {
   /**
    * Assess threat including cascade/trigger-chain evaluation.
    * Use this when you need to account for downstream triggered abilities.
+   *
+   * `async` because trigger-chain evaluation is offloaded to the AI Web Worker
+   * (#1080); callers must `await` the result.
    */
-  assessActionThreatWithTriggers(context: StackContext): number {
+  async assessActionThreatWithTriggers(context: StackContext): Promise<number> {
     const baseThreat = this.assessActionThreat(
       context,
       evaluateGameState(this.gameState, this.playerId, "medium"),
     );
-    const triggerResult = this.evaluateTriggerChains(context);
+    const triggerResult = await this.evaluateTriggerChains(context);
     return Math.min(1, baseThreat + triggerResult.cascadeThreatBonus);
   }
 
@@ -2455,14 +2461,20 @@ export class StackInteractionAI {
    * Evaluate trigger chains that would result from a stack item resolving.
    * Accounts for ETB effects, "whenever you cast" triggers, Cascade keyword,
    * Panharmonicon-style doubling, and secondary cascaded triggers.
+   *
+   * The recursive chain expansion runs in the AI Web Worker (off the main
+   * thread, #1080); the lightweight post-processing stays here. This method is
+   * `async` because callers must `await` the worker result before the AI
+   * commits to the stack. Results are identical to the previous synchronous
+   * computation.
    */
-  evaluateTriggerChains(context: StackContext): {
+  async evaluateTriggerChains(context: StackContext): Promise<{
     chains: TriggerChain[];
     summary: string;
     shouldCounterToPrevent: boolean;
     highestValueChain: TriggerChain | null;
     cascadeThreatBonus: number;
-  } {
+  }> {
     const boardPermanents: BoardPermanent[] = [];
     for (const [playerId, player] of Object.entries(this.gameState.players)) {
       for (const permanent of player.battlefield) {
@@ -2499,7 +2511,7 @@ export class StackInteractionAI {
       )?.life,
     };
 
-    const chains = evaluateTriggerChain(
+    const chains = await evaluateTriggerChainAsync(
       cascadeCtx.stackItem,
       cascadeCtx.battlefield,
     );

--- a/src/ai/worker/__tests__/ai-worker-trigger-chain.test.ts
+++ b/src/ai/worker/__tests__/ai-worker-trigger-chain.test.ts
@@ -1,0 +1,245 @@
+/**
+ * AI Worker — trigger-chain handler tests (#1080)
+ *
+ * Asserts the `evaluateTriggerChain` handler exposed by the AI Web Worker:
+ *  - returns results IDENTICAL to the in-thread evaluator (parity / no
+ *    behavior change), across ETB, cascade, copy-doubler and stress boards;
+ *  - honors `maxDepth`;
+ *  - returns an empty list (not an error) for boards with no triggers.
+ *
+ * The handler object is imported directly (Comlink.expose is a no-op side
+ * effect under jsdom), which is exactly the code that runs inside the worker.
+ */
+import { describe, test, expect } from "@jest/globals";
+
+import { aiWorker } from "../ai-worker";
+import { evaluateTriggerChain } from "../../trigger-chain-evaluator";
+import type {
+  CascadeContext,
+  BoardPermanent,
+} from "../../trigger-chain-evaluator";
+
+function makePermanent(
+  overrides: Partial<BoardPermanent> & {
+    id: string;
+    name: string;
+    controller: string;
+  },
+): BoardPermanent {
+  return {
+    cardId: overrides.id,
+    type: "creature",
+    ...overrides,
+  };
+}
+
+function makeStackItem(
+  overrides: Partial<CascadeContext["stackItem"]> & {
+    id: string;
+    name: string;
+  },
+): CascadeContext["stackItem"] {
+  return {
+    cardId: overrides.id,
+    controller: "player2",
+    type: "spell",
+    manaValue: 3,
+    ...overrides,
+  };
+}
+
+describe("AI Worker — evaluateTriggerChain handler (#1080)", () => {
+  test("returns identical chains to the in-thread evaluator (ETB board)", async () => {
+    const stackItem = makeStackItem({
+      id: "s1",
+      name: "Grizzly Bears",
+      controller: "player1",
+      manaValue: 2,
+      colors: ["green"],
+    });
+    const battlefield: BoardPermanent[] = [
+      makePermanent({
+        id: "cloudblazer",
+        name: "Cloudblazer",
+        controller: "player1",
+        oracleText: "When Cloudblazer enters the battlefield, draw two cards.",
+      }),
+      makePermanent({
+        id: "purphoros",
+        name: "Purphoros, God of the Forge",
+        controller: "player1",
+        type: "enchantment",
+        oracleText:
+          "Whenever a creature enters the battlefield under your control, Purphoros deals 2 damage to each opponent.",
+      }),
+    ];
+
+    const expected = evaluateTriggerChain(stackItem, battlefield);
+    const result = await aiWorker.evaluateTriggerChain({
+      stackItem,
+      battlefield,
+    });
+
+    // Deep equality — the worker path must not alter decisions.
+    expect(result).toEqual(expected);
+    expect(result.length).toBe(expected.length);
+  });
+
+  test("returns identical chains for a Cascade spell", async () => {
+    const stackItem = makeStackItem({
+      id: "cascade1",
+      name: "Bloodbraid Cascade",
+      controller: "player1",
+      manaValue: 4,
+      colors: ["red", "green"],
+    });
+    const battlefield: BoardPermanent[] = [
+      makePermanent({
+        id: "impact-tremors",
+        name: "Impact Tremors",
+        controller: "player1",
+        type: "enchantment",
+        oracleText:
+          "Whenever a creature enters the battlefield under your control, Impact Tremors deals 1 damage to each opponent.",
+      }),
+    ];
+
+    const expected = evaluateTriggerChain(stackItem, battlefield);
+    const result = await aiWorker.evaluateTriggerChain({
+      stackItem,
+      battlefield,
+    });
+
+    expect(result).toEqual(expected);
+    // Cascade keyword should produce at least one cascade chain on both paths.
+    expect(
+      result.some((c) =>
+        c.steps.some((s) => s.ability.triggerType === "cascade"),
+      ),
+    ).toBe(true);
+  });
+
+  test("returns identical chains when a copy doubler is present", async () => {
+    const stackItem = makeStackItem({
+      id: "s2",
+      name: "Solemn Simulacris",
+      controller: "player1",
+      manaValue: 4,
+      colors: ["blue"],
+    });
+    const battlefield: BoardPermanent[] = [
+      makePermanent({
+        id: "panharmonicon",
+        name: "Panharmonicon",
+        controller: "player1",
+        type: "artifact",
+        oracleText:
+          "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
+      }),
+      makePermanent({
+        id: "solemn",
+        name: "Solemn Simulacrum",
+        controller: "player1",
+        oracleText:
+          "When Solemn Simulacrum enters the battlefield, you may search your library for a basic land card.",
+      }),
+    ];
+
+    const expected = evaluateTriggerChain(stackItem, battlefield);
+    const result = await aiWorker.evaluateTriggerChain({
+      stackItem,
+      battlefield,
+    });
+
+    expect(result).toEqual(expected);
+  });
+
+  test("honors maxDepth identically to the in-thread evaluator", async () => {
+    const stackItem = makeStackItem({
+      id: "s3",
+      name: "Token Maker",
+      controller: "player1",
+      manaValue: 3,
+      colors: ["white"],
+    });
+    const battlefield: BoardPermanent[] = [
+      makePermanent({
+        id: "pawn",
+        name: "Pawn of Ulamog",
+        controller: "player1",
+        oracleText:
+          "Whenever another nontoken creature you control dies, create a token.",
+      }),
+    ];
+
+    for (const maxDepth of [1, 3, 5]) {
+      const expected = evaluateTriggerChain(stackItem, battlefield, maxDepth);
+      const result = await aiWorker.evaluateTriggerChain({
+        stackItem,
+        battlefield,
+        maxDepth,
+      });
+      expect(result).toEqual(expected);
+    }
+  });
+
+  test("returns an empty list (no error) for a board with no triggers", async () => {
+    const stackItem = makeStackItem({
+      id: "s4",
+      name: "Grizzly Bears",
+      manaValue: 2,
+      colors: ["green"],
+    });
+    const battlefield: BoardPermanent[] = [];
+
+    const expected = evaluateTriggerChain(stackItem, battlefield);
+    const result = await aiWorker.evaluateTriggerChain({
+      stackItem,
+      battlefield,
+    });
+
+    expect(result).toEqual(expected);
+    expect(result).toHaveLength(0);
+  });
+
+  test("STRESS FIXTURE: 200-permanent board stays identical between worker and main thread", async () => {
+    // Documents the stress board used to validate offloading (#1080 parity).
+    // Real 60fps measurement requires a browser; this test guarantees the
+    // worker returns byte-for-byte the same decision set on a heavy board so
+    // offloading is behavior-preserving. See PR body for the perf rationale.
+    const stackItem = makeStackItem({
+      id: "stress",
+      name: "Bloodbraid Cascade",
+      controller: "player1",
+      manaValue: 5,
+      colors: ["red", "green"],
+    });
+    const names = [
+      "Cloudblazer",
+      "Solemn Simulacrum",
+      "Impact Tremors",
+      "Panharmonicon",
+      "Blood Artist",
+      "Pawn of Ulamog",
+    ];
+    const battlefield: BoardPermanent[] = Array.from({ length: 200 }, (_, i) =>
+      makePermanent({
+        id: `perm_${i}`,
+        name: names[i % names.length],
+        controller: i % 2 === 0 ? "player1" : "player2",
+        type: i % 3 === 0 ? "enchantment" : "creature",
+        oracleText:
+          "When this enters the battlefield, draw a card and create a token.",
+      }),
+    );
+
+    const expected = evaluateTriggerChain(stackItem, battlefield);
+    const result = await aiWorker.evaluateTriggerChain({
+      stackItem,
+      battlefield,
+    });
+
+    expect(result).toEqual(expected);
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/src/ai/worker/__tests__/trigger-chain-worker-bridge.test.ts
+++ b/src/ai/worker/__tests__/trigger-chain-worker-bridge.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Trigger-chain worker bridge tests (#1080)
+ *
+ * The bridge (`trigger-chain-worker-bridge.ts`) is the single seam between the
+ * main thread and the AI Web Worker for trigger-chain evaluation. These tests
+ * cover the three required scenarios:
+ *
+ *  1. Client invocation — when a worker client is available, the bridge
+ *     forwards to it and returns the worker's result (no main-thread compute).
+ *  2. Fallback (no worker) — when the client resolves to null (e.g. jsdom, or
+ *     `Worker` is undefined), the bridge computes on the main thread with
+ *     results IDENTICAL to the direct evaluator.
+ *  3. Fallback (worker error) — when the client throws (or returns null), the
+ *     bridge falls back to main-thread compute identically.
+ *
+ * Plus ordering preservation (chains stay sorted by totalValue) and that the
+ * default resolver degrades gracefully to the fallback in jsdom.
+ */
+import { describe, test, expect, afterEach } from "@jest/globals";
+
+import {
+  evaluateTriggerChainAsync,
+  _setTriggerChainClientResolver,
+  _resetTriggerChainClientResolver,
+  type TriggerChainWorkerClient,
+} from "../trigger-chain-worker-bridge";
+import { evaluateTriggerChain } from "../../trigger-chain-evaluator";
+import type {
+  CascadeContext,
+  BoardPermanent,
+  TriggerChain,
+} from "../../trigger-chain-evaluator";
+
+function makePermanent(
+  overrides: Partial<BoardPermanent> & {
+    id: string;
+    name: string;
+    controller: string;
+  },
+): BoardPermanent {
+  return {
+    cardId: overrides.id,
+    type: "creature",
+    ...overrides,
+  };
+}
+
+const stackItem: CascadeContext["stackItem"] = {
+  id: "s1",
+  cardId: "s1",
+  name: "Bloodbraid Cascade",
+  controller: "player1",
+  type: "spell",
+  manaValue: 4,
+  colors: ["red", "green"],
+};
+
+const battlefield: BoardPermanent[] = [
+  makePermanent({
+    id: "cloudblazer",
+    name: "Cloudblazer",
+    controller: "player1",
+    oracleText: "When Cloudblazer enters the battlefield, draw two cards.",
+  }),
+  makePermanent({
+    id: "impact-tremors",
+    name: "Impact Tremors",
+    controller: "player1",
+    type: "enchantment",
+    oracleText:
+      "Whenever a creature enters the battlefield under your control, Impact Tremors deals 1 damage to each opponent.",
+  }),
+];
+
+const mainThreadResult: TriggerChain[] = evaluateTriggerChain(
+  stackItem,
+  battlefield,
+);
+
+describe("trigger-chain-worker-bridge (#1080)", () => {
+  afterEach(() => {
+    _resetTriggerChainClientResolver();
+  });
+
+  describe("client invocation (worker path)", () => {
+    test("forwards to the worker client and returns its result", async () => {
+      const evaluateMock = jest
+        .fn<Promise<TriggerChain[]>, []>()
+        .mockResolvedValue(mainThreadResult.map((c) => ({ ...c })));
+      const fakeClient: TriggerChainWorkerClient = {
+        evaluateTriggerChain: evaluateMock,
+      };
+      _setTriggerChainClientResolver(async () => fakeClient);
+
+      const result = await evaluateTriggerChainAsync(stackItem, battlefield);
+
+      expect(result).toEqual(mainThreadResult);
+      expect(evaluateMock).toHaveBeenCalledTimes(1);
+      expect(evaluateMock).toHaveBeenCalledWith(
+        stackItem,
+        battlefield,
+        undefined,
+      );
+    });
+
+    test("does not recompute on the main thread when the worker succeeds", async () => {
+      // Return a sentinel from the worker. If the bridge used the worker
+      // result verbatim, the sentinel must surface (proving main-thread
+      // compute did NOT run and overwrite it).
+      const sentinel: TriggerChain[] = [
+        {
+          originStackItem: "SENTINEL",
+          steps: [],
+          totalValue: 999,
+          totalManaCost: 0,
+          hasOptionalSteps: false,
+          controller: "player1",
+          description: "sentinel",
+        },
+      ];
+      const fakeClient: TriggerChainWorkerClient = {
+        evaluateTriggerChain: jest.fn().mockResolvedValue(sentinel),
+      };
+      _setTriggerChainClientResolver(async () => fakeClient);
+
+      const result = await evaluateTriggerChainAsync(stackItem, battlefield);
+
+      expect(result).toEqual(sentinel);
+      expect(result).not.toEqual(mainThreadResult);
+    });
+
+    test("forwards maxDepth to the worker client", async () => {
+      const evaluateMock = jest
+        .fn<Promise<TriggerChain[]>, []>()
+        .mockResolvedValue(mainThreadResult);
+      _setTriggerChainClientResolver(async () => ({
+        evaluateTriggerChain: evaluateMock,
+      }));
+
+      await evaluateTriggerChainAsync(stackItem, battlefield, 2);
+
+      expect(evaluateMock).toHaveBeenCalledWith(stackItem, battlefield, 2);
+    });
+  });
+
+  describe("fallback (worker unavailable)", () => {
+    test("falls back to main-thread compute when client resolves to null", async () => {
+      _setTriggerChainClientResolver(async () => null);
+
+      const result = await evaluateTriggerChainAsync(stackItem, battlefield);
+
+      expect(result).toEqual(mainThreadResult);
+    });
+
+    test("falls back when the client throws (worker error)", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      const throwingClient: TriggerChainWorkerClient = {
+        evaluateTriggerChain: jest
+          .fn()
+          .mockRejectedValue(new Error("worker boom")),
+      };
+      _setTriggerChainClientResolver(async () => throwingClient);
+
+      const result = await evaluateTriggerChainAsync(stackItem, battlefield);
+
+      expect(result).toEqual(mainThreadResult);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      warnSpy.mockRestore();
+    });
+
+    test("falls back when the worker returns null (no proxy)", async () => {
+      const nullClient: TriggerChainWorkerClient = {
+        evaluateTriggerChain: jest.fn().mockResolvedValue(null),
+      };
+      _setTriggerChainClientResolver(async () => nullClient);
+
+      const result = await evaluateTriggerChainAsync(stackItem, battlefield);
+
+      expect(result).toEqual(mainThreadResult);
+    });
+
+    test("falls back when the resolver itself throws", async () => {
+      _setTriggerChainClientResolver(async () => {
+        throw new Error("resolver exploded");
+      });
+
+      const result = await evaluateTriggerChainAsync(stackItem, battlefield);
+
+      expect(result).toEqual(mainThreadResult);
+    });
+
+    test("fallback warning is emitted at most once across calls", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      const throwingClient: TriggerChainWorkerClient = {
+        evaluateTriggerChain: jest
+          .fn()
+          .mockRejectedValue(new Error("worker boom")),
+      };
+      _setTriggerChainClientResolver(async () => throwingClient);
+
+      await evaluateTriggerChainAsync(stackItem, battlefield);
+      await evaluateTriggerChainAsync(stackItem, battlefield);
+      await evaluateTriggerChainAsync(stackItem, battlefield);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("default resolver (jsdom has no Worker global)", () => {
+    test("degrades gracefully to the main-thread fallback", async () => {
+      // Reset to the default resolver explicitly.
+      _resetTriggerChainClientResolver();
+
+      const result = await evaluateTriggerChainAsync(stackItem, battlefield);
+
+      // jsdom provides no `Worker`, so the real client exposes no proxy and
+      // the dynamic import path resolves to null → main-thread fallback.
+      expect(result).toEqual(mainThreadResult);
+    });
+  });
+
+  describe("ordering preservation", () => {
+    test("chains remain sorted by totalValue descending after the round-trip", async () => {
+      const result = await evaluateTriggerChainAsync(stackItem, battlefield);
+
+      const values = result.map((c) => c.totalValue);
+      const sorted = [...values].sort((a, b) => b - a);
+      expect(values).toEqual(sorted);
+    });
+
+    test("maxDepth is honored on the fallback path", async () => {
+      _setTriggerChainClientResolver(async () => null);
+
+      const shallow = await evaluateTriggerChainAsync(
+        stackItem,
+        battlefield,
+        1,
+      );
+      const expectedShallow = evaluateTriggerChain(stackItem, battlefield, 1);
+
+      expect(shallow).toEqual(expectedShallow);
+    });
+  });
+});

--- a/src/ai/worker/ai-worker-client.ts
+++ b/src/ai/worker/ai-worker-client.ts
@@ -1,5 +1,10 @@
 import * as Comlink from "comlink";
-import type { AIWorkerAPI } from "./worker-types";
+import type { AIWorkerAPI, EvaluateTriggerChainPayload } from "./worker-types";
+import type {
+  CascadeContext,
+  BoardPermanent,
+  TriggerChain,
+} from "../trigger-chain-evaluator";
 
 /**
  * Main Thread Client for AI Web Worker
@@ -64,6 +69,31 @@ class AIWorkerClient {
    */
   public get api(): Comlink.Remote<AIWorkerAPI> | null {
     return this.proxy;
+  }
+
+  /**
+   * Offloads trigger-chain evaluation to the AI Web Worker (#1080).
+   *
+   * Returns the worker-computed `TriggerChain[]`, or `null` when the worker is
+   * unavailable (no proxy / not a browser). Callers MUST treat `null` or a
+   * thrown error as "compute on the main thread" — the trigger-chain worker
+   * bridge (`trigger-chain-worker-bridge.ts`) centralizes that fallback so the
+   * AI never breaks if the worker fails to initialize or errors mid-call.
+   */
+  public async evaluateTriggerChain(
+    stackItem: CascadeContext["stackItem"],
+    battlefield: BoardPermanent[],
+    maxDepth?: number,
+  ): Promise<TriggerChain[] | null> {
+    if (!this.proxy) {
+      return null;
+    }
+    const payload: EvaluateTriggerChainPayload = {
+      stackItem,
+      battlefield,
+      maxDepth,
+    };
+    return this.proxy.evaluateTriggerChain(payload);
   }
 
   /**

--- a/src/ai/worker/ai-worker.ts
+++ b/src/ai/worker/ai-worker.ts
@@ -1,12 +1,15 @@
 import * as Comlink from "comlink";
 import { evaluateGameState, quickScore } from "../game-state-evaluator";
 import { detectArchetype } from "../archetype-detector";
+import { evaluateTriggerChain as runTriggerChainEvaluation } from "../trigger-chain-evaluator";
 import type {
   AIWorkerAPI,
   AnalyzeStatePayload,
   CoachContextPayload,
   DigestedCoachContext,
+  EvaluateTriggerChainPayload,
 } from "./worker-types";
+import type { TriggerChain } from "../trigger-chain-evaluator";
 import type { DeckCard } from "@/app/actions";
 
 /**
@@ -14,8 +17,12 @@ import type { DeckCard } from "@/app/actions";
  *
  * This worker offloads heuristic calculations from the main thread
  * to maintain UI responsiveness (60fps).
+ *
+ * NOTE: this object is exported so unit tests can assert handler correctness
+ * (incl. trigger-chain parity, #1080) without going through Comlink.
+ * `Comlink.expose(aiWorker)` at the bottom is the actual worker entrypoint.
  */
-const aiWorker: AIWorkerAPI = {
+export const aiWorker: AIWorkerAPI = {
   async analyzeGameState(payload: AnalyzeStatePayload) {
     const { gameState, playerId } = payload;
     return evaluateGameState(gameState, playerId);
@@ -112,6 +119,19 @@ const aiWorker: AIWorkerAPI = {
       gameSummary,
       timestamp: Date.now(),
     };
+  },
+
+  /**
+   * Evaluates cascade / trigger chains for a resolving stack item.
+   * The pure evaluator lives in `trigger-chain-evaluator.ts` and has no
+   * DOM/main-thread dependencies, so it is safe to run inside the worker.
+   * Returns the exact same `TriggerChain[]` the in-thread evaluator produces.
+   */
+  async evaluateTriggerChain(
+    payload: EvaluateTriggerChainPayload,
+  ): Promise<TriggerChain[]> {
+    const { stackItem, battlefield, maxDepth } = payload;
+    return runTriggerChainEvaluation(stackItem, battlefield, maxDepth);
   },
 };
 

--- a/src/ai/worker/trigger-chain-worker-bridge.ts
+++ b/src/ai/worker/trigger-chain-worker-bridge.ts
@@ -1,0 +1,135 @@
+/**
+ * @fileoverview Trigger-chain worker bridge (issue #1080)
+ *
+ * Trigger-chain evaluation (`trigger-chain-evaluator.ts`) recursively expands
+ * cascade / ETB / "whenever you cast" chains across the full board and is
+ * CPU-heavy. It previously ran synchronously on the main thread during AI
+ * priority decisions, causing jank.
+ *
+ * This module is the single seam that routes that evaluation through the AI
+ * Web Worker when it is available, and falls back to identical main-thread
+ * computation when it is not — so the AI keeps functioning even if the worker
+ * fails to initialize or errors mid-call.
+ *
+ * Design notes:
+ * - The real worker client (`ai-worker-client.ts`) resolves its worker URL with
+ *   `import.meta.url`, which cannot be statically `require()`d under ts-jest /
+ *   Node CommonJS (`SyntaxError: Cannot use 'import.meta' outside a module`).
+ *   To keep this module (and every caller, e.g. `stack-interaction-ai.ts`)
+ *   Jest-safe, the client is loaded with a dynamic `import()` wrapped in
+ *   try/catch — any failure simply activates the main-thread fallback.
+ * - The client resolver is injectable (`_setTriggerChainClientResolver`) so the
+ *   worker path and the fallback path can be unit-tested without a real
+ *   `Worker` global (jsdom does not provide one).
+ * - Trigger chains are order-sensitive (sorted by totalValue). Callers `await`
+ *   the full result before proceeding, so ordering is preserved end-to-end.
+ */
+
+import { evaluateTriggerChain as evaluateTriggerChainOnMain } from "../trigger-chain-evaluator";
+import type {
+  CascadeContext,
+  BoardPermanent,
+  TriggerChain,
+} from "../trigger-chain-evaluator";
+
+/**
+ * Minimal shape of the AI worker client surface this bridge needs.
+ * Declared locally (rather than importing the real client type) so tests can
+ * inject a plain stub and stay decoupled from the import.meta-based client.
+ */
+export interface TriggerChainWorkerClient {
+  evaluateTriggerChain(
+    stackItem: CascadeContext["stackItem"],
+    battlefield: BoardPermanent[],
+    maxDepth?: number,
+  ): Promise<TriggerChain[] | null>;
+}
+
+export type TriggerChainClientResolver =
+  () => Promise<TriggerChainWorkerClient | null>;
+
+let fallbackWarningLogged = false;
+
+/**
+ * Default resolver: lazily dynamic-import the real client (browser / Next.js).
+ * Dynamic import keeps this module Jest-safe — see fileoverview.
+ */
+const defaultResolver: TriggerChainClientResolver = async () => {
+  try {
+    const mod = await import("./ai-worker-client");
+    return mod.aiWorkerClient as unknown as TriggerChainWorkerClient;
+  } catch {
+    return null;
+  }
+};
+
+let clientResolver: TriggerChainClientResolver = defaultResolver;
+
+/**
+ * Replace the client resolver. @internal — used by unit tests to inject a stub
+ * worker client and exercise both the worker path and the fallback path.
+ */
+export function _setTriggerChainClientResolver(
+  resolver: TriggerChainClientResolver,
+): void {
+  clientResolver = resolver;
+}
+
+/**
+ * Restore the default client resolver and reset the one-shot fallback warning.
+ * @internal — call this in `afterEach` of tests that use the setter.
+ */
+export function _resetTriggerChainClientResolver(): void {
+  clientResolver = defaultResolver;
+  fallbackWarningLogged = false;
+}
+
+/**
+ * Evaluate trigger chains off the main thread when the AI worker is available;
+ * otherwise compute on the main thread with identical results.
+ *
+ * Guarantees:
+ * - The returned `TriggerChain[]` is value-identical to a direct
+ *   `evaluateTriggerChain()` call (worker path forwards the same result).
+ * - Order-sensitive: the full, sorted chain list is resolved before this
+ *   resolves, so callers that `await` preserve evaluation order.
+ * - Never throws due to worker unavailability: any resolver/client error is
+ *   swallowed and routed to the main-thread fallback.
+ */
+export async function evaluateTriggerChainAsync(
+  stackItem: CascadeContext["stackItem"],
+  battlefield: BoardPermanent[],
+  maxDepth?: number,
+): Promise<TriggerChain[]> {
+  let client: TriggerChainWorkerClient | null = null;
+  try {
+    client = await clientResolver();
+  } catch {
+    client = null;
+  }
+
+  if (client) {
+    try {
+      const result = await client.evaluateTriggerChain(
+        stackItem,
+        battlefield,
+        maxDepth,
+      );
+      if (result) {
+        return result;
+      }
+    } catch (error) {
+      // Worker present but errored (or returned nothing usable): fall through
+      // to main-thread compute. Warn once to avoid log spam on tight loops.
+      if (!fallbackWarningLogged) {
+        console.warn(
+          "[trigger-chain] AI worker evaluation failed; falling back to main thread:",
+          error,
+        );
+        fallbackWarningLogged = true;
+      }
+    }
+  }
+
+  return evaluateTriggerChainOnMain(stackItem, battlefield, maxDepth);
+}

--- a/src/ai/worker/worker-types.ts
+++ b/src/ai/worker/worker-types.ts
@@ -1,16 +1,22 @@
-import type { AIGameState as GameState } from '@/lib/game-state/types';
-import type { DetailedEvaluation } from '@/ai/game-state-evaluator';
+import type { AIGameState as GameState } from "@/lib/game-state/types";
+import type { DetailedEvaluation } from "@/ai/game-state-evaluator";
+import type {
+  CascadeContext,
+  BoardPermanent,
+  TriggerChain,
+} from "@/ai/trigger-chain-evaluator";
 
 /**
  * Actions that the AI Worker can perform.
  * Useful for logging, tracking, or alternative message-based implementations.
  */
 export enum AIWorkerAction {
-  ANALYZE_STATE = 'ANALYZE_STATE',
-  EVALUATE_BOARD = 'EVALUATE_BOARD',
-  QUICK_SCORE = 'QUICK_SCORE',
-  DETECT_ARCHETYPE = 'DETECT_ARCHETYPE',
-  PREPARE_COACH_CONTEXT = 'PREPARE_COACH_CONTEXT',
+  ANALYZE_STATE = "ANALYZE_STATE",
+  EVALUATE_BOARD = "EVALUATE_BOARD",
+  QUICK_SCORE = "QUICK_SCORE",
+  DETECT_ARCHETYPE = "DETECT_ARCHETYPE",
+  PREPARE_COACH_CONTEXT = "PREPARE_COACH_CONTEXT",
+  EVALUATE_TRIGGER_CHAIN = "EVALUATE_TRIGGER_CHAIN",
 }
 
 /**
@@ -56,7 +62,24 @@ export interface DigestedCoachContext {
 export interface AnalyzeStatePayload {
   gameState: GameState;
   playerId: string;
-  difficulty?: 'easy' | 'medium' | 'hard' | 'expert';
+  difficulty?: "easy" | "medium" | "hard" | "expert";
+}
+
+/**
+ * Payload for offloading cascade / trigger-chain evaluation to the worker.
+ *
+ * Trigger-chain evaluation is CPU-heavy (recursive chain expansion across the
+ * full board) and previously ran synchronously on the main thread, causing jank
+ * during AI turns. Offloading it to the AI Web Worker keeps the UI responsive
+ * (issue #1080).
+ *
+ * All fields are structured-cloneable plain data (no class instances, no Maps
+ * with non-serializable keys) so they can be posted to the worker via Comlink.
+ */
+export interface EvaluateTriggerChainPayload {
+  stackItem: CascadeContext["stackItem"];
+  battlefield: BoardPermanent[];
+  maxDepth?: number;
 }
 
 /**
@@ -88,7 +111,7 @@ export interface AIWorkerAPI {
    * Returns a quick heuristic score for the game state.
    */
   quickScore(payload: AnalyzeStatePayload): Promise<number>;
-  
+
   /**
    * Detects the archetype of a deck.
    * @param deck Array of card definitions or names.
@@ -98,5 +121,17 @@ export interface AIWorkerAPI {
   /**
    * Prepares a compact context for the AI coach.
    */
-  prepareCoachContext(payload: CoachContextPayload): Promise<DigestedCoachContext>;
+  prepareCoachContext(
+    payload: CoachContextPayload,
+  ): Promise<DigestedCoachContext>;
+
+  /**
+   * Evaluates cascade / triggered-ability chains that would result from a stack
+   * item resolving. Offloaded from the main thread to keep AI turns responsive
+   * (#1080). Returns the exact `TriggerChain[]` the in-thread evaluator would
+   * produce (no behavior change), so callers can treat the result identically.
+   */
+  evaluateTriggerChain(
+    payload: EvaluateTriggerChainPayload,
+  ): Promise<TriggerChain[]>;
 }


### PR DESCRIPTION
## Summary

Offloads recursive trigger-chain evaluation (`src/ai/trigger-chain-evaluator.ts`) off the main thread and into the existing AI Web Worker so AI priority decisions no longer cause frame jank during single-player turns (#1080, Phase 32). Results are **identical** to the previous synchronous computation; if the worker is unavailable or errors, the AI transparently falls back to the same main-thread compute.

## Worker protocol

New action added to the existing Comlink-based protocol in `worker-types.ts`:

```ts
enum AIWorkerAction { ..., EVALUATE_TRIGGER_CHAIN = 'EVALUATE_TRIGGER_CHAIN' }

interface EvaluateTriggerChainPayload {
  stackItem: CascadeContext['stackItem']; // plain data, structured-cloneable
  battlefield: BoardPermanent[];
  maxDepth?: number;
}

// AIWorkerAPI.evaluateTriggerChain(payload): Promise<TriggerChain[]>
```

The handler in `ai-worker.ts` calls the **pure** evaluator (no DOM / `window` / main-thread deps — just regex + recursion, so it is worker-safe). The handler object is now `export const aiWorker` so unit tests assert correctness without going through Comlink.

## Fallback design

A new jest-safe seam, `trigger-chain-worker-bridge.ts`, is the only thing callers depend on:

```
caller (stack-interaction-ai)
   └── await evaluateTriggerChainAsync(stackItem, battlefield, maxDepth?)
           ├── worker available?  → forward to aiWorkerClient → return worker result
           └── else / worker threw / returned null  → main-thread evaluateTriggerChain() (identical)
```

- **Why a bridge?** `ai-worker-client.ts` resolves its worker URL with `import.meta.url`, which is a `SyntaxError` under ts-jest / Node CommonJS. A static import would crash every test that loads `stack-interaction-ai.ts`. The bridge loads the client with a **dynamic `import()`** wrapped in try/catch, keeping itself (and all callers) jest-safe.
- **Never bricks the AI:** resolver-throws, client-throws, client-returns-`null`, and no-`Worker`-global (jsdom) all route to the main-thread evaluator. A one-shot `console.warn` logs the fallback (no log spam on tight loops).
- **Order-preserving:** callers `await` the fully-resolved, already-sorted `TriggerChain[]`; trigger chains are order-sensitive and ordering is preserved end-to-end.
- **Injectable resolver** (`_setTriggerChainClientResolver`) lets tests exercise both the worker path and the fallback path without a real `Worker`.

`stack-interaction-ai.ts`: `evaluateTriggerChains()` and `assessActionThreatWithTriggers()` are now `async` and `await` the bridge. All lightweight post-processing (`getTriggerChainSummary`, `shouldCounterToPreventTriggers`, `getHighestValueChain`, `cascadeThreatBonus`) is unchanged and stays on the main thread.

## Acceptance criteria

- [x] Trigger-chain evaluation runs in the AI Web Worker (off the main thread)
- [x] Typed request/response for trigger-chain evaluation in the worker protocol
- [x] Callers invoke it via the worker (async) instead of synchronously on the main thread
- [x] Results identical to the previous main-thread computation (parity tests, incl. a 200-permanent stress fixture)
- [x] Graceful fallback if the worker is unavailable (no proxy / throws / resolver throws) — AI still functions; fallback is logged once
- [x] Unit tests cover worker handler correctness, client invocation, and the fallback path
- [x] `stack-interaction-ai.ts` no longer calls `trigger-chain-evaluator.ts` directly during AI turns (routes through the bridge/worker)
- [x] `tsc --noEmit` clean, ESLint clean on changed files, full suite green (5558 tests)

## Test fixtures

- **Worker handler parity** (`ai-worker-trigger-chain.test.ts`): ETB board, Cascade spell, copy-doubler (Panharmonicon), `maxDepth` sweep, empty board, and a **200-permanent stress board** asserting byte-for-byte equality with the in-thread evaluator.
- **Bridge** (`trigger-chain-worker-bridge.test.ts`): worker path forwards + returns verbatim (no main-thread recompute), `maxDepth` forwarding, and four fallback cases (null client, throwing client, null-returning client, throwing resolver), plus the one-shot warning and ordering preservation.
- **Caller** (`stack-interaction-ai.test.ts`): `evaluateTriggerChains` / `assessActionThreatWithTriggers` are async and return the full post-processed result clamped to expected ranges.

> Note on 60fps: a true frame-budget measurement requires a browser environment. The stress fixture guarantees the offloaded path is behavior-preserving on a heavy board; the perf win comes from moving the recursive expansion off the main thread (documented as the fixture).

## Deviations

- **Commit type `refactor` instead of `perf`:** this repo's commitlint config only allows `[feat, fix, docs, style, refactor, test, chore, revert]` and rejects `perf` (verified against the hook). Used `refactor(ai)` (behavior-preserving restructure of where the evaluation runs) to satisfy the hook; the header is fully lower-case per `header-case`.
- **`ai-turn-loop.ts` not modified:** the issue body lists it as a caller, but `evaluateTriggerChain`/`evaluateTriggerChains` are not referenced from `ai-turn-loop.ts` (grep-verified) — the only production caller is `stack-interaction-ai.ts`, which is now routed through the worker. Touching `ai-turn-loop.ts` would have been an unrelated change.

Resolves #1080
