### PR TITLE
test(ai): resolve #1078 — raise coverage on meta-analysis, deck-review, and post-game heuristic flows

### DIFF
--- a/src/ai/flows/__tests__/ai-deck-coach-review.test.ts
+++ b/src/ai/flows/__tests__/ai-deck-coach-review.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Tests for the heuristic deck-coach-review flow (issue #1078).
+ *
+ * `reviewDeck` (issue #440) selects between an AI proxy path and a heuristic
+ * fallback, gated by rate limiting (issue #526), online status, and the
+ * prompt-security output validator (issue #1107). The heuristic tail also
+ * validates card legality and rebalances add/remove quantities. All of these
+ * branches previously had zero direct coverage.
+ *
+ * The dependencies are mocked so the REAL flow logic (branch selection,
+ * validation, rebalancing, summary prefixing, option filtering) is exercised.
+ * `@/ai/prompt-security` is left real because `validateDeckReviewOutput` is a
+ * pure function already covered elsewhere — feeding it well-formed vs malformed
+ * payloads drives the AI→heuristic fallback branch honestly.
+ */
+
+jest.mock("@/lib/heuristic-deck-coach", () => ({
+  reviewDeckHeuristic: jest.fn(),
+}));
+jest.mock("@/lib/server-card-operations", () => ({
+  validateCardLegality: jest.fn(),
+}));
+jest.mock("@/lib/ai-proxy-client", () => ({
+  callAIProxy: jest.fn(),
+}));
+jest.mock("@/lib/rate-limiter", () => {
+  // Keep the real RateLimitError class so `instanceof` in the flow works, while
+  // stubbing enforceRateLimit and the request queue (queue runs fn inline).
+  const actual = jest.requireActual("@/lib/rate-limiter");
+  return {
+    ...actual,
+    enforceRateLimit: jest.fn(),
+    aiRequestQueue: { add: (fn: () => Promise<unknown>) => fn() },
+  };
+});
+
+import { reviewDeck } from "../ai-deck-coach-review";
+import type { DeckReviewOutput } from "../ai-deck-coach-review";
+import { reviewDeckHeuristic } from "@/lib/heuristic-deck-coach";
+import { validateCardLegality } from "@/lib/server-card-operations";
+import { callAIProxy } from "@/lib/ai-proxy-client";
+import { enforceRateLimit, RateLimitError } from "@/lib/rate-limiter";
+
+const mockedHeuristic = reviewDeckHeuristic as jest.MockedFunction<
+  typeof reviewDeckHeuristic
+>;
+const mockedValidate = validateCardLegality as jest.MockedFunction<
+  typeof validateCardLegality
+>;
+const mockedProxy = callAIProxy as jest.MockedFunction<typeof callAIProxy>;
+const mockedEnforce = enforceRateLimit as jest.MockedFunction<
+  typeof enforceRateLimit
+>;
+
+const DECKLIST = "4 Lightning Bolt\n2 Blood Moon\n3 Forest";
+
+function heuristicResult(
+  overrides: Partial<DeckReviewOutput> = {},
+): DeckReviewOutput {
+  return {
+    reviewSummary: "Heuristic review summary.",
+    deckOptions: [
+      {
+        title: "Optimize for Aggro",
+        description: "Lower your curve.",
+        cardsToAdd: [{ name: "Lightning Bolt", quantity: 2 }],
+        cardsToRemove: [{ name: "Expensive Card", quantity: 2 }],
+      },
+    ],
+    archetype: { primary: "Aggro", confidence: 0.8 },
+    synergies: { present: [], missing: [] },
+    ...overrides,
+  };
+}
+
+function setOnline(online: boolean): void {
+  Object.defineProperty(navigator, "onLine", {
+    value: online,
+    configurable: true,
+    writable: true,
+  });
+}
+
+let errorSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // The flow intentionally logs when the AI path fails and it falls back to
+  // the heuristic — silence that expected noise so it does not pollute output.
+  errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  mockedEnforce.mockImplementation(() => {});
+  mockedHeuristic.mockReturnValue(heuristicResult());
+  mockedValidate.mockResolvedValue({ found: [], notFound: [], illegal: [] });
+  // By default the AI path is unavailable → falls through to heuristic.
+  mockedProxy.mockResolvedValue({ success: false } as never);
+  setOnline(true);
+});
+
+afterEach(() => {
+  setOnline(true);
+  errorSpy.mockRestore();
+});
+
+describe("reviewDeck — rate limiting", () => {
+  it("throws a friendly error when the rate limit is exceeded", async () => {
+    mockedEnforce.mockImplementation(() => {
+      throw new RateLimitError("limited", 5000, 0);
+    });
+    await expect(
+      reviewDeck({ decklist: DECKLIST, format: "modern" }),
+    ).rejects.toThrow(/Rate limit exceeded.*5 seconds/);
+    expect(mockedHeuristic).not.toHaveBeenCalled();
+  });
+
+  it("rethrows non-rate-limit errors unchanged", async () => {
+    mockedEnforce.mockImplementation(() => {
+      throw new Error("unexpected boom");
+    });
+    await expect(
+      reviewDeck({ decklist: DECKLIST, format: "modern" }),
+    ).rejects.toThrow("unexpected boom");
+  });
+
+  it("enforces the limit under a per-format user id", async () => {
+    await reviewDeck({ decklist: DECKLIST, format: "modern" });
+    expect(mockedEnforce).toHaveBeenCalledWith("deck-review-modern");
+  });
+});
+
+describe("reviewDeck — heuristic path", () => {
+  it("returns the heuristic summary WITHOUT a mode prefix when online and AI is off", async () => {
+    const out = await reviewDeck({ decklist: DECKLIST, format: "modern" });
+    expect(out.reviewSummary).toBe("Heuristic review summary.");
+    expect(out.archetype).toEqual({ primary: "Aggro", confidence: 0.8 });
+    expect(out.synergies).toEqual({ present: [], missing: [] });
+  });
+
+  it("prefixes the summary in Heuristic Mode when offline", async () => {
+    setOnline(false);
+    const out = await reviewDeck({ decklist: DECKLIST, format: "modern" });
+    expect(out.reviewSummary).toBe(
+      "[Heuristic Mode - AI Unavailable] Heuristic review summary.",
+    );
+  });
+
+  it("parses the decklist and passes card objects to the heuristic engine", async () => {
+    await reviewDeck({ decklist: DECKLIST, format: "modern" });
+    expect(mockedHeuristic).toHaveBeenCalledWith(
+      DECKLIST,
+      "modern",
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Lightning Bolt", count: 4 }),
+      ]),
+    );
+  });
+
+  it("handles an empty decklist without throwing", async () => {
+    mockedHeuristic.mockReturnValue(
+      heuristicResult({ deckOptions: [] }),
+    );
+    const out = await reviewDeck({ decklist: "", format: "modern" });
+    expect(out.deckOptions).toEqual([]);
+  });
+
+  it("filters out deck options that propose no card changes", async () => {
+    mockedHeuristic.mockReturnValue(
+      heuristicResult({
+        deckOptions: [
+          {
+            title: "No Changes",
+            description: "Nothing to add.",
+            // no cardsToAdd / cardsToRemove
+          },
+          {
+            title: "Has Adds",
+            description: "Add this.",
+            cardsToAdd: [{ name: "Bolt", quantity: 1 }],
+          },
+        ],
+      }),
+    );
+    const out = await reviewDeck({ decklist: DECKLIST, format: "modern" });
+    expect(out.deckOptions).toHaveLength(1);
+    expect(out.deckOptions[0].title).toBe("Has Adds");
+  });
+});
+
+describe("reviewDeck — card legality validation in the heuristic tail", () => {
+  it("removes not-found and illegal cards from the add suggestions", async () => {
+    mockedValidate.mockResolvedValue({
+      found: [],
+      notFound: ["Lightning Bolt"],
+      illegal: ["Blood Moon"],
+    });
+    mockedHeuristic.mockReturnValue(
+      heuristicResult({
+        deckOptions: [
+          {
+            title: "Opt",
+            description: "d",
+            cardsToAdd: [
+              { name: "Lightning Bolt", quantity: 1 },
+              { name: "Blood Moon", quantity: 1 },
+              { name: "Good Card", quantity: 1 },
+            ],
+            cardsToRemove: [{ name: "Cut", quantity: 1 }],
+          },
+        ],
+      }),
+    );
+    const out = await reviewDeck({ decklist: DECKLIST, format: "modern" });
+    expect(out.deckOptions[0].cardsToAdd).toEqual([
+      { name: "Good Card", quantity: 1 },
+    ]);
+  });
+
+  it("does not call validateCardLegality when an option has no cards to add", async () => {
+    mockedHeuristic.mockReturnValue(
+      heuristicResult({
+        deckOptions: [
+          { title: "Removes only", description: "d", cardsToRemove: [{ name: "Cut", quantity: 1 }] },
+        ],
+      }),
+    );
+    await reviewDeck({ decklist: DECKLIST, format: "modern" });
+    expect(mockedValidate).not.toHaveBeenCalled();
+  });
+});
+
+describe("reviewDeck — quantity rebalancing (issue #1078 regression)", () => {
+  it("trims removals down to the add count without looping forever", async () => {
+    // removes (5) exceed adds (2). Pre-fix this hung forever because the
+    // zero-quantity tail item was re-pushed and never let earlier items shrink.
+    mockedHeuristic.mockReturnValue(
+      heuristicResult({
+        deckOptions: [
+          {
+            title: "Rebalance",
+            description: "d",
+            cardsToAdd: [{ name: "Bolt", quantity: 2 }],
+            cardsToRemove: [
+              { name: "Slow A", quantity: 3 },
+              { name: "Slow B", quantity: 2 },
+            ],
+          },
+        ],
+      }),
+    );
+    const out = await reviewDeck({ decklist: DECKLIST, format: "modern" });
+    const option = out.deckOptions[0];
+    const removeCount = (option.cardsToRemove || []).reduce(
+      (s, c) => s + c.quantity,
+      0,
+    );
+    expect(removeCount).toBeLessThanOrEqual(2);
+    // No zero-quantity entries leak through.
+    expect((option.cardsToRemove || []).every((c) => c.quantity > 0)).toBe(true);
+  });
+
+  it("leaves a single oversized removal entry correctly trimmed", async () => {
+    mockedHeuristic.mockReturnValue(
+      heuristicResult({
+        deckOptions: [
+          {
+            title: "One Big Remove",
+            description: "d",
+            cardsToAdd: [{ name: "Bolt", quantity: 2 }],
+            cardsToRemove: [{ name: "Huge", quantity: 6 }],
+          },
+        ],
+      }),
+    );
+    const out = await reviewDeck({ decklist: DECKLIST, format: "modern" });
+    expect(out.deckOptions[0].cardsToRemove).toEqual([
+      { name: "Huge", quantity: 2 },
+    ]);
+  });
+});
+
+describe("reviewDeck — AI vs heuristic branch selection", () => {
+  it("returns the validated AI output when useAI and the proxy succeeds", async () => {
+    mockedProxy.mockResolvedValue({
+      success: true,
+      data: {
+        reviewSummary: "AI summary.",
+        deckOptions: [{ title: "AI option", description: "from model" }],
+      },
+    } as never);
+
+    const out = await reviewDeck({ decklist: DECKLIST, format: "modern" }, true);
+
+    expect(mockedProxy).toHaveBeenCalled();
+    expect(out.reviewSummary).toBe("AI summary.");
+    // Heuristic engine must not run when the AI response is used.
+    expect(mockedHeuristic).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the heuristic when the AI payload is malformed (validator rejects it)", async () => {
+    // validateDeckReviewOutput returns null for non-object payloads.
+    mockedProxy.mockResolvedValue({
+      success: true,
+      data: "not-an-object",
+    } as never);
+
+    const out = await reviewDeck({ decklist: DECKLIST, format: "modern" }, true);
+
+    expect(mockedHeuristic).toHaveBeenCalled();
+    // useAI=true → heuristic summary carries the unavailable-mode prefix.
+    expect(out.reviewSummary).toContain("Heuristic Mode");
+  });
+
+  it("falls back to the heuristic when the proxy reports failure", async () => {
+    mockedProxy.mockResolvedValue({ success: false } as never);
+
+    const out = await reviewDeck({ decklist: DECKLIST, format: "modern" }, true);
+
+    expect(mockedHeuristic).toHaveBeenCalled();
+    expect(out.reviewSummary).toContain("Heuristic Mode");
+  });
+
+  it("falls back to the heuristic when the proxy throws", async () => {
+    mockedProxy.mockRejectedValue(new Error("network down"));
+
+    const out = await reviewDeck({ decklist: DECKLIST, format: "modern" }, true);
+
+    expect(mockedHeuristic).toHaveBeenCalled();
+    expect(out.reviewSummary).toContain("Heuristic Mode");
+  });
+
+  it("skips the AI call entirely when offline, even if useAI is true", async () => {
+    setOnline(false);
+    const out = await reviewDeck({ decklist: DECKLIST, format: "modern" }, true);
+    expect(mockedProxy).not.toHaveBeenCalled();
+    expect(out.reviewSummary).toContain("Heuristic Mode");
+  });
+});

--- a/src/ai/flows/__tests__/ai-meta-analysis.test.ts
+++ b/src/ai/flows/__tests__/ai-meta-analysis.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Tests for the heuristic meta-analysis flow (issue #1078).
+ *
+ * `ai-meta-analysis.ts` wraps `analyzeMetaHeuristic` (issue #440) with a
+ * conversion layer (`convertHeuristicOutput`) plus two post-processing passes:
+ * card-legality validation via `importDecklist` and an add/remove quantity
+ * rebalance. The conversion + legality + rebalance logic previously had zero
+ * direct coverage. These tests pin the output shape, the strength/weakness
+ * inference, the format-specific branches, the legality filtering and the
+ * rebalance edge case so the Lane 3 LLM-rewiring work cannot silently regress.
+ */
+
+import type { MetaAnalysisOutput as HeuristicMetaOutput } from "@/lib/heuristic-meta-analysis";
+
+jest.mock("@/lib/heuristic-meta-analysis", () => ({
+  analyzeMetaHeuristic: jest.fn(),
+}));
+jest.mock("@/lib/server-card-operations", () => ({
+  importDecklist: jest.fn(),
+}));
+
+import { analyzeMetaAndSuggest } from "../ai-meta-analysis";
+import { analyzeMetaHeuristic } from "@/lib/heuristic-meta-analysis";
+import { importDecklist } from "@/lib/server-card-operations";
+
+const mockedAnalyzeMeta = analyzeMetaHeuristic as jest.MockedFunction<
+  typeof analyzeMetaHeuristic
+>;
+const mockedImportDecklist = importDecklist as jest.MockedFunction<
+  typeof importDecklist
+>;
+
+const DECKLIST = ["4 Lightning Bolt", "2 Blood Moon", "3 Bad Card"].join("\n");
+
+/** A canonical heuristic result exercising the strength + weakness descriptions. */
+function baseResult(overrides: Partial<HeuristicMetaOutput> = {}): HeuristicMetaOutput {
+  return {
+    currentMeta: "The modern metagame is dominated by Burn.",
+    archetypes: [
+      {
+        name: "Burn",
+        prevalence: "High",
+        playstyle: "burn",
+        keyCards: ["Lightning Bolt"],
+        weaknesses: ["Lifegain"],
+      },
+      {
+        name: "Tron",
+        prevalence: "Medium",
+        playstyle: "big mana",
+        keyCards: ["Karn Liberated"],
+        weaknesses: ["Aggro"],
+      },
+    ],
+    recommendations: [
+      {
+        title: "Improve Burn Matchup",
+        description:
+          "Your deck is naturally strong against Burn. Enhance this advantage.",
+        cardsToAdd: [{ name: "Lightning Bolt", quantity: 2 }],
+        cardsToRemove: [{ name: "Bad Card", quantity: 1 }],
+        matchup: { against: "Burn", strategy: "Race them down" },
+      },
+      {
+        title: "Improve Tron Matchup",
+        description:
+          "Your deck struggles against Tron. Address these weaknesses.",
+        cardsToAdd: [{ name: "Blood Moon", quantity: 2 }],
+        cardsToRemove: [{ name: "Other Card", quantity: 2 }],
+        matchup: { against: "Tron", strategy: "Pressure the lands" },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function legalImport() {
+  return Promise.resolve({ found: [], notFound: [], illegal: [] });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedAnalyzeMeta.mockImplementation(() => baseResult());
+  mockedImportDecklist.mockImplementation(legalImport);
+});
+
+describe("analyzeMetaAndSuggest — output shape", () => {
+  it("returns a full MetaAnalysisOutput matching the documented contract", async () => {
+    const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
+
+    expect(out).toHaveProperty("metaOverview");
+    expect(out).toHaveProperty("deckStrengths");
+    expect(out).toHaveProperty("deckWeaknesses");
+    expect(out).toHaveProperty("matchupAnalysis");
+    expect(out).toHaveProperty("cardSuggestions");
+    expect(out).toHaveProperty("strategicAdvice");
+    expect(Array.isArray(out.deckStrengths)).toBe(true);
+    expect(Array.isArray(out.matchupAnalysis)).toBe(true);
+    expect(typeof out.strategicAdvice).toBe("string");
+  });
+
+  it("passes decklist, format and focusArchetype through to the heuristic engine", async () => {
+    await analyzeMetaAndSuggest({
+      decklist: DECKLIST,
+      format: "modern",
+      focusArchetype: "Burn",
+    });
+    expect(mockedAnalyzeMeta).toHaveBeenCalledWith(
+      DECKLIST,
+      "modern",
+      expect.any(Array),
+      "Burn",
+    );
+    // The decklist is parsed into card objects (3 named lines here).
+    const cards = mockedAnalyzeMeta.mock.calls[0][2];
+    expect(cards).toHaveLength(3);
+    expect(cards[0]).toMatchObject({ name: "Lightning Bolt", count: 4 });
+  });
+});
+
+describe("analyzeMetaAndSuggest — conversion layer (convertHeuristicOutput)", () => {
+  it("maps metaOverview from the heuristic currentMeta", async () => {
+    const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
+    expect(out.metaOverview).toBe("The modern metagame is dominated by Burn.");
+  });
+
+  it("infers strengths/weaknesses from recommendation descriptions", async () => {
+    const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
+    expect(out.deckStrengths).toContain("Strong against Burn");
+    expect(out.deckWeaknesses).toContain("Weak against Tron");
+  });
+
+  it("converts recommendations into matchup analysis with sideboard notes", async () => {
+    const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
+    expect(out.matchupAnalysis).toHaveLength(2);
+    expect(out.matchupAnalysis[0]).toEqual({
+      archetype: "Burn",
+      recommendation: expect.stringContaining("naturally strong"),
+      sideboardNotes: "Race them down",
+    });
+  });
+
+  it("flattens recommendation cards into add/remove suggestions with reasons", async () => {
+    const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
+    expect(out.cardSuggestions.cardsToAdd.map((c) => c.name)).toEqual([
+      "Lightning Bolt",
+      "Blood Moon",
+    ]);
+    expect(out.cardSuggestions.cardsToRemove.map((c) => c.name)).toEqual([
+      "Bad Card",
+      "Other Card",
+    ]);
+    expect(out.cardSuggestions.cardsToAdd[0].reason).toContain("heuristic");
+    expect(out.cardSuggestions.cardsToRemove[0].reason).toContain("Underperforming");
+  });
+
+  it("renders strategicAdvice referencing format, archetypes and recommendation titles", async () => {
+    const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
+    expect(out.strategicAdvice).toContain("modern");
+    expect(out.strategicAdvice).toContain("Burn");
+    expect(out.strategicAdvice).toContain("Improve Burn Matchup");
+  });
+});
+
+describe("analyzeMetaAndSuggest — format-specific branches", () => {
+  it("adds commander-specific strengths and weaknesses", async () => {
+    const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "commander" });
+    expect(out.deckStrengths).toContain("Access to powerful Commanders and effects");
+    expect(out.deckWeaknesses).toContain(
+      "Slower game pace may struggle against fast combo",
+    );
+  });
+
+  it("adds modern-specific strengths and weaknesses", async () => {
+    const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
+    expect(out.deckStrengths).toContain("Access to powerful modern cards");
+    expect(out.deckWeaknesses).toContain("Must prepare for diverse meta");
+  });
+
+  it("adds no format-specific entries for an unrecognized format", async () => {
+    const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "brawl" });
+    expect(out.deckStrengths).not.toContain("Access to powerful modern cards");
+    expect(out.deckWeaknesses).not.toContain("Must prepare for diverse meta");
+  });
+});
+
+describe("analyzeMetaAndSuggest — decklist parsing edge cases", () => {
+  it("handles an empty decklist without throwing", async () => {
+    const out = await analyzeMetaAndSuggest({ decklist: "", format: "modern" });
+    expect(mockedAnalyzeMeta).toHaveBeenCalledWith(
+      "",
+      "modern",
+      [],
+      undefined,
+    );
+    expect(out.metaOverview).toBeDefined();
+  });
+
+  it("ignores malformed lines (no quantity prefix) and blank lines", async () => {
+    const decklist = [
+      "", // blank
+      "Lightning Bolt", // no quantity
+      "   ", // whitespace
+      "4 Blood Moon", // valid
+      "garbage line",
+    ].join("\n");
+    await analyzeMetaAndSuggest({ decklist, format: "modern" });
+    const cards = mockedAnalyzeMeta.mock.calls[0][2];
+    expect(cards).toHaveLength(1);
+    expect(cards[0].name).toBe("Blood Moon");
+  });
+});
+
+describe("analyzeMetaAndSuggest — card legality validation", () => {
+  it("removes not-found cards from the add suggestions", async () => {
+    mockedImportDecklist.mockResolvedValue({
+      found: [],
+      notFound: ["Blood Moon"],
+      illegal: [],
+    });
+    const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
+    expect(out.cardSuggestions.cardsToAdd.map((c) => c.name)).not.toContain(
+      "Blood Moon",
+    );
+    expect(mockedImportDecklist).toHaveBeenCalled();
+  });
+
+  it("removes illegal cards from the add suggestions", async () => {
+    mockedImportDecklist.mockResolvedValue({
+      found: [],
+      notFound: [],
+      illegal: ["Lightning Bolt"],
+    });
+    const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
+    expect(out.cardSuggestions.cardsToAdd.map((c) => c.name)).not.toContain(
+      "Lightning Bolt",
+    );
+  });
+
+  it("does not call importDecklist when there are no cards to add", async () => {
+    mockedAnalyzeMeta.mockReturnValue(
+      baseResult({
+        recommendations: [
+          {
+            title: "Only Removes",
+            description: "Your deck struggles against Tron. Address these weaknesses.",
+            cardsToAdd: [],
+            cardsToRemove: [{ name: "Bad Card", quantity: 2 }],
+            matchup: { against: "Tron", strategy: "Pressure" },
+          },
+        ],
+      }),
+    );
+    await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
+    expect(mockedImportDecklist).not.toHaveBeenCalled();
+  });
+});
+
+describe("analyzeMetaAndSuggest — quantity rebalancing", () => {
+  it("trims removals down to match additions when removes exceed adds", async () => {
+    mockedAnalyzeMeta.mockReturnValue(
+      baseResult({
+        recommendations: [
+          {
+            title: "Rebalance",
+            description:
+              "Your deck struggles against Tron. Address these weaknesses.",
+            cardsToAdd: [{ name: "Blood Moon", quantity: 2 }],
+            cardsToRemove: [
+              { name: "Too Slow A", quantity: 3 },
+              { name: "Too Slow B", quantity: 2 },
+            ],
+            matchup: { against: "Tron", strategy: "Pressure" },
+          },
+        ],
+      }),
+    );
+
+    const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
+    const addCount = out.cardSuggestions.cardsToAdd.reduce((s, c) => s + c.quantity, 0);
+    const removeCount = out.cardSuggestions.cardsToRemove.reduce(
+      (s, c) => s + c.quantity,
+      0,
+    );
+    // adds stayed at 2; removals (originally 5) were trimmed to <= adds.
+    expect(addCount).toBe(2);
+    expect(removeCount).toBeLessThanOrEqual(addCount);
+  });
+
+  it("leaves removals untouched when adds already meet or exceed them", async () => {
+    mockedAnalyzeMeta.mockReturnValue(
+      baseResult({
+        recommendations: [
+          {
+            title: "More Adds",
+            description:
+              "Your deck is naturally strong against Burn. Enhance this advantage.",
+            cardsToAdd: [{ name: "Bolt", quantity: 4 }],
+            cardsToRemove: [{ name: "Bad", quantity: 1 }],
+            matchup: { against: "Burn", strategy: "Race" },
+          },
+        ],
+      }),
+    );
+    const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
+    expect(out.cardSuggestions.cardsToRemove).toEqual([
+      { name: "Bad", quantity: 1, reason: expect.any(String) },
+    ]);
+  });
+});
+
+describe("analyzeMetaAndSuggest — sideboard cap", () => {
+  it("limits sideboardSuggestions to the first 5 add cards", async () => {
+    mockedAnalyzeMeta.mockReturnValue(
+      baseResult({
+        recommendations: [
+          {
+            title: "Big",
+            description: "Your deck is naturally strong against Burn. Enhance this advantage.",
+            cardsToAdd: Array.from({ length: 8 }, (_, i) => ({
+              name: `Card ${i}`,
+              quantity: 1,
+            })),
+            cardsToRemove: [],
+            matchup: { against: "Burn", strategy: "Race" },
+          },
+        ],
+      }),
+    );
+    const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
+    expect(out.sideboardSuggestions).toHaveLength(5);
+  });
+});

--- a/src/ai/flows/__tests__/ai-post-game-analysis.test.ts
+++ b/src/ai/flows/__tests__/ai-post-game-analysis.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Tests for the heuristic post-game analysis flow (issue #1078).
+ *
+ * `ai-post-game-analysis.ts` replaced its Genkit AI provider calls with pure
+ * heuristic algorithms (issue #446). These tests lock in the CURRENT behavior
+ * of the three exported entry points and their internal helpers — including the
+ * defensive type-guards and the win/loss/draw, life-change, card-advantage,
+ * mistake, rating-clamp and low-life branches — so the Lane 3 LLM-rewiring
+ * work can refactor safely against a concrete baseline.
+ */
+
+import type { GameReplay, GameAnalysisTurn, Threat } from "@/ai/types";
+import {
+  analyzeGame,
+  identifyKeyMoments,
+  generateQuickTips,
+} from "../ai-post-game-analysis";
+
+const PLAYER = "Alex";
+
+/** Build a single analysis turn with sensible defaults. */
+function turn(
+  overrides: Partial<GameAnalysisTurn> & { turnNumber: number },
+): GameAnalysisTurn {
+  return { ...overrides };
+}
+
+/** Build a well-formed Threat entry. */
+function threat(card: string, threatText: string): Threat {
+  return { card, threat: threatText, priority: "low" };
+}
+
+/** A replay where the player won with card advantage. */
+function winningReplay(): GameReplay {
+  return {
+    playerLife: 18,
+    opponentLife: 0,
+    turns: [
+      turn({ turnNumber: 1, cardAdvantage: { [PLAYER]: 1 } }),
+      turn({ turnNumber: 2, cardAdvantage: { [PLAYER]: 2 } }),
+    ],
+  };
+}
+
+describe("analyzeGame", () => {
+  it("returns a complete GameAnalysisOutput shape for a typical winning game", async () => {
+    const out = await analyzeGame({ replay: winningReplay(), playerName: PLAYER });
+
+    expect(typeof out.gameSummary).toBe("string");
+    expect(out.gameSummary).toContain("won");
+    expect(Array.isArray(out.keyMoments)).toBe(true);
+    expect(Array.isArray(out.mistakes)).toBe(true);
+    expect(Array.isArray(out.strengths)).toBe(true);
+    expect(Array.isArray(out.improvementAreas)).toBe(true);
+    expect(Array.isArray(out.deckSuggestions)).toBe(true);
+    expect(Array.isArray(out.tips)).toBe(true);
+    expect(typeof out.overallRating).toBe("number");
+  });
+
+  it("reports a win when player life exceeds opponent life", async () => {
+    const out = await analyzeGame({
+      replay: { playerLife: 20, opponentLife: 5 },
+      playerName: PLAYER,
+    });
+    expect(out.gameSummary).toContain(`${PLAYER} won`);
+    expect(out.gameSummary).toContain("20 life");
+  });
+
+  it("reports a loss when player life is below opponent life", async () => {
+    const out = await analyzeGame({
+      replay: { playerLife: 3, opponentLife: 12 },
+      playerName: PLAYER,
+    });
+    expect(out.gameSummary).toContain(`${PLAYER} lost`);
+  });
+
+  it("reports a draw when life totals are equal", async () => {
+    const out = await analyzeGame({
+      replay: { playerLife: 10, opponentLife: 10 },
+      playerName: PLAYER,
+    });
+    expect(out.gameSummary).toContain("draw");
+  });
+
+  it("falls back to 20 life when player/opponent life are missing", async () => {
+    const out = await analyzeGame({ replay: {}, playerName: PLAYER });
+    // 20 vs 20 → draw
+    expect(out.gameSummary).toContain("draw");
+  });
+
+  it("counts the number of turns actually played", async () => {
+    const replay: GameReplay = {
+      turns: [
+        turn({ turnNumber: 1 }),
+        turn({ turnNumber: 2 }),
+        turn({ turnNumber: 3 }),
+      ],
+    };
+    const out = await analyzeGame({ replay, playerName: PLAYER });
+    expect(out.gameSummary).toContain("Game lasted 3 turns");
+  });
+
+  it("ignores malformed turns that lack a numeric turnNumber", async () => {
+    const replay = {
+      turns: [
+        { turnNumber: 1 },
+        { foo: "bar" }, // no turnNumber → filtered out by type guard
+        { turnNumber: "two" }, // non-numeric → filtered out
+        { turnNumber: 3 },
+      ],
+    } as unknown as GameReplay;
+    const out = await analyzeGame({ replay, playerName: PLAYER });
+    expect(out.gameSummary).toContain("Game lasted 2 turns");
+  });
+
+  it("handles an empty replay (no turns) without throwing", async () => {
+    const out = await analyzeGame({ replay: {}, playerName: PLAYER });
+    expect(out.gameSummary).toContain("Game lasted 0 turns");
+    expect(out.mistakes).toEqual([]);
+    expect(out.keyMoments).toEqual([]);
+    expect(out.strengths.length).toBeGreaterThan(0);
+  });
+
+  it("handles a replay with an empty turns array", async () => {
+    const out = await analyzeGame({ replay: { turns: [] }, playerName: PLAYER });
+    expect(out.gameSummary).toContain("0 turns");
+  });
+});
+
+describe("analyzeGame — key moments (life changes & card advantage)", () => {
+  it("flags significant positive/negative life changes (>= 5)", async () => {
+    const replay: GameReplay = {
+      turns: [
+        turn({ turnNumber: 1, lifeChanges: { [PLAYER]: 6 } }),
+        turn({ turnNumber: 2, lifeChanges: { [PLAYER]: -8 } }),
+        turn({ turnNumber: 3, lifeChanges: { [PLAYER]: 2 } }), // below threshold
+      ],
+    };
+    const out = await analyzeGame({ replay, playerName: PLAYER });
+    expect(out.keyMoments).toHaveLength(2);
+    expect(out.keyMoments[0].impact).toBe("positive");
+    expect(out.keyMoments[1].impact).toBe("negative");
+  });
+
+  it("flags card-advantage shifts (>= 2)", async () => {
+    const replay: GameReplay = {
+      turns: [turn({ turnNumber: 1, cardAdvantage: { [PLAYER]: 3 } })],
+    };
+    const out = await analyzeGame({ replay, playerName: PLAYER });
+    expect(out.keyMoments).toHaveLength(1);
+    expect(out.keyMoments[0].description).toContain("Card advantage");
+  });
+
+  it("limits key moments to the top 5", async () => {
+    const turns: GameAnalysisTurn[] = Array.from({ length: 8 }, (_, i) =>
+      turn({ turnNumber: i + 1, lifeChanges: { [PLAYER]: -5 } }),
+    );
+    const out = await analyzeGame({ replay: { turns }, playerName: PLAYER });
+    expect(out.keyMoments.length).toBeLessThanOrEqual(5);
+  });
+});
+
+describe("analyzeGame — mistakes", () => {
+  it("records missed opportunities as minor mistakes", async () => {
+    const replay: GameReplay = {
+      turns: [
+        turn({
+          turnNumber: 1,
+          missedOpportunities: {
+            [PLAYER]: [
+              threat("Lightning Bolt", "Looming goyf"),
+              threat("Counterspell", "Key spell"),
+            ],
+          },
+        }),
+      ],
+    };
+    const out = await analyzeGame({ replay, playerName: PLAYER });
+    expect(out.mistakes).toHaveLength(2);
+    expect(out.mistakes.every((m) => m.severity === "minor")).toBe(true);
+    expect(out.mistakes[0].description).toContain("Lightning Bolt");
+  });
+
+  it("records suboptimal plays as major mistakes", async () => {
+    const replay: GameReplay = {
+      turns: [
+        turn({
+          turnNumber: 2,
+          suboptimalPlays: { [PLAYER]: ["Attacked into a blocker", "Wasted removal"] },
+        }),
+      ],
+    };
+    const out = await analyzeGame({ replay, playerName: PLAYER });
+    expect(out.mistakes).toHaveLength(2);
+    expect(out.mistakes.every((m) => m.severity === "major")).toBe(true);
+  });
+
+  it("ignores malformed missed-opportunity entries (no card/threat)", async () => {
+    const replay: GameReplay = {
+      turns: [
+        turn({
+          turnNumber: 1,
+          missedOpportunities: {
+            [PLAYER]: [
+              { card: "Bolt" },
+              "not-an-object",
+              { threat: "x" },
+            ] as unknown as Threat[],
+          },
+        }),
+      ],
+    };
+    const out = await analyzeGame({ replay, playerName: PLAYER });
+    expect(out.mistakes).toEqual([]);
+  });
+
+  it("ignores non-string suboptimal plays", async () => {
+    const replay: GameReplay = {
+      turns: [
+        turn({
+          turnNumber: 1,
+          // Intentionally malformed: numeric entries must be skipped.
+          suboptimalPlays: { [PLAYER]: [123, "valid play"] as unknown as string[] },
+        }),
+      ],
+    };
+    const out = await analyzeGame({ replay, playerName: PLAYER });
+    expect(out.mistakes).toHaveLength(1);
+    expect(out.mistakes[0].description).toBe("valid play");
+  });
+
+  it("limits mistakes to the top 5", async () => {
+    const turns: GameAnalysisTurn[] = Array.from({ length: 8 }, (_, i) =>
+      turn({
+        turnNumber: i + 1,
+        suboptimalPlays: { [PLAYER]: ["bad play"] },
+      }),
+    );
+    const out = await analyzeGame({ replay: { turns }, playerName: PLAYER });
+    expect(out.mistakes.length).toBeLessThanOrEqual(5);
+  });
+});
+
+describe("analyzeGame — strengths, improvement areas & tips", () => {
+  it("credits card advantage and life lead as strengths", async () => {
+    const out = await analyzeGame({
+      replay: {
+        playerLife: 20,
+        opponentLife: 5,
+        turns: [turn({ turnNumber: 1, cardAdvantage: { [PLAYER]: 2 } })],
+      },
+      playerName: PLAYER,
+    });
+    expect(out.strengths).toContain("Maintained healthy life total throughout the game");
+    expect(out.strengths).toContain("Generated card advantage through effective play");
+  });
+
+  it("flags low life as an improvement area and adds a survival tip", async () => {
+    const out = await analyzeGame({
+      replay: { playerLife: 8, opponentLife: 18 },
+      playerName: PLAYER,
+    });
+    expect(out.improvementAreas).toContain(
+      "Improve defensive strategies to preserve life total",
+    );
+    expect(out.tips).toContain("Prioritize survival over aggression when life is low");
+  });
+
+  it("flags excessive missed opportunities as an improvement area", async () => {
+    const replay: GameReplay = {
+      turns: [
+        turn({
+          turnNumber: 1,
+          missedOpportunities: {
+            [PLAYER]: [
+              threat("a", "t"),
+              threat("b", "t"),
+              threat("c", "t"),
+              threat("d", "t"),
+            ],
+          },
+        }),
+      ],
+    };
+    const out = await analyzeGame({ replay, playerName: PLAYER });
+    expect(out.improvementAreas).toContain(
+      "Consider all available options more carefully before making decisions",
+    );
+  });
+
+  it("always returns the baseline improvement areas and tips", async () => {
+    const out = await analyzeGame({
+      replay: { playerLife: 20, opponentLife: 20 },
+      playerName: PLAYER,
+    });
+    expect(out.improvementAreas).toContain("Work on timing of spells and abilities");
+    expect(out.improvementAreas).toContain("Develop better understanding of opponent's deck");
+    expect(out.tips.length).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe("analyzeGame — deck suggestions", () => {
+  it("suggests life-gain cards when life is low", async () => {
+    const out = await analyzeGame({
+      replay: { playerLife: 6, opponentLife: 10 },
+      playerName: PLAYER,
+    });
+    expect(
+      out.deckSuggestions.some((s) => /life gain/i.test(s.card)),
+    ).toBe(true);
+  });
+
+  it("suggests lower-cost cards when the average mana cost is high", async () => {
+    const replay: GameReplay = {
+      turns: [
+        turn({ turnNumber: 1, manaCost: 5 }),
+        turn({ turnNumber: 2, manaCost: 5 }),
+      ],
+    };
+    const out = await analyzeGame({ replay, playerName: PLAYER });
+    expect(out.deckSuggestions.some((s) => /Lower-cost/i.test(s.card))).toBe(true);
+  });
+
+  it("always suggests card draw and caps at 3 suggestions", async () => {
+    const out = await analyzeGame({
+      replay: {
+        playerLife: 5,
+        turns: [turn({ turnNumber: 1, manaCost: 6 })],
+      },
+      playerName: PLAYER,
+    });
+    expect(out.deckSuggestions.some((s) => /Card draw/i.test(s.card))).toBe(true);
+    expect(out.deckSuggestions.length).toBeLessThanOrEqual(3);
+  });
+});
+
+describe("analyzeGame — overall rating", () => {
+  it("clamps the rating to the 1..10 range", async () => {
+    // Huge negative life swing and heavy card disadvantage would otherwise
+    // drag the rating well below zero.
+    const low = await analyzeGame({
+      replay: { playerLife: 1, opponentLife: 30 },
+      playerName: PLAYER,
+    });
+    expect(low.overallRating).toBeGreaterThanOrEqual(1);
+    expect(low.overallRating).toBeLessThanOrEqual(10);
+
+    // Dominant position would otherwise push it above 10.
+    const high = await analyzeGame({
+      replay: {
+        playerLife: 40,
+        opponentLife: 1,
+        turns: Array.from({ length: 5 }, (_, i) =>
+          turn({ turnNumber: i + 1, cardAdvantage: { [PLAYER]: 3 } }),
+        ),
+      },
+      playerName: PLAYER,
+    });
+    expect(high.overallRating).toBe(10);
+  });
+
+  it("rewards card advantage in the rating", async () => {
+    const withCa = await analyzeGame({
+      replay: {
+        playerLife: 10,
+        opponentLife: 10,
+        turns: [turn({ turnNumber: 1, cardAdvantage: { [PLAYER]: 4 } })],
+      },
+      playerName: PLAYER,
+    });
+    const withoutCa = await analyzeGame({
+      replay: { playerLife: 10, opponentLife: 10 },
+      playerName: PLAYER,
+    });
+    expect(withCa.overallRating).toBeGreaterThan(withoutCa.overallRating);
+  });
+});
+
+describe("identifyKeyMoments", () => {
+  it("maps positive impact → great_play and negative → mistake", async () => {
+    const replay: GameReplay = {
+      turns: [
+        turn({ turnNumber: 1, lifeChanges: { [PLAYER]: 7 } }), // positive
+        turn({ turnNumber: 2, lifeChanges: { [PLAYER]: -9 } }), // negative
+        turn({ turnNumber: 3, cardAdvantage: { [PLAYER]: 0 } }), // no moment
+      ],
+    };
+    const out = await identifyKeyMoments({ replay, playerName: PLAYER });
+    expect(out.moments).toHaveLength(2);
+    expect(out.moments[0].type).toBe("great_play");
+    expect(out.moments[1].type).toBe("mistake");
+    expect(out.moments[0].whatHappened).toBe(out.moments[0].description);
+    expect(out.moments[0].couldHaveHappened).toBeDefined();
+    expect(out.summary).toContain("2 key moments");
+  });
+
+  it("handles a replay with no detectable moments", async () => {
+    const out = await identifyKeyMoments({ replay: {}, playerName: PLAYER });
+    expect(out.moments).toEqual([]);
+    expect(out.summary).toContain("0 key moments");
+  });
+
+  it("tolerates a malformed replay without throwing", async () => {
+    const out = await identifyKeyMoments({
+      replay: { turns: "not-an-array" } as unknown as GameReplay,
+      playerName: PLAYER,
+    });
+    expect(out.moments).toEqual([]);
+  });
+});
+
+describe("generateQuickTips", () => {
+  it("returns tips plus the improvement focus areas", async () => {
+    const out = await generateQuickTips({
+      replay: { playerLife: 5, opponentLife: 12 },
+      playerName: PLAYER,
+    });
+    expect(out.tips.length).toBeGreaterThan(0);
+    expect(out.focusAreas.length).toBeGreaterThan(0);
+    // Low life surfaces a dedicated survival tip and a defensive focus area.
+    expect(out.tips).toContain("Prioritize survival over aggression when life is low");
+    expect(out.focusAreas).toContain(
+      "Improve defensive strategies to preserve life total",
+    );
+  });
+
+  it("returns the baseline tip set for a comfortable game", async () => {
+    const out = await generateQuickTips({
+      replay: { playerLife: 20, opponentLife: 20 },
+      playerName: PLAYER,
+    });
+    expect(out.tips).toHaveLength(5);
+  });
+});

--- a/src/ai/flows/__tests__/coach-deck-analysis-roles.test.ts
+++ b/src/ai/flows/__tests__/coach-deck-analysis-roles.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Edge-case tests for the structured deck-analysis assembly (issue #1078).
+ *
+ * `coach-deck-analysis.ts` already has a happy-path suite (gained in #952) that
+ * drives `buildStructuredDeckAnalysis` end-to-end. This file targets the
+ * PURE, internal helpers (`classifyRole`, `assessCurve`,
+ * `deriveStrengthsAndGaps`, `buildKeyCards`) and the formatter's empty-state
+ * branches by funnelling crafted decks through the exported
+ * `assembleStructuredAnalysis` + `formatStructuredAnalysisForLLM`. That raises
+ * branch coverage on the role/curve/strength/gap logic that the Lane 3
+ * LLM-rewiring work will touch.
+ */
+
+import type { DeckCard } from "@/app/actions";
+import type {
+  ArchetypeResult,
+  DeckStats,
+} from "@/ai/archetype-signatures";
+import type {
+  SynergyResult,
+  MissingSynergy,
+} from "@/ai/synergy-detector";
+import {
+  assembleStructuredAnalysis,
+  formatStructuredAnalysisForLLM,
+} from "../coach-deck-analysis";
+
+function card(
+  name: string,
+  typeLine: string,
+  count: number,
+  oracle = "",
+  colors: string[] = ["W"],
+): DeckCard {
+  return {
+    id: name.toLowerCase().replace(/\s+/g, "-"),
+    name,
+    cmc: 0,
+    type_line: typeLine,
+    colors,
+    color_identity: colors,
+    legalities: {},
+    count,
+    oracle_text: oracle,
+  };
+}
+
+function makeStats(overrides: Partial<DeckStats> = {}): DeckStats {
+  return {
+    totalCards: 60,
+    creatureCount: 20,
+    landCount: 24,
+    spellCount: 16,
+    avgCmc: 2.5,
+    creatureRatio: 0.5,
+    landRatio: 0.4,
+    spellRatio: 0.4,
+    colorDistribution: { W: 30 },
+    cardTypes: {},
+    keywordCounts: {},
+    manaCurve: [0, 8, 8, 6, 4, 2, 1, 1],
+    ...overrides,
+  };
+}
+
+function archetypeOf(primary: string, confidence = 0.8): ArchetypeResult {
+  return {
+    primary,
+    confidence,
+    secondary: undefined,
+    secondaryConfidence: undefined,
+    allScores: [{ name: primary, score: confidence, category: "value" }],
+  };
+}
+
+describe("assembleStructuredAnalysis — role classification (classifyRole)", () => {
+  function roleOf(deck: DeckCard[]): {
+    threats: number;
+    ramp: number;
+    removal: number;
+    cardDraw: number;
+    disruption: number;
+    lands: number;
+    other: number;
+  } {
+    return assembleStructuredAnalysis(deck, {
+      archetype: archetypeOf("Midrange"),
+      stats: makeStats(),
+      synergies: [],
+      missing: [],
+    }).roleDistribution;
+  }
+
+  it("classifies counterspells as disruption", () => {
+    const r = roleOf([card("Counterspell", "Instant", 2, "Counter target spell.")]);
+    expect(r.disruption).toBe(2);
+  });
+
+  it("classifies hand-disruption (look at hand) as disruption", () => {
+    const r = roleOf([card("Thoughtseize", "Instant", 2, "Look at target player's hand.")]);
+    expect(r.disruption).toBe(2);
+  });
+
+  it("classifies destroy-creature effects as removal", () => {
+    const r = roleOf([card("Doom Blade", "Instant", 2, "Destroy target creature.")]);
+    expect(r.removal).toBe(2);
+  });
+
+  it("classifies ramp (search library for a land) as ramp", () => {
+    // The ramp regex requires "search ... library for ... land" / "add ... mana".
+    // "Tap: Add G" alone does NOT match, so only land-tutors count here.
+    const r = roleOf([
+      card("Cultivate", "Sorcery", 2, "Search your library for a basic land."),
+      card("Kodama's Reach", "Sorcery", 2, "Search your library for a land."),
+    ]);
+    expect(r.ramp).toBe(4);
+  });
+
+  it("classifies card-draw spells as cardDraw", () => {
+    const r = roleOf([card("Divination", "Sorcery", 2, "Draw two cards.")]);
+    expect(r.cardDraw).toBe(2);
+  });
+
+  it("classifies creatures and planeswalkers as threats", () => {
+    const r = roleOf([
+      card("Grizzly Bears", "Creature", 2),
+      card("Chandra", "Planeswalker", 1),
+    ]);
+    expect(r.threats).toBe(3);
+  });
+
+  it("falls back to 'other' for cards matching no role", () => {
+    const r = roleOf([card("Mystery Stone", "Artifact", 3, "A curious relic.")]);
+    expect(r.other).toBe(3);
+  });
+});
+
+describe("assembleStructuredAnalysis — curve assessment (assessCurve)", () => {
+  // assessCurve derives nonLand from stats.totalCards - stats.landCount, so the
+  // helper pins landCount to 0 and totalCards to the desired non-land count.
+  function curveAssessment(manaCurve: number[], nonLand: number): string {
+    return assembleStructuredAnalysis([], {
+      archetype: archetypeOf("Aggro"),
+      stats: makeStats({ manaCurve, totalCards: nonLand, landCount: 0 }),
+      synergies: [],
+      missing: [],
+    }).curveAssessment;
+  }
+
+  it("reports no curve when there are no non-land cards", () => {
+    expect(curveAssessment([0, 0, 0, 0, 0, 0, 0, 0], 0)).toContain(
+      "No non-land cards",
+    );
+  });
+
+  it("labels a very low curve as aggressive", () => {
+    // weighted avg = (8*1 + 2*2)/10 = 1.2
+    expect(curveAssessment([0, 8, 2, 0, 0, 0, 0, 0], 10)).toMatch(/aggressive/i);
+  });
+
+  it("labels a balanced midrange curve", () => {
+    // weighted avg = (4*2 + 4*3 + 4*4)/12 = 3.0
+    expect(curveAssessment([0, 0, 4, 4, 4, 0, 0, 0], 12)).toMatch(/Balanced midrange/);
+  });
+
+  it("labels a top-heavy curve", () => {
+    // weighted avg = (2*3 + 6*4 + 2*5)/10 = 4.0
+    expect(curveAssessment([0, 0, 0, 2, 6, 2, 0, 0], 10)).toMatch(/Top-heavy/);
+  });
+
+  it("labels a very high / slow curve", () => {
+    // weighted avg = (2*4 + 2*5 + 2*6 + 4*7)/10 = 5.8
+    expect(curveAssessment([0, 0, 0, 0, 2, 2, 2, 4], 10)).toMatch(/Very high|slow/);
+  });
+});
+
+describe("assembleStructuredAnalysis — strengths & gaps inference", () => {
+  function analyze(
+    stats: Partial<DeckStats>,
+    synergies: SynergyResult[],
+    missing: MissingSynergy[],
+  ) {
+    return assembleStructuredAnalysis([], {
+      archetype: archetypeOf("Midrange"),
+      stats: makeStats(stats),
+      synergies,
+      missing,
+    });
+  }
+
+  it("flags a gap when no synergy clusters are detected", () => {
+    const { gaps } = analyze({}, [], []);
+    expect(gaps.some((g) => /No strong synergy clusters/.test(g))).toBe(true);
+  });
+
+  it("credits a strong ramp package as a strength", () => {
+    const deck = [card("Cultivate", "Sorcery", 8, "Search your library for a land.")];
+    const { strengths } = assembleStructuredAnalysis(deck, {
+      archetype: archetypeOf("Ramp"),
+      stats: makeStats(),
+      synergies: [],
+      missing: [],
+    });
+    expect(strengths.some((s) => /Strong ramp package/.test(s))).toBe(true);
+  });
+
+  it("flags a ramp deficit for a high-CMC deck with little ramp", () => {
+    const { gaps } = analyze({ avgCmc: 4.2, landCount: 24, totalCards: 60 }, [], []);
+    expect(gaps.some((g) => /Little ramp/.test(g))).toBe(true);
+  });
+
+  it("flags light interaction as a gap", () => {
+    const { gaps } = analyze({}, [], []);
+    expect(gaps.some((g) => /Light on interaction/.test(g))).toBe(true);
+  });
+
+  it("flags thin card draw as a gap", () => {
+    const { gaps } = analyze({}, [], []);
+    expect(gaps.some((g) => /Thin card draw/.test(g))).toBe(true);
+  });
+
+  it("flags a low land ratio as a mana-screw risk", () => {
+    const { gaps } = analyze({ landCount: 18, totalCards: 60 }, [], []);
+    expect(gaps.some((g) => /Low land ratio/.test(g))).toBe(true);
+  });
+
+  it("credits a solid land base as a strength", () => {
+    const { strengths } = analyze({ landCount: 28, totalCards: 60 }, [], []);
+    expect(strengths.some((s) => /Solid land base/.test(s))).toBe(true);
+  });
+
+  it("flags a colour imbalance when one colour dominates", () => {
+    const { gaps } = analyze(
+      { colorDistribution: { W: 50, U: 5 }, totalCards: 60 },
+      [],
+      [],
+    );
+    expect(gaps.some((g) => /Colour imbalance/.test(g))).toBe(true);
+  });
+
+  it("surfaces high/medium missing-synergy suggestions as gaps", () => {
+    const missing: MissingSynergy[] = [
+      {
+        synergy: "Removal Suite",
+        missing: "Single-target removal",
+        description: "d",
+        suggestion: "Add a Doom Blade",
+        impact: "high",
+      },
+      {
+        synergy: "Card Draw",
+        missing: "Draw engine",
+        description: "d",
+        suggestion: "Add Divination",
+        impact: "low",
+      },
+    ];
+    const { gaps } = analyze({}, [], missing);
+    expect(gaps.some((g) => g.includes("Single-target removal"))).toBe(true);
+    // Low-impact missing synergies are not surfaced.
+    expect(gaps.some((g) => g.includes("Draw engine"))).toBe(false);
+  });
+
+  it("limits strengths and gaps to 6 entries each", () => {
+    const deck = [
+      card("Cultivate", "Sorcery", 8, "Search your library for a land."),
+      card("Divination", "Sorcery", 6, "Draw two cards."),
+    ];
+    const manySynergies: SynergyResult[] = Array.from({ length: 8 }, (_, i) => ({
+      name: `Cluster ${i}`,
+      category: "value",
+      score: 50,
+      cards: ["Cultivate"],
+      description: "d",
+    }));
+    const { strengths, gaps } = assembleStructuredAnalysis(deck, {
+      archetype: archetypeOf("Ramp"),
+      stats: makeStats({ landCount: 18, totalCards: 60, colorDistribution: { W: 55, U: 5 } }),
+      synergies: manySynergies,
+      missing: [],
+    });
+    expect(strengths.length).toBeLessThanOrEqual(6);
+    expect(gaps.length).toBeLessThanOrEqual(6);
+  });
+});
+
+describe("assembleStructuredAnalysis — key cards", () => {
+  it("ranks cards in a synergy above non-synergy cards", () => {
+    const synergies: SynergyResult[] = [
+      {
+        name: "Elf Engine",
+        category: "tribal",
+        score: 80,
+        cards: ["Heritage Druid"],
+        description: "d",
+      },
+    ];
+    const deck = [
+      card("Heritage Druid", "Creature — Elf Druid", 2),
+      card("Random Bear", "Creature", 4),
+    ];
+    const { keyCards } = assembleStructuredAnalysis(deck, {
+      archetype: archetypeOf("Tribal"),
+      stats: makeStats(),
+      synergies,
+      missing: [],
+    });
+    expect(keyCards[0].name).toBe("Heritage Druid");
+    expect(keyCards[0].reason).toContain("Elf Engine");
+  });
+
+  it("excludes lands from key cards", () => {
+    const deck = [
+      card("Forest", "Basic Land — Forest", 20),
+      card("Grizzly Bears", "Creature", 4),
+    ];
+    const { keyCards } = assembleStructuredAnalysis(deck, {
+      archetype: archetypeOf("Aggro"),
+      stats: makeStats(),
+      synergies: [],
+      missing: [],
+    });
+    expect(keyCards.every((k) => !/land/i.test(k.name))).toBe(true);
+  });
+});
+
+describe("formatStructuredAnalysisForLLM — empty-state branches", () => {
+  it("renders the 'none detected' line when there are no synergy clusters", () => {
+    const analysis = assembleStructuredAnalysis([], {
+      archetype: archetypeOf("Unknown", 0),
+      stats: makeStats(),
+      synergies: [],
+      missing: [],
+    });
+    const formatted = formatStructuredAnalysisForLLM(analysis);
+    expect(formatted).toContain("**Synergy Clusters**: none detected above threshold.");
+  });
+
+  it("renders a Gaps section when gaps are present", () => {
+    const analysis = assembleStructuredAnalysis([], {
+      archetype: archetypeOf("Midrange"),
+      stats: makeStats({ landCount: 18, totalCards: 60 }),
+      synergies: [],
+      missing: [],
+    });
+    const formatted = formatStructuredAnalysisForLLM(analysis);
+    expect(formatted).toContain("**Gaps / Improvement Targets**:");
+  });
+
+  it("omits the Gaps section when there are no gaps", () => {
+    // A well-rounded deck: 2 synergy clusters, dense ramp/removal/draw, solid
+    // land base, single colour (no imbalance) and no missing synergies.
+    const deck = [
+      card("Cultivate", "Sorcery", 8, "Search your library for a land."),
+      card("Doom Blade", "Instant", 6, "Destroy target creature."),
+      card("Divination", "Sorcery", 5, "Draw two cards."),
+      card("Grizzly Bears", "Creature", 13),
+    ];
+    const analysis = assembleStructuredAnalysis(deck, {
+      archetype: archetypeOf("Midrange"),
+      stats: makeStats({
+        totalCards: 60,
+        landCount: 28,
+        creatureCount: 20,
+        colorDistribution: { W: 32 },
+      }),
+      synergies: [
+        { name: "Value", category: "value", score: 60, cards: ["Cultivate"], description: "d" },
+        { name: "Engine", category: "value", score: 50, cards: ["Divination"], description: "d" },
+      ],
+      missing: [],
+    });
+    const formatted = formatStructuredAnalysisForLLM(analysis);
+    expect(formatted).not.toContain("**Gaps / Improvement Targets**:");
+  });
+});

--- a/src/ai/flows/ai-deck-coach-review.ts
+++ b/src/ai/flows/ai-deck-coach-review.ts
@@ -187,12 +187,17 @@ export async function reviewDeck(
         const removeCount = cardsToRemove.reduce((sum, c) => sum + c.quantity, 0);
 
       if (addCount !== removeCount) {
-        // Adjust removals to match additions
+        // Adjust removals to match additions. Drop entries once their quantity
+        // reaches zero — otherwise the same zero-quantity tail item would be
+        // popped and re-pushed forever, looping infinitely while earlier items
+        // still hold quantity (regression found + fixed for issue #1078).
         const adjustedRemoves = [...cardsToRemove];
         while (adjustedRemoves.reduce((sum, c) => sum + c.quantity, 0) > addCount) {
           const last = adjustedRemoves.pop();
-          if (last) {
-            adjustedRemoves.push({ ...last, quantity: Math.max(0, last.quantity - 1) });
+          if (!last) break;
+          const newQuantity = Math.max(0, last.quantity - 1);
+          if (newQuantity > 0) {
+            adjustedRemoves.push({ ...last, quantity: newQuantity });
           }
         }
         return {


### PR DESCRIPTION
## Summary

Resolves #1078

Raises unit/integration coverage on the three heuristic AI analysis flows that had effectively **0%** direct coverage — `ai-meta-analysis.ts`, `ai-deck-coach-review.ts`, and `ai-post-game-analysis.ts` — plus edge-case coverage for the already-tested `coach-deck-analysis.ts`. This locks in the current heuristic behavior (including the heuristic-vs-LLM branch selection and fallback paths) as a concrete baseline ahead of the Lane 3 LLM-rewiring work.

## Coverage (before → after)

Measured with `jest --coverage` scoped to the four flow files:

| File | Stmts | Branch | Funcs | Lines |
|---|---|---|---|---|
| `ai-meta-analysis.ts` | 0% → **100%** | 0% → **90%** | 0% → **100%** | 0% → **100%** |
| `ai-deck-coach-review.ts` | 0% → **98.3%** | 0% → **97.0%** | 0% → **100%** | 0% → **100%** |
| `ai-post-game-analysis.ts` | 0% → **99.3%** | 0% → **87.8%** | 0% → **96.4%** | 0% → **99.3%** |
| `coach-deck-analysis.ts` | 80.5% → **97.5%** | 65.2% → **87.0%** | 82.4% → **94.1%** | 84.4% → **99.3%** |
| **Aggregate** | **30.5% → 98.6%** | **27.5% → 89.0%** | **19.4% → 97.2%** | **30.6% → 99.5%** |

## What's covered

**`ai-post-game-analysis.ts`** (31 tests) — `analyzeGame`, `identifyKeyMoments`, `generateQuickTips`:
- Win / loss / draw summary branches, missing life-total fallback (→20), turn counting
- Defensive type-guards: malformed turns lacking numeric `turnNumber`, non-array `turns`, empty replay
- Key-moment detection: significant life changes (±5), card-advantage shifts (±2), top-5 cap
- Mistakes: missed opportunities (minor), suboptimal plays (major), malformed entries skipped, top-5 cap
- Strengths, improvement areas (low life, >3 missed opps), deck suggestions (low life, high avg CMC, cap 3)
- Overall rating 1–10 clamping + card-advantage weighting; key-moment type mapping (positive→`great_play`, negative→`mistake`)

**`ai-meta-analysis.ts`** (18 tests) — `analyzeMetaAndSuggest` + `convertHeuristicOutput`:
- Output-shape contract, decklist parsing (passes through cards/focusArchetype)
- Strength/weakness inference from recommendation descriptions, format-specific branches (commander/modern/generic)
- Empty + malformed decklist handling; `strategicAdvice` template content; sideboard cap (5)
- Card-legality validation via `importDecklist` (not-found & illegal filtering; skipped when no adds)
- Add/remove quantity rebalancing (trims when removes exceed adds; untouched otherwise)

**`ai-deck-coach-review.ts`** (17 tests) — `reviewDeck`:
- Rate limiting: friendly `RateLimitError` message + rethrow of other errors + per-format user id
- AI vs heuristic branch selection: validated AI output returned; fallback on malformed payload (validator rejects), `success:false`, proxy throw, and offline
- Offline → `[Heuristic Mode - AI Unavailable]` prefix; option filtering (drops options with no card changes)
- Card-legality filtering in the heuristic tail (skipped when no adds)
- **Quantity-rebalance regression** (see below)

**`coach-deck-analysis.ts`** (27 tests) — `assembleStructuredAnalysis` + `formatStructuredAnalysisForLLm`:
- Role classification branches (disruption/removal/ramp/cardDraw/threats/other)
- Curve assessment all bands (empty / aggressive / balanced / top-heavy / very-high)
- Strengths & gaps inference (synergy density, ramp/removal/draw density, land ratio, colour imbalance, missing-synergy impact), 6-entry caps
- Key-card ranking (synergy cards first, lands excluded) + formatter empty-state branches

## Bug found & fixed

While writing the rebalance regression test, I found a **genuine infinite-loop bug** in `ai-deck-coach-review.ts` (`reviewDeck`, the quantity-rebalance tail). When rebalancing removals, a decremented card whose quantity reached `0` was still pushed back onto the end of the array, so `pop()` kept re-selecting the same zero-quantity tail item and never reached earlier items — an infinite loop whenever trailing removals zeroed out before the total dropped to `addCount` (i.e. the exact `cardsToRemove > cardsToAdd` edge case called out in the issue).

The sibling `ai-meta-analysis.ts` already handled this correctly (it drops zero-quantity items). The fix mirrors that: drop entries once their quantity hits `0` (and break if the array is exhausted). Minimal, behavior-preserving on the terminating cases.

- Fix: `src/ai/flows/ai-deck-coach-review.ts` (+8/-3)
- Regression test: `trims removals down to the add count without looping forever` (would hang pre-fix)

## Verification

- `npm test` → **281 suites, 5766 passed, 0 failed** (10 skipped, 48 todo) — no regressions
- New flows: **93 new tests, all passing**
- `npm run lint` → 0 errors
- `npx tsc --noEmit` → 0 errors in changed files (9 pre-existing `next-intl` module-resolution errors are unrelated to this PR and reproduce on `origin/main`)

## Acceptance criteria

- [x] Coverage raised meaningfully on meta-analysis, deck-review, and post-game-analysis flows (before→after reported above)
- [x] Edge cases covered: empty/null inputs, malformed data, heuristic fallback paths, error handling, and async paths (deck-analysis async via worker bridge is already covered by the existing suite; the heuristic flows' async wrappers are exercised)
- [x] All new tests pass; no regressions
- [x] Genuine bug found (rebalance infinite loop) → fixed + documented with a regression test
