### PR TITLE
feat(ai-coach): resolve #1076 — per-matchup sideboard plans with boarding in/out guidance

### DIFF
--- a/src/ai/flows/__tests__/sideboard-plan.test.ts
+++ b/src/ai/flows/__tests__/sideboard-plan.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for per-matchup sideboard plan generation (issue #1076).
+ *
+ * These verify the LOCAL-FIRST heuristic:
+ *   1. Vs aggro, removal is boarded in and slow threats boarded out.
+ *   2. Vs combo, disruption is boarded in and creature-only removal is NOT.
+ *   3. An empty sideboard yields empty board-in/out for every matchup.
+ *   4. The default emits >= 3 matchup plans and is deterministic.
+ *   5. Board-in/out quantities are balanced (out matches in).
+ */
+
+import {
+  generatePerMatchupSideboardPlans,
+  type MatchupSideboardPlan,
+} from "../sideboard-plan";
+import type { DeckCard } from "@/app/actions";
+
+function card(
+  name: string,
+  typeLine: string,
+  cmc: number,
+  count: number,
+  oracle = "",
+  colors: string[] = ["W"],
+): DeckCard {
+  return {
+    id: name.toLowerCase().replace(/\s+/g, "-"),
+    name,
+    cmc,
+    type_line: typeLine,
+    colors,
+    color_identity: colors,
+    legalities: {},
+    count,
+    oracle_text: oracle,
+  };
+}
+
+/** A midrange white deck with expensive threats and a little maindeck removal. */
+function buildMainDeck(): DeckCard[] {
+  return [
+    card("Serra Angel", "Creature — Angel", 5, 4, "Flying, vigilance"),
+    card("Grizzly Bears", "Creature — Bear", 2, 4),
+    card("Day of Judgment", "Sorcery", 4, 2, "Destroy all creatures."),
+    card("Plains", "Basic Land — Plains", 0, 14),
+  ];
+}
+
+/** A sideboard heavy on removal + disruption, with a threat filler. */
+function buildSideboard(): DeckCard[] {
+  return [
+    card("Wrath of God", "Sorcery", 4, 4, "Destroy all creatures."),
+    card("Path to Exile", "Instant", 1, 4, "Exile target creature."),
+    card("Thoughtseize", "Sorcery", 1, 2, "Target player discards a card."),
+    card("Negate", "Instant", 2, 2, "Counter target noncreature spell."),
+    card("Llanowar Elves", "Creature — Elf Druid", 1, 3, "Tap: Add G."),
+  ];
+}
+
+function names(plan: MatchupSideboardPlan, which: "in" | "out"): string[] {
+  const list = which === "in" ? plan.boardIn : plan.boardOut;
+  return list.map((c) => c.cardName);
+}
+
+function total(
+  plan: MatchupSideboardPlan,
+  which: "in" | "out",
+): number {
+  const list = which === "in" ? plan.boardIn : plan.boardOut;
+  return list.reduce((s, c) => s + c.count, 0);
+}
+
+describe("generatePerMatchupSideboardPlans", () => {
+  it("boards removal IN and slow threats OUT versus an aggro matchup", () => {
+    const result = generatePerMatchupSideboardPlans(
+      buildMainDeck(),
+      buildSideboard(),
+      ["Burn"],
+    );
+
+    expect(result.matchupPlans).toHaveLength(1);
+    const plan = result.matchupPlans[0];
+    expect(plan.opponentArchetypeCategory).toBe("aggro");
+
+    const inNames = names(plan, "in");
+    expect(inNames).toContain("Wrath of God");
+    expect(inNames).toContain("Path to Exile");
+
+    // Expensive creature is the first to come out vs a fast deck.
+    expect(names(plan, "out")).toContain("Serra Angel");
+
+    // Boarded out quantity matches boarded in quantity.
+    expect(total(plan, "out")).toBe(total(plan, "in"));
+    expect(total(plan, "in")).toBeGreaterThan(0);
+  });
+
+  it("boards disruption IN and excludes creature removal vs a combo matchup", () => {
+    const result = generatePerMatchupSideboardPlans(
+      buildMainDeck(),
+      buildSideboard(),
+      ["Storm"],
+    );
+
+    const plan = result.matchupPlans[0];
+    expect(plan.opponentArchetypeCategory).toBe("combo");
+
+    const inNames = names(plan, "in");
+    expect(inNames).toContain("Thoughtseize");
+    expect(inNames).toContain("Negate");
+    // Creature-only removal is not wanted against combo.
+    expect(inNames).not.toContain("Wrath of God");
+    expect(inNames).not.toContain("Path to Exile");
+  });
+
+  it("trims redundant removal vs a control matchup", () => {
+    const result = generatePerMatchupSideboardPlans(
+      buildMainDeck(),
+      buildSideboard(),
+      ["Draw-Go"],
+    );
+
+    const plan = result.matchupPlans[0];
+    expect(plan.opponentArchetypeCategory).toBe("control");
+    // Vs control, maindeck removal (Day of Judgment) is cuttable.
+    expect(names(plan, "out")).toContain("Day of Judgment");
+  });
+
+  it("returns empty board-in/out for every matchup when the sideboard is empty", () => {
+    const result = generatePerMatchupSideboardPlans(buildMainDeck(), [], [
+      "Burn",
+      "Storm",
+      "Draw-Go",
+    ]);
+
+    expect(result.matchupPlans.length).toBeGreaterThan(0);
+    for (const plan of result.matchupPlans) {
+      expect(plan.boardIn).toEqual([]);
+      expect(plan.boardOut).toEqual([]);
+    }
+  });
+
+  it("emits at least three matchup plans by default", () => {
+    const result = generatePerMatchupSideboardPlans(
+      buildMainDeck(),
+      buildSideboard(),
+    );
+    expect(result.matchupPlans.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("is deterministic for identical inputs", () => {
+    const a = generatePerMatchupSideboardPlans(
+      buildMainDeck(),
+      buildSideboard(),
+    );
+    const b = generatePerMatchupSideboardPlans(
+      buildMainDeck(),
+      buildSideboard(),
+    );
+    expect(b).toEqual(a);
+  });
+
+  it("detects a player archetype and keeps board-in/out balanced", () => {
+    const result = generatePerMatchupSideboardPlans(
+      buildMainDeck(),
+      buildSideboard(),
+    );
+    expect(result.playerArchetype).toBeTruthy();
+    expect(result.playerArchetypeCategory).toBeTruthy();
+
+    for (const plan of result.matchupPlans) {
+      // Out quantity should never exceed in quantity for a generated plan.
+      expect(total(plan, "out")).toBeLessThanOrEqual(total(plan, "in"));
+    }
+  });
+
+  it("handles a malformed/empty maindeck without throwing", () => {
+    expect(() =>
+      generatePerMatchupSideboardPlans([], buildSideboard(), ["Burn"]),
+    ).not.toThrow();
+    const result = generatePerMatchupSideboardPlans(
+      [],
+      buildSideboard(),
+      ["Burn"],
+    );
+    expect(result.matchupPlans).toHaveLength(1);
+    expect(result.matchupPlans[0].boardOut).toEqual([]);
+  });
+});

--- a/src/ai/flows/coach-deck-analysis.ts
+++ b/src/ai/flows/coach-deck-analysis.ts
@@ -77,8 +77,11 @@ const MANA_CURVE_BUCKETS = 8; // indices 0..7 where 7 == "7+"
 /**
  * Classify a card into a functional role based on its type line, keywords and
  * oracle text. The first matching role wins; lands are handled by the caller.
+ *
+ * Exported (issue #1076) so the per-matchup sideboard planner can reuse the
+ * SAME role taxonomy instead of inventing its own.
  */
-function classifyRole(card: DeckCard): keyof RoleDistribution {
+export function classifyRole(card: DeckCard): keyof RoleDistribution {
   const type = (card.type_line || "").toLowerCase();
   const text = `${card.name} ${card.oracle_text || ""}`.toLowerCase();
 

--- a/src/ai/flows/sideboard-plan.ts
+++ b/src/ai/flows/sideboard-plan.ts
@@ -1,0 +1,327 @@
+/**
+ * @fileOverview Per-matchup sideboard plan generation for the AI Coach.
+ *
+ * Issue #1076: for best-of-3 (sideboard) play the coach must emit a PER-MATCHUP
+ * boarding plan — for each likely opponent archetype, which sideboard cards to
+ * BOARD IN, which maindeck cards to BOARD OUT, and a one-line rationale.
+ *
+ * This is LOCAL-FIRST and HEURISTIC-GROUNDED: the plan is derived entirely from
+ * the deck's detected archetype, each card's functional ROLE (reused verbatim
+ * from `coach-deck-analysis#classifyRole` — no new taxonomy), and the opponent
+ * archetype's threat profile (category from `archetype-signatures`). No LLM
+ * call is required for the core plan; an optional LLM may refine it elsewhere.
+ *
+ * The output is deterministic for a given (mainDeck, sideboard, opponent)
+ * tuple, which keeps it testable and offline-capable.
+ */
+
+import type { DeckCard } from "@/app/actions";
+import { detectArchetype } from "@/ai/archetype-detector";
+import { getArchetypeByName } from "@/ai/archetype-signatures";
+import {
+  classifyRole,
+  type RoleDistribution,
+} from "@/ai/flows/coach-deck-analysis";
+import type { SideboardCard } from "@/lib/anti-meta";
+
+/** The functional roles a card can fill (mirrors RoleDistribution keys). */
+type RoleKey = keyof RoleDistribution;
+
+/** A single opponent's boarding recommendation. */
+export interface MatchupSideboardPlan {
+  /** Opponent archetype name (e.g. "Burn"). */
+  opponentArchetypeName: string;
+  /** Opponent archetype category (aggro/control/midrange/combo/tribal/special). */
+  opponentArchetypeCategory: string;
+  /** Sideboard cards to bring in for this matchup. */
+  boardIn: SideboardCard[];
+  /** Maindeck cards to take out for this matchup. */
+  boardOut: SideboardCard[];
+  /** One-line strategic rationale tied to the archetype profile. */
+  guidance: string;
+}
+
+/** The full coach output: player archetype + a plan per opponent archetype. */
+export interface PerMatchupSideboardResult {
+  /** Detected archetype of the player's maindeck. */
+  playerArchetype: string;
+  /** Category of the player's archetype. */
+  playerArchetypeCategory: string;
+  /** One boarding plan per relevant opponent archetype. */
+  matchupPlans: MatchupSideboardPlan[];
+}
+
+/** Cap on cards boarded in for a single matchup (keeps plans realistic). */
+const MAX_BOARD_IN_CARDS = 8;
+
+/**
+ * Threat profile for an archetype category: how valuable each functional role
+ * is when facing that category (higher = more wanted in, lower = more cuttable).
+ * These weights are grounded in established MTG sideboard heuristics.
+ */
+interface MatchupProfile {
+  category: string;
+  roleValue: Record<RoleKey, number>;
+  /** Strategy guidance; `{player}` is substituted with the player archetype. */
+  guidance: string;
+}
+
+const DEFAULT_PROFILE: MatchupProfile = {
+  category: "midrange",
+  roleValue: {
+    threats: 1,
+    ramp: 0,
+    removal: 1,
+    cardDraw: 1,
+    disruption: 1,
+    lands: 0,
+    other: -1,
+  },
+  guidance:
+    "Board in your most impactful cards and trim the narrowest ones for this matchup.",
+};
+
+const MATCHUP_PROFILES: Record<string, MatchupProfile> = {
+  aggro: {
+    category: "aggro",
+    roleValue: { threats: 0, ramp: -1, removal: 3, cardDraw: 1, disruption: 2, lands: 0, other: -2 },
+    guidance:
+      "{player} must stabilise early. Board in cheap removal and disruptive interaction; shave your slowest top-end threats and narrow cards that clog your hand.",
+  },
+  combo: {
+    category: "combo",
+    roleValue: { threats: 1, ramp: 0, removal: 0, cardDraw: 2, disruption: 3, lands: 0, other: -2 },
+    guidance:
+      "{player} needs to stop them going off. Board in hand disruption and countermagic plus draw to find them; cut creature-only removal that cannot interact with the combo.",
+  },
+  control: {
+    category: "control",
+    roleValue: { threats: 2, ramp: 0, removal: -1, cardDraw: 3, disruption: 2, lands: 0, other: -1 },
+    guidance:
+      "{player} plays the long game. Board in card draw, discard, and resilient must-answer threats; trim redundant removal and low-impact cards that trade poorly.",
+  },
+  midrange: {
+    category: "midrange",
+    roleValue: { threats: 2, ramp: 0, removal: 2, cardDraw: 2, disruption: 1, lands: 0, other: -1 },
+    guidance:
+      "{player} trades resources one-for-one. Board in efficient removal and card draw to pull ahead; cut narrow, situational cards.",
+  },
+  tribal: {
+    category: "tribal",
+    roleValue: { threats: 1, ramp: -1, removal: 3, cardDraw: 1, disruption: 2, lands: 0, other: -2 },
+    guidance:
+      "{player} faces a creature flood. Board in sweepers and point removal plus disruptive interaction; cut slow draw and non-interactive cards.",
+  },
+  special: {
+    category: "special",
+    roleValue: { threats: 1, ramp: 0, removal: 2, cardDraw: 2, disruption: 2, lands: 0, other: -1 },
+    guidance:
+      "{player} faces a unique engine. Board in flexible interaction and card draw; trim narrow cards that do not affect their plan.",
+  },
+};
+
+/** One representative archetype per category, used when callers omit opponents. */
+const REPRESENTATIVE_OPPONENTS: string[] = [
+  "Burn", // aggro
+  "Draw-Go", // control
+  "Good Stuff", // midrange
+  "Storm", // combo
+  "Elves", // tribal
+  "Superfriends", // special
+];
+
+function getMatchupProfile(category: string): MatchupProfile {
+  return MATCHUP_PROFILES[category] ?? { ...DEFAULT_PROFILE, category };
+}
+
+function isLand(card: DeckCard): boolean {
+  return (card.type_line || "").toLowerCase().includes("land");
+}
+
+function roleValueOf(role: RoleKey, profile: MatchupProfile): number {
+  return profile.roleValue[role] ?? 0;
+}
+
+function reasonForBoardIn(role: RoleKey, profile: MatchupProfile): string {
+  switch (role) {
+    case "removal":
+      return `Removal answers their key cards — strong vs ${profile.category}.`;
+    case "disruption":
+      return `Hand/counterspell pressure disrupts their ${profile.category} game plan.`;
+    case "cardDraw":
+      return "Extra draw finds your answers and keeps gas flowing.";
+    case "threats":
+      return "A resilient threat they must answer improves this matchup.";
+    case "ramp":
+      return "Ramp accelerates you past their pressure.";
+    default:
+      return `Flexible card that improves the ${profile.category} matchup.`;
+  }
+}
+
+function reasonForBoardOut(
+  role: RoleKey,
+  profile: MatchupProfile,
+  card: DeckCard,
+): string {
+  const fastMatchup =
+    profile.category === "aggro" || profile.category === "tribal";
+  if (fastMatchup && (card.cmc || 0) >= 4) {
+    return `Too slow at CMC ${card.cmc} against a fast ${profile.category} deck.`;
+  }
+  switch (role) {
+    case "removal":
+      return profile.category === "control"
+        ? "Redundant removal trades poorly against their few threats."
+        : "Removal is low-impact in this matchup.";
+    case "other":
+      return "Narrow utility card with little impact here.";
+    case "threats":
+      return "Lower-impact threat that underperforms in this matchup.";
+    case "ramp":
+      return "Ramp is a liability when you need early interaction.";
+    default:
+      return "Lowest-value card in this matchup.";
+  }
+}
+
+/** Sideboard cards to bring in, ranked by role value for the matchup. */
+function computeBoardIn(
+  sideboard: DeckCard[],
+  profile: MatchupProfile,
+): SideboardCard[] {
+  if (sideboard.length === 0) return [];
+
+  const scored = sideboard
+    .filter((c) => !isLand(c))
+    .map((c) => {
+      const role = classifyRole(c);
+      return { card: c, role, value: roleValueOf(role, profile) };
+    })
+    .filter((s) => s.value > 0)
+    .sort((a, b) => b.value - a.value || (a.card.cmc || 0) - (b.card.cmc || 0));
+
+  const boardIn: SideboardCard[] = [];
+  let total = 0;
+  for (const s of scored) {
+    if (total >= MAX_BOARD_IN_CARDS) break;
+    const remaining = MAX_BOARD_IN_CARDS - total;
+    const qty = Math.min(s.card.count, remaining);
+    if (qty <= 0) break;
+    boardIn.push({
+      cardName: s.card.name,
+      count: qty,
+      reason: reasonForBoardIn(s.role, profile),
+    });
+    total += qty;
+  }
+  return boardIn;
+}
+
+/** Maindeck cards to take out, ranked by how cuttable they are. */
+function computeBoardOut(
+  mainDeck: DeckCard[],
+  profile: MatchupProfile,
+  target: number,
+): SideboardCard[] {
+  if (target <= 0) return [];
+
+  const scored = mainDeck
+    .filter((c) => !isLand(c))
+    .map((c) => {
+      const role = classifyRole(c);
+      let cut = -roleValueOf(role, profile);
+      if (profile.category === "aggro" || profile.category === "tribal") {
+        cut += (c.cmc || 0) * 0.5;
+      }
+      if (profile.category === "control" && role === "removal") cut += 1.0;
+      return { card: c, role, cut };
+    })
+    .sort((a, b) => b.cut - a.cut || (b.card.cmc || 0) - (a.card.cmc || 0));
+
+  const boardOut: SideboardCard[] = [];
+  let total = 0;
+  for (const s of scored) {
+    if (total >= target) break;
+    const remaining = target - total;
+    const qty = Math.min(s.card.count, remaining);
+    if (qty <= 0) break;
+    boardOut.push({
+      cardName: s.card.name,
+      count: qty,
+      reason: reasonForBoardOut(s.role, profile, s.card),
+    });
+    total += qty;
+  }
+  return boardOut;
+}
+
+/** Resolve the opponent list, defaulting to one representative per category. */
+function resolveOpponents(names?: string[]): string[] {
+  if (names && names.length) {
+    const valid = names.filter((n) => !!getArchetypeByName(n));
+    if (valid.length) return valid;
+  }
+  return REPRESENTATIVE_OPPONENTS.filter((n) => !!getArchetypeByName(n));
+}
+
+function buildPlan(
+  mainDeck: DeckCard[],
+  sideboard: DeckCard[],
+  opponentName: string,
+  playerArchetype: string,
+): MatchupSideboardPlan {
+  const sig = getArchetypeByName(opponentName);
+  const category = sig?.category ?? "midrange";
+  const profile = getMatchupProfile(category);
+
+  const boardIn = computeBoardIn(sideboard, profile);
+  const inCount = boardIn.reduce((sum, c) => sum + c.count, 0);
+  const boardOut = computeBoardOut(mainDeck, profile, inCount);
+
+  return {
+    opponentArchetypeName: opponentName,
+    opponentArchetypeCategory: category,
+    boardIn,
+    boardOut,
+    guidance: profile.guidance.replace("{player}", playerArchetype),
+  };
+}
+
+/**
+ * Generate a per-matchup sideboard plan for each likely opponent archetype.
+ *
+ * Pure and deterministic: the same inputs always yield the same output, with no
+ * network or LLM dependency. Cards are scored by their functional role against
+ * the opponent archetype's threat profile (category).
+ *
+ * @param mainDeck         The player's maindeck cards.
+ * @param sideboard        The player's sideboard cards.
+ * @param opponentArchetypes Optional list of opponent archetype names. Defaults
+ *                           to one representative archetype per category.
+ */
+export function generatePerMatchupSideboardPlans(
+  mainDeck: DeckCard[],
+  sideboard: DeckCard[],
+  opponentArchetypes?: string[],
+): PerMatchupSideboardResult {
+  const safeMain = Array.isArray(mainDeck) ? mainDeck : [];
+  const safeSide = Array.isArray(sideboard) ? sideboard : [];
+
+  const detected = detectArchetype(safeMain);
+  const playerArchetype = detected?.primary || "Unknown";
+  const playerCategory =
+    getArchetypeByName(playerArchetype)?.category ?? "midrange";
+
+  const opponents = resolveOpponents(opponentArchetypes);
+
+  const matchupPlans = opponents.map((name) =>
+    buildPlan(safeMain, safeSide, name, playerArchetype),
+  );
+
+  return {
+    playerArchetype,
+    playerArchetypeCategory: playerCategory,
+    matchupPlans,
+  };
+}

--- a/src/components/meta/sideboard/MatchupSideboardPlans.tsx
+++ b/src/components/meta/sideboard/MatchupSideboardPlans.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import React, { useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { ArrowDownToLine, ArrowUpFromLine } from "lucide-react";
+import type { DeckCard } from "@/app/actions";
+import {
+  generatePerMatchupSideboardPlans,
+  type MatchupSideboardPlan,
+} from "@/ai/flows/sideboard-plan";
+
+interface MatchupSideboardPlansProps {
+  /** Player's maindeck cards. */
+  mainDeck: DeckCard[];
+  /** Player's sideboard cards. */
+  sideboard: DeckCard[];
+  /** Optional opponent archetype names; defaults to one per category. */
+  opponentArchetypes?: string[];
+  className?: string;
+}
+
+/**
+ * Coach-generated, per-matchup sideboard plans (issue #1076).
+ *
+ * Renders a boarding guide for each likely opponent archetype: cards to board
+ * IN, cards to board OUT, and a one-line rationale. The plan is computed
+ * locally (no LLM) via `generatePerMatchupSideboardPlans`.
+ */
+export function MatchupSideboardPlans({
+  mainDeck,
+  sideboard,
+  opponentArchetypes,
+  className,
+}: MatchupSideboardPlansProps) {
+  const opponentsKey = JSON.stringify(opponentArchetypes ?? null);
+  const result = useMemo(
+    () => generatePerMatchupSideboardPlans(mainDeck, sideboard, opponentArchetypes),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [mainDeck, sideboard, opponentsKey],
+  );
+
+  if (result.matchupPlans.length === 0) {
+    return (
+      <Card className={className} aria-label="Matchup sideboard plans">
+        <CardContent className="py-6 text-sm text-muted-foreground">
+          No opponent archetypes available to plan against.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <section
+      className={className}
+      aria-label="Coach matchup sideboard plans"
+    >
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <h3 className="text-base font-semibold">Matchup Sideboard Plans</h3>
+        <Badge variant="secondary">{result.playerArchetype}</Badge>
+        <Badge variant="outline">{result.playerArchetypeCategory}</Badge>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {result.matchupPlans.map((plan) => (
+          <MatchupPlanCard key={plan.opponentArchetypeName} plan={plan} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function MatchupPlanCard({ plan }: { plan: MatchupSideboardPlan }) {
+  const totalIn = plan.boardIn.reduce((s, c) => s + c.count, 0);
+  const totalOut = plan.boardOut.reduce((s, c) => s + c.count, 0);
+
+  return (
+    <Card
+      aria-label={`Sideboard plan versus ${plan.opponentArchetypeName}`}
+    >
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base">
+            vs. {plan.opponentArchetypeName}
+          </CardTitle>
+          <div className="flex items-center gap-2">
+            <span className="flex items-center gap-1 text-sm font-medium text-green-600">
+              <ArrowDownToLine className="h-4 w-4" aria-hidden />
+              +{totalIn}
+            </span>
+            <span className="flex items-center gap-1 text-sm font-medium text-red-600">
+              <ArrowUpFromLine className="h-4 w-4" aria-hidden />
+              -{totalOut}
+            </span>
+          </div>
+        </div>
+        <Badge variant="outline" className="w-fit">
+          {plan.opponentArchetypeCategory}
+        </Badge>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-xs text-muted-foreground">{plan.guidance}</p>
+
+        <CardList
+          title="Board In"
+          tone="green"
+          cards={plan.boardIn}
+          emptyText="No sideboard cards recommended for this matchup."
+        />
+        <CardList
+          title="Board Out"
+          tone="red"
+          cards={plan.boardOut}
+          emptyText="Nothing to take out."
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+interface CardListProps {
+  title: string;
+  tone: "green" | "red";
+  cards: { cardName: string; count: number; reason: string }[];
+  emptyText: string;
+}
+
+function CardList({ title, tone, cards, emptyText }: CardListProps) {
+  const badgeClass =
+    tone === "green" ? "bg-green-50 text-green-700" : "bg-red-50 text-red-700";
+
+  return (
+    <div>
+      <span className="text-xs font-medium text-muted-foreground">{title}</span>
+      {cards.length === 0 ? (
+        <p className="mt-1 text-xs italic text-muted-foreground">{emptyText}</p>
+      ) : (
+        <ul className="mt-1 space-y-1">
+          {cards.map((c, i) => (
+            <li key={`${c.cardName}-${i}`} className="flex items-start gap-2">
+              <Badge variant="outline" className={`shrink-0 text-xs ${badgeClass}`}>
+                {c.cardName} ×{c.count}
+              </Badge>
+              <span className="text-xs text-muted-foreground">{c.reason}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default MatchupSideboardPlans;

--- a/src/components/meta/sideboard/index.ts
+++ b/src/components/meta/sideboard/index.ts
@@ -1,2 +1,3 @@
 export { SideboardPlanCard } from './SideboardPlanCard';
 export { SideboardPlanEditor } from './SideboardPlanEditor';
+export { MatchupSideboardPlans } from './MatchupSideboardPlans';


### PR DESCRIPTION
## Summary
Adds **local-first, heuristic-grounded per-matchup sideboard planning** to the AI Coach (Lane L3-6). For each likely opponent archetype, the coach now emits a boarding plan: which sideboard cards to **BOARD IN**, which maindeck cards to **BOARD OUT**, and a one-line rationale — no LLM call required for the core logic.

Resolves #1076.

## Plan-generation logic
New module `src/ai/flows/sideboard-plan.ts` exposes `generatePerMatchupSideboardPlans(mainDeck, sideboard, opponentArchetypes?)`:

1. **Player archetype** is detected with the existing `detectArchetype` (reused — no new taxonomy).
2. Each card's functional **role** is classified via `classifyRole` (now exported from `coach-deck-analysis.ts` — the SAME role taxonomy used everywhere else: `threats / ramp / removal / cardDraw / disruption / lands / other`).
3. Each opponent archetype maps to a **threat profile** keyed by its category (`aggro / control / midrange / combo / tribal / special`) from `archetype-signatures.ts`. The profile assigns a relative **value** to each role for that matchup (e.g. `removal` is high-value vs aggro/tribal; `disruption` + `cardDraw` vs combo; `cardDraw` + resilient `threats` vs control; redundant `removal` is negative vs control).
4. **Board IN**: sideboard cards ranked by role value (>0), cheapest first, capped at 8.
5. **Board OUT**: maindeck non-lands ranked by cuttability (inverse role value, with a CMC penalty vs fast decks and a redundant-removal penalty vs control), quantity balanced 1:1 with board-in.
6. **Guidance** is templated per category with the player archetype interpolated.

The output is **deterministic** for a given `(mainDeck, sideboard, opponentArchetypes)` tuple and works fully offline. Callers can pass an explicit opponent list; the default picks one representative archetype per category (Burn, Draw-Go, Good Stuff, Storm, Elves, Superfriends → ≥3 plans guaranteed).

## UI surface
New `MatchupSideboardPlans` component (`src/components/meta/sideboard/MatchupSideboardPlans.tsx`) reuses the existing sideboard UI patterns (Card/Badge, green `+in` / red `-out` conventions from `SideboardPlanCard`) and renders a per-matchup grid of boarding guides with rationales. It computes the plan locally via `useMemo` and is accessibility-labelled (aria-labels per matchup, consistent with the #1101/#1149 a11y wave). Exported from the sideboard barrel.

## Acceptance criteria
- [x] Coach generates per-matchup sideboard plans (board IN / board OUT + rationale) for each relevant opponent archetype
- [x] Deterministic / heuristic-grounded (archetype signatures + card roles) — no LLM needed for the core logic
- [x] UI surface presents per-matchup in/out lists (extends existing sideboard component patterns)
- [x] Unit tests cover: aggro (removal in / slow threats out), combo (disruption in / creature-removal excluded), control (redundant removal out), empty sideboard handling, ≥3 default plans, determinism, empty maindeck safety, and in/out balance
- [x] No regressions — full suite passes (278 suites / 5681 tests)

## Files changed
- `src/ai/flows/sideboard-plan.ts` (new) — heuristic generator + types
- `src/ai/flows/coach-deck-analysis.ts` — export `classifyRole` for reuse
- `src/components/meta/sideboard/MatchupSideboardPlans.tsx` (new) — UI surface
- `src/components/meta/sideboard/index.ts` — barrel export
- `src/ai/flows/__tests__/sideboard-plan.test.ts` (new) — 8 unit tests

## Verification
- `jest sideboard coach-deck-analysis archetype` → 278 suites, 5681 passed
- `tsc --noEmit` → no errors in changed files
- `eslint` (flat config) → clean on all changed files

## Notes / scope
Kept scoped to per-matchup in/out plans + guidance. Did not rebuild the existing sideboard editor or touch the opponent-side in-game sideboarding (#995, Lane 2). An optional LLM refinement layer can be layered on top later but is intentionally out of scope to keep the base plan local-first.