### PR TITLE
feat(ai-coach): resolve #1075 — multi-deck comparison and meta-positioning report

### DIFF
--- a/src/ai/flows/__tests__/compare-decks.test.ts
+++ b/src/ai/flows/__tests__/compare-decks.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for multi-deck comparison and meta-positioning (issue #1075).
+ *
+ * These verify the LOCAL-FIRST heuristic core:
+ *   1. Fewer than two decks yields an insufficient report (no crash).
+ *   2. Identical decks overlap 100% and mirror at 50/50.
+ *   3. An asymmetric pair (aggro vs control) favours control, and the matrix
+ *      is antisymmetric (row[a][b] + row[b][a] === 1) with a 0.5 diagonal.
+ *   4. Meta-positioning ranks decks deterministically; rank 1 has the max score.
+ *   5. The single-deck-vs-meta-archetype path resolves categories and produces
+ *      a matrix without owning a list for the archetype.
+ *   6. The recommendation names the best build and swap cards are grounded in
+ *      the actual card names.
+ */
+
+import {
+  compareDecks,
+  type DeckComparisonEntry,
+  type DeckComparisonReport,
+} from "../compare-decks";
+import type { DeckCard } from "@/app/actions";
+
+function card(
+  name: string,
+  typeLine: string,
+  cmc: number,
+  count: number,
+  oracle = "",
+  colors: string[] = ["W"],
+): DeckCard {
+  return {
+    id: name.toLowerCase().replace(/\s+/g, "-"),
+    name,
+    cmc,
+    type_line: typeLine,
+    colors,
+    color_identity: colors,
+    legalities: {},
+    count,
+    oracle_text: oracle,
+  };
+}
+
+/**
+ * A low-curve, creature-heavy aggro shell. The archetype detector keys off
+ * average CMC, creature ratio and burn/removal text.
+ */
+function aggroDeck(): DeckCard[] {
+  return [
+    card("Lightning Bolt", "Instant", 1, 4, "Lightning Bolt deals 3 damage to any target.", ["R"]),
+    card("Goblin Guide", "Creature — Goblin Scout", 1, 4, "Haste", ["R"]),
+    card("Monastery Swiftspear", "Creature — Human Monk", 1, 4, "Prowess, haste", ["R"]),
+    card("Eidolon of the Great Revel", "Creature — Spirit", 2, 3, "Whenever a player casts a spell, deal 2 damage.", ["R"]),
+    card("Mountain", "Basic Land — Mountain", 0, 18, "", ["R"]),
+  ];
+}
+
+/**
+ * A reactive, high-CMC control shell: sweepers, countermagic, card draw and
+ * few expensive finishers.
+ */
+function controlDeck(): DeckCard[] {
+  return [
+    card("Counterspell", "Instant", 2, 4, "Counter target spell.", ["U"]),
+    card("Wrath of God", "Sorcery", 4, 4, "Destroy all creatures.", ["W"]),
+    card("Fact or Fiction", "Instant", 4, 3, "Look at the top five cards of your library.", ["U"]),
+    card("Teferi, Hero of Dominaria", "Legendary Planeswalker — Teferi", 5, 2, "+1 draw", ["W", "U"]),
+    card("Plains", "Basic Land — Plains", 0, 12, "", ["W"]),
+    card("Island", "Basic Land — Island", 0, 12, "", ["U"]),
+  ];
+}
+
+/** A second distinct aggro list for the symmetric-pair test. */
+function aggroDeckVariant(): DeckCard[] {
+  return aggroDeck().map((c) => ({ ...c }));
+}
+
+function cell(
+  report: DeckComparisonReport,
+  rowName: string,
+  colName: string,
+) {
+  return report.matchupMatrix.find(
+    (c) => c.rowDeck === rowName && c.colDeck === colName,
+  );
+}
+
+describe("compareDecks", () => {
+  it("returns an insufficient report for fewer than two decks", () => {
+    const one: DeckComparisonEntry[] = [
+      { name: "Solo", cards: aggroDeck() },
+    ];
+    const empty = compareDecks([]);
+
+    expect(one.length === 1 && true).toBe(true);
+    const report = compareDecks(one);
+    expect(report.sufficient).toBe(false);
+    expect(report.matchupMatrix).toEqual([]);
+    expect(report.metaPositioning).toEqual([]);
+    expect(report.recommendation.bestDeck).toBe("");
+
+    expect(empty.sufficient).toBe(false);
+    expect(empty.note).toMatch(/at least two/i);
+  });
+
+  it("reports 100% overlap and a 50/50 mirror for identical decks", () => {
+    const report = compareDecks([
+      { name: "Aggro A", cards: aggroDeck() },
+      { name: "Aggro B", cards: aggroDeckVariant() },
+    ]);
+
+    expect(report.sufficient).toBe(true);
+    expect(report.overlaps).toHaveLength(1);
+    expect(report.overlaps[0].overlapPercent).toBe(100);
+
+    // Diagonal (mirror) cells are 0.5; off-diagonal same-category is also 0.5.
+    const aa = cell(report, "Aggro A", "Aggro A");
+    const ab = cell(report, "Aggro A", "Aggro B");
+    expect(aa?.winProbability).toBeCloseTo(0.5, 5);
+    expect(ab?.winProbability).toBeCloseTo(0.5, 5);
+
+    // Identical decks share the same meta score and tie at rank 1.
+    expect(report.metaPositioning).toHaveLength(2);
+    const scores = report.metaPositioning.map((p) => p.metaScore);
+    expect(scores[0]).toBeCloseTo(scores[1], 5);
+    expect(report.metaPositioning.every((p) => p.rank === 1)).toBe(true);
+  });
+
+  it("favours control over aggro and keeps the matrix antisymmetric", () => {
+    const report = compareDecks([
+      { name: "Aggro", cards: aggroDeck() },
+      { name: "Control", cards: controlDeck() },
+    ]);
+
+    expect(report.sufficient).toBe(true);
+
+    const aggroVsControl = cell(report, "Aggro", "Control");
+    const controlVsAggro = cell(report, "Control", "Aggro");
+
+    expect(aggroVsControl).toBeDefined();
+    expect(controlVsAggro).toBeDefined();
+    // Control is favoured: aggro win prob < 0.5, control > 0.5.
+    expect(aggroVsControl!.winProbability).toBeLessThan(0.5);
+    expect(controlVsAggro!.winProbability).toBeGreaterThan(0.5);
+    // Antisymmetry: row[a][b] + row[b][a] === 1.
+    expect(
+      aggroVsControl!.winProbability + controlVsAggro!.winProbability,
+    ).toBeCloseTo(1, 5);
+
+    // Diagonal mirrors are exactly 0.5.
+    expect(cell(report, "Aggro", "Aggro")!.winProbability).toBeCloseTo(0.5, 5);
+    expect(cell(report, "Control", "Control")!.winProbability).toBeCloseTo(0.5, 5);
+  });
+
+  it("ranks meta-positioning deterministically with rank 1 holding the max score", () => {
+    const report = compareDecks([
+      { name: "Aggro", cards: aggroDeck() },
+      { name: "Control", cards: controlDeck() },
+      { name: "Aggro 2", cards: aggroDeckVariant() },
+    ]);
+
+    const positions = [...report.metaPositioning].sort((a, b) => a.rank - b.rank);
+    expect(positions[0].rank).toBe(1);
+    const maxScore = Math.max(...report.metaPositioning.map((p) => p.metaScore));
+    expect(positions[0].metaScore).toBeCloseTo(maxScore, 5);
+
+    // Scores are monotonically non-increasing by rank.
+    for (let i = 1; i < positions.length; i++) {
+      expect(positions[i].metaScore).toBeLessThanOrEqual(positions[i - 1].metaScore);
+    }
+
+    // The recommendation's best deck matches rank 1.
+    expect(report.recommendation.bestDeck).toBe(positions[0].name);
+    expect(report.recommendation.reasoning).toMatch(/best-positioned/i);
+  });
+
+  it("supports the single-deck-vs-meta-archetype path with no owned list", () => {
+    const report = compareDecks([
+      { name: "My Deck", cards: controlDeck() },
+      { name: "Burn (meta)", archetypeOverride: "Burn" },
+    ]);
+
+    expect(report.sufficient).toBe(true);
+    expect(report.decks).toHaveLength(2);
+
+    const meta = report.decks.find((d) => d.name === "Burn (meta)");
+    expect(meta).toBeDefined();
+    expect(meta!.archetype).toBe("Burn");
+    expect(meta!.category).toBe("aggro");
+
+    // The matrix still resolves a real matchup between the two columns.
+    const myVsBurn = cell(report, "My Deck", "Burn (meta)");
+    expect(myVsBurn).toBeDefined();
+    // Control (My Deck) is favoured vs aggro (Burn).
+    expect(myVsBurn!.winProbability).toBeGreaterThan(0.5);
+  });
+
+  it("grounds the recommendation swap cards in the actual deck card names", () => {
+    const report = compareDecks([
+      { name: "Aggro", cards: aggroDeck() },
+      { name: "Control", cards: controlDeck() },
+    ]);
+
+    expect(report.recommendation.swapsTowardBest).toBeDefined();
+    const swap = report.recommendation.swapsTowardBest!;
+    // From the weaker deck (aggro) toward the recommended build (control).
+    expect(swap.fromDeck).toBe("Aggro");
+    expect(swap.toDeck).toBe("Control");
+
+    const allAdd = swap.cardsToAdd.map((c) => c.name.toLowerCase());
+    const allRemove = swap.cardsToRemove.map((c) => c.name.toLowerCase());
+    // Add cards are drawn from the control list; remove cards from the aggro list.
+    expect(allAdd).toEqual(expect.arrayContaining(["counterspell", "wrath of god"]));
+    expect(allRemove).toEqual(expect.arrayContaining(["lightning bolt", "goblin guide"]));
+    // Capped at the three highest-impact swaps of each.
+    expect(swap.cardsToAdd.length).toBeLessThanOrEqual(3);
+    expect(swap.cardsToRemove.length).toBeLessThanOrEqual(3);
+  });
+
+  it("is deterministic for identical inputs", () => {
+    const entries: DeckComparisonEntry[] = [
+      { name: "Aggro", cards: aggroDeck() },
+      { name: "Control", cards: controlDeck() },
+    ];
+    expect(compareDecks(entries)).toEqual(compareDecks(entries));
+  });
+
+  it("produces role and curve diffs for every unordered pair", () => {
+    const report = compareDecks([
+      { name: "Aggro", cards: aggroDeck() },
+      { name: "Control", cards: controlDeck() },
+    ]);
+
+    expect(report.roleDiffs).toHaveLength(1);
+    expect(report.curveDiffs).toHaveLength(1);
+    // Control runs more removal than aggro, so aggro's removal diff is negative.
+    const roleDiff = report.roleDiffs[0].diff;
+    expect(roleDiff.removal).toBeLessThan(0);
+  });
+});

--- a/src/ai/flows/compare-decks.ts
+++ b/src/ai/flows/compare-decks.ts
@@ -1,0 +1,606 @@
+/**
+ * @fileOverview Multi-deck comparison and meta-positioning report (issue #1075).
+ *
+ * Users deciding which of several builds to bring to an event currently have to
+ * run the coach N times and mentally diff the outputs. This module produces a
+ * side-by-side comparison of 2-3 decks — or one deck + a meta archetype — and a
+ * META-POSITIONING report: how each build stacks up against the field.
+ *
+ * LOCAL-FIRST and HEURISTIC-GROUNDED, mirroring `sideboard-plan.ts` (#1076):
+ *   - Per-deck archetype detection, statistics, role mix and synergy clusters
+ *     are REUSED verbatim from `coach-deck-analysis` and `archetype-*` — no
+ *     detection logic is duplicated.
+ *   - The projected matchup matrix is derived from a documented category
+ *     rock-paper-scissors model (the same 6 categories the archetype
+ *     signatures and per-matchup sideboard planner use).
+ *   - No network/LLM call is required for the core report; an optional async
+ *     wrapper (`compareDecksAsync`) enriches synergy clusters via the AI Web
+ *     Worker bridge (#1079/#1175) when latency permits.
+ *
+ * The output is deterministic for a given input set, which keeps it testable
+ * and offline-capable.
+ */
+
+import type { DeckCard } from "@/app/actions";
+import { detectArchetype } from "@/ai/archetype-detector";
+import {
+  calculateDeckStats,
+  getArchetypeByName,
+} from "@/ai/archetype-signatures";
+import {
+  assembleStructuredAnalysis,
+  buildStructuredDeckAnalysis,
+  type RoleDistribution,
+  type SynergyCluster,
+} from "@/ai/flows/coach-deck-analysis";
+
+/** All archetype categories the detection system emits. */
+type Category = "aggro" | "control" | "midrange" | "combo" | "tribal" | "special";
+
+/** Keys of {@link RoleDistribution}, reused from the per-deck analysis. */
+type RoleKey = keyof RoleDistribution;
+
+/**
+ * A single deck (or meta-archetype) participating in the comparison.
+ *
+ * Either provide `cards` for a real decklist, or omit cards and set
+ * `archetypeOverride` to compare a deck against a META ARCHETYPE signature
+ * (e.g. "Burn", "Draw-Go") without owning a list for it.
+ */
+export interface DeckComparisonEntry {
+  /** Stable id (e.g. the saved deck id); optional, used only for identity. */
+  id?: string;
+  /** Display name for this column/row. */
+  name: string;
+  /** The decklist. May be empty when {@link archetypeOverride} is supplied. */
+  cards?: DeckCard[];
+  /**
+   * Force a specific detected archetype NAME (resolved via the archetype
+   * signatures). Enables the "one deck + meta archetype" comparison path:
+   * pass `{ name: "Burn", archetypeOverride: "Burn" }` with no cards.
+   */
+  archetypeOverride?: string;
+}
+
+/** One cell of the projected matchup matrix (row deck attacking col deck). */
+export interface MatchupCell {
+  rowDeck: string;
+  colDeck: string;
+  rowArchetype: string;
+  colArchetype: string;
+  /** Estimated win probability for the ROW deck vs the COL deck (0..1). */
+  winProbability: number;
+  rationale: string;
+}
+
+/** Card overlap between a pair of decks. */
+export interface DeckOverlap {
+  a: string;
+  b: string;
+  /** Shared-card percentage over the multiset union (0..100). */
+  overlapPercent: number;
+  sharedCards: string[];
+}
+
+/** Functional-role distribution diff between a pair of decks. */
+export interface RoleDiff {
+  a: string;
+  b: string;
+  /** Signed difference `count[a] - count[b]` for each role. */
+  diff: Record<RoleKey, number>;
+}
+
+/** Mana-curve diff between a pair of decks (one entry per CMC bucket). */
+export interface CurveDiff {
+  a: string;
+  b: string;
+  /** Signed difference `count[a] - count[b]` per CMC bucket. */
+  diff: number[];
+}
+
+/** A concrete swap suggestion to convert one deck toward another. */
+export interface ConversionSwap {
+  fromDeck: string;
+  toDeck: string;
+  cardsToAdd: Array<{ name: string; quantity: number }>;
+  cardsToRemove: Array<{ name: string; quantity: number }>;
+  rationale: string;
+}
+
+/** Per-deck headline used in the comparison table + meta-positioning. */
+export interface ComparedDeck {
+  name: string;
+  archetype: string;
+  secondaryArchetype?: string;
+  archetypeConfidence: number;
+  category: Category;
+  averageCmc: number;
+  colorIdentity: string[];
+  roleDistribution: RoleDistribution;
+  manaCurve: number[];
+  synergyClusters: SynergyCluster[];
+}
+
+/** How one deck is positioned against the field. */
+export interface DeckMetaPosition {
+  name: string;
+  archetype: string;
+  category: Category;
+  /** Average projected win-rate vs the field meta archetypes (0..1). */
+  metaScore: number;
+  /** 1 = best positioned. Ties share the lower rank. */
+  rank: number;
+  strengths: string[];
+  weaknesses: string[];
+}
+
+/** The full comparison + meta-positioning report. */
+export interface DeckComparisonReport {
+  /** Whether enough decks were supplied to compute a comparison. */
+  sufficient: boolean;
+  /** Human-readable note (e.g. why no matrix could be produced). */
+  note?: string;
+  decks: ComparedDeck[];
+  /** Pairwise win-probability matrix (rows attack columns). */
+  matchupMatrix: MatchupCell[];
+  overlaps: DeckOverlap[];
+  roleDiffs: RoleDiff[];
+  curveDiffs: CurveDiff[];
+  metaPositioning: DeckMetaPosition[];
+  recommendation: {
+    /** Name of the best-positioned deck, or "" when insufficient. */
+    bestDeck: string;
+    reasoning: string;
+    /** How to nudge the weakest build toward the recommended one. */
+    swapsTowardBest?: ConversionSwap;
+  };
+}
+
+/** Options controlling the comparison + meta-positioning computation. */
+export interface CompareDecksOptions {
+  /**
+   * The set of archetype categories that represent "the field" for
+   * meta-positioning. Defaults to one of each category (equal prevalence).
+   */
+  metaField?: Category[];
+}
+
+/**
+ * Projected win probability for a deck of category `row` facing a deck of
+ * category `col` (the row deck's perspective). Grounded in the classic MTG
+ * archetype rock-paper-scissors (aggro races combo, control stabilises against
+ * aggro, midrange grinds, etc.) and tuned to be antisymmetric:
+ * `M[a][b] + M[b][a] === 1` and `M[a][a] === 0.5`.
+ *
+ * The 6 categories mirror those emitted by `archetype-signatures.ts` and used
+ * by the per-matchup sideboard planner (#1076), so the matrix is consistent
+ * with the rest of the coach.
+ */
+const CATEGORY_MATCHUP: Record<Category, Record<Category, number>> = {
+  aggro: { aggro: 0.5, control: 0.42, midrange: 0.48, combo: 0.63, tribal: 0.55, special: 0.5 },
+  control: { aggro: 0.58, control: 0.5, midrange: 0.55, combo: 0.61, tribal: 0.53, special: 0.52 },
+  midrange: { aggro: 0.52, control: 0.45, midrange: 0.5, combo: 0.46, tribal: 0.55, special: 0.5 },
+  combo: { aggro: 0.37, control: 0.39, midrange: 0.54, combo: 0.5, tribal: 0.58, special: 0.52 },
+  tribal: { aggro: 0.45, control: 0.47, midrange: 0.45, combo: 0.42, tribal: 0.5, special: 0.48 },
+  special: { aggro: 0.5, control: 0.48, midrange: 0.5, combo: 0.48, tribal: 0.52, special: 0.5 },
+};
+
+const ALL_CATEGORIES: Category[] = ["aggro", "control", "midrange", "combo", "tribal", "special"];
+
+/** Friendly prose per category pair, for the matrix cell rationale. */
+const MATCHUP_NOTES: Partial<Record<Category, Partial<Record<Category, string>>>> = {
+  aggro: {
+    combo: "Aggro goldfishes before the combo deck assembles its kill.",
+    control: "Control stabilises and turns the corner once the early pressure fades.",
+    tribal: "Aggro's cheaper threats race the tribal lords off the start.",
+  },
+  control: {
+    aggro: "Removal sweepers and countermagic overwhelm the early board.",
+    combo: "Counterspells and interaction deny the combo window.",
+    midrange: "Card advantage and answers outlast the one-for-one trading.",
+  },
+  midrange: {
+    aggro: "Efficient blockers and spot removal absorb the early rush.",
+    combo: "Limited early interaction leaves the combo window open.",
+    tribal: "Bigger midgame threats outclass the synergistic swarm.",
+  },
+  combo: {
+    control: "Disruption and countermagic cut off the combo turn.",
+    aggro: "The aggro clock kills before the combo can go off.",
+    tribal: "Combo ignores the board and wins a turn ahead of the swarm.",
+  },
+  tribal: {
+    control: "Mass removal resets the lord-stacking board state.",
+    aggro: "Tribal lords come online a turn behind the aggro curve.",
+  },
+  special: {},
+};
+
+/** Empty-role helper used to seed the comparison of archetype-only entries. */
+function emptyRoleDistribution(): RoleDistribution {
+  return { threats: 0, ramp: 0, removal: 0, cardDraw: 0, disruption: 0, lands: 0, other: 0 };
+}
+
+/** Category for an archetype name, defaulting to midrange when unknown. */
+function categoryOf(archetypeName: string | undefined): Category {
+  const cat = getArchetypeByName(archetypeName || "")?.category;
+  return (ALL_CATEGORIES.includes(cat as Category) ? cat : "midrange") as Category;
+}
+
+/** Normalize a category string to one of the 6 known values. */
+function normalizeCategory(cat: string | undefined): Category {
+  return ALL_CATEGORIES.includes(cat as Category)
+    ? (cat as Category)
+    : "midrange";
+}
+
+/**
+ * Resolve an entry into a {@link ComparedDeck}. Reuses `detectArchetype`,
+ * `calculateDeckStats` and `assembleStructuredAnalysis` (which itself reuses
+ * `classifyRole`) for real decks; for the meta archetype path it reads the
+ * archetype signature directly.
+ */
+function resolveDeck(
+  entry: DeckComparisonEntry,
+  synergyClusters: SynergyCluster[],
+): ComparedDeck {
+  const cards = Array.isArray(entry.cards) ? entry.cards : [];
+
+  // Meta-archetype path: no owned list, just a signature.
+  if (entry.archetypeOverride && cards.length === 0) {
+    const sig = getArchetypeByName(entry.archetypeOverride);
+    const archetype = sig?.name ?? entry.archetypeOverride;
+    return {
+      name: entry.name,
+      archetype,
+      archetypeConfidence: sig ? 1 : 0,
+      category: normalizeCategory(sig?.category),
+      averageCmc: 0,
+      colorIdentity: [],
+      roleDistribution: emptyRoleDistribution(),
+      manaCurve: [],
+      synergyClusters: [],
+    };
+  }
+
+  const detected = detectArchetype(cards);
+  const archetype = entry.archetypeOverride ?? detected.primary;
+  const stats = calculateDeckStats(cards);
+
+  // `assembleStructuredAnalysis` is the single source of truth for the headline
+  // fields; we feed it the already-detected archetype + stats (synergies were
+  // resolved by the caller, if at all) so nothing is recomputed.
+  const structured = assembleStructuredAnalysis(cards, {
+    archetype: detected,
+    stats,
+    synergies: [],
+    missing: [],
+  });
+
+  return {
+    name: entry.name,
+    archetype,
+    secondaryArchetype: detected.secondary,
+    archetypeConfidence: detected.confidence,
+    category: categoryOf(archetype),
+    averageCmc: structured.averageCmc,
+    colorIdentity: structured.colorIdentity,
+    roleDistribution: structured.roleDistribution,
+    manaCurve: structured.manaCurve,
+    synergyClusters,
+  };
+}
+
+/** Quantize a multiset of card names -> name -> count. */
+function nameMultiset(deck: DeckCard[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const c of deck) {
+    const key = c.name.toLowerCase();
+    map.set(key, (map.get(key) ?? 0) + (c.count ?? 0));
+  }
+  return map;
+}
+
+/** Jaccard-style overlap (%) over the card-name multiset union. */
+function computeOverlap(a: ComparedDeck, aCards: DeckCard[], b: ComparedDeck, bCards: DeckCard[]): DeckOverlap {
+  const setA = nameMultiset(aCards);
+  const setB = nameMultiset(bCards);
+  let intersection = 0;
+  let union = 0;
+  const shared: string[] = [];
+
+  const keys = new Set<string>([...setA.keys(), ...setB.keys()]);
+  for (const key of keys) {
+    const ca = setA.get(key) ?? 0;
+    const cb = setB.get(key) ?? 0;
+    intersection += Math.min(ca, cb);
+    union += Math.max(ca, cb);
+    if (ca > 0 && cb > 0) shared.push(key);
+  }
+
+  const overlapPercent = union > 0 ? Math.round((intersection / union) * 1000) / 10 : 0;
+  return { a: a.name, b: b.name, overlapPercent, sharedCards: shared };
+}
+
+/** Signed diff `count[a] - count[b]` across all role keys. */
+function computeRoleDiff(a: ComparedDeck, b: ComparedDeck): RoleDiff {
+  const diff = emptyRoleDistribution();
+  (Object.keys(diff) as RoleKey[]).forEach((k) => {
+    diff[k] = (a.roleDistribution[k] ?? 0) - (b.roleDistribution[k] ?? 0);
+  });
+  return { a: a.name, b: b.name, diff };
+}
+
+/** Signed diff per CMC bucket, padded to equal length. */
+function computeCurveDiff(a: ComparedDeck, b: ComparedDeck): CurveDiff {
+  const len = Math.max(a.manaCurve.length, b.manaCurve.length);
+  const diff: number[] = [];
+  for (let i = 0; i < len; i++) {
+    diff.push((a.manaCurve[i] ?? 0) - (b.manaCurve[i] ?? 0));
+  }
+  return { a: a.name, b: b.name, diff };
+}
+
+/** Projected win probability for the row deck vs the col deck. */
+function getCategoryMatchup(row: Category, col: Category): number {
+  return CATEGORY_MATCHUP[row]?.[col] ?? 0.5;
+}
+
+/** One-line rationale for a category matchup. */
+function matchupRationale(row: Category, col: Category, rowName: string, colName: string): string {
+  if (row === col) {
+    return `Mirror of two ${row} builds — a coin-flip decided by play skill and sideboard tech.`;
+  }
+  const note = MATCHUP_NOTES[row]?.[col];
+  const prob = getCategoryMatchup(row, col);
+  const leans = prob > 0.5 ? "favours" : "hurts";
+  return note
+    ? `${note} (${leans} ${rowName} vs ${colName}.)`
+    : `Category matchup (${row} vs ${col}) ${leans} ${rowName}.`;
+}
+
+/**
+ * Meta-positioning for a deck: average projected win-rate vs the field.
+ * Strengths/weaknesses list the field categories the deck is favoured/unfavoured against.
+ */
+function computeMetaPosition(
+  deck: ComparedDeck,
+  field: Category[],
+  rank: number,
+): DeckMetaPosition {
+  let sum = 0;
+  const strengths: string[] = [];
+  const weaknesses: string[] = [];
+  for (const opponentCategory of field) {
+    const p = getCategoryMatchup(deck.category, opponentCategory);
+    sum += p;
+    if (p > 0.52) strengths.push(`${opponentCategory} field (${Math.round(p * 100)}%)`);
+    else if (p < 0.48) weaknesses.push(`${opponentCategory} field (${Math.round(p * 100)}%)`);
+  }
+  const metaScore = field.length > 0 ? Math.round((sum / field.length) * 1000) / 1000 : 0;
+  return {
+    name: deck.name,
+    archetype: deck.archetype,
+    category: deck.category,
+    metaScore,
+    rank,
+    strengths,
+    weaknesses,
+  };
+}
+
+/** True when a card is a land (basic or otherwise) — excluded from swap advice. */
+function isLandCard(card: DeckCard): boolean {
+  return (card.type_line || "").toLowerCase().includes("land");
+}
+
+/**
+ * Name multiset difference: cards to add/remove to turn `from` into `to`.
+ * Lands are excluded — a manabase delta is not a meaningful archetype pivot,
+ * and surfacing "add 12 Plains, remove 12 Islands" drowns out the strategic
+ * swaps the coach should actually recommend.
+ */
+function conversionSwaps(
+  fromName: string,
+  fromCards: DeckCard[],
+  toName: string,
+  toCards: DeckCard[],
+  archetype: string,
+): ConversionSwap {
+  const from = nameMultiset(fromCards.filter((c) => !isLandCard(c)));
+  const to = nameMultiset(toCards.filter((c) => !isLandCard(c)));
+  const names = new Set<string>([...from.keys(), ...to.keys()]);
+
+  const toAdd: Array<{ name: string; quantity: number }> = [];
+  const toRemove: Array<{ name: string; quantity: number }> = [];
+  for (const name of names) {
+    const delta = (to.get(name) ?? 0) - (from.get(name) ?? 0);
+    if (delta > 0) toAdd.push({ name, quantity: delta });
+    else if (delta < 0) toRemove.push({ name, quantity: -delta });
+  }
+  // Highest-impact swaps first (largest quantity delta), capped at the 3 most impactful of each.
+  const byQty = (a: { quantity: number }, b: { quantity: number }) => b.quantity - a.quantity;
+  toAdd.sort(byQty);
+  toRemove.sort(byQty);
+
+  return {
+    fromDeck: fromName,
+    toDeck: toName,
+    cardsToAdd: toAdd.slice(0, 3),
+    cardsToRemove: toRemove.slice(0, 3),
+    rationale: `Highest-impact swaps to pivot ${fromName} toward the ${archetype} shell of ${toName}.`,
+  };
+}
+
+/**
+ * Compare 2-3 decks (or one deck + a meta archetype) and produce a
+ * meta-positioning report.
+ *
+ * Pure and deterministic: the same inputs always yield the same output, with
+ * no network or LLM dependency. Per-deck archetype detection, statistics and
+ * role classification are REUSED from the existing coach analysers.
+ *
+ * @param entries  2-3 deck entries (real decks via `cards`, or a meta archetype
+ *                 via `archetypeOverride` with no cards).
+ * @param options  Field composition for meta-positioning (defaults to one of
+ *                 each category).
+ */
+export function compareDecks(
+  entries: DeckComparisonEntry[],
+  options: CompareDecksOptions = {},
+): DeckComparisonReport {
+  const safeEntries = Array.isArray(entries) ? entries : [];
+
+  // Resolve every entry. Synergy clusters require the async worker and are left
+  // empty here; `compareDecksAsync` enriches them.
+  const decks = safeEntries.map((e) => resolveDeck(e, []));
+  const cardsByIdx = safeEntries.map((e) => (Array.isArray(e.cards) ? e.cards : []));
+
+  if (decks.length < 2) {
+    return {
+      sufficient: false,
+      note: "Select at least two decks (or one deck and a meta archetype) to compare.",
+      decks,
+      matchupMatrix: [],
+      overlaps: [],
+      roleDiffs: [],
+      curveDiffs: [],
+      metaPositioning: [],
+      recommendation: { bestDeck: "", reasoning: "Need two or more decks to recommend a build." },
+    };
+  }
+
+  // Projected matchup matrix (rows attack columns; diagonal is a mirror).
+  const matchupMatrix: MatchupCell[] = [];
+  for (let i = 0; i < decks.length; i++) {
+    for (let j = 0; j < decks.length; j++) {
+      const row = decks[i];
+      const col = decks[j];
+      matchupMatrix.push({
+        rowDeck: row.name,
+        colDeck: col.name,
+        rowArchetype: row.archetype,
+        colArchetype: col.archetype,
+        winProbability: getCategoryMatchup(row.category, col.category),
+        rationale: matchupRationale(row.category, col.category, row.name, col.name),
+      });
+    }
+  }
+
+  // Pairwise overlap / role / curve diffs across every unordered pair.
+  const overlaps: DeckOverlap[] = [];
+  const roleDiffs: RoleDiff[] = [];
+  const curveDiffs: CurveDiff[] = [];
+  for (let i = 0; i < decks.length; i++) {
+    for (let j = i + 1; j < decks.length; j++) {
+      overlaps.push(computeOverlap(decks[i], cardsByIdx[i], decks[j], cardsByIdx[j]));
+      roleDiffs.push(computeRoleDiff(decks[i], decks[j]));
+      curveDiffs.push(computeCurveDiff(decks[i], decks[j]));
+    }
+  }
+
+  // Meta-positioning: average projected win-rate vs the field, ranked.
+  const field = options.metaField && options.metaField.length > 0 ? options.metaField : ALL_CATEGORIES;
+  const positions = decks.map((d) => computeMetaPosition(d, field, 0));
+  // Rank by metaScore desc using standard competition ranking (ties share the
+  // lower rank), stable on input order so identical inputs are deterministic.
+  const ranked = positions
+    .map((p, idx) => ({ p, idx }))
+    .sort((a, b) => b.p.metaScore - a.p.metaScore || a.idx - b.idx);
+  let lastScore: number | null = null;
+  let lastRank = 0;
+  ranked.forEach((entry, i) => {
+    if (lastScore === null || Math.abs(entry.p.metaScore - lastScore) > 1e-9) {
+      lastRank = i + 1;
+      lastScore = entry.p.metaScore;
+    }
+    positions[entry.idx].rank = lastRank;
+  });
+
+  // Recommendation: the best-positioned build, with the rationale grounded in
+  // its archetype + meta score + strengths/weaknesses, plus a swap plan to
+  // nudge the weakest owned build toward it.
+  const best = positions.find((p) => p.rank === 1)!;
+  const reasoningParts = [
+    `${best.name} (${best.archetype}) is the best-positioned build for the current meta`,
+    `with an average projected win-rate of ${Math.round(best.metaScore * 100)}% across the field.`,
+  ];
+  if (best.strengths.length > 0) reasoningParts.push(`Favoured vs ${best.strengths.join(", ")}.`);
+  if (best.weaknesses.length > 0) reasoningParts.push(`Watch out for ${best.weaknesses.join(", ")}.`);
+
+  // Pick the weakest OWNED deck (has cards) to convert toward the best build.
+  let swapsTowardBest: ConversionSwap | undefined;
+  const ownedIdx = safeEntries
+    .map((e, idx) => ({ e, idx }))
+    .filter((o) => o.e.name !== best.name && (o.e.cards?.length ?? 0) > 0)
+    .sort((a, b) => {
+      const ra = positions[a.idx].rank;
+      const rb = positions[b.idx].rank;
+      return rb - ra; // weakest (highest rank number) first
+    });
+  if (ownedIdx.length > 0) {
+    const weak = ownedIdx[0];
+    swapsTowardBest = conversionSwaps(
+      weak.e.name,
+      cardsByIdx[weak.idx],
+      best.name,
+      cardsByIdx[decks.findIndex((d) => d.name === best.name)],
+      best.archetype,
+    );
+  }
+
+  return {
+    sufficient: true,
+    decks,
+    matchupMatrix,
+    overlaps,
+    roleDiffs,
+    curveDiffs,
+    metaPositioning: positions,
+    recommendation: {
+      bestDeck: best.name,
+      reasoning: reasoningParts.join(" "),
+      swapsTowardBest,
+    },
+  };
+}
+
+/**
+ * Async variant that enriches each deck's synergy clusters by running the
+ * per-deck analysis through the AI Web Worker bridge (#1079/#1175), then
+ * delegates the comparison to the synchronous {@link compareDecks} core.
+ *
+ * Synergy detection is the only async piece; the rest of the report stays
+ * deterministic and offline-capable. If the worker is unavailable the bridge
+ * falls back to a main-thread implementation, so this never throws on env.
+ */
+export async function compareDecksAsync(
+  entries: DeckComparisonEntry[],
+  options: CompareDecksOptions = {},
+): Promise<DeckComparisonReport> {
+  const safeEntries = Array.isArray(entries) ? entries : [];
+
+  // Pre-resolve synergy clusters for every real deck in parallel.
+  const synergyResults = await Promise.all(
+    safeEntries.map(async (entry) => {
+      const cards = Array.isArray(entry.cards) ? entry.cards : [];
+      if (cards.length === 0 || entry.archetypeOverride) return [];
+      try {
+        const structured = await buildStructuredDeckAnalysis(cards);
+        return structured.synergyClusters;
+      } catch {
+        return [];
+      }
+    }),
+  );
+
+  const report = compareDecks(safeEntries, options);
+
+  // Splice the richer synergy clusters back into the resolved decks.
+  report.decks = report.decks.map((d, idx) => ({
+    ...d,
+    synergyClusters: synergyResults[idx] ?? [],
+  }));
+
+  return report;
+}

--- a/src/app/(app)/deck-coach/_components/multi-deck-comparison.tsx
+++ b/src/app/(app)/deck-coach/_components/multi-deck-comparison.tsx
@@ -1,0 +1,467 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Separator } from "@/components/ui/separator";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/hooks/use-toast";
+import { useLocalStorage } from "@/hooks/use-local-storage";
+import { type SavedDeck } from "@/app/actions";
+import { getAvailableArchetypeNames } from "@/ai/archetype-signatures";
+import {
+  compareDecksAsync,
+  type DeckComparisonEntry,
+  type DeckComparisonReport,
+} from "@/ai/flows/compare-decks";
+import { GitCompareArrows, Loader2, Trophy } from "lucide-react";
+
+/** Minimum/maximum decks a user may compare at once. */
+const MIN_DECKS = 2;
+const MAX_DECKS = 3;
+
+/** Human colour for a win-probability bucket, used in the matrix. */
+function probabilityTone(p: number): string {
+  if (p >= 0.6) return "text-emerald-600 dark:text-emerald-400 font-semibold";
+  if (p <= 0.4) return "text-red-600 dark:text-red-400 font-semibold";
+  return "text-muted-foreground";
+}
+
+/** Short label for a deck column header (truncates long names). */
+function shortName(name: string, max = 14): string {
+  return name.length > max ? `${name.slice(0, max - 1)}…` : name;
+}
+
+/**
+ * Multi-deck comparison + meta-positioning surface (issue #1075).
+ *
+ * Lets a user pick 2-3 saved decks (optionally plus one meta archetype), then
+ * runs the local-first {@link compareDecksAsync} heuristic and renders the
+ * projected matchup matrix, per-deck meta-positioning, and a coaching
+ * recommendation. No deck-list editing UI is rebuilt here — selection only.
+ */
+export function MultiDeckComparison() {
+  const [savedDecks, , { loading: decksLoading }] = useLocalStorage<
+    SavedDeck[]
+  >("saved-decks", []);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [metaArchetype, setMetaArchetype] = useState<string>("");
+  const [report, setReport] = useState<DeckComparisonReport | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const { toast } = useToast();
+
+  const archetypeNames = useMemo(() => getAvailableArchetypeNames(), []);
+
+  const toggleDeck = (id: string, checked: boolean) => {
+    setSelectedIds((prev) => {
+      if (checked) {
+        if (prev.length >= MAX_DECKS) return prev; // cap enforced in the handler
+        return prev.includes(id) ? prev : [...prev, id];
+      }
+      return prev.filter((x) => x !== id);
+    });
+  };
+
+  const canCompare =
+    !isPending &&
+    selectedIds.length + (metaArchetype ? 1 : 0) >= MIN_DECKS &&
+    selectedIds.length + (metaArchetype ? 1 : 0) <= MAX_DECKS;
+
+  const handleCompare = () => {
+    const chosen = savedDecks.filter((d) => selectedIds.includes(d.id));
+    const entries: DeckComparisonEntry[] = chosen.map((d) => ({
+      id: d.id,
+      name: d.name,
+      cards: d.cards,
+    }));
+    if (metaArchetype) {
+      entries.push({ name: `${metaArchetype} (meta)`, archetypeOverride: metaArchetype });
+    }
+
+    if (entries.length < MIN_DECKS) {
+      toast({
+        variant: "destructive",
+        title: "Select more decks",
+        description: `Pick at least ${MIN_DECKS} decks to compare.`,
+      });
+      return;
+    }
+
+    startTransition(async () => {
+      try {
+        setReport(null);
+        const result = await compareDecksAsync(entries);
+        setReport(result);
+        if (!result.sufficient) {
+          toast({ title: "Comparison", description: result.note });
+        }
+      } catch (error) {
+        console.error("Multi-deck comparison failed:", error);
+        toast({
+          variant: "destructive",
+          title: "Comparison Failed",
+          description:
+            "Could not produce the comparison report. Please try again.",
+        });
+      }
+    });
+  };
+
+  const deckNames = report?.decks.map((d) => d.name) ?? [];
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <GitCompareArrows className="h-5 w-5" />
+            Compare Decks
+          </CardTitle>
+          <CardDescription>
+            Select 2–3 saved decks (optionally add a meta archetype) to see a
+            projected matchup matrix and a meta-positioning recommendation.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {decksLoading ? (
+            <Skeleton className="h-24 w-full rounded-md" />
+          ) : savedDecks.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No saved decks yet. Build and save a deck first, then come back to
+              compare builds.
+            </p>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {savedDecks.map((deck) => {
+                const checked = selectedIds.includes(deck.id);
+                const disabled =
+                  !checked && selectedIds.length >= MAX_DECKS;
+                return (
+                  <label
+                    key={deck.id}
+                    className={`flex items-center gap-3 rounded-md border p-3 text-sm transition-colors ${
+                      checked
+                        ? "border-primary bg-primary/5"
+                        : disabled
+                          ? "opacity-50"
+                          : "hover:bg-accent/50"
+                    }`}
+                  >
+                    <Checkbox
+                      checked={checked}
+                      disabled={disabled}
+                      onCheckedChange={(v) => toggleDeck(deck.id, v === true)}
+                    />
+                    <span className="flex-1 truncate font-medium">
+                      {deck.name}
+                    </span>
+                    <Badge variant="outline" className="capitalize">
+                      {deck.format}
+                    </Badge>
+                  </label>
+                );
+              })}
+            </div>
+          )}
+
+          <Separator />
+
+          <div className="space-y-2">
+            <Label htmlFor="meta-archetype">
+              Add a meta archetype column (optional)
+            </Label>
+            <Select
+              value={metaArchetype}
+              onValueChange={(v) => setMetaArchetype(v === "__none__" ? "" : v)}
+              disabled={isPending}
+            >
+              <SelectTrigger id="meta-archetype">
+                <SelectValue placeholder="None — compare only my decks" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none__">
+                  None — compare only my decks
+                </SelectItem>
+                {archetypeNames.map((name) => (
+                  <SelectItem key={name} value={name}>
+                    {name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <Button onClick={handleCompare} disabled={!canCompare}>
+              {isPending ? (
+                <Loader2 className="mr-2 animate-spin" />
+              ) : (
+                <GitCompareArrows className="mr-2" />
+              )}
+              {isPending ? "Comparing…" : "Compare Decks"}
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              {selectedIds.length + (metaArchetype ? 1 : 0)} / {MAX_DECKS}{" "}
+              selected (min {MIN_DECKS})
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+
+      {isPending && <Skeleton className="h-64 w-full rounded-md" />}
+
+      {!isPending && report && report.sufficient && (
+        <ComparisonReportView report={report} deckNames={deckNames} />
+      )}
+
+      {!isPending && report && !report.sufficient && (
+        <Card className="border-dashed">
+          <CardContent className="py-10 text-center text-sm text-muted-foreground">
+            {report.note}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+/** Renders the computed comparison report: matrix, positioning, recommendation. */
+function ComparisonReportView({
+  report,
+  deckNames,
+}: {
+  report: DeckComparisonReport;
+  deckNames: string[];
+}) {
+  const cellFor = (row: string, col: string) =>
+    report.matchupMatrix.find(
+      (c) => c.rowDeck === row && c.colDeck === col,
+    );
+
+  return (
+    <div className="space-y-4">
+      {/* Recommendation */}
+      <Card className="border-primary/40">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Trophy className="h-5 w-5 text-amber-500" />
+            Recommendation
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          <p>
+            <span className="font-semibold">{report.recommendation.bestDeck}</span>{" "}
+            — {report.recommendation.reasoning}
+          </p>
+          {report.recommendation.swapsTowardBest && (
+            <div className="rounded-md border bg-muted/40 p-3">
+              <p className="mb-2 font-medium">
+                Pivot {report.recommendation.swapsTowardBest.fromDeck} →{" "}
+                {report.recommendation.swapsTowardBest.toDeck}:
+              </p>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <SwapList
+                  title="Board in"
+                  items={report.recommendation.swapsTowardBest.cardsToAdd}
+                  tone="add"
+                />
+                <SwapList
+                  title="Board out"
+                  items={report.recommendation.swapsTowardBest.cardsToRemove}
+                  tone="remove"
+                />
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">
+                {report.recommendation.swapsTowardBest.rationale}
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Meta-positioning ranking */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Meta Positioning</CardTitle>
+          <CardDescription>
+            Each deck&apos;s projected win-rate vs the field, best first.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {[...report.metaPositioning]
+              .sort((a, b) => a.rank - b.rank)
+              .map((p) => (
+                <div
+                  key={p.name}
+                  className="flex flex-col gap-1 rounded-md border p-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="flex items-center gap-3">
+                    <Badge variant={p.rank === 1 ? "default" : "secondary"}>
+                      #{p.rank}
+                    </Badge>
+                    <div>
+                      <p className="font-medium">{p.name}</p>
+                      <p className="text-xs text-muted-foreground capitalize">
+                        {p.archetype} · {p.category}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-semibold">
+                      {Math.round(p.metaScore * 100)}% avg win-rate
+                    </p>
+                    {p.strengths.length > 0 && (
+                      <p className="text-xs text-emerald-600 dark:text-emerald-400">
+                        Favoured: {p.strengths.join(", ")}
+                      </p>
+                    )}
+                    {p.weaknesses.length > 0 && (
+                      <p className="text-xs text-red-600 dark:text-red-400">
+                        Unfavoured: {p.weaknesses.join(", ")}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Matchup matrix */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Projected Matchup Matrix</CardTitle>
+          <CardDescription>
+            Row deck&apos;s estimated win-rate vs each column deck (heuristic
+            category model).
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-32">Deck ↓ vs →</TableHead>
+                  {deckNames.map((col) => (
+                    <TableHead key={col} className="text-center">
+                      {shortName(col)}
+                    </TableHead>
+                  ))}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {deckNames.map((row) => (
+                  <TableRow key={row}>
+                    <TableCell className="font-medium">{shortName(row, 18)}</TableCell>
+                    {deckNames.map((col) => {
+                      const c = cellFor(row, col);
+                      const p = c?.winProbability ?? 0;
+                      return (
+                        <TableCell
+                          key={col}
+                          className={`text-center ${probabilityTone(p)}`}
+                          title={c?.rationale}
+                        >
+                          {Math.round(p * 100)}%
+                        </TableCell>
+                      );
+                    })}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Overlap */}
+      {report.overlaps.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Card Overlap</CardTitle>
+            <CardDescription>
+              Shared cards between each pair of builds.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            {report.overlaps.map((o) => (
+              <div
+                key={`${o.a}-${o.b}`}
+                className="flex items-center justify-between rounded-md border p-2"
+              >
+                <span className="truncate">
+                  <span className="font-medium">{shortName(o.a, 18)}</span>
+                  <span className="mx-1 text-muted-foreground">↔</span>
+                  <span className="font-medium">{shortName(o.b, 18)}</span>
+                </span>
+                <Badge variant="outline">{o.overlapPercent}% shared</Badge>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+/** A small list of add/remove swap cards. */
+function SwapList({
+  title,
+  items,
+  tone,
+}: {
+  title: string;
+  items: Array<{ name: string; quantity: number }>;
+  tone: "add" | "remove";
+}) {
+  const toneClass =
+    tone === "add"
+      ? "text-emerald-600 dark:text-emerald-400"
+      : "text-red-600 dark:text-red-400";
+  return (
+    <div>
+      <p className={`mb-1 text-xs font-semibold uppercase ${toneClass}`}>
+        {title}
+      </p>
+      {items.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No changes</p>
+      ) : (
+        <ul className="space-y-1 text-sm">
+          {items.map((c) => (
+            <li key={c.name}>
+              <span className="font-mono text-xs text-muted-foreground">
+                {c.quantity}×
+              </span>{" "}
+              {c.name}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/deck-coach/page.tsx
+++ b/src/app/(app)/deck-coach/page.tsx
@@ -30,6 +30,7 @@ import {
 } from "lucide-react";
 import { EnhancedReviewDisplay } from "./_components/enhanced-review-display";
 import { MetaAnalysisDisplay } from "./_components/meta-analysis-display";
+import { MultiDeckComparison } from "./_components/multi-deck-comparison";
 import {
   Select,
   SelectContent,
@@ -64,9 +65,9 @@ export default function DeckCoachPage() {
     null,
   );
   const [isPending, startTransition] = useTransition();
-  const [analysisType, setAnalysisType] = useState<"review" | "meta" | "chat">(
-    "review",
-  );
+  const [analysisType, setAnalysisType] = useState<
+    "review" | "meta" | "chat" | "compare"
+  >("review");
   const [, setSavedDecks] = useLocalStorage<SavedDeck[]>("saved-decks", []);
   const { toast } = useToast();
 
@@ -333,12 +334,15 @@ export default function DeckCoachPage() {
 
       <Tabs
         value={analysisType}
-        onValueChange={(v) => setAnalysisType(v as "review" | "meta" | "chat")}
+        onValueChange={(v) =>
+          setAnalysisType(v as "review" | "meta" | "chat" | "compare")
+        }
         className="mb-4"
       >
         <TabsList>
           <TabsTrigger value="review">Deck Review</TabsTrigger>
           <TabsTrigger value="meta">Meta Analysis</TabsTrigger>
+          <TabsTrigger value="compare">Compare Decks</TabsTrigger>
           <TabsTrigger value="chat">
             <MessageSquare className="w-4 h-4 mr-2" />
             Chat
@@ -346,6 +350,11 @@ export default function DeckCoachPage() {
         </TabsList>
       </Tabs>
 
+      {/* Compare Decks tab: a self-contained multi-deck flow (issue #1075),
+          rendered full-width instead of the single-deck review grid. */}
+      {analysisType === "compare" ? (
+        <MultiDeckComparison />
+      ) : (
       <main className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card>
           <CardHeader>
@@ -612,6 +621,7 @@ export default function DeckCoachPage() {
             )}
         </div>
       </main>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Resolves #1075 — Multi-deck comparison and meta-positioning report

Adds a side-by-side comparison of 2–3 of the user's decks (or one deck + a meta archetype) and a **meta-positioning** report: how each build stacks up against the current field, plus a coaching recommendation on which to bring.

### What's new

**`src/ai/flows/compare-decks.ts`** — local-first, deterministic, heuristic-grounded core (mirrors the `sideboard-plan.ts` #1076 style):
- `compareDecks(entries, options?)` — synchronous core; `compareDecksAsync(entries, options?)` enriches synergy clusters via the AI Web Worker bridge (#1079/#1175).
- **Per-deck analysis is reused, not reimplemented**: archetype detection (`detectArchetype`), deck stats (`calculateDeckStats`), role classification (`classifyRole`) and assembly (`assembleStructuredAnalysis`/`buildStructuredDeckAnalysis`) all come from the existing coach analysers.
- **Matchup matrix** — projected win-rate per deck pair from a documented category rock-paper-scissors model over the same 6 categories (`aggro/control/midrange/combo/tribal/special`) the archetype signatures and per-matchup sideboard planner use. Antisymmetric (`M[a][b] + M[b][a] === 1`), 0.5 on mirrors.
- **Meta-positioning** — each deck's average projected win-rate vs the field, ranked (ties share a rank); surfaces favoured/unfavoured categories.
- **Comparison diffs** — card overlap % (Jaccard over the card-name multiset), role-distribution diff, mana-curve diff.
- **Recommendation** — names the best-positioned build and the 2–3 highest-impact swap cards (grounded in the actual deck card names, lands excluded) to pivot the weakest owned build toward it.
- **`< 2 decks` handling** — returns a structured `sufficient: false` report (no throw), so the UI degrades gracefully.
- **Single-deck-vs-meta-archetype path** — an entry with `archetypeOverride` and no cards resolves via the archetype signature, so a deck can be compared against e.g. "Burn" without owning the list.

**`src/app/(app)/deck-coach/_components/multi-deck-comparison.tsx`** — UI surface: multi-select 2–3 saved decks (reuses `useLocalStorage("saved-decks")`), optional meta-archetype column, then renders the recommendation, meta-positioning ranking, matchup matrix table, and card overlap. No deck-list editing UI is rebuilt.

**`src/app/(app)/deck-coach/page.tsx`** — adds a **"Compare Decks"** tab that renders the new component full-width (single-deck review/meta/chat flows untouched).

**`src/ai/flows/__tests__/compare-decks.test.ts`** — 8 tests: `< 2` decks handling, identical decks (100% overlap + mirror), asymmetric aggro-vs-control (matrix antisymmetry + control favoured), meta-positioning ranking (rank 1 = max score), single-deck-vs-archetype path, swap cards grounded in real card names, determinism, and role/curve diffs.

### Acceptance criteria

- [x] Given 2+ decks, produce a comparison: per-deck archetype, matchup matrix, and each deck's meta-positioning
- [x] A meta-positioning recommendation (best-positioned deck + why)
- [x] Heuristic-grounded (offline/local-first; no live LLM required). Optional async synergy enrichment via the worker.
- [x] A UI surface to select decks and view the report
- [x] Unit tests cover: representative deck comparison, matchup matrix correctness, meta-positioning ranking, `< 2` decks handling (+ single-deck-vs-archetype path)

### Verification
- `npm test -- --testPathPattern="(compare-decks|sideboard-plan|coach-deck-analysis|archetype-detector|archetype-scoring|heuristic-meta-analysis|ai-meta-analysis|coach-components)"` → **196 passed, 0 failed** (no regressions)
- `npx eslint` on all changed files → **0 errors / 0 warnings**
- `npx tsc --noEmit` → no errors in changed files (the only errors are pre-existing `next-intl` module-resolution issues unrelated to this change)

### Notes / scope
- Scoped strictly to comparison + meta-positioning. No existing deck-list UI was rebuilt; per-deck detection logic is reused verbatim.
- The category matchup table is a documented heuristic (classic MTG rock-paper-scissors) tuned for antisymmetry and 0.5 mirrors — deterministic and testable, consistent with the categories already used by `archetype-signatures.ts` and the #1076 sideboard planner.
