### PR TITLE
perf(ai): resolve #1079 — offload synergy detection to the AI Web Worker

### DIFF
--- a/src/ai/flows/__tests__/coach-context-prefetch.test.ts
+++ b/src/ai/flows/__tests__/coach-context-prefetch.test.ts
@@ -126,7 +126,10 @@ describe("buildStructuredDeckAnalysisParallel", () => {
   it("produces output identical to the serial builder", async () => {
     const deck = buildDeck();
     const parallel = await buildStructuredDeckAnalysisParallel(deck);
-    const serial = buildStructuredDeckAnalysis(deck);
+    // Serial builder is now async (synergy detection goes through the worker
+    // bridge, #1079). Both paths fall back to identical main-thread compute in
+    // jsdom, so their output must still match exactly.
+    const serial = await buildStructuredDeckAnalysis(deck);
     expect(parallel).toEqual(serial);
   });
 });

--- a/src/ai/flows/__tests__/coach-deck-analysis.test.ts
+++ b/src/ai/flows/__tests__/coach-deck-analysis.test.ts
@@ -79,7 +79,14 @@ function buildElfRampDeck(): DeckCard[] {
 
 describe("buildStructuredDeckAnalysis", () => {
   const deck = buildElfRampDeck();
-  const analysis = buildStructuredDeckAnalysis(deck);
+  // Synergy detection now runs through the AI Web Worker bridge (#1079), which
+  // makes the builder async. The shared analysis is awaited once per describe
+  // block via beforeAll so the individual assertions stay synchronous.
+  let analysis: StructuredDeckAnalysis;
+
+  beforeAll(async () => {
+    analysis = await buildStructuredDeckAnalysis(deck);
+  });
 
   it("returns a structured object, not a raw card list", () => {
     expect(analysis).not.toBeNull();
@@ -155,8 +162,8 @@ describe("buildStructuredDeckAnalysis", () => {
     }
   });
 
-  it("handles an empty deck without throwing", () => {
-    const empty = buildStructuredDeckAnalysis([]);
+  it("handles an empty deck without throwing", async () => {
+    const empty = await buildStructuredDeckAnalysis([]);
     expect(empty.totalCards).toBe(0);
     expect(empty.archetype).toBe("Unknown");
     expect(empty.synergyClusters).toEqual([]);
@@ -165,8 +172,13 @@ describe("buildStructuredDeckAnalysis", () => {
 
 describe("formatStructuredAnalysisForLLM", () => {
   const deck = buildElfRampDeck();
-  const analysis = buildStructuredDeckAnalysis(deck);
-  const formatted = formatStructuredAnalysisForLLM(analysis);
+  let analysis: StructuredDeckAnalysis;
+  let formatted: string;
+
+  beforeAll(async () => {
+    analysis = await buildStructuredDeckAnalysis(deck);
+    formatted = formatStructuredAnalysisForLLM(analysis);
+  });
 
   it("emits the structured header and key sections", () => {
     expect(formatted).toContain("### Structured Deck Analysis");

--- a/src/ai/flows/coach-context-prefetch.ts
+++ b/src/ai/flows/coach-context-prefetch.ts
@@ -29,7 +29,8 @@
 import type { DeckCard } from "@/app/actions";
 import { detectArchetype } from "@/ai/archetype-detector";
 import { calculateDeckStats } from "@/ai/archetype-signatures";
-import { detectSynergies, detectMissingSynergies } from "@/ai/synergy-detector";
+import { detectMissingSynergies } from "@/ai/synergy-detector";
+import { detectSynergiesAsync } from "@/ai/worker/synergy-worker-bridge";
 import {
   assembleStructuredAnalysis,
   formatStructuredAnalysisForLLM,
@@ -127,16 +128,21 @@ export function _coachContextCacheSize(): number {
 /**
  * Resolve the three INDEPENDENT deck analyses concurrently.
  *
- * `detectArchetype`, `calculateDeckStats` and `detectSynergies` do not depend
+ * `detectArchetype`, `calculateDeckStats` and synergy detection do not depend
  * on one another. Running them through `Promise.all` guarantees that whenever
  * any becomes async it executes in parallel with the others rather than
  * serially — the core latency fix for issue #928.
+ *
+ * Synergy detection is routed through the AI Web Worker bridge (issue #1079)
+ * so the CPU-heavy scoring runs off the main thread, falling back to identical
+ * main-thread compute when the worker is unavailable. It is already a Promise,
+ * so it overlaps with the other two analyses.
  */
 async function resolveIndependentAnalyses(deck: DeckCard[]) {
   const [archetype, stats, synergies] = await Promise.all([
     Promise.resolve(detectArchetype(deck)),
     Promise.resolve(calculateDeckStats(deck)),
-    Promise.resolve(detectSynergies(deck)),
+    detectSynergiesAsync(deck),
   ]);
   return { archetype, stats, synergies };
 }

--- a/src/ai/flows/coach-deck-analysis.ts
+++ b/src/ai/flows/coach-deck-analysis.ts
@@ -20,11 +20,11 @@ import {
   type DeckStats,
 } from "@/ai/archetype-signatures";
 import {
-  detectSynergies,
   detectMissingSynergies,
   type SynergyResult,
   type MissingSynergy,
 } from "@/ai/synergy-detector";
+import { detectSynergiesAsync } from "@/ai/worker/synergy-worker-bridge";
 
 /** A single synergy cluster surfaced to the coach. */
 export interface SynergyCluster {
@@ -372,15 +372,20 @@ export function assembleStructuredAnalysis(
  * and backward compatibility. New, latency-sensitive callers should use the
  * context pre-fetcher in `./coach-context-prefetch` (issue #928), which
  * resolves the independent pieces in parallel and caches the result.
+ *
+ * Synergy detection runs through the AI Web Worker bridge (`issue #1079`) so
+ * the CPU-heavy scoring is offloaded off the main thread, with an identical
+ * main-thread fallback if the worker is unavailable. This makes the function
+ * async — callers must `await` it.
  */
-export function buildStructuredDeckAnalysis(
+export async function buildStructuredDeckAnalysis(
   deck: DeckCard[],
-): StructuredDeckAnalysis {
+): Promise<StructuredDeckAnalysis> {
   const safeDeck = Array.isArray(deck) ? deck : [];
 
   const archetype = detectArchetype(safeDeck);
   const stats = calculateDeckStats(safeDeck);
-  const synergies = detectSynergies(safeDeck);
+  const synergies = await detectSynergiesAsync(safeDeck);
   const missing = detectMissingSynergies(safeDeck, archetype.primary);
 
   return assembleStructuredAnalysis(safeDeck, {

--- a/src/ai/worker/__tests__/ai-worker-synergy.test.ts
+++ b/src/ai/worker/__tests__/ai-worker-synergy.test.ts
@@ -1,0 +1,231 @@
+/**
+ * AI Worker — synergy detection handler tests (#1079)
+ *
+ * Asserts the `detectSynergies` handler exposed by the AI Web Worker:
+ *  - returns results IDENTICAL to the in-thread detector (parity / no behavior
+ *    change) across tribal, multi-synergy, stress and empty decks;
+ *  - honors `minScore` and `maxResults`;
+ *  - returns an empty list (not an error) for decks with no detectable
+ *    synergies.
+ *
+ * The handler object is imported directly (Comlink.expose is a no-op side
+ * effect under jsdom), which is exactly the code that runs inside the worker.
+ */
+import { describe, test, expect } from "@jest/globals";
+
+import { aiWorker } from "../ai-worker";
+import { detectSynergies } from "../../synergy-detector";
+import type { SynergyResult } from "../../synergy-detector";
+import type { DeckCard } from "@/app/actions";
+
+function makeCard(
+  name: string,
+  typeLine: string,
+  count: number,
+  oracle = "",
+  cmc = 2,
+): DeckCard {
+  return {
+    id: name.toLowerCase().replace(/\s+/g, "-"),
+    name,
+    cmc,
+    type_line: typeLine,
+    colors: ["G"],
+    color_identity: ["G"],
+    legalities: {},
+    count,
+    oracle_text: oracle,
+  };
+}
+
+/** A dense Elf-ramp deck that triggers tribal + ramp + card-draw synergies. */
+function buildElfRampDeck(): DeckCard[] {
+  return [
+    makeCard("Llanowar Elves", "Creature — Elf Druid", 4, "Tap: Add G.", 1),
+    makeCard("Elvish Mystic", "Creature — Elf Druid", 4, "Tap: Add G.", 1),
+    makeCard(
+      "Elvish Archdruid",
+      "Creature — Elf Druid",
+      3,
+      "Other Elf creatures get +1/+1. Tap: Add G for each Elf you control.",
+      3,
+    ),
+    makeCard("Heritage Druid", "Creature — Elf Druid", 3, "", 1),
+    makeCard("Nettle Sentinel", "Creature — Elf Warrior", 4, "", 1),
+    makeCard("Ezuri, Renegade Leader", "Legendary Creature — Elf", 2, "", 3),
+    makeCard(
+      "Craterhoof Behemoth",
+      "Creature — Beast",
+      2,
+      "When this enters, creatures you control gain trample.",
+      8,
+    ),
+    makeCard(
+      "Cultivate",
+      "Sorcery",
+      3,
+      "Search your library for up to two basic land cards. You may put one onto the battlefield tapped.",
+      3,
+    ),
+    makeCard("Harmonize", "Sorcery", 2, "Draw three cards.", 4),
+    makeCard("Forest", "Basic Land — Forest", 18, "", 0),
+  ];
+}
+
+describe("AI Worker — detectSynergies handler (#1079)", () => {
+  test("returns identical results to the in-thread detector (Elf-ramp deck)", async () => {
+    const deck = buildElfRampDeck();
+
+    const expected = detectSynergies(deck);
+    const result = await aiWorker.detectSynergies({ deck });
+
+    // Deep equality — the worker path must not alter scores or ordering.
+    expect(result).toEqual(expected);
+    expect(result.length).toBe(expected.length);
+    // The Elf deck should surface at least one synergy on both paths.
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  test("results stay sorted by score descending after the round-trip", async () => {
+    const deck = buildElfRampDeck();
+
+    const result = await aiWorker.detectSynergies({ deck });
+
+    const scores = result.map((s) => s.score);
+    const sorted = [...scores].sort((a, b) => b - a);
+    expect(scores).toEqual(sorted);
+  });
+
+  test("honors minScore identically to the in-thread detector", async () => {
+    const deck = buildElfRampDeck();
+
+    for (const minScore of [0, 30, 60, 90]) {
+      const expected = detectSynergies(deck, minScore);
+      const result = await aiWorker.detectSynergies({ deck, minScore });
+      expect(result).toEqual(expected);
+      for (const s of result) expect(s.score).toBeGreaterThanOrEqual(minScore);
+    }
+  });
+
+  test("honors maxResults identically to the in-thread detector", async () => {
+    const deck = buildElfRampDeck();
+
+    for (const maxResults of [1, 3, 50]) {
+      const expected = detectSynergies(deck, undefined, maxResults);
+      const result = await aiWorker.detectSynergies({
+        deck,
+        maxResults,
+      });
+      expect(result).toEqual(expected);
+      expect(result.length).toBeLessThanOrEqual(maxResults);
+    }
+  });
+
+  test("returns identical results for a multi-synergy board", async () => {
+    // Mix tribal (goblins), removal, card draw and ramp signals so several
+    // distinct synergies register simultaneously. A low minScore lets multiple
+    // clusters surface (their raw scores get reduced by the minimumCards
+    // penalty); parity must hold regardless of threshold.
+    const deck: DeckCard[] = [
+      makeCard("Goblin Guide", "Creature — Goblin Warrior", 4, "Haste", 1),
+      makeCard(
+        "Goblin Chieftain",
+        "Creature — Goblin",
+        3,
+        "Other Goblins get +1/+1.",
+        3,
+      ),
+      makeCard("Krenko, Mob Boss", "Legendary Creature — Goblin", 2, "", 4),
+      makeCard(
+        "Lightning Bolt",
+        "Instant",
+        4,
+        "Lightning Bolt deals 3 damage to any target.",
+        1,
+      ),
+      makeCard("Murder", "Instant", 3, "Destroy target creature.", 3),
+      makeCard("Divination", "Sorcery", 3, "Draw two cards.", 3),
+      makeCard(
+        "Rampant Growth",
+        "Sorcery",
+        4,
+        "Search your library for a basic land card.",
+        2,
+      ),
+      makeCard("Mountain", "Basic Land — Mountain", 18, "", 0),
+    ];
+
+    const minScore = 0;
+    const expected = detectSynergies(deck, minScore);
+    const result = await aiWorker.detectSynergies({ deck, minScore });
+
+    expect(result).toEqual(expected);
+    expect(result.length).toBeGreaterThan(1);
+  });
+
+  test("returns an empty list (no error) for an empty deck", async () => {
+    const expected = detectSynergies([]);
+    const result = await aiWorker.detectSynergies({ deck: [] });
+
+    expect(result).toEqual(expected);
+    expect(result).toHaveLength(0);
+  });
+
+  test("returns an empty list (no error) for a deck with no detectable synergies", async () => {
+    // Vanilla cards with no synergy-bearing keywords/types → nothing scores.
+    const deck: DeckCard[] = [
+      makeCard("Vanilla Bear", "Creature — Bear", 10, "", 2),
+      makeCard("Forest", "Basic Land — Forest", 12, "", 0),
+    ];
+
+    const expected = detectSynergies(deck);
+    const result = await aiWorker.detectSynergies({ deck });
+
+    expect(result).toEqual(expected);
+    expect(result).toHaveLength(0);
+  });
+
+  test("STRESS FIXTURE: 100-card deck stays identical between worker and main thread", async () => {
+    // Documents the stress deck used to validate offloading (#1079 parity).
+    // Real 60fps measurement requires a browser; this test guarantees the
+    // worker returns byte-for-byte the same synergy set on a heavy deck so
+    // offloading is behavior-preserving. See PR body for the perf rationale.
+    const cardNames = [
+      "Llanowar Elves",
+      "Elvish Archdruid",
+      "Goblin Chieftain",
+      "Craterhoof Behemoth",
+      "Harmonize",
+      "Rampant Growth",
+    ];
+    const deck: DeckCard[] = Array.from({ length: 100 }, (_, i) =>
+      makeCard(
+        `${cardNames[i % cardNames.length]} ${i}`,
+        "Creature",
+        1,
+        "draw a card",
+      ),
+    );
+
+    const expected = detectSynergies(deck);
+    const result = await aiWorker.detectSynergies({ deck });
+
+    expect(result).toEqual(expected);
+    expect(result.length).toBe(expected.length);
+  });
+
+  test("returned results are the SynergyResult shape (no shape drift)", async () => {
+    const deck = buildElfRampDeck();
+    const result = (await aiWorker.detectSynergies({
+      deck,
+    })) as SynergyResult[];
+
+    for (const s of result) {
+      expect(typeof s.name).toBe("string");
+      expect(typeof s.score).toBe("number");
+      expect(Array.isArray(s.cards)).toBe(true);
+      expect(typeof s.description).toBe("string");
+      expect(typeof s.category).toBe("string");
+    }
+  });
+});

--- a/src/ai/worker/__tests__/synergy-worker-bridge.test.ts
+++ b/src/ai/worker/__tests__/synergy-worker-bridge.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Synergy worker bridge tests (#1079)
+ *
+ * The bridge (`synergy-worker-bridge.ts`) is the single seam between the main
+ * thread and the AI Web Worker for synergy detection. These tests cover the
+ * three required scenarios:
+ *
+ *  1. Client invocation — when a worker client is available, the bridge
+ *     forwards to it and returns the worker's result (no main-thread compute).
+ *  2. Fallback (no worker) — when the client resolves to null (e.g. jsdom, or
+ *     `Worker` is undefined), the bridge computes on the main thread with
+ *     results IDENTICAL to the direct detector.
+ *  3. Fallback (worker error) — when the client throws (or returns null), the
+ *     bridge falls back to main-thread compute identically.
+ *
+ * Plus ordering preservation (results stay sorted by score) and that the
+ * default resolver degrades gracefully to the fallback in jsdom.
+ */
+import { describe, test, expect, afterEach } from "@jest/globals";
+
+import {
+  detectSynergiesAsync,
+  _setSynergyClientResolver,
+  _resetSynergyClientResolver,
+  type SynergyWorkerClient,
+} from "../synergy-worker-bridge";
+import { detectSynergies } from "../../synergy-detector";
+import type { SynergyResult } from "../../synergy-detector";
+import type { DeckCard } from "@/app/actions";
+
+function makeCard(
+  name: string,
+  typeLine: string,
+  count: number,
+  oracle = "",
+  cmc = 2,
+): DeckCard {
+  return {
+    id: name.toLowerCase().replace(/\s+/g, "-"),
+    name,
+    cmc,
+    type_line: typeLine,
+    colors: ["G"],
+    color_identity: ["G"],
+    legalities: {},
+    count,
+    oracle_text: oracle,
+  };
+}
+
+function buildElfRampDeck(): DeckCard[] {
+  return [
+    makeCard("Llanowar Elves", "Creature — Elf Druid", 4, "Tap: Add G.", 1),
+    makeCard("Elvish Mystic", "Creature — Elf Druid", 4, "Tap: Add G.", 1),
+    makeCard(
+      "Elvish Archdruid",
+      "Creature — Elf Druid",
+      3,
+      "Other Elf creatures get +1/+1. Tap: Add G for each Elf you control.",
+      3,
+    ),
+    makeCard("Heritage Druid", "Creature — Elf Druid", 3, "", 1),
+    makeCard("Nettle Sentinel", "Creature — Elf Warrior", 4, "", 1),
+    makeCard("Craterhoof Behemoth", "Creature — Beast", 2, "", 8),
+    makeCard(
+      "Cultivate",
+      "Sorcery",
+      3,
+      "Search your library for a basic land.",
+      3,
+    ),
+    makeCard("Harmonize", "Sorcery", 2, "Draw three cards.", 4),
+    makeCard("Forest", "Basic Land — Forest", 18, "", 0),
+  ];
+}
+
+const deck = buildElfRampDeck();
+const mainThreadResult: SynergyResult[] = detectSynergies(deck);
+
+describe("synergy-worker-bridge (#1079)", () => {
+  afterEach(() => {
+    _resetSynergyClientResolver();
+  });
+
+  describe("client invocation (worker path)", () => {
+    test("forwards to the worker client and returns its result", async () => {
+      const detectMock = jest
+        .fn<Promise<SynergyResult[]>, []>()
+        .mockResolvedValue(mainThreadResult.map((s) => ({ ...s })));
+      const fakeClient: SynergyWorkerClient = {
+        detectSynergies: detectMock,
+      };
+      _setSynergyClientResolver(async () => fakeClient);
+
+      const result = await detectSynergiesAsync(deck);
+
+      expect(result).toEqual(mainThreadResult);
+      expect(detectMock).toHaveBeenCalledTimes(1);
+      expect(detectMock).toHaveBeenCalledWith(deck, undefined, undefined);
+    });
+
+    test("does not recompute on the main thread when the worker succeeds", async () => {
+      // Return a sentinel from the worker. If the bridge used the worker
+      // result verbatim, the sentinel must surface (proving main-thread
+      // compute did NOT run and overwrite it).
+      const sentinel: SynergyResult[] = [
+        {
+          name: "SENTINEL",
+          score: 999,
+          cards: ["Sentinel Card"],
+          description: "sentinel",
+          category: "sentinel",
+        },
+      ];
+      const fakeClient: SynergyWorkerClient = {
+        detectSynergies: jest.fn().mockResolvedValue(sentinel),
+      };
+      _setSynergyClientResolver(async () => fakeClient);
+
+      const result = await detectSynergiesAsync(deck);
+
+      expect(result).toEqual(sentinel);
+      expect(result).not.toEqual(mainThreadResult);
+    });
+
+    test("forwards minScore and maxResults to the worker client", async () => {
+      const detectMock = jest
+        .fn<Promise<SynergyResult[]>, []>()
+        .mockResolvedValue(mainThreadResult);
+      _setSynergyClientResolver(async () => ({
+        detectSynergies: detectMock,
+      }));
+
+      await detectSynergiesAsync(deck, 50, 3);
+
+      expect(detectMock).toHaveBeenCalledWith(deck, 50, 3);
+    });
+  });
+
+  describe("fallback (worker unavailable)", () => {
+    test("falls back to main-thread compute when client resolves to null", async () => {
+      _setSynergyClientResolver(async () => null);
+
+      const result = await detectSynergiesAsync(deck);
+
+      expect(result).toEqual(mainThreadResult);
+    });
+
+    test("falls back when the client throws (worker error)", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      const throwingClient: SynergyWorkerClient = {
+        detectSynergies: jest.fn().mockRejectedValue(new Error("worker boom")),
+      };
+      _setSynergyClientResolver(async () => throwingClient);
+
+      const result = await detectSynergiesAsync(deck);
+
+      expect(result).toEqual(mainThreadResult);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      warnSpy.mockRestore();
+    });
+
+    test("falls back when the worker returns null (no proxy)", async () => {
+      const nullClient: SynergyWorkerClient = {
+        detectSynergies: jest.fn().mockResolvedValue(null),
+      };
+      _setSynergyClientResolver(async () => nullClient);
+
+      const result = await detectSynergiesAsync(deck);
+
+      expect(result).toEqual(mainThreadResult);
+    });
+
+    test("falls back when the resolver itself throws", async () => {
+      _setSynergyClientResolver(async () => {
+        throw new Error("resolver exploded");
+      });
+
+      const result = await detectSynergiesAsync(deck);
+
+      expect(result).toEqual(mainThreadResult);
+    });
+
+    test("fallback warning is emitted at most once across calls", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      const throwingClient: SynergyWorkerClient = {
+        detectSynergies: jest.fn().mockRejectedValue(new Error("worker boom")),
+      };
+      _setSynergyClientResolver(async () => throwingClient);
+
+      await detectSynergiesAsync(deck);
+      await detectSynergiesAsync(deck);
+      await detectSynergiesAsync(deck);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      warnSpy.mockRestore();
+    });
+
+    test("fallback returns identical results across minScore / maxResults", async () => {
+      _setSynergyClientResolver(async () => null);
+
+      for (const [minScore, maxResults] of [
+        [0, 50],
+        [50, 3],
+        [90, 1],
+      ] as const) {
+        const result = await detectSynergiesAsync(deck, minScore, maxResults);
+        const expected = detectSynergies(deck, minScore, maxResults);
+        expect(result).toEqual(expected);
+      }
+    });
+  });
+
+  describe("default resolver (jsdom has no Worker global)", () => {
+    test("degrades gracefully to the main-thread fallback", async () => {
+      // Reset to the default resolver explicitly.
+      _resetSynergyClientResolver();
+
+      const result = await detectSynergiesAsync(deck);
+
+      // jsdom provides no `Worker`, so the real client exposes no proxy and
+      // the dynamic import path resolves to null → main-thread fallback.
+      expect(result).toEqual(mainThreadResult);
+    });
+  });
+
+  describe("ordering preservation", () => {
+    test("results remain sorted by score descending after the round-trip", async () => {
+      const result = await detectSynergiesAsync(deck);
+
+      const scores = result.map((s) => s.score);
+      const sorted = [...scores].sort((a, b) => b - a);
+      expect(scores).toEqual(sorted);
+    });
+  });
+});

--- a/src/ai/worker/ai-worker-client.ts
+++ b/src/ai/worker/ai-worker-client.ts
@@ -1,10 +1,16 @@
 import * as Comlink from "comlink";
-import type { AIWorkerAPI, EvaluateTriggerChainPayload } from "./worker-types";
+import type {
+  AIWorkerAPI,
+  EvaluateTriggerChainPayload,
+  DetectSynergiesPayload,
+} from "./worker-types";
 import type {
   CascadeContext,
   BoardPermanent,
   TriggerChain,
 } from "../trigger-chain-evaluator";
+import type { SynergyResult } from "../synergy-detector";
+import type { DeckCard } from "@/app/actions";
 
 /**
  * Main Thread Client for AI Web Worker
@@ -94,6 +100,27 @@ class AIWorkerClient {
       maxDepth,
     };
     return this.proxy.evaluateTriggerChain(payload);
+  }
+
+  /**
+   * Offloads deck synergy detection to the AI Web Worker (#1079).
+   *
+   * Returns the worker-computed `SynergyResult[]`, or `null` when the worker is
+   * unavailable (no proxy / not a browser). Callers MUST treat `null` or a
+   * thrown error as "compute on the main thread" — the synergy worker bridge
+   * (`synergy-worker-bridge.ts`) centralizes that fallback so the coach never
+   * breaks if the worker fails to initialize or errors mid-call.
+   */
+  public async detectSynergies(
+    deck: DeckCard[],
+    minScore?: number,
+    maxResults?: number,
+  ): Promise<SynergyResult[] | null> {
+    if (!this.proxy) {
+      return null;
+    }
+    const payload: DetectSynergiesPayload = { deck, minScore, maxResults };
+    return this.proxy.detectSynergies(payload);
   }
 
   /**

--- a/src/ai/worker/ai-worker.ts
+++ b/src/ai/worker/ai-worker.ts
@@ -2,14 +2,17 @@ import * as Comlink from "comlink";
 import { evaluateGameState, quickScore } from "../game-state-evaluator";
 import { detectArchetype } from "../archetype-detector";
 import { evaluateTriggerChain as runTriggerChainEvaluation } from "../trigger-chain-evaluator";
+import { detectSynergies as runSynergyDetection } from "../synergy-detector";
 import type {
   AIWorkerAPI,
   AnalyzeStatePayload,
   CoachContextPayload,
   DigestedCoachContext,
   EvaluateTriggerChainPayload,
+  DetectSynergiesPayload,
 } from "./worker-types";
 import type { TriggerChain } from "../trigger-chain-evaluator";
+import type { SynergyResult } from "../synergy-detector";
 import type { DeckCard } from "@/app/actions";
 
 /**
@@ -132,6 +135,20 @@ export const aiWorker: AIWorkerAPI = {
   ): Promise<TriggerChain[]> {
     const { stackItem, battlefield, maxDepth } = payload;
     return runTriggerChainEvaluation(stackItem, battlefield, maxDepth);
+  },
+
+  /**
+   * Detects card-to-card synergies across an entire deck.
+   * The pure detector lives in `synergy-detector.ts` (which only imports a
+   * type and a plain-data synergy database) and has no DOM/main-thread
+   * dependencies, so it is safe to run inside the worker. Returns the exact
+   * same `SynergyResult[]` the in-thread detector produces.
+   */
+  async detectSynergies(
+    payload: DetectSynergiesPayload,
+  ): Promise<SynergyResult[]> {
+    const { deck, minScore, maxResults } = payload;
+    return runSynergyDetection(deck, minScore, maxResults);
   },
 };
 

--- a/src/ai/worker/synergy-worker-bridge.ts
+++ b/src/ai/worker/synergy-worker-bridge.ts
@@ -1,0 +1,131 @@
+/**
+ * @fileoverview Synergy worker bridge (issue #1079)
+ *
+ * Synergy detection (`synergy-detector.ts`) scores card-to-card synergy across
+ * an entire deck and is CPU-heavy. It previously ran synchronously on the main
+ * thread during deck-coach analysis, causing jank on 60+ card decks.
+ *
+ * This module is the single seam that routes that detection through the AI
+ * Web Worker when it is available, and falls back to identical main-thread
+ * computation when it is not — so the coach keeps functioning even if the
+ * worker fails to initialize or errors mid-call.
+ *
+ * It deliberately mirrors `trigger-chain-worker-bridge.ts` (#1080), which is
+ * the established convention for offloading CPU-heavy AI compute to the worker:
+ *
+ * Design notes:
+ * - The real worker client (`ai-worker-client.ts`) resolves its worker URL with
+ *   `import.meta.url`, which cannot be statically `require()`d under ts-jest /
+ *   Node CommonJS (`SyntaxError: Cannot use 'import.meta' outside a module`).
+ *   To keep this module (and every caller, e.g. `coach-deck-analysis.ts`,
+ *   `coach-context-prefetch.ts`) Jest-safe, the client is loaded with a dynamic
+ *   `import()` wrapped in try/catch — any failure simply activates the
+ *   main-thread fallback.
+ * - The client resolver is injectable (`_setSynergyClientResolver`) so the
+ *   worker path and the fallback path can be unit-tested without a real
+ *   `Worker` global (jsdom does not provide one).
+ * - Synergy results are order-sensitive (sorted by score descending). Callers
+ *   `await` the full result before proceeding, so ordering is preserved
+ *   end-to-end.
+ */
+
+import { detectSynergies as detectSynergiesOnMain } from "../synergy-detector";
+import type { SynergyResult } from "../synergy-detector";
+import type { DeckCard } from "@/app/actions";
+
+/**
+ * Minimal shape of the AI worker client surface this bridge needs.
+ * Declared locally (rather than importing the real client type) so tests can
+ * inject a plain stub and stay decoupled from the import.meta-based client.
+ */
+export interface SynergyWorkerClient {
+  detectSynergies(
+    deck: DeckCard[],
+    minScore?: number,
+    maxResults?: number,
+  ): Promise<SynergyResult[] | null>;
+}
+
+export type SynergyClientResolver = () => Promise<SynergyWorkerClient | null>;
+
+let fallbackWarningLogged = false;
+
+/**
+ * Default resolver: lazily dynamic-import the real client (browser / Next.js).
+ * Dynamic import keeps this module Jest-safe — see fileoverview.
+ */
+const defaultResolver: SynergyClientResolver = async () => {
+  try {
+    const mod = await import("./ai-worker-client");
+    return mod.aiWorkerClient as unknown as SynergyWorkerClient;
+  } catch {
+    return null;
+  }
+};
+
+let clientResolver: SynergyClientResolver = defaultResolver;
+
+/**
+ * Replace the client resolver. @internal — used by unit tests to inject a stub
+ * worker client and exercise both the worker path and the fallback path.
+ */
+export function _setSynergyClientResolver(
+  resolver: SynergyClientResolver,
+): void {
+  clientResolver = resolver;
+}
+
+/**
+ * Restore the default client resolver and reset the one-shot fallback warning.
+ * @internal — call this in `afterEach` of tests that use the setter.
+ */
+export function _resetSynergyClientResolver(): void {
+  clientResolver = defaultResolver;
+  fallbackWarningLogged = false;
+}
+
+/**
+ * Detect synergies off the main thread when the AI worker is available;
+ * otherwise compute on the main thread with identical results.
+ *
+ * Guarantees:
+ * - The returned `SynergyResult[]` is value-identical to a direct
+ *   `detectSynergies()` call (worker path forwards the same result).
+ * - Order-sensitive: the full, score-sorted result list is resolved before
+ *   this resolves, so callers that `await` preserve ordering.
+ * - Never throws due to worker unavailability: any resolver/client error is
+ *   swallowed and routed to the main-thread fallback.
+ */
+export async function detectSynergiesAsync(
+  deck: DeckCard[],
+  minScore?: number,
+  maxResults?: number,
+): Promise<SynergyResult[]> {
+  let client: SynergyWorkerClient | null = null;
+  try {
+    client = await clientResolver();
+  } catch {
+    client = null;
+  }
+
+  if (client) {
+    try {
+      const result = await client.detectSynergies(deck, minScore, maxResults);
+      if (result) {
+        return result;
+      }
+    } catch (error) {
+      // Worker present but errored (or returned nothing usable): fall through
+      // to main-thread compute. Warn once to avoid log spam on tight loops.
+      if (!fallbackWarningLogged) {
+        console.warn(
+          "[synergy] AI worker detection failed; falling back to main thread:",
+          error,
+        );
+        fallbackWarningLogged = true;
+      }
+    }
+  }
+
+  return detectSynergiesOnMain(deck, minScore, maxResults);
+}

--- a/src/ai/worker/worker-types.ts
+++ b/src/ai/worker/worker-types.ts
@@ -5,6 +5,8 @@ import type {
   BoardPermanent,
   TriggerChain,
 } from "@/ai/trigger-chain-evaluator";
+import type { SynergyResult } from "@/ai/synergy-detector";
+import type { DeckCard } from "@/app/actions";
 
 /**
  * Actions that the AI Worker can perform.
@@ -17,6 +19,7 @@ export enum AIWorkerAction {
   DETECT_ARCHETYPE = "DETECT_ARCHETYPE",
   PREPARE_COACH_CONTEXT = "PREPARE_COACH_CONTEXT",
   EVALUATE_TRIGGER_CHAIN = "EVALUATE_TRIGGER_CHAIN",
+  DETECT_SYNERGIES = "DETECT_SYNERGIES",
 }
 
 /**
@@ -83,6 +86,24 @@ export interface EvaluateTriggerChainPayload {
 }
 
 /**
+ * Payload for offloading deck synergy detection to the worker.
+ *
+ * Synergy detection (`synergy-detector.ts`) scores card-to-card synergy across
+ * an entire deck and is CPU-heavy. It previously ran synchronously on the main
+ * thread during deck-coach analysis, causing jank on 60+ card decks. Offloading
+ * it to the AI Web Worker keeps the UI responsive (issue #1079).
+ *
+ * All fields are structured-cloneable plain data (a plain deck card list +
+ * scoring options) so they can be posted to the worker via Comlink. The
+ * detector itself has no DOM/main-thread dependencies.
+ */
+export interface DetectSynergiesPayload {
+  deck: DeckCard[];
+  minScore?: number;
+  maxResults?: number;
+}
+
+/**
  * Response from the AI Worker.
  */
 export interface AIWorkerResponse<T = unknown> {
@@ -134,4 +155,12 @@ export interface AIWorkerAPI {
   evaluateTriggerChain(
     payload: EvaluateTriggerChainPayload,
   ): Promise<TriggerChain[]>;
+
+  /**
+   * Detects card-to-card synergies across an entire deck. Offloaded from the
+   * main thread to keep deck-coach analysis responsive (#1079). Returns the
+   * exact `SynergyResult[]` the in-thread detector would produce (no behavior
+   * change), so callers can treat the result identically.
+   */
+  detectSynergies(payload: DetectSynergiesPayload): Promise<SynergyResult[]>;
 }


### PR DESCRIPTION
## Summary

Offloads CPU-heavy deck **synergy detection** (`detectSynergies`) off the main thread and into the AI Web Worker, eliminating UI jank during deck-coach analysis on 60+ card decks. Mirrors the established worker-bridge convention from #1080/#1173 (trigger-chain offloading) exactly.

Resolves #1079.

## What changed

Synergy scoring (`src/ai/synergy-detector.ts`) is fully deterministic and CPU-heavy. It previously ran synchronously on the main thread during deck-coach analysis. This PR routes it through the AI Web Worker via a new bridge, with an **identical-result main-thread fallback** if the worker is unavailable or errors.

**Worker protocol + handler + client** (mirrors `evaluateTriggerChain`):
- `worker-types.ts` — `DETECT_SYNERGIES` action, `DetectSynergiesPayload`, `detectSynergies()` on `AIWorkerAPI`.
- `ai-worker.ts` — pure `detectSynergies` handler (detector is worker-safe: only a type import + a plain-data synergy database).
- `ai-worker-client.ts` — `detectSynergies()` RPC (returns `null` when no proxy).

**Bridge** (new — mirrors `trigger-chain-worker-bridge.ts`):
- `synergy-worker-bridge.ts` — `detectSynergiesAsync()`: routes to worker, falls back to identical main-thread compute, Jest-safe dynamic `import()` of the client, one-shot fallback warning, injectable resolver for tests.

**Callers wired through the bridge**:
- `coach-deck-analysis.ts` — `buildStructuredDeckAnalysis` is now async and resolves synergies via the bridge.
- `coach-context-prefetch.ts` — the latency-critical async path resolves synergies via the bridge inside the existing `Promise.all` (parallelism preserved).

## Why it mirrors #1080

`evaluateTriggerChain` → `detectSynergies` follow the same seam: typed action → pure worker handler → client RPC → bridge (dynamic import + fallback + injectable resolver) → async caller. Consistency with that merged PR was the primary design constraint.

## Parity & fallback

- The worker returns the **exact** `SynergyResult[]` the in-thread detector produces (byte-for-byte, including score-desc ordering). No behavior change.
- Any worker unavailability/init error/mid-call error is swallowed and routed to main-thread compute (logged once).

## Test plan

- [x] `ai-worker-synergy.test.ts` — worker handler **parity** vs in-thread detector across tribal / multi-synergy / stress (100-card) / empty / no-synergy decks; `minScore` + `maxResults` honored identically; ordering preserved.
- [x] `synergy-worker-bridge.test.ts` — client invocation (forwards, no recompute, forwards args), **fallback** (null client / worker error / null result / resolver throw), one-shot warning, ordering, default-resolver degradation in jsdom.
- [x] `coach-deck-analysis.test.ts` + `coach-context-prefetch.test.ts` — updated for the async builder; parallel-vs-serial output parity still holds.
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] Full suite: **275 suites / 5624 tests pass, 0 failures**

## Notes / scope

- Action named `DETECT_SYNERGIES` (method `detectSynergies`) to mirror the `evaluateTriggerChain` ↔ `EVALUATE_TRIGGER_CHAIN` mapping exactly (issue/task used singular shorthand).
- `detectMissingSynergies` is intentionally **not** offloaded here — #1079 targets the scoring hot path; offloading the missing-synergy pass is a separate concern.
- `src/lib/heuristic-deck-coach.ts` still calls `detectSynergies` synchronously; it is a separate heuristic coach outside the deck-coach-analysis pipeline and is left as a follow-up to avoid unrelated async propagation.
- Real 60fps measurement requires a browser; parity/stress tests guarantee offloading is behavior-preserving.