### PR TITLE
fix(multiplayer): resolve #1178 — SSR-safe P2PDiagnosticsPanel fixes hydration mismatch on /multiplayer/

### DIFF
--- a/src/hooks/use-p2p-diagnostics.ts
+++ b/src/hooks/use-p2p-diagnostics.ts
@@ -57,7 +57,14 @@ export function useP2PDiagnostics(
     pollIntervalMs = DEFAULT_POLL_MS,
   } = options;
 
-  const supported = isICEDiagnosticsSupported();
+  // Issue #1178: `isICEDiagnosticsSupported()` reads `window.RTCPeerConnection`,
+  // which is absent during SSR. Computing it during render made the server
+  // output (unsupported) differ from the client's first render (supported),
+  // producing a React hydration mismatch on /multiplayer/. Initialize to a
+  // stable SSR value and read the real capability in an effect after hydration
+  // so the first client render matches the server, then update.
+  const [supported, setSupported] = useState(false);
+
   const [snapshot, setSnapshot] = useState<ICEDiagnosticsSnapshot | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -72,6 +79,14 @@ export function useP2PDiagnostics(
   const refresh = useCallback(() => {
     refreshNonce.current += 1;
     setNonce(refreshNonce.current);
+  }, []);
+
+  // Detect WebRTC support post-hydration. Kept separate from the polling
+  // effect: it runs once after mount so SSR and the first client render agree
+  // on `supported` (issue #1178). Flipping this re-triggers the polling effect
+  // below via its dependency on `supported`.
+  useEffect(() => {
+    setSupported(isICEDiagnosticsSupported());
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Resolves #1178 — fixes the React hydration mismatch on `/multiplayer/` caused by the `P2PDiagnosticsPanel` (introduced by #1088 / PR #1167). The E2E `e2e/multiplayer-lobby.spec.ts:35` was flaky-failing because of this.

## Root cause

`useP2PDiagnostics` computed WebRTC support **during render**:

```ts
const supported = isICEDiagnosticsSupported(); // reads window.RTCPeerConnection
```

`isICEDiagnosticsSupported()` is SSR-guarded and returns `false` on the server (no `window`) but `true` in the browser (which has `RTCPeerConnection`). Because `supported` drove render-time branches in the panel, the server-rendered HTML and the client's first render diverged → hydration mismatch.

Concretely, the panel is mounted in **probe mode** (`<P2PDiagnosticsPanel />`, `liveMode = false`). The "Run connection test" button renders only when `!liveMode && supported`, so it appeared on the client but **not** in the server HTML. React's error trace pointed exactly at `P2PDiagnosticsPanel`:

> `Hydration failed because the server rendered HTML didn't match the client.` … diff shows `data-testid="p2p-diag-run-test"` button present on client only.

## Fix

Apply the standard SSR-safe pattern in `src/hooks/use-p2p-diagnostics.ts`:

1. Initialize `supported` to a stable SSR value (`false`) via `useState`, so the server output and the client's **first** render match (both render the `!supported` branch → no mismatch).
2. Read the real capability in a `useEffect` **after hydration** and flip `supported`. This re-triggers the existing polling effect (which lists `supported` as a dependency), so live diagnostics/probe still work exactly as before.

The panel itself needed no change — it derives `supported` from the hook (`live.supported`), which is now hydration-safe. No features were altered.

`src/lib/ice-diagnostics.ts` was audited: it has **no** top-level (module-load) browser access — all `window`/`RTCPeerConnection` reads live inside functions (`isICEDiagnosticsSupported`, `runDiagnosticsProbe`), and both are already SSR-guarded. No change needed there.

## Verification

- `npx tsc --noEmit` — clean.
- `npx jest use-p2p-diagnostics p2p-diagnostics-panel` — **16/16 pass** (no regression; existing hook + panel tests green).
- `npx playwright test multiplayer-lobby -g "should navigate to host page" --repeat-each=3` — **FAIL 0** (passes reliably across repeats).
- Dedicated hydration probe (console capture on `/multiplayer`): **`HYDRATION_ISSUES: (none)`** after the fix; the panel is visible post-hydration.
- **A/B proof:** with the fix reverted (via `git stash`), the same probe reproduced the exact React hydration error pointing at `P2PDiagnosticsPanel`; with the fix restored, the error is gone.

Note: `npm run lint` is non-functional in this environment (ESLint 6.4.0 with no config file present anywhere in the repo — a pre-existing tooling gap unrelated to this change, so out of scope).

## Files changed

- `src/hooks/use-p2p-diagnostics.ts` — defer `isICEDiagnosticsSupported()` from render to `useEffect`; seed `supported` with stable SSR value `false`.

Resolves #1178

## Summary by Sourcery

Ensure the multiplayer P2P diagnostics hook is SSR-safe to prevent hydration mismatches on the /multiplayer page.

Bug Fixes:
- Fix React hydration mismatch on the /multiplayer page caused by P2PDiagnosticsPanel computing WebRTC support during render.

Enhancements:
- Make WebRTC support detection in useP2PDiagnostics run post-hydration while preserving existing diagnostics behavior.