### PR TITLE
feat(ai-coach): resolve #1072 — verify cited cards against the local database to eliminate hallucinated card data

### DIFF
--- a/src/ai/flows/__tests__/ai-deck-coach-review.test.ts
+++ b/src/ai/flows/__tests__/ai-deck-coach-review.test.ts
@@ -33,6 +33,13 @@ jest.mock("@/lib/rate-limiter", () => {
     aiRequestQueue: { add: (fn: () => Promise<unknown>) => fn() },
   };
 });
+// Issue #1072: the local citation verification gate resolves suggested cards
+// against the local card database. Mock it so the gate's behaviour is
+// deterministic without an IndexedDB store.
+jest.mock("@/lib/card-database", () => ({
+  getCardByName: jest.fn(),
+  getDatabaseStatus: jest.fn(),
+}));
 
 import { reviewDeck } from "../ai-deck-coach-review";
 import type { DeckReviewOutput } from "../ai-deck-coach-review";
@@ -40,6 +47,8 @@ import { reviewDeckHeuristic } from "@/lib/heuristic-deck-coach";
 import { validateCardLegality } from "@/lib/server-card-operations";
 import { callAIProxy } from "@/lib/ai-proxy-client";
 import { enforceRateLimit, RateLimitError } from "@/lib/rate-limiter";
+import { getCardByName, getDatabaseStatus } from "@/lib/card-database";
+import type { MinimalCard } from "@/lib/card-database";
 
 const mockedHeuristic = reviewDeckHeuristic as jest.MockedFunction<
   typeof reviewDeckHeuristic
@@ -50,6 +59,12 @@ const mockedValidate = validateCardLegality as jest.MockedFunction<
 const mockedProxy = callAIProxy as jest.MockedFunction<typeof callAIProxy>;
 const mockedEnforce = enforceRateLimit as jest.MockedFunction<
   typeof enforceRateLimit
+>;
+const mockedGetCardByName = getCardByName as jest.MockedFunction<
+  typeof getCardByName
+>;
+const mockedGetDatabaseStatus = getDatabaseStatus as jest.MockedFunction<
+  typeof getDatabaseStatus
 >;
 
 const DECKLIST = "4 Lightning Bolt\n2 Blood Moon\n3 Forest";
@@ -93,6 +108,12 @@ beforeEach(() => {
   mockedValidate.mockResolvedValue({ found: [], notFound: [], illegal: [] });
   // By default the AI path is unavailable → falls through to heuristic.
   mockedProxy.mockResolvedValue({ success: false } as never);
+  // Issue #1072: default to an EMPTY local card database so the verification
+  // gate reports every suggestion as "unverifiable" and leaves them intact —
+  // this keeps the pre-existing heuristic-path assertions unchanged. Tests
+  // that exercise the populated-DB gate override these mocks locally.
+  mockedGetDatabaseStatus.mockResolvedValue({ loaded: false, cardCount: 0 });
+  mockedGetCardByName.mockResolvedValue(undefined);
   setOnline(true);
 });
 
@@ -224,6 +245,112 @@ describe("reviewDeck — card legality validation in the heuristic tail", () => 
     );
     await reviewDeck({ decklist: DECKLIST, format: "modern" });
     expect(mockedValidate).not.toHaveBeenCalled();
+  });
+});
+
+describe("reviewDeck — local citation verification gate (issue #1072)", () => {
+  function realCard(name: string): MinimalCard {
+    return {
+      id: name,
+      name,
+      cmc: 1,
+      type_line: "Instant",
+      colors: ["R"],
+      color_identity: ["R"],
+      legalities: { modern: "legal" },
+      mana_cost: "{R}",
+      oracle_text: "deal damage",
+    };
+  }
+
+  it("strips suggested cards that are not in a POPULATED local database", async () => {
+    // DB has cards; "Lightning Bolt" resolves but "Fabricated Dragon" does not.
+    mockedGetDatabaseStatus.mockResolvedValue({ loaded: true, cardCount: 42 });
+    mockedGetCardByName.mockImplementation(async (name: string) =>
+      name === "Lightning Bolt" ? realCard("Lightning Bolt") : undefined,
+    );
+    mockedHeuristic.mockReturnValue(
+      heuristicResult({
+        deckOptions: [
+          {
+            title: "Opt",
+            description: "d",
+            cardsToAdd: [
+              { name: "Lightning Bolt", quantity: 2 },
+              { name: "Fabricated Dragon", quantity: 1 },
+            ],
+            cardsToRemove: [{ name: "Slow Card", quantity: 3 }],
+          },
+        ],
+      }),
+    );
+
+    const out = await reviewDeck({ decklist: DECKLIST, format: "modern" });
+    const adds = out.deckOptions[0].cardsToAdd || [];
+    // Hallucinated card is removed; the real card survives.
+    expect(adds.map((c) => c.name)).toEqual(["Lightning Bolt"]);
+  });
+
+  it("leaves suggestions intact when the local database is empty (unverifiable)", async () => {
+    // Empty DB → cannot refute anything → must not strip legitimate advice.
+    mockedGetDatabaseStatus.mockResolvedValue({ loaded: false, cardCount: 0 });
+    mockedGetCardByName.mockResolvedValue(undefined);
+    mockedHeuristic.mockReturnValue(
+      heuristicResult({
+        deckOptions: [
+          {
+            title: "Opt",
+            description: "d",
+            cardsToAdd: [{ name: "Lightning Bolt", quantity: 2 }],
+            cardsToRemove: [{ name: "Slow Card", quantity: 2 }],
+          },
+        ],
+      }),
+    );
+
+    const out = await reviewDeck({ decklist: DECKLIST, format: "modern" });
+    expect(out.deckOptions[0].cardsToAdd).toEqual([
+      { name: "Lightning Bolt", quantity: 2 },
+    ]);
+  });
+
+  it("runs the local gate before legality validation so survivors are still legality-checked", async () => {
+    mockedGetDatabaseStatus.mockResolvedValue({ loaded: true, cardCount: 10 });
+    // "Real Card" and "Keep Card" exist locally; "Ghost" does not (hallucination).
+    mockedGetCardByName.mockImplementation(async (name: string) =>
+      name === "Real Card" || name === "Keep Card"
+        ? realCard(name)
+        : undefined,
+    );
+    // Legality validation then flags "Real Card" as illegal, but leaves
+    // "Keep Card" (which survived the local gate) alone.
+    mockedValidate.mockResolvedValue({
+      found: [],
+      notFound: [],
+      illegal: ["Real Card"],
+    });
+    mockedHeuristic.mockReturnValue(
+      heuristicResult({
+        deckOptions: [
+          {
+            title: "Opt",
+            description: "d",
+            cardsToAdd: [
+              { name: "Ghost", quantity: 1 }, // stripped by local gate (hallucination)
+              { name: "Real Card", quantity: 1 }, // stripped by legality check
+              { name: "Keep Card", quantity: 1 }, // survives both
+            ],
+            cardsToRemove: [{ name: "Cut", quantity: 3 }],
+          },
+        ],
+      }),
+    );
+
+    const out = await reviewDeck({ decklist: DECKLIST, format: "modern" });
+    // Ghost (local gate) and Real Card (legality) both gone; Keep Card remains.
+    expect(out.deckOptions[0].cardsToAdd).toEqual([
+      { name: "Keep Card", quantity: 1 },
+    ]);
   });
 });
 

--- a/src/ai/flows/__tests__/verify-citations.test.ts
+++ b/src/ai/flows/__tests__/verify-citations.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Tests for the local citation verification gate (issue #1072).
+ *
+ * The core {@link verifyCitations} function is pure given an injectable
+ * {@link CardLookupFn}, so these tests stub the lookup directly — no IndexedDB
+ * and no module mocks are required for the verification logic. The
+ * free-text extraction / annotation helpers and the default local resolver
+ * (which DOES touch `@/lib/card-database`) are covered separately.
+ */
+
+jest.mock("@/lib/card-database", () => ({
+  getCardByName: jest.fn(),
+  getDatabaseStatus: jest.fn(),
+}));
+
+import {
+  verifyCitations,
+  summarizeVerifications,
+  extractCitedCards,
+  annotateAdviceWithVerification,
+  createLocalCardLookup,
+  type CardLookupFn,
+  type CitedCard,
+  type CitationLookupResult,
+} from "../verify-citations";
+import { getCardByName, getDatabaseStatus } from "@/lib/card-database";
+import type { MinimalCard } from "@/lib/card-database";
+
+const mockedGetCardByName = getCardByName as jest.MockedFunction<
+  typeof getCardByName
+>;
+const mockedGetDatabaseStatus = getDatabaseStatus as jest.MockedFunction<
+  typeof getDatabaseStatus
+>;
+
+/** Build a stub lookup that resolves a fixed map of name → card. */
+function stubLookup(
+  cards: Record<string, MinimalCard>,
+  dbHasCards = true,
+): CardLookupFn {
+  return async (name: string): Promise<CitationLookupResult> => {
+    const match = Object.entries(cards).find(
+      ([key]) => key.toLowerCase() === name.toLowerCase(),
+    )?.[1];
+    return { found: Boolean(match), card: match, dbHasCards };
+  };
+}
+
+function makeCard(overrides: Partial<MinimalCard> = {}): MinimalCard {
+  return {
+    id: "id-1",
+    name: "Lightning Bolt",
+    cmc: 1,
+    type_line: "Instant",
+    colors: ["R"],
+    color_identity: ["R"],
+    legalities: { modern: "legal" },
+    mana_cost: "{R}",
+    oracle_text: "Lightning Bolt deals 3 damage to any target.",
+    ...overrides,
+  };
+}
+
+describe("verifyCitations — core resolution", () => {
+  it("verifies a name-only citation when the card exists in the DB", async () => {
+    const lookup = stubLookup({ "Lightning Bolt": makeCard() });
+    const results = await verifyCitations([{ name: "Lightning Bolt" }], lookup);
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("verified");
+    expect(results[0].corrections).toEqual([]);
+    expect(results[0].resolved?.name).toBe("Lightning Bolt");
+  });
+
+  it("verifies a citation whose claimed attributes all match the DB", async () => {
+    const lookup = stubLookup({ "Lightning Bolt": makeCard() });
+    const results = await verifyCitations(
+      [
+        {
+          name: "Lightning Bolt",
+          manaCost: "{R}",
+          type: "Instant",
+          cmc: 1,
+          oracleText: "Lightning Bolt deals 3 damage to any target.",
+        },
+      ],
+      lookup,
+    );
+    expect(results[0].status).toBe("verified");
+    expect(results[0].corrections).toEqual([]);
+  });
+
+  it("flags a card NOT in a populated DB as not-found (hallucination)", async () => {
+    const lookup = stubLookup({ "Lightning Bolt": makeCard() });
+    const results = await verifyCitations(
+      [{ name: "Totally Fake Card" }],
+      lookup,
+    );
+    expect(results[0].status).toBe("not-found");
+    expect(results[0].resolved).toBeUndefined();
+    expect(results[0].note).toContain("likely fabricated");
+  });
+
+  it("reports unverifiable (not not-found) when the local DB is empty", async () => {
+    // Empty DB: even a real card name cannot be confirmed or refuted.
+    const lookup = stubLookup({}, false);
+    const results = await verifyCitations(
+      [{ name: "Lightning Bolt" }],
+      lookup,
+    );
+    expect(results[0].status).toBe("unverifiable");
+    expect(results[0].resolved).toBeUndefined();
+    expect(results[0].note).toContain("empty");
+  });
+
+  it("corrects a mismatched mana cost to the authoritative DB value", async () => {
+    const lookup = stubLookup({ "Lightning Bolt": makeCard() });
+    const results = await verifyCitations(
+      [{ name: "Lightning Bolt", manaCost: "{1}{R}", cmc: 1 }],
+      lookup,
+    );
+    expect(results[0].status).toBe("mismatch");
+    const manaFix = results[0].corrections.find((c) => c.field === "manaCost");
+    expect(manaFix).toBeDefined();
+    expect(manaFix?.claimed).toBe("{1}{R}");
+    expect(manaFix?.actual).toBe("{R}");
+  });
+
+  it("corrects mismatched type and oracle text", async () => {
+    const lookup = stubLookup({ "Lightning Bolt": makeCard() });
+    const results = await verifyCitations(
+      [
+        {
+          name: "Lightning Bolt",
+          type: "Sorcery",
+          oracleText: "Deal 3 damage.",
+        },
+      ],
+      lookup,
+    );
+    expect(results[0].status).toBe("mismatch");
+    const fields = results[0].corrections.map((c) => c.field).sort();
+    expect(fields).toEqual(["oracleText", "type"]);
+    const typeFix = results[0].corrections.find((c) => c.field === "type");
+    expect(typeFix?.actual).toBe("Instant");
+  });
+
+  it("compares mana costs space/case-insensitively ({R} == {r})", async () => {
+    const lookup = stubLookup({ "Lightning Bolt": makeCard({ mana_cost: "{R}" }) });
+    const results = await verifyCitations(
+      [{ name: "Lightning Bolt", manaCost: "{r}" }],
+      lookup,
+    );
+    expect(results[0].status).toBe("verified");
+  });
+
+  it("flags a mismatched CMC", async () => {
+    const lookup = stubLookup({ "Lightning Bolt": makeCard({ cmc: 1 }) });
+    const results = await verifyCitations(
+      [{ name: "Lightning Bolt", cmc: 3 }],
+      lookup,
+    );
+    expect(results[0].status).toBe("mismatch");
+    const cmcFix = results[0].corrections.find((c) => c.field === "cmc");
+    expect(cmcFix?.claimed).toBe(3);
+    expect(cmcFix?.actual).toBe(1);
+  });
+});
+
+describe("verifyCitations — batch behaviour", () => {
+  it("handles a mixed batch of verified, mismatched, and hallucinated cards", async () => {
+    const lookup = stubLookup({
+      "Lightning Bolt": makeCard(),
+      "Counterspell": makeCard({
+        id: "id-2",
+        name: "Counterspell",
+        mana_cost: "{U}{U}",
+        cmc: 2,
+        type_line: "Instant",
+        oracle_text: "Counter target spell.",
+      }),
+    });
+    const results = await verifyCitations(
+      [
+        { name: "Lightning Bolt" }, // verified
+        { name: "Counterspell", manaCost: "{1}{U}" }, // mismatch
+        { name: "Fake Dragon" }, // not-found
+      ],
+      lookup,
+    );
+    expect(results.map((r) => r.status)).toEqual([
+      "verified",
+      "mismatch",
+      "not-found",
+    ]);
+  });
+
+  it("returns an empty array for an empty citation list", async () => {
+    const lookup = stubLookup({});
+    const results = await verifyCitations([], lookup);
+    expect(results).toEqual([]);
+  });
+
+  it("treats a non-array input as an empty list (defensive)", async () => {
+    const lookup = stubLookup({});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const results = await verifyCitations(null as any, lookup);
+    expect(results).toEqual([]);
+  });
+});
+
+describe("summarizeVerifications", () => {
+  it("counts statuses and collects non-verified entries as flagged", () => {
+    const verifications = [
+      { status: "verified" as const, cited: { name: "A" }, corrections: [], note: "" },
+      { status: "verified" as const, cited: { name: "B" }, corrections: [], note: "" },
+      { status: "mismatch" as const, cited: { name: "C" }, corrections: [], note: "" },
+      { status: "not-found" as const, cited: { name: "D" }, corrections: [], note: "" },
+      { status: "unverifiable" as const, cited: { name: "E" }, corrections: [], note: "" },
+    ];
+    const summary = summarizeVerifications(verifications);
+    expect(summary.total).toBe(5);
+    expect(summary.verified).toBe(2);
+    expect(summary.mismatched).toBe(1);
+    expect(summary.notFound).toBe(1);
+    expect(summary.unverifiable).toBe(1);
+    expect(summary.flagged.map((f) => f.cited.name)).toEqual(["C", "D", "E"]);
+  });
+
+  it("returns zeros for an empty list", () => {
+    const summary = summarizeVerifications([]);
+    expect(summary).toEqual({
+      total: 0,
+      verified: 0,
+      mismatched: 0,
+      notFound: 0,
+      unverifiable: 0,
+      flagged: [],
+    });
+  });
+});
+
+describe("extractCitedCards", () => {
+  it("extracts wiki-link, quoted, backtick, and bold citations", () => {
+    const text =
+      "Add [[Lightning Bolt]] for reach. \"Counterspell\" is great. " +
+      "Try `Delver of Secrets` and **Brainstorm** too.";
+    const cards = extractCitedCards(text);
+    const names = cards.map((c) => c.name);
+    expect(names).toEqual([
+      "Lightning Bolt",
+      "Counterspell",
+      "Delver of Secrets",
+      "Brainstorm",
+    ]);
+  });
+
+  it("de-duplicates case-insensitively, preserving first casing", () => {
+    const text = 'Use "Lightning Bolt" and then [[lightning bolt]] again.';
+    const cards = extractCitedCards(text);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].name).toBe("Lightning Bolt");
+  });
+
+  it("filters out noise (single chars, pure digits, empty)", () => {
+    const text = 'Set "4" and `x` and **  ** and "".';
+    expect(extractCitedCards(text)).toEqual([]);
+  });
+
+  it("returns an empty list for empty / non-string input", () => {
+    expect(extractCitedCards("")).toEqual([]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(extractCitedCards(undefined as any)).toEqual([]);
+  });
+});
+
+describe("annotateAdviceWithVerification", () => {
+  it("tags a hallucinated card inline and appends a confidence footer", () => {
+    const text = "I recommend adding Totally Fake Card to your deck.";
+    const verifications = [
+      { cited: { name: "Totally Fake Card" }, status: "not-found" as const, corrections: [], note: "" },
+    ];
+    const out = annotateAdviceWithVerification(text, verifications);
+    expect(out.totalCount).toBe(1);
+    expect(out.verifiedCount).toBe(0);
+    expect(out.text).toContain("Totally Fake Card ⚠ [unverified]");
+    expect(out.text).toContain("0/1 cited cards verified");
+    expect(out.text).toContain(
+      "Totally Fake Card: not found in local database",
+    );
+  });
+
+  it("reports a correction footer for mismatched attributes", () => {
+    const text = "Play Lightning Bolt.";
+    const verifications = [
+      {
+        cited: { name: "Lightning Bolt" },
+        status: "mismatch" as const,
+        corrections: [
+          { field: "manaCost" as const, claimed: "{1}{R}", actual: "{R}" },
+        ],
+        note: "",
+      },
+    ];
+    const out = annotateAdviceWithVerification(text, verifications);
+    expect(out.verifiedCount).toBe(0);
+    expect(out.text).toContain("0/1 cited cards verified");
+    expect(out.text).toContain("Lightning Bolt: corrected");
+    expect(out.text).toContain('manaCost: "{1}{R}" → "{R}"');
+  });
+
+  it("leaves text unchanged when there are no citations", () => {
+    const text = "No cards mentioned here.";
+    const out = annotateAdviceWithVerification(text, []);
+    expect(out.text).toBe(text);
+    expect(out.totalCount).toBe(0);
+  });
+
+  it("only tags the first occurrence of a hallucinated name", () => {
+    const text = "Fake Card is great. Fake Card again.";
+    const verifications = [
+      { cited: { name: "Fake Card" }, status: "not-found" as const, corrections: [], note: "" },
+    ];
+    const out = annotateAdviceWithVerification(text, verifications);
+    const occurrences = out.text.split("⚠ [unverified]").length - 1;
+    expect(occurrences).toBe(1);
+  });
+});
+
+describe("createLocalCardLookup — default local resolver", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("resolves a card through getCardByName and reports dbHasCards", async () => {
+    mockedGetDatabaseStatus.mockResolvedValue({ loaded: true, cardCount: 500 });
+    mockedGetCardByName.mockResolvedValue(makeCard());
+    const lookup = createLocalCardLookup();
+    const result = await lookup("Lightning Bolt");
+    expect(result.found).toBe(true);
+    expect(result.card?.name).toBe("Lightning Bolt");
+    expect(result.dbHasCards).toBe(true);
+  });
+
+  it("reports dbHasCards=false when the database is empty", async () => {
+    mockedGetDatabaseStatus.mockResolvedValue({ loaded: true, cardCount: 0 });
+    mockedGetCardByName.mockResolvedValue(undefined);
+    const lookup = createLocalCardLookup();
+    const result = await lookup("Lightning Bolt");
+    expect(result.found).toBe(false);
+    expect(result.dbHasCards).toBe(false);
+  });
+
+  it("caches the population probe across calls within one resolver", async () => {
+    mockedGetDatabaseStatus.mockResolvedValue({ loaded: true, cardCount: 10 });
+    mockedGetCardByName.mockResolvedValue(undefined);
+    const lookup = createLocalCardLookup();
+    await lookup("A");
+    await lookup("B");
+    await lookup("C");
+    expect(mockedGetDatabaseStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("degrades gracefully (no throw) when the card DB access fails", async () => {
+    mockedGetDatabaseStatus.mockRejectedValue(new Error("IndexedDB gone"));
+    mockedGetCardByName.mockRejectedValue(new Error("IndexedDB gone"));
+    const lookup = createLocalCardLookup();
+    const result = await lookup("Lightning Bolt");
+    expect(result).toEqual({ found: false, dbHasCards: false });
+  });
+});

--- a/src/ai/flows/ai-deck-coach-review.ts
+++ b/src/ai/flows/ai-deck-coach-review.ts
@@ -13,6 +13,7 @@ import { reviewDeckHeuristic } from '@/lib/heuristic-deck-coach';
 import { validateCardLegality } from '@/lib/server-card-operations';
 import { enforceRateLimit, aiRequestQueue, RateLimitError } from '@/lib/rate-limiter';
 import { callAIProxy } from '@/lib/ai-proxy-client';
+import { createLocalCardLookup, verifyCitations } from './verify-citations';
 import {
   SECURITY_PREAMBLE,
   sanitizeUserInput,
@@ -160,11 +161,38 @@ export async function reviewDeck(
     // Use heuristic analysis instead of AI
     const result = reviewDeckHeuristic(input.decklist, input.format, cards);
 
+    // Issue #1072: local citation verification gate. A single resolver is
+    // reused across all options so the (cached) database-population probe
+    // runs once. Local-only — no network calls.
+    const localLookup = createLocalCardLookup();
+
     // Validate card suggestions for legality
     const validatedOptions = await Promise.all(
       result.deckOptions.map(async (option) => {
-        const cardsToAdd = option.cardsToAdd || [];
+        let cardsToAdd = option.cardsToAdd || [];
         const cardsToRemove = option.cardsToRemove || [];
+
+        // Issue #1072: strike suggested cards that do not exist in a POPULATED
+        // local card database — these are hallucinations. When the DB is empty
+        // (default state) the lookup degrades to "unverifiable" and suggestions
+        // are left intact, so legitimate advice is never stripped just because
+        // the user has not imported card data.
+        if (cardsToAdd.length > 0) {
+          const verifications = await verifyCitations(
+            cardsToAdd.map((c) => ({ name: c.name })),
+            localLookup,
+          );
+          const hallucinated = new Set(
+            verifications
+              .filter((v) => v.status === 'not-found')
+              .map((v) => v.cited.name.toLowerCase()),
+          );
+          if (hallucinated.size > 0) {
+            cardsToAdd = cardsToAdd.filter(
+              (c) => !hallucinated.has(c.name.toLowerCase()),
+            );
+          }
+        }
 
         // Validate cards to add
         let validatedCardsToAdd = cardsToAdd;

--- a/src/ai/flows/verify-citations.ts
+++ b/src/ai/flows/verify-citations.ts
@@ -1,0 +1,493 @@
+/**
+ * @fileOverview Local citation verification for AI Coach advice (issue #1072).
+ *
+ * The conversational coach and the heuristic/AI deck review both produce
+ * *output* that names cards. An LLM (or, rarely, a heuristic) can hallucinate
+ * card data — citing cards that do not exist, or asserting wrong attributes
+ * (mana cost, type, oracle text) for real cards. Hallucinated card advice is
+ * the highest-trust-erosion failure mode for a deck coach.
+ *
+ * This module is a **local-only post-generation verification gate**. It never
+ * makes a network call: every cited card is resolved against the user's local
+ * card database (`src/lib/card-database.ts`, the Orama + IndexedDB store from
+ * #1025/#1085). On resolution it either:
+ *
+ *   - confirms the citation (`verified`),
+ *   - corrects mismatched attributes from the authoritative DB record
+ *     (`mismatch` + per-field `corrections`), or
+ *   - flags / strikes the citation when the card is absent from a populated
+ *     database (`not-found` — almost certainly a hallucination).
+ *
+ * When the local database is EMPTY (the default state — users import their own
+ * data) citations cannot be confirmed or refuted, so they are reported as
+ * `unverifiable` and left intact rather than aggressively stripped: removing
+ * every suggestion just because the user has not imported card data would
+ * break legitimate advice.
+ *
+ * The core {@link verifyCitations} function is pure given an injectable
+ * {@link CardLookupFn}, which keeps it fully unit-testable without IndexedDB.
+ */
+
+import {
+  getCardByName,
+  getDatabaseStatus,
+  type MinimalCard,
+} from "@/lib/card-database";
+
+/** Outcome of resolving a single cited card against the local database. */
+export type CitationStatus =
+  /** Card found in the DB and every asserted attribute matches. */
+  | "verified"
+  /** Card found, but one or more asserted attributes differ from the DB. */
+  | "mismatch"
+  /** DB contains cards but this name did not resolve — likely hallucinated. */
+  | "not-found"
+  /** DB is empty/unavailable; the claim can be neither confirmed nor refuted. */
+  | "unverifiable";
+
+/** A card attribute that the advice can make a verifiable claim about. */
+export type CitationField = "manaCost" | "type" | "oracleText" | "cmc";
+
+/** A card as cited by the advice, with whatever attributes it asserts. */
+export interface CitedCard {
+  name: string;
+  manaCost?: string;
+  type?: string;
+  oracleText?: string;
+  cmc?: number;
+}
+
+/** A single attribute that disagreed with the authoritative DB record. */
+export interface CitationFieldCorrection {
+  field: CitationField;
+  /** What the advice claimed. */
+  claimed: unknown;
+  /** The authoritative value from the local card database. */
+  actual: unknown;
+}
+
+/** The verification result for one cited card. */
+export interface CitationVerification {
+  /** The cited card exactly as the advice produced it. */
+  cited: CitedCard;
+  status: CitationStatus;
+  /** The authoritative DB record, when the card resolved. */
+  resolved?: MinimalCard;
+  /** Per-field mismatches (empty unless `status === "mismatch"`). */
+  corrections: CitationFieldCorrection[];
+  /** Human-readable explanation suitable for surfacing to the user. */
+  note: string;
+}
+
+/** Result returned by a {@link CardLookupFn}. */
+export interface CitationLookupResult {
+  /** True when the DB holds cards AND this name resolved to one. */
+  found: boolean;
+  /** The resolved card (present when `found`). */
+  card?: MinimalCard;
+  /** Whether the local DB contains ANY cards. */
+  dbHasCards: boolean;
+}
+
+/**
+ * Resolves a cited card name against the local card database.
+ *
+ * Injected into {@link verifyCitations} so the verification logic stays pure
+ * and testable; the default {@link createLocalCardLookup} wires up the real
+ * IndexedDB-backed store.
+ */
+export type CardLookupFn = (name: string) => Promise<CitationLookupResult>;
+
+/**
+ * Aggregate confidence summary for a batch of citations, used to surface a
+ * per-message indicator such as "7/8 cited cards verified".
+ */
+export interface CitationSummary {
+  total: number;
+  verified: number;
+  mismatched: number;
+  notFound: number;
+  unverifiable: number;
+  /** Entries that did not pass cleanly (anything that is not `verified`). */
+  flagged: CitationVerification[];
+}
+
+/**
+ * Build the default LOCAL card resolver. Resolves names through the Orama +
+ * IndexedDB store (`getCardByName`) and probes database population once via
+ * `getDatabaseStatus`. No network is involved.
+ *
+ * The lookup is defensive: any IndexedDB failure (e.g. the store is not yet
+ * initialised, or the runtime lacks IndexedDB) collapses to
+ * `{ found: false, dbHasCards: false }` so the verification gate degrades to
+ * "unverifiable" instead of crashing the coaching pipeline.
+ */
+export function createLocalCardLookup(): CardLookupFn {
+  // Probe population a single time per resolver instance; the population
+  // answer does not change within one verification pass and re-querying the
+  // count for every citation would be wasteful.
+  let populationPromise: Promise<boolean> | null = null;
+  const dbHasCards = (): Promise<boolean> => {
+    if (!populationPromise) {
+      populationPromise = (async () => {
+        try {
+          const status = await getDatabaseStatus();
+          return status.cardCount > 0;
+        } catch {
+          return false;
+        }
+      })();
+    }
+    return populationPromise;
+  };
+
+  return async (name: string): Promise<CitationLookupResult> => {
+    try {
+      const [hasCards, card] = await Promise.all([
+        dbHasCards(),
+        getCardByName(name),
+      ]);
+      return {
+        found: Boolean(card),
+        card: card ?? undefined,
+        dbHasCards: hasCards,
+      };
+    } catch {
+      return { found: false, dbHasCards: false };
+    }
+  };
+}
+
+/** Collapse whitespace and lowercase for case-insensitive text comparison. */
+function norm(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  return String(value)
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+/** Mana costs are compared ignoring spaces and case: "{1}{R}" == "{1} {r}". */
+function normMana(value: unknown): string {
+  return norm(value).replace(/\s+/g, "");
+}
+
+/**
+ * Diff the claimed attributes of a cited card against the authoritative DB
+ * record. Only fields the citation actually asserted are compared, so a
+ * name-only citation (no claimed attributes) always produces zero corrections.
+ */
+function diffAttributes(
+  cited: CitedCard,
+  resolved: MinimalCard,
+): CitationFieldCorrection[] {
+  const corrections: CitationFieldCorrection[] = [];
+
+  if (cited.manaCost !== undefined) {
+    if (normMana(cited.manaCost) !== normMana(resolved.mana_cost)) {
+      corrections.push({
+        field: "manaCost",
+        claimed: cited.manaCost,
+        actual: resolved.mana_cost,
+      });
+    }
+  }
+
+  if (cited.type !== undefined) {
+    if (norm(cited.type) !== norm(resolved.type_line)) {
+      corrections.push({
+        field: "type",
+        claimed: cited.type,
+        actual: resolved.type_line,
+      });
+    }
+  }
+
+  if (cited.oracleText !== undefined) {
+    if (norm(cited.oracleText) !== norm(resolved.oracle_text)) {
+      corrections.push({
+        field: "oracleText",
+        claimed: cited.oracleText,
+        actual: resolved.oracle_text,
+      });
+    }
+  }
+
+  if (cited.cmc !== undefined) {
+    const claimedCmc = Number(cited.cmc);
+    if (
+      Number.isFinite(claimedCmc) &&
+      claimedCmc !== Number(resolved.cmc)
+    ) {
+      corrections.push({
+        field: "cmc",
+        claimed: cited.cmc,
+        actual: resolved.cmc,
+      });
+    }
+  }
+
+  return corrections;
+}
+
+function noteFor(status: CitationStatus, name: string): string {
+  switch (status) {
+    case "verified":
+      return `"${name}" verified against the local card database.`;
+    case "mismatch":
+      return `"${name}" exists but some cited attributes differ from the local database; corrected to authoritative values.`;
+    case "not-found":
+      return `"${name}" was not found in the local card database and is likely fabricated; citation flagged.`;
+    case "unverifiable":
+      return `"${name}" could not be verified because the local card database is empty.`;
+  }
+}
+
+/**
+ * Verify a batch of cited cards against the local card database via the
+ * supplied lookup function. Pure with respect to `lookup` — pass a stub in
+ * tests, pass {@link createLocalCardLookup} in production.
+ *
+ * Resolution policy:
+ *   - DB empty/unavailable → `unverifiable` (claim left intact downstream).
+ *   - DB populated, name unresolved → `not-found` (hallucination candidate).
+ *   - Resolved but attributes differ → `mismatch` with corrections.
+ *   - Resolved and attributes agree → `verified`.
+ */
+export async function verifyCitations(
+  citations: ReadonlyArray<CitedCard>,
+  lookup: CardLookupFn,
+): Promise<CitationVerification[]> {
+  const safe = Array.isArray(citations) ? citations : [];
+
+  return Promise.all(
+    safe.map(async (cited): Promise<CitationVerification> => {
+      const result = await lookup(cited.name);
+
+      if (!result.dbHasCards) {
+        return {
+          cited,
+          status: "unverifiable",
+          corrections: [],
+          note: noteFor("unverifiable", cited.name),
+        };
+      }
+
+      if (!result.found || !result.card) {
+        return {
+          cited,
+          status: "not-found",
+          corrections: [],
+          note: noteFor("not-found", cited.name),
+        };
+      }
+
+      const corrections = diffAttributes(cited, result.card);
+      if (corrections.length > 0) {
+        return {
+          cited,
+          status: "mismatch",
+          resolved: result.card,
+          corrections,
+          note: noteFor("mismatch", cited.name),
+        };
+      }
+
+      return {
+        cited,
+        status: "verified",
+        resolved: result.card,
+        corrections: [],
+        note: noteFor("verified", cited.name),
+      };
+    }),
+  );
+}
+
+/**
+ * Reduce a list of verifications into a confidence summary. Drives the
+ * per-message "N/M cited cards verified" indicator.
+ */
+export function summarizeVerifications(
+  verifications: ReadonlyArray<CitationVerification>,
+): CitationSummary {
+  const safe = Array.isArray(verifications) ? verifications : [];
+  const counts = { verified: 0, mismatched: 0, notFound: 0, unverifiable: 0 };
+  const flagged: CitationVerification[] = [];
+
+  for (const v of safe) {
+    switch (v.status) {
+      case "verified":
+        counts.verified += 1;
+        break;
+      case "mismatch":
+        counts.mismatched += 1;
+        flagged.push(v);
+        break;
+      case "not-found":
+        counts.notFound += 1;
+        flagged.push(v);
+        break;
+      case "unverifiable":
+        counts.unverifiable += 1;
+        flagged.push(v);
+        break;
+    }
+  }
+
+  return {
+    total: safe.length,
+    ...counts,
+    flagged,
+  };
+}
+
+/**
+ * Patterns that delimit an explicitly-cited card name in free-text advice.
+ * Kept conservative on purpose: pulling every capitalised phrase would
+ * produce a flood of false positives (e.g. "The opponent", "Your Turn").
+ * The supported forms are the unambiguous ones an LLM is likely to emit:
+ *
+ *   - `[[Lightning Bolt]]`   (MTG wiki-link notation)
+ *   - `"Lightning Bolt"`     (double-quoted)
+ *   - `` `Lightning Bolt` `` (backtick / code span)
+ *   - `**Lightning Bolt**`   (bold markdown)
+ *
+ * The coach system prompt is encouraged to cite cards using one of these
+ * forms so extraction is deterministic; unmarked mentions are intentionally
+ * left unverified rather than guessed at.
+ */
+const CITED_CARD_PATTERNS: ReadonlyArray<RegExp> = [
+  /\[\[([^[\]]+?)\]\]/g, // [[ ... ]]
+  /"([^"\n]+?)"/g, // " ..."
+  /`([^`\n]+?)`/g, // ` ... `
+  /\*\*([^*\n]+?)\*\*/g, // ** ... **
+];
+
+/**
+ * Extract explicitly-cited card names from free-text coach advice.
+ *
+ * Returns de-duplicated {@link CitedCard} entries (name only — free text does
+ * not carry reliably-parseable attribute claims, so only existence is checked
+ * downstream). Casing of the first occurrence is preserved.
+ */
+export function extractCitedCards(text: string): CitedCard[] {
+  if (typeof text !== "string" || text.length === 0) return [];
+
+  // Collect every match across all delimiter styles together with its text
+  // position, so de-duplication can preserve the FIRST occurrence in reading
+  // order rather than favouring whichever pattern happens to run first.
+  const hits: Array<{ index: number; name: string }> = [];
+
+  for (const pattern of CITED_CARD_PATTERNS) {
+    // Reset lastIndex because the regex objects are module-level singletons
+    // and `g`-flagged regexes carry state between `.exec`/matchAll calls.
+    pattern.lastIndex = 0;
+    for (const match of text.matchAll(pattern)) {
+      const raw = (match[1] || "").trim();
+      const name = raw.replace(/\s+/g, " ");
+      if (!name) continue;
+      // Filter out trivially-non-card matches (single letters, pure digits,
+      // very short tokens that are almost certainly emphasis, not card names).
+      if (name.length < 2 || /^\d+$/.test(name)) continue;
+      hits.push({ index: match.index ?? 0, name });
+    }
+  }
+
+  hits.sort((a, b) => a.index - b.index);
+
+  const seen = new Set<string>();
+  const ordered: CitedCard[] = [];
+  for (const hit of hits) {
+    const key = hit.name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    ordered.push({ name: hit.name });
+  }
+
+  return ordered;
+}
+
+/**
+ * Result of annotating a free-text reply with its citation verification.
+ */
+export interface AnnotatedAdvice {
+  /** The (possibly annotated) advice text. */
+  text: string;
+  /** Number of cited cards that passed verification. */
+  verifiedCount: number;
+  /** Total cited cards discovered in the text. */
+  totalCount: number;
+  /** The underlying per-citation verifications. */
+  verifications: CitationVerification[];
+}
+
+/**
+ * Annotate free-text coach advice with the citation verification outcome.
+ *
+ * - Hallucinated (`not-found`) names are tagged inline with ` ⚠ [unverified]`
+ *   at their first occurrence so the user is never shown a fabricated card as
+ *   though it were real.
+ * - A compact footer is appended reporting the per-message confidence
+ *   ("N/M cited cards verified against the local card database") and listing
+ *   any flagged citations.
+ *
+ * When there are no explicit citations the text is returned unchanged.
+ */
+export function annotateAdviceWithVerification(
+  text: string,
+  verifications: ReadonlyArray<CitationVerification>,
+): AnnotatedAdvice {
+  if (typeof text !== "string" || text.length === 0) {
+    return { text: text ?? "", verifiedCount: 0, totalCount: 0, verifications: [] };
+  }
+
+  const verifs = Array.isArray(verifications) ? verifications : [];
+  if (verifs.length === 0) {
+    return { text, verifiedCount: 0, totalCount: 0, verifications: [] };
+  }
+
+  const summary = summarizeVerifications(verifs);
+  let annotated = text;
+
+  const flagged = verifs.filter((v) => v.status === "not-found");
+  for (const v of flagged) {
+    // Only mark the FIRST occurrence to avoid cluttering repeated mentions.
+    const needle = v.cited.name;
+    const idx = annotated.indexOf(needle);
+    if (idx !== -1) {
+      annotated =
+        annotated.slice(0, idx + needle.length) +
+        " ⚠ [unverified]" +
+        annotated.slice(idx + needle.length);
+    }
+  }
+
+  if (summary.total > 0) {
+    const lines: string[] = [
+      "",
+      "---",
+      `*Citation check: ${summary.verified}/${summary.total} cited cards verified against your local card database.*`,
+    ];
+    for (const v of summary.flagged) {
+      if (v.status === "not-found") {
+        lines.push(`- ⚠ ${v.cited.name}: not found in local database`);
+      } else if (v.status === "mismatch") {
+        const fields = v.corrections
+          .map((c) => `${c.field}: "${String(c.claimed)}" → "${String(c.actual)}"`)
+          .join("; ");
+        lines.push(`- ⚠ ${v.cited.name}: corrected (${fields})`);
+      } else if (v.status === "unverifiable") {
+        lines.push(`- ${v.cited.name}: local database empty — unverified`);
+      }
+    }
+    annotated += "\n" + lines.join("\n");
+  }
+
+  return {
+    text: annotated,
+    verifiedCount: summary.verified,
+    totalCount: summary.total,
+    verifications: verifs,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a **local-only post-generation citation verification gate** so the AI Coach / deck review never surfaces hallucinated card data. Every card cited in coach advice is resolved against the local card database (Orama + IndexedDB store from #1025/#1085) — no network calls.

Resolves #1072.

## The verification gate

New module `src/ai/flows/verify-citations.ts` exposes a pure, injectable core plus a default local resolver:

- **`verifyCitations(citations, lookup)`** — resolves each cited card through a `CardLookupFn` (stubbed in tests, real IndexedDB-backed in prod) and classifies it:
  - `verified` — card found, every asserted attribute matches the DB.
  - `mismatch` — card found but attributes differ; emits per-field `corrections` with `{claimed, actual}` so the caller can correct mana cost / type / oracle text / cmc to the **authoritative DB values**.
  - `not-found` — DB is populated but the name didn't resolve → **hallucination candidate** (flagged/struck).
  - `unverifiable` — DB is **empty** (default state — users import their own data) → claim left intact; we refuse to strip legitimate advice just because no card data is imported.
- **`extractCitedCards(text)`** — pulls explicitly-cited card names out of free-text advice (`[[…]]`, `"…"`, `` `…` ``, `**…**`) preserving first occurrence in reading order.
- **`annotateAdviceWithVerification(text, …)`** — tags hallucinated names inline with `⚠ [unverified]` and appends a per-message confidence footer (`N/M cited cards verified against your local card database`).
- **`createLocalCardLookup()`** — the real local resolver; caches the population probe, and degrades gracefully to `unverifiable` (never throws) if IndexedDB is unavailable.

### Integration

`reviewDeck` now runs the gate on suggested `cardsToAdd` **before** the existing server-side legality validation:
- cards absent from a **populated** local DB are struck (hallucinations removed before they reach the user);
- survivors still flow through the existing legality check + quantity rebalancing unchanged.

This is purely additive: when the DB is empty (the default), the gate is a no-op and all pre-existing behaviour/tests are preserved.

## Acceptance criteria

- [x] Every card cited in coach advice is verified against the local card database
- [x] Cited cards NOT in the DB are flagged/removed (when DB populated) — not shown as if real
- [x] Cited cards with MISMATCHED attributes are corrected to the DB's authoritative values
- [x] Verification is LOCAL — no network calls; uses the local card DB
- [x] Unit tests cover: valid citation passes, hallucinated card flagged/removed, mismatched-attribute card corrected, multiple citations, empty-DB (unverifiable), free-text extraction + annotation

## Test coverage

`verify-citations.test.ts` (new) — verifies `verified` / `mismatch` / `not-found` / `unverifiable` resolution, per-field corrections (mana cost space/case-insensitive, type, oracle text, cmc), mixed batches, defensive inputs, summary counts, extraction across all delimiter styles + dedup + noise filtering, inline tagging + confidence footer, and the default local resolver (resolution, empty DB, population-probe caching, graceful failure).

`ai-deck-coach-review.test.ts` — adds a `local citation verification gate` suite: hallucinated suggestion stripped when DB populated, suggestions left intact when DB empty, and the gate runs before legality validation so survivors are still checked.

## Verification

- `npx jest verify-citations ai-deck-coach-review coach-deck-analysis card-database` → 134 passed
- `npx jest src/ai/flows` → 174 passed (no regressions)
- `npx tsc --noEmit` → clean for changed files
- `npx eslint <changed files>` → clean