### PR TITLE
feat(ai-coach): resolve #1074 — persist coaching conversations and deck context across sessions in IndexedDB

### DIFF
--- a/src/app/(app)/deck-coach/page.tsx
+++ b/src/app/(app)/deck-coach/page.tsx
@@ -19,7 +19,15 @@ import {
   analyzeMetaAndSuggest,
   type MetaAnalysisOutput,
 } from "@/ai/flows/ai-meta-analysis";
-import { Bot, Loader2, TrendingUp, MessageSquare } from "lucide-react";
+import {
+  Bot,
+  Loader2,
+  TrendingUp,
+  MessageSquare,
+  History,
+  Plus,
+  Trash2,
+} from "lucide-react";
 import { EnhancedReviewDisplay } from "./_components/enhanced-review-display";
 import { MetaAnalysisDisplay } from "./_components/meta-analysis-display";
 import {
@@ -40,6 +48,7 @@ import {
 import { ManaCurveAnalysis } from "@/components/meta/mana-curve";
 import { DeckCoachChatPanel } from "@/components/chat";
 import { useDeckCoachChat } from "@/hooks/use-deck-coach-chat";
+import { DEFAULT_DECK_ID } from "@/lib/coach-conversation-storage";
 
 type DeckOption = DeckReviewOutput["deckOptions"][0];
 
@@ -61,13 +70,30 @@ export default function DeckCoachPage() {
   const [, setSavedDecks] = useLocalStorage<SavedDeck[]>("saved-decks", []);
   const { toast } = useToast();
 
-  // Chat state for conversational AI
+  // The deck currently loaded into the coach (id of the selected saved deck, or
+  // "default" when working from a pasted decklist). Coach conversations are
+  // scoped to this id so history is per-deck (issue #1074).
+  const [selectedDeckId, setSelectedDeckId] = useState<string>(DEFAULT_DECK_ID);
+
+  // Chat state for conversational AI. Passing format + deck cards means each
+  // persisted conversation carries its deck context and can be resumed
+  // self-contained (issue #1074).
   const {
     messages,
     isLoading: isChatLoading,
     sendMessage,
     cancelGeneration,
-  } = useDeckCoachChat();
+    conversations,
+    activeConversationId,
+    storageNotice,
+    resumeConversation,
+    startNewConversation,
+    removeConversation,
+  } = useDeckCoachChat({
+    deckId: selectedDeckId,
+    format,
+    deckCards: originalDeckCards ?? undefined,
+  });
 
   const handleAnalyzeDeck = (type: "review" | "meta") => {
     if (decklist.trim().length === 0) {
@@ -145,6 +171,7 @@ export default function DeckCoachPage() {
 
   const handleDeckSelect = (deck: SavedDeck) => {
     setFormat(deck.format);
+    setSelectedDeckId(deck.id);
     const decklistStr = deck.cards
       .map((c) => `${c.count} ${c.name}`)
       .join("\n");
@@ -393,6 +420,9 @@ export default function DeckCoachPage() {
               onChange={(e) => {
                 setDecklist(e.target.value);
                 setOriginalDeckCards(null);
+                // Editing the decklist detaches from any saved deck; scope
+                // coach history back to the default bucket (issue #1074).
+                setSelectedDeckId(DEFAULT_DECK_ID);
               }}
               disabled={isPending}
             />
@@ -489,12 +519,83 @@ export default function DeckCoachPage() {
 
           {/* Chat Interface */}
           {analysisType === "chat" && (
-            <DeckCoachChatPanel
-              messages={messages}
-              isLoading={isChatLoading}
-              onSendMessage={handleChatMessage}
-              onCancel={cancelGeneration}
-            />
+            <div className="flex flex-col gap-3">
+              {/* Storage degradation notice (quota / unavailable). Non-blocking:
+                  the coach keeps working in-session (issue #1074/#1085). */}
+              {storageNotice && (
+                <div
+                  role="status"
+                  aria-live="polite"
+                  className="rounded-md border border-yellow-500/40 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-900 dark:text-yellow-200"
+                >
+                  {storageNotice}
+                </div>
+              )}
+
+              {/* Conversation history: resume or delete prior sessions, or start
+                  a new one. Persists across refresh/restart via IndexedDB
+                  (issue #1074). */}
+              {conversations.length > 0 && (
+                <div className="rounded-md border bg-card/60 p-2">
+                  <div className="mb-2 flex items-center gap-2 px-1">
+                    <History className="h-3.5 w-3.5 text-muted-foreground" />
+                    <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                      Recent conversations
+                    </span>
+                    <button
+                      type="button"
+                      onClick={startNewConversation}
+                      className="ml-auto inline-flex items-center gap-1 rounded-md border border-input bg-background px-2 py-1 text-[11px] font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+                      title="Start a new conversation"
+                    >
+                      <Plus className="h-3 w-3" aria-hidden="true" />
+                      New
+                    </button>
+                  </div>
+                  <ul className="max-h-32 space-y-1 overflow-y-auto pr-1">
+                    {conversations.map((conv) => {
+                      const active = conv.id === activeConversationId;
+                      return (
+                        <li key={conv.id}>
+                          <div
+                            className={`group flex items-center gap-1 rounded-md px-2 py-1 text-xs ${
+                              active
+                                ? "bg-primary/10 text-primary"
+                                : "hover:bg-accent/50"
+                            }`}
+                          >
+                            <button
+                              type="button"
+                              onClick={() => resumeConversation(conv.id)}
+                              className="flex-1 truncate text-left"
+                              title={conv.title}
+                            >
+                              {conv.title}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => removeConversation(conv.id)}
+                              className="invisible inline-flex items-center rounded p-1 text-muted-foreground hover:text-destructive group-hover:visible"
+                              aria-label={`Delete conversation: ${conv.title}`}
+                              title="Delete conversation"
+                            >
+                              <Trash2 className="h-3 w-3" aria-hidden="true" />
+                            </button>
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              )}
+
+              <DeckCoachChatPanel
+                messages={messages}
+                isLoading={isChatLoading}
+                onSendMessage={handleChatMessage}
+                onCancel={cancelGeneration}
+              />
+            </div>
           )}
 
           {/* Empty state */}

--- a/src/hooks/__tests__/use-deck-coach-chat.test.ts
+++ b/src/hooks/__tests__/use-deck-coach-chat.test.ts
@@ -18,7 +18,10 @@ import {
   beforeAll,
 } from "@jest/globals";
 import { renderHook, act } from "@testing-library/react";
-import { useDeckCoachChat } from "../use-deck-coach-chat";
+import {
+  useDeckCoachChat,
+  clearAllCoachConversations,
+} from "../use-deck-coach-chat";
 
 jest.mock("@/ai/worker/ai-worker-client", () => ({
   aiWorkerClient: { api: null },
@@ -67,10 +70,13 @@ const flush = () => new Promise<void>((r) => setTimeout(r, 0));
 let lastFetchOptions: { signal?: AbortSignal | null } = {};
 let lastRequestBody: { messages?: unknown[]; format?: string } = {};
 
-beforeEach(() => {
+beforeEach(async () => {
   lastFetchOptions = {};
   lastRequestBody = {};
-  // The hook persists history to localStorage; clear it so tests are isolated.
+  // The hook persists conversations to IndexedDB (issue #1074); clear the store
+  // so each test starts isolated and a prior test's conversation is never
+  // auto-resumed into the next one.
+  await clearAllCoachConversations();
   localStorage.clear();
   (globalThis as unknown as { fetch: unknown }).fetch = jest.fn(
     async (_url: string, init?: RequestInit) => {
@@ -208,5 +214,177 @@ describe("useDeckCoachChat — cancel/abort", () => {
       (m) => m.role === "assistant",
     );
     expect(assistant?.content).toContain("Hel");
+  });
+});
+
+describe("useDeckCoachChat — IndexedDB persistence (#1074)", () => {
+  it("persists a completed conversation and resumes it after a simulated reload", async () => {
+    // First "session": send a message and let the stream complete.
+    const first = renderHook(() =>
+      useDeckCoachChat({ format: "modern", deckId: "deck-z" }),
+    );
+    await act(async () => {
+      await first.result.current.sendMessage("how do I sideboard?", {
+        deckCards: [{ name: "Sol Ring", count: 1 } as never],
+      });
+    });
+    // The finalized assistant message must be present before we tear down.
+    expect(
+      first.result.current.messages.some((m) => m.role === "assistant"),
+    ).toBe(true);
+    first.unmount();
+
+    // Simulate a page reload: a brand-new hook instance mounts and its
+    // auto-resume effect should load the most-recent conversation.
+    const reloaded = renderHook(() =>
+      useDeckCoachChat({ format: "modern", deckId: "deck-z" }),
+    );
+    await act(async () => {
+      await flush();
+      await flush();
+    });
+
+    const restored = reloaded.result.current.messages;
+    expect(restored.length).toBeGreaterThanOrEqual(2);
+    expect(restored.some((m) => m.content === "how do I sideboard?")).toBe(
+      true,
+    );
+    expect(restored.some((m) => m.content === "Hello")).toBe(true);
+    // The resumed conversation is the active one.
+    expect(reloaded.result.current.activeConversationId).not.toBeNull();
+    expect(reloaded.result.current.conversations.length).toBeGreaterThanOrEqual(
+      1,
+    );
+    reloaded.unmount();
+  });
+
+  it("saves streaming-era fields once the assistant message completes", async () => {
+    const { result } = renderHook(() =>
+      useDeckCoachChat({ format: "modern", deckId: "deck-fields" }),
+    );
+    await act(async () => {
+      await result.current.sendMessage("hi", {
+        deckCards: [{ name: "Sol Ring", count: 1 } as never],
+      });
+    });
+
+    const assistant = result.current.messages.find(
+      (m) => m.role === "assistant",
+    );
+    expect(assistant?.provider).toBe("openai");
+    expect(assistant?.usage?.totalTokens).toBe(4);
+
+    // Read the persisted conversation directly and assert the finalized fields
+    // (provider/usage) were written — i.e. we saved once on completion, not
+    // per token.
+    const { loadMostRecentConversation } =
+      await import("@/lib/coach-conversation-storage");
+    const persisted = await loadMostRecentConversation("deck-fields");
+    expect(persisted).not.toBeNull();
+    const persistedAssistant = persisted!.messages.find(
+      (m) => m.role === "assistant",
+    );
+    expect(persistedAssistant?.provider).toBe("openai");
+    expect(persistedAssistant?.usage?.totalTokens).toBe(4);
+  });
+
+  it("resumes a past conversation via resumeConversation", async () => {
+    // Seed two conversations for the deck.
+    const seed = renderHook(() =>
+      useDeckCoachChat({ format: "modern", deckId: "deck-resume" }),
+    );
+    await act(async () => {
+      await seed.result.current.sendMessage("first question", {
+        deckCards: [{ name: "Sol Ring", count: 1 } as never],
+      });
+    });
+    const firstId = seed.result.current.activeConversationId;
+    seed.unmount();
+
+    const seed2 = renderHook(() =>
+      useDeckCoachChat({ format: "modern", deckId: "deck-resume" }),
+    );
+    // Auto-resume loaded the most recent (firstId); start a fresh conversation
+    // and complete it so a second persisted conversation exists.
+    await act(async () => {
+      seed2.result.current.startNewConversation();
+      await flush();
+    });
+    await act(async () => {
+      await seed2.result.current.sendMessage("second question", {
+        deckCards: [{ name: "Sol Ring", count: 1 } as never],
+      });
+    });
+    const secondId = seed2.result.current.activeConversationId;
+    expect(secondId).not.toBe(firstId);
+    seed2.unmount();
+
+    // Mount again and explicitly resume the FIRST conversation.
+    const app = renderHook(() =>
+      useDeckCoachChat({ format: "modern", deckId: "deck-resume" }),
+    );
+    await act(async () => {
+      await flush();
+      await flush();
+    });
+
+    await act(async () => {
+      await app.result.current.resumeConversation(firstId!);
+      await flush();
+    });
+    expect(app.result.current.activeConversationId).toBe(firstId);
+    expect(
+      app.result.current.messages.some((m) => m.content === "first question"),
+    ).toBe(true);
+    app.unmount();
+  });
+
+  it("degrades gracefully on quota errors (no crash, surfaces a notice)", async () => {
+    // Force every IndexedDB put to reject with a quota error for this test.
+    // Return a fake request that fires ONLY onerror so the storage layer
+    // classifies + rejects (the real fake-indexeddb request would otherwise
+    // fire onsuccess first).
+    const realPut = IDBObjectStore.prototype.put;
+    const quotaError = new DOMException(
+      "The quota has been exceeded",
+      "QuotaExceededError",
+    );
+    IDBObjectStore.prototype.put = function () {
+      const fakeReq: {
+        error: unknown;
+        onsuccess: ((ev: Event) => void) | null;
+        onerror: ((ev: Event) => void) | null;
+      } = { error: null, onsuccess: null, onerror: null };
+      setTimeout(() => {
+        fakeReq.error = quotaError;
+        if (typeof fakeReq.onerror === "function") {
+          fakeReq.onerror(new Event("error"));
+        }
+      }, 0);
+      return fakeReq as unknown as IDBRequest;
+    };
+
+    try {
+      const { result } = renderHook(() =>
+        useDeckCoachChat({ format: "modern", deckId: "deck-quota" }),
+      );
+
+      // The send must not throw even though persistence fails.
+      await act(async () => {
+        await result.current.sendMessage("hello", {
+          deckCards: [{ name: "Sol Ring", count: 1 } as never],
+        });
+      });
+
+      // The assistant message still rendered in-session.
+      expect(result.current.messages.some((m) => m.role === "assistant")).toBe(
+        true,
+      );
+      // A non-null storage notice surfaced the degraded persistence.
+      expect(result.current.storageNotice).not.toBeNull();
+      expect(result.current.storageNotice).toMatch(/save/i);
+    } finally {
+      IDBObjectStore.prototype.put = realPut;
+    }
   });
 });

--- a/src/hooks/use-deck-coach-chat.ts
+++ b/src/hooks/use-deck-coach-chat.ts
@@ -9,6 +9,25 @@ import type {
 import { DeckCard } from "@/ai/flows/context-builder";
 import { aiWorkerClient } from "@/ai/worker/ai-worker-client";
 import type { DigestedCoachContext } from "@/ai/worker/worker-types";
+import {
+  COACH_CONVERSATION_STORE,
+  DEFAULT_DECK_ID,
+  type CoachConversation,
+  type CoachConversationDeckContext,
+  clearAllCoachConversations,
+  createConversationRecord,
+  deleteConversation,
+  deleteConversationsForDeck,
+  deriveConversationTitle,
+  loadConversation,
+  loadConversations,
+  loadMostRecentConversation,
+  saveConversation,
+} from "@/lib/coach-conversation-storage";
+import {
+  isQuotaExceededError,
+  type QuotaExceededError,
+} from "@/lib/storage-quota";
 
 const BASE_STORAGE_KEY = "deck-coach-chat-history";
 
@@ -55,37 +74,10 @@ function parseSseEvent(rawEvent: string): CoachStreamEventPayload | null {
   }
 }
 
+/** Legacy localStorage key helper (kept only to clear stale pre-#1074 data). */
 function getStorageKey(deckId?: string): string {
   if (!deckId) return BASE_STORAGE_KEY;
   return `${BASE_STORAGE_KEY}-${deckId}`;
-}
-
-function loadFromStorage(deckId?: string): ChatMessage[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const key = getStorageKey(deckId);
-    const stored = localStorage.getItem(key);
-    if (stored) {
-      const parsed = JSON.parse(stored);
-      return parsed.map((m: ChatMessage) => ({
-        ...m,
-        timestamp: new Date(m.timestamp),
-      }));
-    }
-  } catch (e) {
-    console.error("Failed to load chat history:", e);
-  }
-  return [];
-}
-
-function saveToStorage(messages: ChatMessage[], deckId?: string) {
-  if (typeof window === "undefined") return;
-  try {
-    const key = getStorageKey(deckId);
-    localStorage.setItem(key, JSON.stringify(messages));
-  } catch (e) {
-    console.error("Failed to save chat history:", e);
-  }
 }
 
 export interface UseDeckCoachChatOptions {
@@ -94,18 +86,34 @@ export interface UseDeckCoachChatOptions {
   format?: string;
   archetype?: string;
   strategy?: string;
-  deckId?: string; // Add deckId for isolation
+  deckId?: string; // Scope conversations to a deck; "default" when unset.
 }
 
 export interface UseDeckCoachChatReturn {
   messages: ChatMessage[];
   isLoading: boolean;
   isStreaming: boolean;
+  /** Persisted conversations for the active deck, newest-first. */
+  conversations: CoachConversation[];
+  /** id of the conversation currently loaded into the chat, if any. */
+  activeConversationId: string | null;
+  /**
+   * Human-readable storage notice when persistence is degraded (e.g. quota
+   * exceeded). `null` when persistence is healthy. The in-session coach keeps
+   * working regardless — this is purely informational (issue #1074/#1085).
+   */
+  storageNotice: string | null;
   sendMessage: (content: string, options?: ChatRequestOptions) => Promise<void>;
   cancelGeneration: () => void;
   addAssistantMessage: (content: string) => void;
   clearMessages: () => void;
   setLoading: (loading: boolean) => void;
+  /** Load a past conversation into the chat (resume). */
+  resumeConversation: (conversationId: string) => Promise<void>;
+  /** Start a fresh conversation (clears the chat; next send creates a record). */
+  startNewConversation: () => void;
+  /** Delete a persisted conversation by id. */
+  removeConversation: (conversationId: string) => Promise<void>;
 }
 
 export interface ChatRequestOptions {
@@ -122,46 +130,205 @@ export function useDeckCoachChat(
 ): UseDeckCoachChatReturn {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [conversations, setConversations] = useState<CoachConversation[]>([]);
+  const [activeConversationId, setActiveConversationId] = useState<
+    string | null
+  >(null);
+  const [storageNotice, setStorageNotice] = useState<string | null>(null);
+
   const messagesRef = useRef(messages);
   const deckIdRef = useRef(options.deckId);
+  /** Live deck context (format/archetype/strategy/cards) from options/overrides. */
+  const deckContextRef = useRef<CoachConversationDeckContext>({});
+  /** id of the conversation currently loaded into the chat. */
+  const activeConversationIdRef = useRef<string | null>(null);
+  /** True once the user has interacted (sent/resumed/started/cleared). */
+  const interactedRef = useRef(false);
+  /** True once the initial auto-resume has run for the current deck. */
+  const hydratedRef = useRef(false);
+
   /**
    * AbortController for the in-flight coach stream. The Cancel button aborts
    * it; the fetch rejects with an AbortError which the stream loop treats as a
    * user-initiated stop rather than a failure (issue #1077).
    */
   const abortControllerRef = useRef<AbortController | null>(null);
-  /** Id of the assistant message currently being streamed into. */
+  /** id of the assistant message currently being streamed into. */
   const streamingMessageIdRef = useRef<string | null>(null);
 
-  // Load messages when deckId changes
-  useEffect(() => {
-    const stored = loadFromStorage(options.deckId);
-    setMessages(stored.length > 0 ? stored : (options.initialMessages ?? []));
-    deckIdRef.current = options.deckId;
-  }, [options.deckId, options.initialMessages]);
+  /**
+   * Apply a messages update and keep {@link messagesRef} in sync *synchronously*.
+   *
+   * React's state is asynchronous, and an effect-based ref mirror only runs
+   * after commit — too late for `persistCurrent`, which reads the ref inside
+   * `sendMessage`'s `finally` before effects flush. Updating the ref here (from
+   * the previous ref value, not the updater's `prev`) keeps it deterministic so
+   * the finalized assistant message (provider/usage/cancelled) is captured by
+   * the single post-completion write (issue #1074).
+   */
+  const updateMessages = useCallback(
+    (updater: (prev: ChatMessage[]) => ChatMessage[]) => {
+      const next = updater(messagesRef.current);
+      messagesRef.current = next;
+      setMessages(next);
+    },
+    [],
+  );
 
-  // Keep ref in sync
-  useEffect(() => {
-    messagesRef.current = messages;
-  }, [messages]);
+  /** Resolve the effective deck id for the current scope. */
+  const getDeckId = useCallback(() => deckIdRef.current || DEFAULT_DECK_ID, []);
 
-  // Persist to localStorage
-  useEffect(() => {
-    if (messages.length > 0) {
-      saveToStorage(messages, deckIdRef.current);
-    }
-  }, [messages]);
-
-  const addMessage = useCallback((content: string, role: ChatMessageRole) => {
-    const newMessage: ChatMessage = {
-      id: crypto.randomUUID(),
-      role,
-      content,
-      timestamp: new Date(),
+  /** Sync the latest option-supplied deck context into the ref. */
+  const refreshDeckContext = useCallback(() => {
+    deckContextRef.current = {
+      format: options.format,
+      archetype: options.archetype,
+      strategy: options.strategy,
+      deckCards: options.deckCards,
     };
-    setMessages((prev) => [...prev, newMessage]);
-    return newMessage;
-  }, []);
+  }, [options.format, options.archetype, options.strategy, options.deckCards]);
+
+  /** Refresh the persisted-conversation list for the active deck. */
+  const refreshConversations = useCallback(async () => {
+    const list = await loadConversations(getDeckId());
+    setConversations(list);
+  }, [getDeckId]);
+
+  // messagesRef is kept synchronously in sync by `updateMessages` (see below);
+  // no effect-based mirror is needed.
+
+  /**
+   * Persist the current chat state (messages + live deck context) to IndexedDB.
+   * Creates a conversation record on first save and updates it thereafter.
+   * Quota errors surface as a `storageNotice` and never throw (issue #1074).
+   */
+  const persistCurrent = useCallback(async () => {
+    const currentMessages = messagesRef.current;
+    // Nothing meaningful to persist yet (no user content).
+    if (currentMessages.length === 0) return;
+
+    refreshDeckContext();
+    const now = new Date().toISOString();
+    const existingId = activeConversationIdRef.current;
+
+    let record: CoachConversation;
+    if (existingId) {
+      const existing = await loadConversation(existingId);
+      record = existing
+        ? {
+            ...existing,
+            title: deriveConversationTitle(currentMessages),
+            deckContext: deckContextRef.current,
+            messages: currentMessages,
+            updatedAt: now,
+          }
+        : createConversationRecord({
+            id: existingId,
+            deckId: getDeckId(),
+            messages: currentMessages,
+            deckContext: deckContextRef.current,
+            now: new Date(now),
+          });
+    } else {
+      const newId = crypto.randomUUID();
+      activeConversationIdRef.current = newId;
+      record = createConversationRecord({
+        id: newId,
+        deckId: getDeckId(),
+        messages: currentMessages,
+        deckContext: deckContextRef.current,
+        now: new Date(now),
+      });
+    }
+
+    const result = await saveConversation(record);
+    if (!result.ok) {
+      if (isQuotaExceededError(result.error)) {
+        const storeName = (result.error as QuotaExceededError).storeName;
+        setStorageNotice(
+          `Storage is full — this conversation isn't being saved, but the coach still works this session.` +
+            (storeName ? ` (${storeName})` : ""),
+        );
+      } else {
+        setStorageNotice(
+          "Couldn't save this conversation locally — the coach still works this session.",
+        );
+      }
+      return;
+    }
+    // Healthy write: clear any prior notice and refresh the sidebar list.
+    setStorageNotice(null);
+    await refreshConversations();
+    setActiveConversationId(activeConversationIdRef.current);
+  }, [getDeckId, refreshConversations, refreshDeckContext]);
+
+  // Load most-recent conversation + list when deckId changes (auto-resume).
+  useEffect(() => {
+    let cancelled = false;
+    hydratedRef.current = false;
+    interactedRef.current = false;
+    deckIdRef.current = options.deckId;
+    refreshDeckContext();
+
+    (async () => {
+      // Clear stale legacy localStorage history from pre-#1074 builds.
+      if (typeof window !== "undefined") {
+        try {
+          localStorage.removeItem(getStorageKey(options.deckId));
+        } catch {
+          /* ignore */
+        }
+      }
+
+      const [recent, list] = await Promise.all([
+        loadMostRecentConversation(options.deckId || DEFAULT_DECK_ID),
+        loadConversations(options.deckId || DEFAULT_DECK_ID),
+      ]);
+      if (cancelled) return;
+
+      setConversations(list);
+      // Race guard: if the user started interacting before this async load
+      // resolved (e.g. sent a message immediately on mount), do NOT clobber
+      // their in-progress state with the resumed history (issue #1074).
+      if (interactedRef.current) {
+        hydratedRef.current = true;
+        return;
+      }
+      if (recent && recent.messages.length > 0) {
+        activeConversationIdRef.current = recent.id;
+        setActiveConversationId(recent.id);
+        messagesRef.current = recent.messages;
+        setMessages(recent.messages);
+        deckContextRef.current = recent.deckContext ?? {};
+      } else {
+        activeConversationIdRef.current = null;
+        setActiveConversationId(null);
+        const initial = options.initialMessages ?? [];
+        messagesRef.current = initial;
+        setMessages(initial);
+      }
+      hydratedRef.current = true;
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [options.deckId]);
+
+  const addMessage = useCallback(
+    (content: string, role: ChatMessageRole) => {
+      const newMessage: ChatMessage = {
+        id: crypto.randomUUID(),
+        role,
+        content,
+        timestamp: new Date(),
+      };
+      updateMessages((prev) => [...prev, newMessage]);
+      return newMessage;
+    },
+    [updateMessages],
+  );
 
   const addAssistantMessage = useCallback(
     (content: string) => {
@@ -172,6 +339,8 @@ export function useDeckCoachChat(
 
   const sendMessage = useCallback(
     async (content: string, chatOptions: ChatRequestOptions = {}) => {
+      // Mark as interacted so a late auto-resume load can't clobber this turn.
+      interactedRef.current = true;
       // 1. Add user message
       const userMessage = addMessage(content, "user");
 
@@ -187,7 +356,7 @@ export function useDeckCoachChat(
         timestamp: new Date(),
       };
 
-      setMessages((prev) => [...prev, initialAssistantMsg]);
+      updateMessages((prev) => [...prev, initialAssistantMsg]);
       streamingMessageIdRef.current = assistantMsgId;
 
       // AbortController enables the Cancel button (issue #1077).
@@ -198,7 +367,7 @@ export function useDeckCoachChat(
       const patchAssistant = (patch: Partial<ChatMessage>) => {
         const id = streamingMessageIdRef.current;
         if (!id) return;
-        setMessages((prev) =>
+        updateMessages((prev) =>
           prev.map((msg) =>
             msg.id === id && msg.role === "assistant"
               ? { ...msg, ...patch }
@@ -207,6 +376,11 @@ export function useDeckCoachChat(
         );
       };
 
+      // Persist the user's message immediately so it survives a refresh even if
+      // the stream is interrupted mid-flight (issue #1074). The finalized
+      // assistant message is persisted again in `finally` below.
+      void persistCurrent();
+
       try {
         const currentDeckCards =
           chatOptions.deckCards || options.deckCards || [];
@@ -214,6 +388,13 @@ export function useDeckCoachChat(
           chatOptions.format || options.format || "commander";
         const currentArchetype = chatOptions.archetype || options.archetype;
         const currentStrategy = chatOptions.strategy || options.strategy;
+        // Update live context so the persisted snapshot reflects this turn.
+        deckContextRef.current = {
+          format: currentFormat,
+          archetype: currentArchetype,
+          strategy: currentStrategy,
+          deckCards: currentDeckCards,
+        };
 
         // Payload reduction: if the deck is large, use digested context
         let digestedContext: DigestedCoachContext | undefined;
@@ -344,7 +525,7 @@ export function useDeckCoachChat(
           patchAssistant({ cancelled: true });
         } else {
           console.error("Chat error:", error);
-          setMessages((prev) =>
+          updateMessages((prev) =>
             prev.map((msg) =>
               msg.id === assistantMsgId
                 ? {
@@ -359,14 +540,20 @@ export function useDeckCoachChat(
         abortControllerRef.current = null;
         streamingMessageIdRef.current = null;
         setIsLoading(false);
+        // Persist the finalized assistant message (with provider/usage/cancelled
+        // attached by the stream). This is the single post-completion write — we
+        // deliberately do NOT write on every streaming token (issue #1074).
+        await persistCurrent();
       }
     },
     [
       addMessage,
+      updateMessages,
       options.deckCards,
       options.format,
       options.archetype,
       options.strategy,
+      persistCurrent,
     ],
   );
 
@@ -381,18 +568,84 @@ export function useDeckCoachChat(
   }, []);
 
   const clearMessages = useCallback(() => {
+    interactedRef.current = true;
+    messagesRef.current = [];
     setMessages([]);
-    localStorage.removeItem(getStorageKey(deckIdRef.current));
+    const id = activeConversationIdRef.current;
+    activeConversationIdRef.current = null;
+    setActiveConversationId(null);
+    if (id) {
+      void deleteConversation(id).then(refreshConversations);
+    } else {
+      // No active record to delete; still clear any deck-scoped legacy data.
+      void deleteConversationsForDeck(getDeckId()).then(refreshConversations);
+    }
+  }, [getDeckId, refreshConversations]);
+
+  const resumeConversation = useCallback(async (conversationId: string) => {
+    interactedRef.current = true;
+    // Abort any in-flight stream before switching context.
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+    streamingMessageIdRef.current = null;
+    setIsLoading(false);
+
+    const conv = await loadConversation(conversationId);
+    if (!conv) return;
+    activeConversationIdRef.current = conv.id;
+    setActiveConversationId(conv.id);
+    messagesRef.current = conv.messages;
+    setMessages(conv.messages);
+    deckContextRef.current = conv.deckContext ?? {};
+    setStorageNotice(null);
   }, []);
+
+  const startNewConversation = useCallback(() => {
+    interactedRef.current = true;
+    // Abort any in-flight stream before starting fresh.
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+    streamingMessageIdRef.current = null;
+    setIsLoading(false);
+    activeConversationIdRef.current = null;
+    setActiveConversationId(null);
+    messagesRef.current = [];
+    setMessages([]);
+    setStorageNotice(null);
+  }, []);
+
+  const removeConversation = useCallback(
+    async (conversationId: string) => {
+      interactedRef.current = true;
+      await deleteConversation(conversationId);
+      if (activeConversationIdRef.current === conversationId) {
+        activeConversationIdRef.current = null;
+        setActiveConversationId(null);
+        messagesRef.current = [];
+        setMessages([]);
+      }
+      await refreshConversations();
+    },
+    [refreshConversations],
+  );
 
   return {
     messages,
     isLoading,
     isStreaming: isLoading,
+    conversations,
+    activeConversationId,
+    storageNotice,
     sendMessage,
     cancelGeneration,
     addAssistantMessage,
     clearMessages,
     setLoading: setIsLoading,
+    resumeConversation,
+    startNewConversation,
+    removeConversation,
   };
 }
+
+// Re-export store name + clearAll for tests/inspection.
+export { COACH_CONVERSATION_STORE, clearAllCoachConversations };

--- a/src/lib/__tests__/coach-conversation-storage.test.ts
+++ b/src/lib/__tests__/coach-conversation-storage.test.ts
@@ -1,0 +1,312 @@
+/**
+ * @fileoverview Tests for coach conversation IndexedDB persistence (issue #1074).
+ *
+ * Asserts the full local-first contract:
+ *  - save/load/delete round-trip
+ *  - persistence across a simulated reload (new storage read after "restart")
+ *  - deck context is stored alongside messages (self-contained resume)
+ *  - quota-exceeded writes degrade gracefully (no throw, typed result)
+ *  - listing is deck-scoped and newest-first
+ *  - auto-resume picks the most-recent conversation
+ *
+ * `fake-indexeddb` (loaded in jest.setup.js) backs the IndexedDB layer.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+import type { ChatMessage } from "@/types/chat";
+import {
+  COACH_CONVERSATION_STORE,
+  DEFAULT_DECK_ID,
+  clearAllCoachConversations,
+  createConversationRecord,
+  deleteConversation,
+  deleteConversationsForDeck,
+  deriveConversationTitle,
+  loadConversation,
+  loadConversations,
+  loadMostRecentConversation,
+  saveConversation,
+} from "../coach-conversation-storage";
+
+function msg(
+  partial: Partial<ChatMessage> & { role: ChatMessage["role"] },
+): ChatMessage {
+  return {
+    id: `m-${Math.random().toString(36).slice(2)}`,
+    content: "hello",
+    timestamp: new Date("2026-01-01T00:00:00Z"),
+    ...partial,
+  };
+}
+
+function makeConversation(
+  overrides: Partial<Parameters<typeof createConversationRecord>[0]> = {},
+) {
+  return createConversationRecord({
+    id: overrides.id ?? `c-${Math.random().toString(36).slice(2)}`,
+    deckId: overrides.deckId ?? DEFAULT_DECK_ID,
+    messages: overrides.messages ?? [
+      msg({ role: "user", content: "How do I beat aggro?" }),
+      msg({ role: "assistant", content: "Add more cheap interaction." }),
+    ],
+    deckContext: overrides.deckContext ?? {
+      format: "modern",
+      archetype: "control",
+      deckCards: [],
+    },
+    ...overrides,
+  });
+}
+
+describe("coach-conversation-storage", () => {
+  beforeEach(async () => {
+    await clearAllCoachConversations();
+  });
+
+  afterEach(async () => {
+    await clearAllCoachConversations();
+  });
+
+  describe("deriveConversationTitle", () => {
+    it("uses the first user message, trimmed to one line", () => {
+      const title = deriveConversationTitle([
+        msg({ role: "assistant", content: "hi" }),
+        msg({ role: "user", content: "  What   should I\nsideboard?  " }),
+      ]);
+      expect(title).toBe("What should I sideboard?");
+    });
+
+    it("truncates long titles with an ellipsis", () => {
+      const long = "x".repeat(120);
+      const title = deriveConversationTitle([
+        msg({ role: "user", content: long }),
+      ]);
+      expect(title.length).toBeLessThanOrEqual(61);
+      expect(title.endsWith("…")).toBe(true);
+    });
+
+    it("falls back to a default label when there is no user content", () => {
+      expect(deriveConversationTitle([])).toBe("New coaching session");
+      expect(
+        deriveConversationTitle([msg({ role: "assistant", content: "hi" })]),
+      ).toBe("New coaching session");
+    });
+  });
+
+  describe("save / load round-trip", () => {
+    it("persists a conversation and reads it back by id", async () => {
+      const conv = makeConversation({
+        deckContext: { format: "pioneer", archetype: "aggro" },
+      });
+      const result = await saveConversation(conv);
+      expect(result.ok).toBe(true);
+
+      const loaded = await loadConversation(conv.id);
+      expect(loaded).not.toBeNull();
+      expect(loaded!.id).toBe(conv.id);
+      expect(loaded!.deckId).toBe(conv.deckId);
+      expect(loaded!.messages).toHaveLength(2);
+      // Messages survive the structured-clone round-trip; timestamps normalize
+      // back into Date instances.
+      expect(loaded!.messages[0].role).toBe("user");
+      expect(loaded!.messages[0].content).toBe("How do I beat aggro?");
+      expect(loaded!.messages[0].timestamp).toBeInstanceOf(Date);
+    });
+
+    it("updates an existing conversation in place (idempotent put)", async () => {
+      const conv = makeConversation();
+      await saveConversation(conv);
+
+      const updated = {
+        ...conv,
+        messages: [...conv.messages, msg({ role: "user", content: "thanks" })],
+        updatedAt: new Date("2026-02-02T00:00:00Z").toISOString(),
+      };
+      await saveConversation(updated);
+
+      const list = await loadConversations(conv.deckId);
+      expect(list).toHaveLength(1);
+      expect(list[0].messages).toHaveLength(3);
+    });
+
+    it("round-trips streaming-era message fields (provider/usage/cancelled)", async () => {
+      const conv = makeConversation({
+        messages: [
+          msg({ role: "user", content: "q" }),
+          msg({
+            role: "assistant",
+            content: "a",
+            provider: "openai",
+            usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 },
+            cancelled: true,
+          }),
+        ],
+      });
+      await saveConversation(conv);
+      const loaded = await loadConversation(conv.id);
+      const a = loaded!.messages[1];
+      expect(a.provider).toBe("openai");
+      expect(a.usage).toEqual({
+        promptTokens: 1,
+        completionTokens: 2,
+        totalTokens: 3,
+      });
+      expect(a.cancelled).toBe(true);
+    });
+  });
+
+  describe("listing & deck scoping", () => {
+    it("lists conversations for a deck newest-first", async () => {
+      const a = makeConversation({ id: "a", deckId: "deck-1" });
+      const b = makeConversation({ id: "b", deckId: "deck-1" });
+      const other = makeConversation({ id: "other", deckId: "deck-2" });
+      // Insert a first, then b with a later updatedAt so b should sort first.
+      a.updatedAt = "2026-01-01T00:00:00Z";
+      b.updatedAt = "2026-06-01T00:00:00Z";
+      await saveConversation(a);
+      await saveConversation(b);
+      await saveConversation(other);
+
+      const list = await loadConversations("deck-1");
+      expect(list.map((c) => c.id)).toEqual(["b", "a"]);
+    });
+
+    it("isolates decks (one deck does not see another's conversations)", async () => {
+      await saveConversation(makeConversation({ id: "x", deckId: "d1" }));
+      await saveConversation(makeConversation({ id: "y", deckId: "d2" }));
+      expect((await loadConversations("d1")).map((c) => c.id)).toEqual(["x"]);
+      expect((await loadConversations("d2")).map((c) => c.id)).toEqual(["y"]);
+    });
+
+    it("auto-resumes the most recent conversation for a deck", async () => {
+      await saveConversation(makeConversation({ id: "old", deckId: "d1" }));
+      const recent = makeConversation({ id: "recent", deckId: "d1" });
+      recent.updatedAt = "2026-09-01T00:00:00Z";
+      await saveConversation(recent);
+
+      const got = await loadMostRecentConversation("d1");
+      expect(got!.id).toBe("recent");
+      expect(got!.messages.length).toBeGreaterThan(0);
+    });
+
+    it("returns null when there is nothing to resume", async () => {
+      expect(await loadMostRecentConversation("empty-deck")).toBeNull();
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes a single conversation by id", async () => {
+      const conv = makeConversation({ id: "doomed" });
+      await saveConversation(conv);
+      expect(await loadConversation("doomed")).not.toBeNull();
+
+      await deleteConversation("doomed");
+      expect(await loadConversation("doomed")).toBeNull();
+    });
+
+    it("deletes every conversation for a deck", async () => {
+      await saveConversation(makeConversation({ id: "k1", deckId: "dk" }));
+      await saveConversation(makeConversation({ id: "k2", deckId: "dk" }));
+      await saveConversation(makeConversation({ id: "keep", deckId: "other" }));
+
+      await deleteConversationsForDeck("dk");
+      expect(await loadConversations("dk")).toHaveLength(0);
+      expect((await loadConversations("other")).map((c) => c.id)).toEqual([
+        "keep",
+      ]);
+    });
+  });
+
+  describe("persistence across a simulated reload", () => {
+    it("survives a fresh read after the in-memory state is dropped", async () => {
+      // Write a conversation (simulating a completed chat turn).
+      const conv = makeConversation({
+        id: "persist-me",
+        deckContext: { format: "legacy", archetype: "combo", deckCards: [] },
+      });
+      const saved = await saveConversation(conv);
+      expect(saved.ok).toBe(true);
+
+      // Simulate app restart: drop all in-memory references and re-read from
+      // storage as the hook's mount effect would.
+      const resumed = await loadMostRecentConversation(conv.deckId);
+      expect(resumed!.id).toBe("persist-me");
+      expect(resumed!.deckContext.format).toBe("legacy");
+      expect(resumed!.messages.map((m) => m.content)).toEqual([
+        "How do I beat aggro?",
+        "Add more cheap interaction.",
+      ]);
+    });
+  });
+
+  describe("deck context is stored", () => {
+    it("preserves format/archetype/strategy/cards on the conversation", async () => {
+      const conv = makeConversation({
+        deckContext: {
+          format: "commander",
+          archetype: "tokens",
+          strategy: "go-wide",
+          deckCards: [{ id: "1", name: "Sol Ring", count: 1 } as never],
+        },
+      });
+      await saveConversation(conv);
+      const loaded = await loadConversation(conv.id);
+      expect(loaded!.deckContext.format).toBe("commander");
+      expect(loaded!.deckContext.archetype).toBe("tokens");
+      expect(loaded!.deckContext.strategy).toBe("go-wide");
+      expect(loaded!.deckContext.deckCards).toHaveLength(1);
+    });
+  });
+
+  describe("graceful quota handling", () => {
+    it("returns a typed QuotaExceededError result instead of throwing", async () => {
+      // Force the underlying IndexedDB put to reject with a quota error. We
+      // return a minimal fake IDBRequest that fires ONLY `onerror`, so the
+      // storage layer's `request.onerror` handler classifies + rejects (the
+      // real fake-indexeddb request would otherwise fire onsuccess first).
+      const realPut = IDBObjectStore.prototype.put;
+      const quotaError = new DOMException(
+        "The quota has been exceeded",
+        "QuotaExceededError",
+      );
+      IDBObjectStore.prototype.put = function () {
+        const fakeReq: {
+          error: unknown;
+          onsuccess: ((ev: Event) => void) | null;
+          onerror: ((ev: Event) => void) | null;
+        } = { error: null, onsuccess: null, onerror: null };
+        setTimeout(() => {
+          fakeReq.error = quotaError;
+          if (typeof fakeReq.onerror === "function") {
+            fakeReq.onerror(new Event("error"));
+          }
+        }, 0);
+        return fakeReq as unknown as IDBRequest;
+      };
+
+      try {
+        const conv = makeConversation();
+        const result = await saveConversation(conv);
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          // The classified error is recognisable as quota-related.
+          expect(result.error.name).toBe("QuotaExceededError");
+          // The store name is annotated so the UI can reference it.
+          expect((result.error as { storeName?: string }).storeName).toBe(
+            COACH_CONVERSATION_STORE,
+          );
+        }
+        // Critical: it did not throw, so the in-session coach would keep going.
+      } finally {
+        IDBObjectStore.prototype.put = realPut;
+      }
+    });
+  });
+});

--- a/src/lib/coach-conversation-storage.ts
+++ b/src/lib/coach-conversation-storage.ts
@@ -1,0 +1,298 @@
+/**
+ * @fileoverview IndexedDB persistence for AI Coach conversations.
+ *
+ * Issue #1074: coaching conversations were lost on refresh/restart because the
+ * coach route is fully stateless and the chat hook only mirrored its history to
+ * localStorage (small, synchronous, easily evicted). This module stores whole
+ * conversations — messages plus the deck context they were discussing — in a
+ * dedicated IndexedDB object store so a user returning to the coach sees their
+ * prior history and can resume.
+ *
+ * Design notes:
+ *  - Reuses the shared {@link IndexedDBStorage} wrapper so quota classification
+ *    (#1085), atomic single-transaction writes, and lazy initialisation are
+ *    inherited rather than re-implemented. A *separate* database name keeps the
+ *    coach store isolated from the main app stores — no version bump on the
+ *    shared config, no migration risk.
+ *  - Local-first: everything lives in the browser/Tauri IndexedDB. No telemetry
+ *    of conversation content leaves the device.
+ *  - Graceful degrade: read helpers never throw (they return `[]`/`null` on any
+ *    failure, including IndexedDB being unavailable in private mode / SSR), and
+ *    writes go through {@link withQuotaGuard} so quota exhaustion is surfaced as
+ *    a typed result instead of crashing the in-session coach.
+ */
+
+import type { ChatMessage } from "@/types/chat";
+import type { DeckCard } from "@/ai/flows/context-builder";
+import { IndexedDBStorage } from "./indexeddb-storage";
+import { withQuotaGuard, type QuotaGuardResult } from "./storage-quota";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+/**
+ * Snapshot of the deck context a conversation is anchored to. Stored alongside
+ * the messages so a resumed conversation is self-contained — the coach can
+ * re-establish context without the user re-explaining format, archetype, etc.
+ */
+export interface CoachConversationDeckContext {
+  format?: string;
+  archetype?: string;
+  strategy?: string;
+  deckCards?: DeckCard[];
+  /** Opaque digest used for payload reduction; preserved verbatim if present. */
+  digestedContext?: unknown;
+}
+
+/**
+ * A persisted coaching conversation. Stored as a single document keyed by `id`
+ * so saving/updating is one atomic IndexedDB `put`.
+ */
+export interface CoachConversation {
+  id: string;
+  /** Deck this conversation is scoped to ("default" when unscoped). */
+  deckId: string;
+  /** Short human-readable summary derived from the first user message. */
+  title: string;
+  /** Deck-context snapshot (format/archetype/strategy/cards). */
+  deckContext: CoachConversationDeckContext;
+  messages: ChatMessage[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ============================================================================
+// CONFIG
+// ============================================================================
+
+/** IndexedDB object store name for coach conversations. */
+export const COACH_CONVERSATION_STORE = "coach-conversations";
+
+/** deckId used when the coach is opened without a specific deck. */
+export const DEFAULT_DECK_ID = "default";
+
+/** Max length of an auto-derived conversation title. */
+const TITLE_MAX_LENGTH = 60;
+
+/**
+ * Dedicated IndexedDB database for coach conversations. Kept separate from the
+ * main "PlanarNexusStorage" database so adding this store cannot version-conflict
+ * with existing app stores or require migrating them.
+ */
+const coachStorage = new IndexedDBStorage({
+  dbName: "PlanarNexusCoach",
+  version: 1,
+  stores: [COACH_CONVERSATION_STORE],
+});
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Derive a short, human-readable title from a list of messages (the first user
+ * message is the most descriptive). Falls back to a generic label when there is
+ * no user content yet.
+ */
+export function deriveConversationTitle(messages: ChatMessage[]): string {
+  const firstUser = messages.find((m) => m.role === "user" && m.content.trim());
+  const text = firstUser?.content.trim();
+  if (!text) return "New coaching session";
+  const single = text.replace(/\s+/g, " ");
+  return single.length > TITLE_MAX_LENGTH
+    ? `${single.slice(0, TITLE_MAX_LENGTH - 1)}…`
+    : single;
+}
+
+/**
+ * Normalise a raw stored message's timestamp back into a `Date`. IndexedDB
+ * preserves `Date` instances via structured clone, but the value may also arrive
+ * as an ISO string (e.g. after a JSON backup round-trip), so handle both.
+ */
+function normalizeMessage(raw: ChatMessage): ChatMessage {
+  return {
+    ...raw,
+    timestamp: new Date(
+      (raw.timestamp as unknown as string | Date) ?? Date.now(),
+    ),
+  };
+}
+
+/** True when IndexedDB can be used in the current environment. */
+function indexedDBAvailable(): boolean {
+  if (typeof window === "undefined") return false;
+  return typeof indexedDB !== "undefined";
+}
+
+// ============================================================================
+// READS (never throw — degrade to empty/null)
+// ============================================================================
+
+/**
+ * Load every persisted conversation for a deck, newest-first. Returns `[]` when
+ * IndexedDB is unavailable or the read fails so callers (the chat hook) can
+ * render an empty state without crashing.
+ */
+export async function loadConversations(
+  deckId: string = DEFAULT_DECK_ID,
+): Promise<CoachConversation[]> {
+  if (!indexedDBAvailable()) return [];
+  try {
+    const all = await coachStorage.getAll<CoachConversation>(
+      COACH_CONVERSATION_STORE,
+    );
+    return all
+      .filter((c) => c && c.deckId === deckId)
+      .sort((a, b) => (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""));
+  } catch (error) {
+    console.error("Failed to load coach conversations:", error);
+    return [];
+  }
+}
+
+/**
+ * Load a single conversation by id (any deck). Returns `null` when not found or
+ * when IndexedDB is unavailable.
+ */
+export async function loadConversation(
+  id: string,
+): Promise<CoachConversation | null> {
+  if (!indexedDBAvailable() || !id) return null;
+  try {
+    const conv = await coachStorage.get<CoachConversation>(
+      COACH_CONVERSATION_STORE,
+      id,
+    );
+    if (!conv) return null;
+    return {
+      ...conv,
+      messages: Array.isArray(conv.messages)
+        ? conv.messages.map(normalizeMessage)
+        : [],
+    };
+  } catch (error) {
+    console.error("Failed to load coach conversation:", error);
+    return null;
+  }
+}
+
+/**
+ * Load the most recently updated conversation for a deck (the auto-resume
+ * target on page open). Returns `null` when there is none.
+ */
+export async function loadMostRecentConversation(
+  deckId: string = DEFAULT_DECK_ID,
+): Promise<CoachConversation | null> {
+  const list = await loadConversations(deckId);
+  if (list.length === 0) return null;
+  // list is newest-first; re-normalise messages for the chosen conversation.
+  return loadConversation(list[0].id);
+}
+
+// ============================================================================
+// WRITES (quota-guarded, non-crashing)
+// ============================================================================
+
+/**
+ * Persist (create or replace) a conversation atomically. Quota exhaustion is
+ * returned as a typed {@link QuotaGuardResult} (`{ ok: false, error }`) so the
+ * caller can surface a notice and keep the in-session coach working; other
+ * unexpected errors are logged and also returned as a failed result rather than
+ * thrown.
+ */
+export async function saveConversation(
+  conversation: CoachConversation,
+): Promise<QuotaGuardResult<CoachConversation>> {
+  if (!indexedDBAvailable()) {
+    // Nothing we can do (SSR / private mode); report as a non-crashing failure.
+    return {
+      ok: false,
+      error: new Error("IndexedDB unavailable — conversation not persisted"),
+    };
+  }
+  try {
+    const result = await withQuotaGuard(() =>
+      coachStorage.set(COACH_CONVERSATION_STORE, conversation),
+    );
+    if (!result.ok) return result;
+    return { ok: true, value: conversation };
+  } catch (error) {
+    // Defensive: withQuotaGuard rethrows non-quota errors; never let a persistence
+    // failure crash the coach. Log and report.
+    console.error("Failed to save coach conversation:", error);
+    return {
+      ok: false,
+      error:
+        error instanceof Error
+          ? error
+          : new Error("Failed to save coach conversation"),
+    };
+  }
+}
+
+/**
+ * Delete a single conversation by id. Never throws — a failure is logged and the
+ * caller can continue.
+ */
+export async function deleteConversation(id: string): Promise<void> {
+  if (!indexedDBAvailable() || !id) return;
+  try {
+    await coachStorage.delete(COACH_CONVERSATION_STORE, id);
+  } catch (error) {
+    console.error("Failed to delete coach conversation:", error);
+  }
+}
+
+/**
+ * Delete every conversation scoped to a deck. Used by "clear" flows.
+ */
+export async function deleteConversationsForDeck(
+  deckId: string = DEFAULT_DECK_ID,
+): Promise<void> {
+  const list = await loadConversations(deckId);
+  await Promise.all(list.map((c) => deleteConversation(c.id)));
+}
+
+/**
+ * Remove every coach conversation regardless of deck. Primarily a test/utility
+ * helper (e.g. wiping the store between unit tests); also used by full clears.
+ */
+export async function clearAllCoachConversations(): Promise<void> {
+  if (!indexedDBAvailable()) return;
+  try {
+    await coachStorage.clear(COACH_CONVERSATION_STORE);
+  } catch (error) {
+    console.error("Failed to clear coach conversations:", error);
+  }
+}
+
+// ============================================================================
+// FACTORY
+// ============================================================================
+
+/**
+ * Build a fresh, unsaved conversation object with sensible defaults. The caller
+ * persists it via {@link saveConversation} (typically indirectly through the
+ * chat hook).
+ */
+export function createConversationRecord(opts: {
+  id: string;
+  deckId?: string;
+  messages?: ChatMessage[];
+  deckContext?: CoachConversationDeckContext;
+  now?: Date;
+}): CoachConversation {
+  const now = opts.now ?? new Date();
+  const iso = now.toISOString();
+  const messages = opts.messages ?? [];
+  return {
+    id: opts.id,
+    deckId: opts.deckId ?? DEFAULT_DECK_ID,
+    title: deriveConversationTitle(messages),
+    deckContext: opts.deckContext ?? {},
+    messages,
+    createdAt: iso,
+    updatedAt: iso,
+  };
+}


### PR DESCRIPTION
## Summary

Resolves #1074. The Deck Coach route is fully stateless and the chat hook only mirrored its history to `localStorage`, so refreshing the page, switching tabs, or restarting the app discarded the entire conversation — along with any format/budget/owned-card context the user had stated. This adds **local-first IndexedDB persistence** for coaching conversations (messages + the deck context they were discussing), with auto-resume, a session history switcher, and graceful quota handling.

Local-first: everything lives in the browser/Tauri IndexedDB. No conversation content leaves the device.

## Storage schema

New dedicated database (`PlanarNexusCoach`, kept separate from the main `PlanarNexusStorage` to avoid version conflicts / migrations) with one object store:

- **`coach-conversations`** (keyPath: `id`) — documents of shape:
  ```ts
  interface CoachConversation {
    id: string;
    deckId: string;                 // scopes history per deck ("default" when unscoped)
    title: string;                  // auto-derived from the first user message
    deckContext: { format, archetype, strategy, deckCards, digestedContext }; // self-contained
    messages: ChatMessage[];        // full #1077 shape: provider/usage/cancelled
    createdAt: string;
    updatedAt: string;
  }
  ```

Reuses the shared `IndexedDBStorage` wrapper, so single-transaction atomic writes (#895 pattern) and quota classification (#1085) are inherited rather than re-implemented.

## Resume flow (`use-deck-coach-chat`)

- **Mount / deck change** → loads the most-recent conversation for the deck + the sidebar list (auto-resume). Stale legacy `localStorage` history from pre-#1074 builds is cleared.
- **Send** → the user message is persisted immediately (survives a refresh mid-stream); the finalized assistant message is persisted **once** in `sendMessage`'s `finally` (never per streaming token — see the new `updateMessages` synchronous-ref helper that makes the finalized provider/usage/cancelled fields available to that single write).
- **Race guard** → an `interactedRef` flag prevents a late auto-resume load from clobbering a conversation the user has already started.
- New hook surface: `conversations`, `activeConversationId`, `storageNotice`, `resumeConversation(id)`, `startNewConversation()`, `removeConversation(id)`.
- The deck-coach page now passes `deckId`/`format`/`deckCards` into the hook (so each conversation carries its real deck context) and renders a **Recent conversations** list (resume / delete / new) plus the storage notice above the chat panel.

## Quota / unavailable handling (coordinates with #1085)

- Writes go through `withQuotaGuard`; a `QuotaExceededError` is surfaced as a non-blocking `storageNotice` and the **in-session coach keeps working**.
- All reads degrade to `[]` / `null` on any failure (including IndexedDB being unavailable in private mode / SSR) — never crashes.

## Tests

- **`src/lib/__tests__/coach-conversation-storage.test.ts`** — save/load/delete round-trip, idempotent update, streaming-era fields (`provider`/`usage`/`cancelled`) persistence, deck-scoped listing (newest-first), auto-resume, **simulated-reload persistence round-trip**, deck-context stored, and **quota-error graceful degrade (no throw, typed `QuotaExceededError`, store name annotated)**.
- **`src/hooks/__tests__/use-deck-coach-chat.test.ts`** — extended: IndexedDB isolation in `beforeEach`, plus **persistence across a simulated reload**, finalize-once field persistence, `resumeConversation`, and **quota no-crash + notice**.
- Existing streaming/cancel tests preserved.

## Verification

- `npm test -- coach conversation use-deck-coach-chat indexeddb` → **274 suites / 5623 tests passed, 0 failed**
- `npx tsc --noEmit` → clean
- `npm run lint` → 0 errors (warnings unchanged from baseline)

## Files changed

- `src/lib/coach-conversation-storage.ts` *(new)* — IndexedDB CRUD + quota guard for coach conversations
- `src/hooks/use-deck-coach-chat.ts` — load-on-mount, save-on-completion, resume/list/delete, race guard, quota notice
- `src/app/(app)/deck-coach/page.tsx` — pass deck context into the hook; conversation history switcher + storage notice UI
- `src/lib/__tests__/coach-conversation-storage.test.ts` *(new)*
- `src/hooks/__tests__/use-deck-coach-chat.test.ts` — isolation + persistence/resume/quota tests

Resolves #1074