### PR TITLE
feat(meta-analysis): resolve #1073 — route meta-analysis through the LLM provider (heuristic fallback)

### DIFF
--- a/src/ai/flows/__tests__/ai-meta-analysis.test.ts
+++ b/src/ai/flows/__tests__/ai-meta-analysis.test.ts
@@ -19,7 +19,11 @@ jest.mock("@/lib/server-card-operations", () => ({
   importDecklist: jest.fn(),
 }));
 
-import { analyzeMetaAndSuggest } from "../ai-meta-analysis";
+import {
+  analyzeMetaAndSuggest,
+  coerceMetaAnalysisOutput,
+  extractJsonFromLLM,
+} from "../ai-meta-analysis";
 import { analyzeMetaHeuristic } from "@/lib/heuristic-meta-analysis";
 import { importDecklist } from "@/lib/server-card-operations";
 
@@ -82,6 +86,16 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockedAnalyzeMeta.mockImplementation(() => baseResult());
   mockedImportDecklist.mockImplementation(legalImport);
+
+  // Ensure the LLM provider routing added in #1073 never fires in the
+  // heuristic-only suites: no provider key may be considered configured,
+  // regardless of what the host shell has exported.
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.GOOGLE_AI_API_KEY;
+  delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+  delete process.env.ZAI_API_KEY;
+  delete process.env.CUSTOM_AI_API_KEY;
 });
 
 describe("analyzeMetaAndSuggest — output shape", () => {
@@ -329,5 +343,329 @@ describe("analyzeMetaAndSuggest — sideboard cap", () => {
     );
     const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
     expect(out.sideboardSuggestions).toHaveLength(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #1073 — LLM provider routing, structured-output validation, failover,
+// and the local-first heuristic fallback.
+// ---------------------------------------------------------------------------
+
+describe("extractJsonFromLLM", () => {
+  it("parses a plain JSON string", () => {
+    expect(extractJsonFromLLM('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it("strips a ```json fenced block", () => {
+    const text = "Here you go:\n```json\n{\"metaOverview\":\"x\"}\n```\nthanks";
+    expect(extractJsonFromLLM(text)).toEqual({ metaOverview: "x" });
+  });
+
+  it("extracts the outermost {...} block from surrounding prose", () => {
+    expect(extractJsonFromLLM('sure! {"a":1,"b":2} done')).toEqual({ a: 1, b: 2 });
+  });
+
+  it("returns null for non-JSON text", () => {
+    expect(extractJsonFromLLM("I cannot help with that.")).toBeNull();
+    expect(extractJsonFromLLM("")).toBeNull();
+  });
+});
+
+describe("coerceMetaAnalysisOutput", () => {
+  function validRaw(overrides: Record<string, unknown> = {}) {
+    return {
+      metaOverview: "LLM overview",
+      strategicAdvice: "Concrete advice",
+      deckStrengths: ["Strength A"],
+      deckWeaknesses: ["Weakness A"],
+      matchupAnalysis: [{ archetype: "Burn", recommendation: "Race them" }],
+      cardSuggestions: {
+        cardsToAdd: [{ name: "Skullcrack", quantity: 2 }],
+        cardsToRemove: [{ name: "Bad Card", quantity: 2 }],
+      },
+      ...overrides,
+    };
+  }
+
+  it("coerces a well-formed LLM object into MetaAnalysisOutput", () => {
+    const out = coerceMetaAnalysisOutput(validRaw());
+    expect(out).not.toBeNull();
+    expect(out!.matchupAnalysis[0]).toEqual({
+      archetype: "Burn",
+      recommendation: "Race them",
+    });
+    // Missing reasons are defaulted rather than dropped.
+    expect(out!.cardSuggestions.cardsToAdd[0]).toEqual({
+      name: "Skullcrack",
+      quantity: 2,
+      reason: "LLM suggestion",
+    });
+  });
+
+  it("clamps invalid quantities to a minimum of 1", () => {
+    const out = coerceMetaAnalysisOutput(
+      validRaw({
+        cardSuggestions: {
+          cardsToAdd: [{ name: "X", quantity: -3 }],
+          cardsToRemove: [{ name: "Y", quantity: "two" }],
+        },
+      }),
+    );
+    expect(out!.cardSuggestions.cardsToAdd[0].quantity).toBe(1);
+    expect(out!.cardSuggestions.cardsToRemove[0].quantity).toBe(1);
+  });
+
+  it("returns null for a non-object", () => {
+    expect(coerceMetaAnalysisOutput("not an object")).toBeNull();
+    expect(coerceMetaAnalysisOutput(null)).toBeNull();
+    expect(coerceMetaAnalysisOutput([1, 2, 3])).toBeNull();
+  });
+
+  it("returns null when required top-level strings are missing", () => {
+    expect(coerceMetaAnalysisOutput({ metaOverview: "ov" })).toBeNull();
+    expect(coerceMetaAnalysisOutput({ strategicAdvice: "adv" })).toBeNull();
+  });
+
+  it("returns null when no substantive section survives validation", () => {
+    expect(
+      coerceMetaAnalysisOutput({ metaOverview: "ov", strategicAdvice: "adv" }),
+    ).toBeNull();
+  });
+
+  it("keeps sideboardSuggestions only when non-empty", () => {
+    const withSb = coerceMetaAnalysisOutput(
+      validRaw({ sideboardSuggestions: [{ name: "Relic", quantity: 1 }] }),
+    );
+    expect(withSb!.sideboardSuggestions).toHaveLength(1);
+
+    const emptySb = coerceMetaAnalysisOutput(validRaw({ sideboardSuggestions: [] }));
+    expect(emptySb!.sideboardSuggestions).toBeUndefined();
+  });
+});
+
+describe("analyzeMetaAndSuggest — LLM provider routing (#1073)", () => {
+  /** A well-formed LLM JSON response that references the deck specifically. */
+  function validLLMJson(overrides: Record<string, unknown> = {}): string {
+    return JSON.stringify({
+      metaOverview: "Your Burn shell is well-positioned in the Modern meta.",
+      deckStrengths: ["Efficient red reach for your specific list"],
+      deckWeaknesses: ["Soft to lifegain out of Tron sideboards"],
+      matchupAnalysis: [
+        {
+          archetype: "Burn",
+          recommendation: "In the mirror, your bolt density lets you outrace.",
+          sideboardNotes: "Bring in Skullcrack for their lifegain",
+        },
+      ],
+      cardSuggestions: {
+        cardsToAdd: [
+          { name: "Skullcrack", quantity: 2, reason: "Answers lifegain in your weak matchup." },
+        ],
+        cardsToRemove: [
+          { name: "Bad Card", quantity: 2, reason: "Underperforms across the current meta." },
+        ],
+      },
+      strategicAdvice: "Tight advice tied to your Burn deck's mana curve.",
+      ...overrides,
+    });
+  }
+
+  /** Test-seam model resolver that returns an opaque marker per provider. */
+  function seamModel(provider: string): Promise<unknown> {
+    return Promise.resolve(`model:${provider}`);
+  }
+
+  /** Heuristic-path marker so we can prove the fallback ran. */
+  function isHeuristic(out: { cardSuggestions: { cardsToAdd: { reason: string }[] } }) {
+    return out.cardSuggestions.cardsToAdd.some((c) => c.reason.includes("heuristic"));
+  }
+
+  it("returns the LLM-enriched output when a provider is configured", async () => {
+    const getModel = jest.fn(seamModel);
+    const generateText = jest.fn().mockResolvedValue({ text: validLLMJson() });
+
+    const out = await analyzeMetaAndSuggest(
+      { decklist: DECKLIST, format: "modern" },
+      {
+        providers: ["openai"],
+        isConfigured: () => true,
+        getModel,
+        generateText,
+      },
+    );
+
+    expect(getModel).toHaveBeenCalledWith("openai", undefined);
+    expect(generateText).toHaveBeenCalledTimes(1);
+    expect(out.metaOverview).toBe("Your Burn shell is well-positioned in the Modern meta.");
+    expect(out.matchupAnalysis[0].archetype).toBe("Burn");
+    // Enriched output replaces the heuristic boilerplate reason.
+    expect(isHeuristic(out)).toBe(false);
+  });
+
+  it("falls back to the heuristic output when no provider is configured", async () => {
+    const getModel = jest.fn(seamModel);
+    const generateText = jest.fn();
+
+    const out = await analyzeMetaAndSuggest(
+      { decklist: DECKLIST, format: "modern" },
+      {
+        providers: ["openai", "anthropic"],
+        isConfigured: () => false,
+        getModel,
+        generateText,
+      },
+    );
+
+    // No provider was even attempted (local-first short-circuit).
+    expect(getModel).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
+    expect(out.metaOverview).toBe("The modern metagame is dominated by Burn.");
+    expect(isHeuristic(out)).toBe(true);
+  });
+
+  it("falls back to heuristic when the LLM returns unparseable then schema-invalid text", async () => {
+    const getModel = jest.fn(seamModel);
+    const generateText = jest
+      .fn()
+      // Provider A: prose, not JSON.
+      .mockResolvedValueOnce({ text: "Sorry, I cannot produce that analysis." })
+      // Provider B: parses but lacks required fields + substance.
+      .mockResolvedValueOnce({ text: JSON.stringify({ metaOverview: "only" }) });
+
+    const out = await analyzeMetaAndSuggest(
+      { decklist: DECKLIST, format: "modern" },
+      {
+        providers: ["openai", "anthropic"],
+        isConfigured: () => true,
+        getModel,
+        generateText,
+      },
+    );
+
+    // Both providers were tried (parse-failure also advances the failover).
+    expect(generateText).toHaveBeenCalledTimes(2);
+    // ...and neither produced usable output → heuristic fallback.
+    expect(out.metaOverview).toBe("The modern metagame is dominated by Burn.");
+    expect(isHeuristic(out)).toBe(true);
+  });
+
+  it("fails over to the next provider when the primary provider errors", async () => {
+    const getModel = jest.fn(seamModel);
+    const generateText = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("openai is down"))
+      .mockResolvedValueOnce({ text: validLLMJson() });
+
+    const out = await analyzeMetaAndSuggest(
+      { decklist: DECKLIST, format: "modern" },
+      {
+        providers: ["openai", "anthropic"],
+        isConfigured: () => true,
+        getModel,
+        generateText,
+      },
+    );
+
+    expect(getModel).toHaveBeenCalledWith("openai", undefined);
+    expect(getModel).toHaveBeenCalledWith("anthropic", undefined);
+    expect(generateText).toHaveBeenCalledTimes(2);
+    // Provider A threw → provider B's enriched output is returned.
+    expect(out.metaOverview).toBe("Your Burn shell is well-positioned in the Modern meta.");
+    expect(isHeuristic(out)).toBe(false);
+  });
+
+  it("fails over on a provider parse failure and returns the next provider's valid output", async () => {
+    const getModel = jest.fn(seamModel);
+    const generateText = jest
+      .fn()
+      // Provider A returns garbage JSON.
+      .mockResolvedValueOnce({ text: "nope" })
+      // Provider B returns a valid enriched object.
+      .mockResolvedValueOnce({ text: validLLMJson() });
+
+    const out = await analyzeMetaAndSuggest(
+      { decklist: DECKLIST, format: "modern" },
+      {
+        providers: ["openai", "anthropic"],
+        isConfigured: () => true,
+        getModel,
+        generateText,
+      },
+    );
+
+    expect(generateText).toHaveBeenCalledTimes(2);
+    expect(out.strategicAdvice).toBe("Tight advice tied to your Burn deck's mana curve.");
+  });
+
+  it("falls back to heuristic when model setup fails for every provider", async () => {
+    const getModel = jest.fn().mockRejectedValue(new Error("sdk missing"));
+    const generateText = jest.fn();
+
+    const out = await analyzeMetaAndSuggest(
+      { decklist: DECKLIST, format: "modern" },
+      {
+        providers: ["openai", "anthropic"],
+        isConfigured: () => true,
+        getModel,
+        generateText,
+      },
+    );
+
+    expect(getModel).toHaveBeenCalledTimes(2);
+    expect(generateText).not.toHaveBeenCalled();
+    expect(isHeuristic(out)).toBe(true);
+  });
+
+  it("forwards provider/modelId/options to the model resolver and LLM call", async () => {
+    const getModel = jest.fn(seamModel);
+    const generateText = jest.fn().mockResolvedValue({ text: validLLMJson() });
+
+    await analyzeMetaAndSuggest(
+      { decklist: DECKLIST, format: "modern", focusArchetype: "Burn" },
+      {
+        providers: ["anthropic"],
+        modelId: "claude-x",
+        isConfigured: () => true,
+        getModel,
+        generateText,
+      },
+    );
+
+    expect(getModel).toHaveBeenCalledWith("anthropic", "claude-x");
+    const call = generateText.mock.calls[0][0];
+    expect(call.temperature).toBe(0.2);
+    // The grounding context includes the decklist + focus archetype.
+    expect(call.messages[0].content).toContain("Lightning Bolt");
+    expect(call.messages[0].content).toContain("Burn");
+    expect(call.system).toContain("STRICT JSON");
+  });
+
+  it("respects an aborted signal and falls back to heuristic", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const getModel = jest.fn(seamModel);
+    const generateText = jest.fn();
+
+    const out = await analyzeMetaAndSuggest(
+      { decklist: DECKLIST, format: "modern" },
+      {
+        providers: ["openai"],
+        isConfigured: () => true,
+        signal: controller.signal,
+        getModel,
+        generateText,
+      },
+    );
+
+    expect(getModel).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
+    expect(isHeuristic(out)).toBe(true);
+  });
+
+  it("without options, behaves like the heuristic-only flow (default deployment)", async () => {
+    // No opts ⇒ no provider ⇒ heuristic, byte-for-byte.
+    const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
+    expect(out.metaOverview).toBe("The modern metagame is dominated by Burn.");
+    expect(isHeuristic(out)).toBe(true);
   });
 });

--- a/src/ai/flows/ai-meta-analysis.ts
+++ b/src/ai/flows/ai-meta-analysis.ts
@@ -1,18 +1,34 @@
 /**
- * @fileOverview Heuristic-powered meta analysis for deck optimization.
+ * @fileOverview Meta analysis flow for deck optimization.
  *
- * Issue #440: Replace AI provider calls with heuristic metagame analysis.
+ * Issue #1073: route the meta-analysis flow through the LLM provider instead
+ * of emitting heuristic-only output, while keeping the heuristic engine as the
+ * documented LOCAL-FIRST fallback.
  *
- * This module provides heuristic-based deck optimization based on current
- * Magic: The Gathering metagame analysis using format-specific data.
+ * Resolution strategy:
+ *   1. Always compute the deck-specific heuristic snapshot first. It is both
+ *      the grounding context handed to the LLM AND the guaranteed fallback.
+ *   2. If a provider is configured, ask the LLM to produce a richer, deck-aware
+ *      {@link MetaAnalysisOutput} grounded in that snapshot. The response is
+ *      parsed and strictly validated — malformed LLM output is never surfaced.
+ *   3. Provider failover composes with the factory chain (issue #1077): on a
+ *      provider error, setup failure, or unparseable response, the next
+ *      configured provider is tried.
+ *   4. When no provider is configured, every provider fails, or every response
+ *      fails validation, the heuristic output is returned unchanged.
  *
  * - analyzeMetaAndSuggest - Analyzes the metagame and provides deck improvement suggestions.
  * - MetaAnalysisInput - The input type for analyzeMetaAndSuggest function.
  * - MetaAnalysisOutput - The return type for analyzeMetaAndSuggest function.
  */
 
-import { analyzeMetaHeuristic } from '@/lib/heuristic-meta-analysis';
-import { importDecklist } from '@/lib/server-card-operations';
+import {
+  getAIModel,
+  getProviderFailoverChain,
+  isProviderConfigured,
+} from "@/ai/providers/factory";
+import { analyzeMetaHeuristic } from "@/lib/heuristic-meta-analysis";
+import { importDecklist } from "@/lib/server-card-operations";
 
 export interface MetaAnalysisInput {
   decklist: string;
@@ -65,6 +81,37 @@ export interface MetaAnalysisOutput {
   };
   sideboardSuggestions?: CardSuggestion[];
   strategicAdvice: string;
+}
+
+/**
+ * Options for {@link analyzeMetaAndSuggest}. All optional — when omitted (the
+ * default client call), the flow stays heuristic-only and the behavior is
+ * byte-for-byte identical to the pre-#1073 implementation.
+ */
+export interface AnalyzeMetaOptions {
+  /**
+   * Optional provider name to lead the failover chain. When omitted, the
+   * factory's {@link getProviderFailoverChain} default order is used.
+   */
+  provider?: string | null;
+  /** Optional model id forwarded to every provider. */
+  modelId?: string;
+  /** Ordered provider names to try; overrides the factory chain (test seam). */
+  providers?: ReadonlyArray<string>;
+  /** Abort signal; aborting cancels the LLM call and returns the heuristic. */
+  signal?: AbortSignal | null;
+  /** Test seam: override provider resolution. Defaults to the real factory. */
+  getModel?: (provider: string, modelId?: string) => Promise<unknown>;
+  /** Test seam: override credential detection. Defaults to the real factory. */
+  isConfigured?: (provider: string) => boolean;
+  /** Test seam: override the LLM text call. Defaults to a lazy `ai` import. */
+  generateText?: (args: {
+    model: unknown;
+    system: string;
+    messages: Array<{ role: "system" | "user" | "assistant"; content: string }>;
+    temperature?: number;
+    abortSignal?: AbortSignal | null;
+  }) => Promise<{ text: string }>;
 }
 
 /**
@@ -140,41 +187,16 @@ function convertHeuristicOutput(
   };
 }
 
-export async function analyzeMetaAndSuggest(
-  input: MetaAnalysisInput
+/**
+ * Build the heuristic output with card-legality validation and add/remove
+ * quantity rebalancing. Extracted verbatim from {@link analyzeMetaAndSuggest}
+ * so the LLM-enrichment path and the fallback share one validated heuristic
+ * base, and the offline path remains byte-for-byte identical to pre-#1073.
+ */
+async function buildHeuristicOutput(
+  input: MetaAnalysisInput,
+  heuristicResult: ReturnType<typeof analyzeMetaHeuristic>
 ): Promise<MetaAnalysisOutput> {
-  // Parse the decklist to get card data
-  const lines = input.decklist.split('\n').filter(line => line.trim() !== '');
-  const cards: HeuristicCard[] = [];
-
-  // Simple parser
-  for (const line of lines) {
-    const match = line.match(/^(\d+)\s+(.+)$/);
-    if (match) {
-      const [, quantity, name] = match;
-      cards.push({
-        name: name.trim(),
-        count: parseInt(quantity, 10),
-        // Add placeholder properties to satisfy DeckCard type
-        id: crypto.randomUUID(),
-        cmc: 0,
-        colors: [],
-        legalities: {},
-        type_line: 'Unknown',
-        mana_cost: '{0}',
-        color_identity: [],
-      });
-    }
-  }
-
-  // Use heuristic analysis instead of AI
-  const heuristicResult = analyzeMetaHeuristic(
-    input.decklist,
-    input.format,
-    cards,
-    input.focusArchetype
-  );
-
   // Validate card suggestions for legality
   const validatedOutput = convertHeuristicOutput(heuristicResult, input.format);
 
@@ -212,4 +234,334 @@ export async function analyzeMetaAndSuggest(
   }
 
   return validatedOutput;
+}
+
+/**
+ * Extract a JSON value from an LLM text response. Tolerates markdown code
+ * fences and surrounding prose; returns `null` when nothing parses so the
+ * caller can fall back to the heuristic output.
+ */
+export function extractJsonFromLLM(text: string): unknown {
+  if (!text) return null;
+
+  let cleaned = text.trim();
+
+  // Strip a ```json / ``` code fence if present.
+  const fence = cleaned.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence) {
+    cleaned = fence[1].trim();
+  }
+
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    // Fall through to brace extraction.
+  }
+
+  // Fallback: pull out the outermost {...} block.
+  const start = cleaned.indexOf("{");
+  const end = cleaned.lastIndexOf("}");
+  if (start !== -1 && end > start) {
+    try {
+      return JSON.parse(cleaned.slice(start, end + 1));
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (entry): entry is string => typeof entry === "string" && entry.length > 0,
+  );
+}
+
+function toCardSuggestion(value: unknown): CardSuggestion | null {
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as Record<string, unknown>;
+  const name = typeof record.name === "string" ? record.name.trim() : "";
+  if (!name) return null;
+  const rawQuantity = Number(record.quantity);
+  const quantity = Number.isFinite(rawQuantity) ? Math.max(1, Math.floor(rawQuantity)) : 1;
+  const reason = isNonEmptyString(record.reason) ? record.reason : "LLM suggestion";
+  return { name, quantity, reason };
+}
+
+function toCardSuggestionArray(value: unknown): CardSuggestion[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map(toCardSuggestion)
+    .filter((card): card is CardSuggestion => card !== null);
+}
+
+function toMatchupRecommendation(value: unknown): MatchupRecommendation | null {
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as Record<string, unknown>;
+  const archetype = typeof record.archetype === "string" ? record.archetype.trim() : "";
+  const recommendation = typeof record.recommendation === "string" ? record.recommendation.trim() : "";
+  if (!archetype || !recommendation) return null;
+  const sideboardNotes = typeof record.sideboardNotes === "string" && record.sideboardNotes.trim()
+    ? record.sideboardNotes
+    : undefined;
+  return sideboardNotes === undefined
+    ? { archetype, recommendation }
+    : { archetype, recommendation, sideboardNotes };
+}
+
+/**
+ * Validate and coerce an arbitrary LLM-produced value into a
+ * {@link MetaAnalysisOutput}. Returns `null` when the shape is structurally
+ * unsalvageable so the caller falls back to the heuristic output rather than
+ * surfacing malformed content to the user.
+ */
+export function coerceMetaAnalysisOutput(raw: unknown): MetaAnalysisOutput | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const record = raw as Record<string, unknown>;
+
+  const metaOverview = typeof record.metaOverview === "string" ? record.metaOverview.trim() : "";
+  const strategicAdvice = typeof record.strategicAdvice === "string" ? record.strategicAdvice.trim() : "";
+  if (!metaOverview || !strategicAdvice) return null;
+
+  const deckStrengths = toStringArray(record.deckStrengths);
+  const deckWeaknesses = toStringArray(record.deckWeaknesses);
+
+  const matchupAnalysis = Array.isArray(record.matchupAnalysis)
+    ? record.matchupAnalysis
+        .map(toMatchupRecommendation)
+        .filter((m): m is MatchupRecommendation => m !== null)
+    : [];
+
+  const cardSuggestionsRecord =
+    typeof record.cardSuggestions === "object" && record.cardSuggestions !== null
+      ? (record.cardSuggestions as Record<string, unknown>)
+      : {};
+  const cardsToAdd = toCardSuggestionArray(cardSuggestionsRecord.cardsToAdd);
+  const cardsToRemove = toCardSuggestionArray(cardSuggestionsRecord.cardsToRemove);
+
+  // Require at least one substantive, validated section beyond the overview so
+  // a bare `{ metaOverview, strategicAdvice }` never displaces the heuristic.
+  const hasSubstance =
+    matchupAnalysis.length > 0 ||
+    cardsToAdd.length > 0 ||
+    cardsToRemove.length > 0 ||
+    deckStrengths.length > 0 ||
+    deckWeaknesses.length > 0;
+  if (!hasSubstance) return null;
+
+  const sideboardSuggestions = Array.isArray(record.sideboardSuggestions)
+    ? toCardSuggestionArray(record.sideboardSuggestions)
+    : undefined;
+
+  const output: MetaAnalysisOutput = {
+    metaOverview,
+    deckStrengths,
+    deckWeaknesses,
+    matchupAnalysis,
+    cardSuggestions: { cardsToAdd, cardsToRemove },
+    strategicAdvice,
+  };
+  if (sideboardSuggestions && sideboardSuggestions.length > 0) {
+    output.sideboardSuggestions = sideboardSuggestions;
+  }
+  return output;
+}
+
+/**
+ * Build the system + user messages that ask the LLM for a structured,
+ * deck-specific meta analysis grounded in the heuristic snapshot.
+ */
+function buildMetaLLMMessages(
+  input: MetaAnalysisInput,
+  heuristic: MetaAnalysisOutput,
+): {
+  system: string;
+  messages: Array<{ role: "system" | "user" | "assistant"; content: string }>;
+} {
+  const system = [
+    "You are an expert Magic: The Gathering metagame analyst.",
+    "Produce a STRICT JSON object (no prose, no markdown fences) matching this TypeScript type exactly:",
+    "{ metaOverview: string; deckStrengths: string[]; deckWeaknesses: string[];",
+    "  matchupAnalysis: { archetype: string; recommendation: string; sideboardNotes?: string }[];",
+    "  cardSuggestions: { cardsToAdd: { name: string; quantity: number; reason: string }[];",
+    "                     cardsToRemove: { name: string; quantity: number; reason: string }[] };",
+    "  sideboardSuggestions?: { name: string; quantity: number; reason: string }[];",
+    "  strategicAdvice: string }.",
+    "Reference the player's SPECIFIC deck, archetype and cards (never generic boilerplate).",
+    "Keep the total quantity of cardsToAdd equal to the total quantity of cardsToRemove.",
+    "Output ONLY the JSON object.",
+  ].join(" ");
+
+  const grounding = {
+    format: input.format,
+    focusArchetype: input.focusArchetype ?? null,
+    decklist: input.decklist,
+    heuristicSnapshot: {
+      metaOverview: heuristic.metaOverview,
+      deckStrengths: heuristic.deckStrengths,
+      deckWeaknesses: heuristic.deckWeaknesses,
+      matchupAnalysis: heuristic.matchupAnalysis,
+      cardSuggestions: heuristic.cardSuggestions,
+    },
+  };
+
+  const user = `Analyse this deck's metagame position and return the JSON object.\n\n${JSON.stringify(
+    grounding,
+    null,
+    2,
+  )}`;
+
+  return { system, messages: [{ role: "user", content: user }] };
+}
+
+/**
+ * Try to produce a richer, LLM-generated {@link MetaAnalysisOutput} grounded in
+ * the heuristic snapshot. Returns `null` when no provider is configured, every
+ * provider fails, or every response fails validation — in all those cases the
+ * caller returns the heuristic output unchanged (local-first fallback).
+ *
+ * Failure policy mirrors the conversational coach (issue #1077): a provider
+ * error, model-setup error, or unparseable response advances to the next
+ * provider in the failover chain.
+ */
+async function tryEnrichMetaWithLLM(
+  input: MetaAnalysisInput,
+  heuristic: MetaAnalysisOutput,
+  opts: AnalyzeMetaOptions,
+): Promise<MetaAnalysisOutput | null> {
+  const chain =
+    opts.providers && opts.providers.length > 0
+      ? [...opts.providers]
+      : getProviderFailoverChain(opts.provider ?? null);
+  if (chain.length === 0) return null;
+
+  const isConfigured = opts.isConfigured ?? isProviderConfigured;
+
+  // Local-first: if nothing in the chain is configured, skip the LLM entirely
+  // (and avoid importing the `ai` package) so unconfigured deployments behave
+  // exactly like the heuristic-only flow.
+  if (!chain.some((provider) => isConfigured(provider))) {
+    return null;
+  }
+
+  const getModel = opts.getModel ?? getAIModel;
+  const generate =
+    opts.generateText ??
+    (async (args: {
+      model: unknown;
+      system: string;
+      messages: Array<{ role: "system" | "user" | "assistant"; content: string }>;
+      temperature?: number;
+      abortSignal?: AbortSignal | null;
+    }) => {
+      // Lazy import keeps the heavy `ai` package out of the initial bundle and
+      // out of client bundles where this branch is never reached (no provider
+      // is configured client-side). Mirrors `board-state-vision.ts` (#1022).
+      const { generateText } = await import("ai");
+      const result = await generateText({
+        model: args.model as never,
+        system: args.system,
+        messages: args.messages,
+        temperature: args.temperature,
+        ...(args.abortSignal ? { abortSignal: args.abortSignal } : {}),
+      });
+      return { text: result.text };
+    });
+
+  const { system, messages } = buildMetaLLMMessages(input, heuristic);
+
+  for (const provider of chain) {
+    if (opts.signal?.aborted) return null;
+
+    // Skip providers without detectable credentials (doomed network calls).
+    if (!isConfigured(provider)) continue;
+
+    let model: unknown;
+    try {
+      model = await getModel(provider, opts.modelId);
+    } catch {
+      // Model setup failed — try the next provider.
+      continue;
+    }
+
+    if (opts.signal?.aborted) return null;
+
+    let text: string;
+    try {
+      const result = await generate({
+        model,
+        system,
+        messages,
+        temperature: 0.2,
+        abortSignal: opts.signal ?? null,
+      });
+      text = result.text;
+    } catch {
+      // Provider errored — fail over to the next provider.
+      continue;
+    }
+
+    const parsed = extractJsonFromLLM(text);
+    const coerced = parsed == null ? null : coerceMetaAnalysisOutput(parsed);
+    if (coerced) {
+      return coerced;
+    }
+    // Valid JSON but wrong schema, or empty/unparseable — advance to the next
+    // provider; if all are exhausted, the caller falls back to heuristic.
+  }
+
+  return null;
+}
+
+export async function analyzeMetaAndSuggest(
+  input: MetaAnalysisInput,
+  opts: AnalyzeMetaOptions = {}
+): Promise<MetaAnalysisOutput> {
+  // Parse the decklist to get card data
+  const lines = input.decklist.split('\n').filter(line => line.trim() !== '');
+  const cards: HeuristicCard[] = [];
+
+  // Simple parser
+  for (const line of lines) {
+    const match = line.match(/^(\d+)\s+(.+)$/);
+    if (match) {
+      const [, quantity, name] = match;
+      cards.push({
+        name: name.trim(),
+        count: parseInt(quantity, 10),
+        // Add placeholder properties to satisfy DeckCard type
+        id: crypto.randomUUID(),
+        cmc: 0,
+        colors: [],
+        legalities: {},
+        type_line: 'Unknown',
+        mana_cost: '{0}',
+        color_identity: [],
+      });
+    }
+  }
+
+  // Use heuristic analysis as grounding context AND fallback.
+  const heuristicResult = analyzeMetaHeuristic(
+    input.decklist,
+    input.format,
+    cards,
+    input.focusArchetype
+  );
+
+  // Build the validated heuristic output (legality + rebalance) once; it is the
+  // guaranteed local-first fallback when no provider is configured or the LLM
+  // fails to produce valid structured output.
+  const heuristicOutput = await buildHeuristicOutput(input, heuristicResult);
+
+  // Attempt LLM enrichment; on any failure (no provider, error, parse failure,
+  // failover exhausted) return the heuristic output unchanged.
+  const enriched = await tryEnrichMetaWithLLM(input, heuristicOutput, opts);
+  return enriched ?? heuristicOutput;
 }


### PR DESCRIPTION
## Summary

Routes the meta-analysis flow (`analyzeMetaAndSuggest`) through the LLM provider factory so it can produce richer, deck-specific natural-language output when a provider is configured, while keeping the heuristic engine as the documented **local-first fallback** (issue #1073).

Resolves #1073.

## What changed

- **`src/ai/flows/ai-meta-analysis.ts`**
  - `analyzeMetaAndSuggest(input, opts?)` now computes the validated heuristic snapshot first, then attempts LLM enrichment. On any failure it returns the already-built heuristic output unchanged.
  - New `tryEnrichMetaWithLLM` composes with the factory failover chain from #1077 (`getProviderFailoverChain` + `isProviderConfigured`). On a provider error, a model-setup error, or an unparseable/invalid response, the next configured provider is tried.
  - New `coerceMetaAnalysisOutput` strictly validates/coerces the LLM JSON into `MetaAnalysisOutput` — malformed or substance-less output is rejected (never surfaced); the flow falls back to heuristic.
  - New `extractJsonFromLLM` tolerates markdown fences + surrounding prose.
  - Existing `convertHeuristicOutput` + legality-validation + add/remove rebalance extracted verbatim into `buildHeuristicOutput` so the fallback and the LLM share one validated base; the no-provider path is **byte-for-byte identical** to pre-#1073.
  - Bundle-safe: only the SDK-free factory helpers are statically imported; the `ai` package is lazily `import()`-ed inside the LLM branch (mirrors `board-state-vision.ts`, #1022). On the client no provider key is visible, so the LLM branch is never entered.
- **`src/ai/flows/__tests__/ai-meta-analysis.test.ts`** — added suites covering: LLM-enriched path, no-provider heuristic fallback, parse-failure → heuristic, failover (primary errors → next provider), failover on parse failure, model-setup failure, option forwarding, abort signal, default no-opts = heuristic, plus direct unit tests for `coerceMetaAnalysisOutput` / `extractJsonFromLLM`.

## Design — routing, fallback, validation

1. **Routing**: build `getProviderFailoverChain(opts.provider)`. For each provider where `isProviderConfigured` is true, resolve the model and call `generateText` with a system prompt demanding strict JSON and a user payload grounding the LLM in the deck's heuristic snapshot (archetype, strengths/weaknesses, matchup analysis, heuristic card suggestions).
2. **Fallback (local-first)**: if no provider is configured, every provider fails, or every response fails validation → return the pre-computed heuristic `MetaAnalysisOutput` unchanged.
3. **Validation**: `generateText` free-form text → `extractJsonFromLLM` → `coerceMetaAnalysisOutput`. Missing required fields, non-objects, empty substance, or bad quantities are rejected/coerced; rejection advances the failover and ultimately yields the heuristic.
4. **Failover**: provider error / setup error / parse failure all advance to the next provider (#1077 chain), so the composition is transparent.

## Acceptance criteria

- [x] Meta-analysis routes through the LLM provider when one is configured, producing richer, deck-specific output
- [x] Heuristic output remains the **fallback** when no provider is configured / the LLM fails (local-first preserved)
- [x] LLM output is validated/structured; parse/validation failure falls back to heuristic (malformed output never surfaced)
- [x] Provider failover composes (reuses the #1077 chain)
- [x] Unit tests cover: LLM path (mocked provider), heuristic fallback, parse-failure fallback, failover

## Test seam

Provider resolution, credential detection, and the LLM call are injectable via `opts` (mirrors `coach-stream.ts`), so tests are hermetic with no real network calls and no `jest.mock` of the factory/SDK.

## Verification

- `jest src/ai/flows/__tests__/ai-meta-analysis.test.ts src/ai/providers/__tests__/factory.test.ts` → **47 passed**.
- `tsc --noEmit` → no errors in changed files (remaining `next-intl` resolution errors are pre-existing in unrelated files).
- `eslint src` → no new warnings/errors in changed files.