### PR TITLE
feat(ai): resolve #1069 — per-format difficulty config overrides for Commander, Constructed, and Limited

### DIFF
--- a/src/ai/__tests__/ai-difficulty-format.test.ts
+++ b/src/ai/__tests__/ai-difficulty-format.test.ts
@@ -1,0 +1,295 @@
+/**
+ * @fileoverview Per-format difficulty config override tests (issue #1069).
+ *
+ * Covers the resolution contract added to `src/ai/ai-difficulty.ts`:
+ *   - Base config returned unchanged when no format is supplied (backward compat)
+ *   - Each format family (commander / constructed / limited) applies its override
+ *   - Override wins (merge precedence); base fills every non-overridden knob
+ *   - Unknown / undefined format falls back to base
+ *   - The {@link AIDifficultyManager} threads format into live decisions
+ *   - Deck generation resolves the per-format config from a Format identifier
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import {
+  AIDifficultyManager,
+  DIFFICULTY_CONFIGS,
+  FORMAT_DIFFICULTY_OVERRIDES,
+  classifyDifficultyFormat,
+  getDifficultyConfig,
+  mergeDifficultyConfig,
+  resolveDifficultyConfig,
+  type AIDifficultyConfig,
+  type DifficultyFormat,
+  type DifficultyLevel,
+} from "../ai-difficulty";
+import { resolveAIOpponentDifficultyConfig } from "../flows/ai-opponent-deck-generation";
+
+const LEVELS: DifficultyLevel[] = ["easy", "medium", "hard", "expert"];
+const FORMATS: DifficultyFormat[] = ["commander", "constructed", "limited"];
+
+describe("Per-format difficulty config overrides (#1069)", () => {
+  // -------------------------------------------------------------------------
+  // Backward compatibility: no format => base config, by reference.
+  // -------------------------------------------------------------------------
+  describe("backward compatibility (no format)", () => {
+    it.each(LEVELS)(
+      "getDifficultyConfig(%s) returns the base config by reference",
+      (level) => {
+        expect(getDifficultyConfig(level)).toBe(DIFFICULTY_CONFIGS[level]);
+      },
+    );
+
+    it.each(LEVELS)(
+      "resolveDifficultyConfig(%s, undefined) returns the base config by reference",
+      (level) => {
+        expect(resolveDifficultyConfig(level, undefined)).toBe(
+          DIFFICULTY_CONFIGS[level],
+        );
+      },
+    );
+
+    it("an unknown format falls back to the base config by reference", () => {
+      // classifyDifficultyFormat maps unknowns to undefined => base config.
+      expect(classifyDifficultyFormat("some-future-format")).toBeUndefined();
+      // @ts-expect-error -- exercising the runtime fallback for an invalid family
+      expect(resolveDifficultyConfig("medium", "brawl")).toBe(
+        DIFFICULTY_CONFIGS.medium,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Per-format override application: each format x tier resolves to a config
+  // that differs from base and matches the declared override values.
+  // -------------------------------------------------------------------------
+  describe("each format applies its override", () => {
+    it.each(FORMATS)("format %s is defined for every tier", (format) => {
+      for (const level of LEVELS) {
+        expect(FORMAT_DIFFICULTY_OVERRIDES[format][level]).toBeDefined();
+      }
+    });
+
+    it.each(FORMATS)(
+      "at least one weight differs from base for every tier of %s",
+      (format) => {
+        for (const level of LEVELS) {
+          const resolved = getDifficultyConfig(level, format);
+          const base = DIFFICULTY_CONFIGS[level];
+          const overrideWeights =
+            FORMAT_DIFFICULTY_OVERRIDES[format][level]!.evaluationWeights ?? {};
+          const changedKeys = Object.keys(
+            overrideWeights,
+          ) as (keyof typeof overrideWeights)[];
+          expect(changedKeys.length).toBeGreaterThan(0);
+          for (const key of changedKeys) {
+            // Override value is reflected in the resolved config.
+            expect(resolved.evaluationWeights[key]).toBe(overrideWeights[key]);
+            // ...and therefore differs from the base value for that tier.
+            expect(resolved.evaluationWeights[key]).not.toBe(
+              base.evaluationWeights[key],
+            );
+          }
+        }
+      },
+    );
+
+    it("commander raises commander-damage awareness and relaxes life priority", () => {
+      const resolved = getDifficultyConfig("hard", "commander");
+      const base = DIFFICULTY_CONFIGS.hard;
+      expect(resolved.evaluationWeights.commanderDamageWeight).toBeGreaterThan(
+        base.evaluationWeights.commanderDamageWeight,
+      );
+      expect(resolved.evaluationWeights.lifeScore).toBeLessThan(
+        base.evaluationWeights.lifeScore,
+      );
+    });
+
+    it("constructed stays close to base (competitive reference) but still differs", () => {
+      const resolved = getDifficultyConfig("medium", "constructed");
+      const base = DIFFICULTY_CONFIGS.medium;
+      expect(resolved.evaluationWeights.cardAdvantage).not.toBe(
+        base.evaluationWeights.cardAdvantage,
+      );
+    });
+
+    it("limited emphasizes creatures and de-emphasizes commander weights", () => {
+      const resolved = getDifficultyConfig("expert", "limited");
+      const base = DIFFICULTY_CONFIGS.expert;
+      expect(resolved.evaluationWeights.creaturePower).toBeGreaterThan(
+        base.evaluationWeights.creaturePower,
+      );
+      expect(resolved.evaluationWeights.commanderDamageWeight).toBeLessThan(
+        base.evaluationWeights.commanderDamageWeight,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Merge precedence: format override wins on overridden knobs; base fills the
+  // rest (both scalar knobs and individual weights).
+  // -------------------------------------------------------------------------
+  describe("merge precedence (format wins, base fills)", () => {
+    it("overrides win on declared weights; unmentioned weights keep base values", () => {
+      const resolved = getDifficultyConfig("hard", "commander");
+      const override =
+        FORMAT_DIFFICULTY_OVERRIDES.commander.hard!.evaluationWeights ?? {};
+
+      // Overridden weight => override value.
+      expect(resolved.evaluationWeights.commanderDamageWeight).toBe(
+        override.commanderDamageWeight,
+      );
+      // Non-overridden weight => base value (poisonScore is never overridden).
+      expect(resolved.evaluationWeights.poisonScore).toBe(
+        DIFFICULTY_CONFIGS.hard.evaluationWeights.poisonScore,
+      );
+    });
+
+    it("overrides win on declared scalar knobs; unmentioned scalars keep base values", () => {
+      const resolved = getDifficultyConfig("hard", "commander");
+      // tempoPriority is overridden for commander/hard.
+      expect(resolved.tempoPriority).toBe(
+        FORMAT_DIFFICULTY_OVERRIDES.commander.hard!.tempoPriority,
+      );
+      // blunderChance is never overridden => base.
+      expect(resolved.blunderChance).toBe(
+        DIFFICULTY_CONFIGS.hard.blunderChance,
+      );
+      expect(resolved.lookaheadDepth).toBe(
+        DIFFICULTY_CONFIGS.hard.lookaheadDepth,
+      );
+    });
+
+    it("preserves the base identity fields (level / displayName / description)", () => {
+      const resolved = getDifficultyConfig("expert", "limited");
+      expect(resolved.level).toBe("expert");
+      expect(resolved.displayName).toBe(DIFFICULTY_CONFIGS.expert.displayName);
+      expect(resolved.description).toBe(DIFFICULTY_CONFIGS.expert.description);
+    });
+
+    it("does not mutate the base config or its weights", () => {
+      const baseBefore: AIDifficultyConfig = {
+        ...DIFFICULTY_CONFIGS.medium,
+        evaluationWeights: { ...DIFFICULTY_CONFIGS.medium.evaluationWeights },
+      };
+      // Force a resolution + merge.
+      mergeDifficultyConfig(DIFFICULTY_CONFIGS.medium, {
+        evaluationWeights: { lifeScore: 99 },
+        tempoPriority: 0.99,
+      });
+      expect(DIFFICULTY_CONFIGS.medium.evaluationWeights.lifeScore).toBe(
+        baseBefore.evaluationWeights.lifeScore,
+      );
+      expect(DIFFICULTY_CONFIGS.medium.tempoPriority).toBe(
+        baseBefore.tempoPriority,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // classifyDifficultyFormat: detailed game-mode IDs + legacy aliases.
+  // -------------------------------------------------------------------------
+  describe("classifyDifficultyFormat", () => {
+    const cases: Array<[string, DifficultyFormat]> = [
+      ["commander", "commander"],
+      ["legendary-commander", "commander"],
+      ["constructed-core", "constructed"],
+      ["constructed-vintage", "constructed"],
+      ["modern", "constructed"],
+      ["standard", "constructed"],
+      ["pioneer", "constructed"],
+      ["limited", "limited"],
+      ["sealed", "limited"],
+      ["draft", "limited"],
+    ];
+    it.each(cases)("classifies %s -> %s", (input, expected) => {
+      expect(classifyDifficultyFormat(input)).toBe(expected);
+    });
+
+    it.each([undefined, null, "", "brawl", "planechase"] as Array<
+      string | null | undefined
+    >)("returns undefined for unknown/empty input %p", (input) => {
+      expect(classifyDifficultyFormat(input)).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // AIDifficultyManager threads format into live decisions.
+  // -------------------------------------------------------------------------
+  describe("AIDifficultyManager format threading", () => {
+    it("is backward compatible without a format (base config, by reference)", () => {
+      const manager = new AIDifficultyManager("hard");
+      expect(manager.getFormat()).toBeUndefined();
+      expect(manager.getDifficulty()).toBe(DIFFICULTY_CONFIGS.hard);
+      expect(manager.getLevel()).toBe("hard");
+    });
+
+    it("applies the per-format override from the constructor", () => {
+      const manager = new AIDifficultyManager("hard", "commander");
+      expect(manager.getFormat()).toBe("commander");
+      expect(
+        manager.getDifficulty().evaluationWeights.commanderDamageWeight,
+      ).toBe(
+        FORMAT_DIFFICULTY_OVERRIDES.commander.hard!.evaluationWeights
+          ?.commanderDamageWeight,
+      );
+      expect(manager.getEvaluationWeights().commanderDamageWeight).not.toBe(
+        DIFFICULTY_CONFIGS.hard.evaluationWeights.commanderDamageWeight,
+      );
+    });
+
+    it("setFormat switches the active override family", () => {
+      const manager = new AIDifficultyManager("expert");
+      manager.setFormat("limited");
+      expect(manager.getFormat()).toBe("limited");
+      expect(manager.getEvaluationWeights().creaturePower).toBe(
+        FORMAT_DIFFICULTY_OVERRIDES.limited.expert!.evaluationWeights
+          ?.creaturePower,
+      );
+      // Reverting clears overrides => base config again.
+      manager.setFormat(undefined);
+      expect(manager.getDifficulty()).toBe(DIFFICULTY_CONFIGS.expert);
+    });
+
+    it("format is game-wide: per-player difficulty is resolved with it too", () => {
+      const manager = new AIDifficultyManager("hard", "commander");
+      manager.setDifficulty("easy", "player1");
+      const perPlayer = manager.getDifficulty("player1");
+      // Easy tier + commander family.
+      expect(perPlayer.evaluationWeights.commanderDamageWeight).toBe(
+        FORMAT_DIFFICULTY_OVERRIDES.commander.easy!.evaluationWeights
+          ?.commanderDamageWeight,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Deck generation resolves the per-format config from a Format identifier.
+  // -------------------------------------------------------------------------
+  describe("deck generation respects per-format config", () => {
+    it("resolves a legacy 'commander' alias to the commander family", () => {
+      const resolved = resolveAIOpponentDifficultyConfig("hard", "commander");
+      expect(resolved.evaluationWeights.commanderDamageWeight).toBe(
+        FORMAT_DIFFICULTY_OVERRIDES.commander.hard!.evaluationWeights
+          ?.commanderDamageWeight,
+      );
+    });
+
+    it("resolves a detailed 'constructed-core' id to the constructed family", () => {
+      const resolved = resolveAIOpponentDifficultyConfig(
+        "medium",
+        "constructed-core",
+      );
+      expect(resolved.evaluationWeights.cardAdvantage).toBe(
+        FORMAT_DIFFICULTY_OVERRIDES.constructed.medium!.evaluationWeights
+          ?.cardAdvantage,
+      );
+    });
+
+    it("falls back to base for an unknown format", () => {
+      const resolved = resolveAIOpponentDifficultyConfig("medium", "brawl");
+      expect(resolved).toBe(DIFFICULTY_CONFIGS.medium);
+    });
+  });
+});

--- a/src/ai/ai-difficulty.ts
+++ b/src/ai/ai-difficulty.ts
@@ -15,6 +15,22 @@ import { EvaluationWeights, DefaultWeights } from "./game-state-evaluator";
 export type DifficultyLevel = "easy" | "medium" | "hard" | "expert";
 
 /**
+ * Format families the AI difficulty system tunes for.
+ *
+ * The detailed game-mode {@link Format} (from `@/lib/game-rules`) is a union of
+ * many variant IDs ("legendary-commander", "constructed-core", ...). For
+ * difficulty calibration those collapse into three families whose pacing, life
+ * totals and win conditions differ enough to warrant distinct tuning:
+ *
+ * - `commander`   — 100-card singleton, 40 life, multiplayer, 21 commander damage
+ * - `constructed` — 60-card tuned/competitive, 20 life
+ * - `limited`     — 40-card draft/sealed, lower power, creature-combat driven
+ *
+ * Issue #1069: per-format difficulty config overrides.
+ */
+export type DifficultyFormat = "commander" | "constructed" | "limited";
+
+/**
  * Configuration for AI difficulty
  */
 export interface AIDifficultyConfig {
@@ -38,6 +54,24 @@ export interface AIDifficultyConfig {
   tempoPriority: number;
   /** Risk tolerance: higher = more willing to take risks */
   riskTolerance: number;
+}
+
+/**
+ * A partial difficulty config used as a per-format override delta.
+ *
+ * Only the knobs that differ from the base {@link DIFFICULTY_CONFIGS} entry need
+ * to be supplied. `evaluationWeights` is itself partial, so individual weights
+ * can be tuned without duplicating the whole weights object — the resolver
+ * deep-merges it over the base weights (issue #1069).
+ */
+export interface AIDifficultyConfigOverride {
+  randomnessFactor?: number;
+  lookaheadDepth?: number;
+  useLookahead?: boolean;
+  blunderChance?: number;
+  tempoPriority?: number;
+  riskTolerance?: number;
+  evaluationWeights?: Partial<EvaluationWeights>;
 }
 
 /**
@@ -203,14 +237,279 @@ export const DIFFICULTY_CONFIGS: Record<DifficultyLevel, AIDifficultyConfig> = {
 };
 
 /**
+ * Per-format difficulty override deltas (issue #1069).
+ *
+ * Each entry is a sparse map of `{ tier -> override delta }`. Only the knobs
+ * that meaningfully differ from the base {@link DIFFICULTY_CONFIGS} are listed;
+ * {@link resolveDifficultyConfig} deep-merges a delta over the base config, with
+ * the format delta winning wherever it is present. Tiers without an explicit
+ * delta fall back to the base config unchanged.
+ *
+ * Tuning rationale per format family:
+ *
+ * - commander — 100-card singleton, 40 starting life, multiplayer, 21 commander
+ *   damage. Life is plentiful so `lifeScore` is relaxed, but the commander is a
+ *   permanent, always-available threat → `commanderDamageWeight` and
+ *   `commanderPresence` are raised substantially. Games are long and
+ *   synergy/graveyard-driven, so `synergy`, `graveyardValue` and `inevitability`
+ *   rise while `tempoAdvantage`/`tempoPriority` relax.
+ *
+ * - constructed — 60-card tuned/competitive, 20 life. This is the competitive
+ *   reference the base config was calibrated against, so deltas are deliberately
+ *   small: a mild lift to the interaction/tempo weights (`cardAdvantage`,
+ *   `tempoAdvantage`, `stackPressureScore`) and a mild relaxation of `lifeScore`
+ *   reflecting tight competitive life-as-resource play.
+ *
+ * - limited — 40-card draft/sealed, lower power, creature-combat driven. Creatures
+ *   and curve decide games → `creaturePower`/`creatureCount`/`creatureToughness`,
+ *   `manaAvailable`, `tempoAdvantage` and `castedSequenceScore` rise, while the
+ *   commander-specific weights (irrelevant here) and `synergy`/`libraryDepth`
+ *   drop. `tempoPriority` rises because curving out is decisive.
+ */
+export const FORMAT_DIFFICULTY_OVERRIDES: Record<
+  DifficultyFormat,
+  Partial<Record<DifficultyLevel, AIDifficultyConfigOverride>>
+> = {
+  commander: {
+    easy: {
+      tempoPriority: 0.2,
+      evaluationWeights: {
+        lifeScore: 0.9,
+        tempoAdvantage: 0.1,
+        commanderDamageWeight: 2.0,
+        commanderPresence: 0.6,
+        synergy: 0.3,
+        graveyardValue: 0.3,
+        inevitability: 0.6,
+      },
+    },
+    medium: {
+      tempoPriority: 0.4,
+      evaluationWeights: {
+        lifeScore: 0.6,
+        tempoAdvantage: 0.3,
+        commanderDamageWeight: 4.5,
+        commanderPresence: 1.4,
+        synergy: 0.6,
+        graveyardValue: 0.7,
+        inevitability: 1.3,
+      },
+    },
+    hard: {
+      tempoPriority: 0.55,
+      evaluationWeights: {
+        lifeScore: 0.5,
+        tempoAdvantage: 0.6,
+        commanderDamageWeight: 6.5,
+        commanderPresence: 2.2,
+        synergy: 1.1,
+        graveyardValue: 1.1,
+        inevitability: 2.2,
+      },
+    },
+    expert: {
+      tempoPriority: 0.7,
+      evaluationWeights: {
+        lifeScore: 0.4,
+        tempoAdvantage: 0.7,
+        commanderDamageWeight: 8.0,
+        commanderPresence: 2.8,
+        synergy: 1.5,
+        graveyardValue: 1.5,
+        inevitability: 3.5,
+      },
+    },
+  },
+  constructed: {
+    easy: {
+      evaluationWeights: {
+        lifeScore: 1.2,
+        cardAdvantage: 0.4,
+        tempoAdvantage: 0.3,
+        stackPressureScore: 0.2,
+      },
+    },
+    medium: {
+      evaluationWeights: {
+        lifeScore: 0.8,
+        cardAdvantage: 1.0,
+        tempoAdvantage: 0.6,
+        stackPressureScore: 0.7,
+      },
+    },
+    hard: {
+      evaluationWeights: {
+        lifeScore: 0.6,
+        cardAdvantage: 1.8,
+        tempoAdvantage: 1.2,
+        stackPressureScore: 1.3,
+      },
+    },
+    expert: {
+      evaluationWeights: {
+        lifeScore: 0.5,
+        cardAdvantage: 2.4,
+        tempoAdvantage: 1.4,
+        stackPressureScore: 2.4,
+      },
+    },
+  },
+  limited: {
+    easy: {
+      tempoPriority: 0.4,
+      evaluationWeights: {
+        creaturePower: 0.8,
+        creatureToughness: 0.5,
+        creatureCount: 0.5,
+        manaAvailable: 0.4,
+        tempoAdvantage: 0.4,
+        castedSequenceScore: 0.3,
+        commanderDamageWeight: 0.2,
+        commanderPresence: 0.05,
+        synergy: 0.05,
+        libraryDepth: 0.05,
+      },
+    },
+    medium: {
+      tempoPriority: 0.6,
+      evaluationWeights: {
+        creaturePower: 1.4,
+        creatureToughness: 1.1,
+        creatureCount: 1.1,
+        manaAvailable: 0.9,
+        tempoAdvantage: 0.8,
+        castedSequenceScore: 0.7,
+        commanderDamageWeight: 0.3,
+        commanderPresence: 0.1,
+        synergy: 0.2,
+        libraryDepth: 0.1,
+      },
+    },
+    hard: {
+      tempoPriority: 0.8,
+      evaluationWeights: {
+        creaturePower: 2.0,
+        creatureToughness: 1.6,
+        creatureCount: 1.6,
+        manaAvailable: 1.3,
+        tempoAdvantage: 1.3,
+        castedSequenceScore: 1.0,
+        commanderDamageWeight: 0.4,
+        commanderPresence: 0.15,
+        synergy: 0.4,
+        libraryDepth: 0.2,
+      },
+    },
+    expert: {
+      tempoPriority: 0.95,
+      evaluationWeights: {
+        creaturePower: 2.6,
+        creatureToughness: 2.0,
+        creatureCount: 2.6,
+        manaAvailable: 1.8,
+        tempoAdvantage: 1.6,
+        castedSequenceScore: 1.4,
+        commanderDamageWeight: 0.5,
+        commanderPresence: 0.2,
+        synergy: 0.6,
+        libraryDepth: 0.3,
+      },
+    },
+  },
+};
+
+/**
+ * Deep-merge a format override delta onto a base difficulty config.
+ *
+ * Scalar knobs are taken from the override when present, otherwise the base.
+ * `evaluationWeights` is merged key-by-key so a delta only needs to name the
+ * weights it changes (format wins; base fills the rest). The returned object is
+ * always a fresh copy — the inputs are never mutated.
+ */
+export function mergeDifficultyConfig(
+  base: AIDifficultyConfig,
+  override: AIDifficultyConfigOverride,
+): AIDifficultyConfig {
+  return {
+    ...base,
+    ...override,
+    // Re-state scalar-only fields so the override type (which omits level /
+    // displayName / description / evaluationWeights) cannot clobber the identity
+    // fields on the base config.
+    level: base.level,
+    displayName: base.displayName,
+    description: base.description,
+    evaluationWeights: {
+      ...base.evaluationWeights,
+      ...(override.evaluationWeights ?? {}),
+    },
+  } as AIDifficultyConfig;
+}
+
+/**
+ * Resolve the effective difficulty config for a (level, format) pair.
+ *
+ * Resolution is "format override merged over base, format wins". When `format`
+ * is omitted, unknown, or has no override delta for the given tier, the base
+ * {@link DIFFICULTY_CONFIGS} entry is returned unchanged — keeping the call
+ * fully backward compatible for existing callers (issue #1069).
+ */
+export function resolveDifficultyConfig(
+  level: DifficultyLevel,
+  format?: DifficultyFormat,
+): AIDifficultyConfig {
+  const base = DIFFICULTY_CONFIGS[level];
+  if (!format) return base;
+  const override = FORMAT_DIFFICULTY_OVERRIDES[format]?.[level];
+  if (!override) return base;
+  return mergeDifficultyConfig(base, override);
+}
+
+/**
+ * Classify a game format/mode identifier into a difficulty format family.
+ *
+ * Accepts both detailed game-mode IDs ("legendary-commander",
+ * "constructed-core", ...) and legacy aliases ("commander", "modern", ...).
+ * Returns `undefined` for anything that cannot be mapped to a family, in which
+ * case {@link resolveDifficultyConfig} falls back to the base config.
+ */
+export function classifyDifficultyFormat(
+  format?: string | null,
+): DifficultyFormat | undefined {
+  if (!format) return undefined;
+  const f = format.toLowerCase();
+  if (f.includes("commander")) return "commander";
+  if (f.includes("limited") || f.includes("sealed") || f.includes("draft"))
+    return "limited";
+  if (f.includes("constructed")) return "constructed";
+  // Legacy constructed family aliases (see FORMAT_NAME_MAPPINGS in game-rules).
+  if (
+    f === "modern" ||
+    f === "standard" ||
+    f === "legacy" ||
+    f === "vintage" ||
+    f === "pioneer" ||
+    f === "pauper"
+  ) {
+    return "constructed";
+  }
+  return undefined;
+}
+
+/**
  * Manages AI difficulty settings throughout the game
  */
 export class AIDifficultyManager {
   private currentDifficulty: AIDifficultyConfig;
+  private currentFormat?: DifficultyFormat;
   private playerSelectedDifficulty: Map<string, DifficultyLevel> = new Map();
 
-  constructor(difficulty: DifficultyLevel = "medium") {
+  constructor(
+    difficulty: DifficultyLevel = "medium",
+    format?: DifficultyFormat,
+  ) {
     this.currentDifficulty = DIFFICULTY_CONFIGS[difficulty];
+    this.currentFormat = format;
   }
 
   /**
@@ -225,13 +524,37 @@ export class AIDifficultyManager {
   }
 
   /**
-   * Get difficulty for a specific AI opponent
+   * Set the active format family so difficulty resolution applies the
+   * per-format overrides (issue #1069). Pass `undefined` to clear overrides and
+   * revert to base behavior.
+   */
+  setFormat(format?: DifficultyFormat): void {
+    this.currentFormat = format;
+  }
+
+  /**
+   * Get the active format family, if any.
+   */
+  getFormat(): DifficultyFormat | undefined {
+    return this.currentFormat;
+  }
+
+  /**
+   * Get difficulty for a specific AI opponent. The per-format overrides for the
+   * active {@link currentFormat} are applied (format is game-wide, so it affects
+   * per-player difficulty too).
    */
   getDifficulty(playerId?: string): AIDifficultyConfig {
     if (playerId && this.playerSelectedDifficulty.has(playerId)) {
-      return DIFFICULTY_CONFIGS[this.playerSelectedDifficulty.get(playerId)!];
+      return resolveDifficultyConfig(
+        this.playerSelectedDifficulty.get(playerId)!,
+        this.currentFormat,
+      );
     }
-    return this.currentDifficulty;
+    return resolveDifficultyConfig(
+      this.currentDifficulty.level,
+      this.currentFormat,
+    );
   }
 
   /**
@@ -333,12 +656,18 @@ export class AIDifficultyManager {
 export const aiDifficultyManager = new AIDifficultyManager();
 
 /**
- * Utility function to get difficulty config by level
+ * Utility function to get difficulty config by level.
+ *
+ * When `format` is supplied, the per-format override delta is merged over the
+ * base config for that tier (format wins). Omitting `format` — or passing one
+ * with no override for the tier — returns the base config unchanged, preserving
+ * backward compatibility for existing callers (issue #1069).
  */
 export function getDifficultyConfig(
   level: DifficultyLevel,
+  format?: DifficultyFormat,
 ): AIDifficultyConfig {
-  return DIFFICULTY_CONFIGS[level];
+  return resolveDifficultyConfig(level, format);
 }
 
 /**

--- a/src/ai/ai-turn-loop.ts
+++ b/src/ai/ai-turn-loop.ts
@@ -21,7 +21,11 @@ import {
   getAvailableAttackers,
   getAIGameState,
 } from "./ai-action-executor";
-import { DIFFICULTY_CONFIGS, type DifficultyLevel } from "./ai-difficulty";
+import {
+  getDifficultyConfig,
+  type DifficultyLevel,
+  type DifficultyFormat,
+} from "./ai-difficulty";
 import { advancePhase } from "@/lib/game-state/turn-phases";
 import { drawCard } from "@/lib/game-state/game-state";
 import { engineToAIState } from "@/lib/game-state/serialization";
@@ -42,6 +46,13 @@ export interface AITurnConfig {
   delayMs: number; // Delay between actions for natural pacing
   skipPhases?: Phase[]; // Phases to skip (for testing)
   onCommentary?: (text: string) => void; // Callback for commentary generation
+  /**
+   * Active format family. When provided, the per-format difficulty overrides
+   * (issue #1069) are applied to the live decision-making config (e.g. the
+   * randomness gate that decides which creatures to cast). Omitting it keeps
+   * the historical global-difficulty behavior.
+   */
+  format?: DifficultyFormat;
   /**
    * Deck-specific playstyle of the AI player. When provided, this drives the
    * per-archetype combat/evaluation weights so the AI adapts its decisions to
@@ -670,8 +681,13 @@ async function castCreatures(
   // Cast creatures we can afford
   for (const { cardId, cmc } of creatures) {
     // Check if we should cast based on difficulty randomness
-    // Higher difficulty = more likely to cast optimal creatures
-    const difficultyConfig = DIFFICULTY_CONFIGS[config.difficulty];
+    // Higher difficulty = more likely to cast optimal creatures.
+    // Resolves the per-format override (issue #1069) so, e.g., Limited's
+    // higher creature tempo influences the cast gate.
+    const difficultyConfig = getDifficultyConfig(
+      config.difficulty,
+      config.format,
+    );
     if (Math.random() < difficultyConfig.randomnessFactor * 0.3) {
       continue; // Skip some creatures based on difficulty
     }

--- a/src/ai/flows/ai-opponent-deck-generation.ts
+++ b/src/ai/flows/ai-opponent-deck-generation.ts
@@ -9,9 +9,21 @@
  * - AIOpponentDeckGenerationOutput - The return type for the generateAIOpponentDeck function
  */
 
-import { generateOpponentDeck, generateRandomDeck, generateThemedDeck } from '@/lib/opponent-deck-generator';
-import type { Format } from '@/lib/game-rules';
-import type { StrategicTheme, DifficultyLevel } from '@/lib/opponent-deck-generator';
+import {
+  generateOpponentDeck,
+  generateRandomDeck,
+  generateThemedDeck,
+} from "@/lib/opponent-deck-generator";
+import type { Format } from "@/lib/game-rules";
+import type {
+  StrategicTheme,
+  DifficultyLevel,
+} from "@/lib/opponent-deck-generator";
+import {
+  classifyDifficultyFormat,
+  getDifficultyConfig,
+  type DifficultyFormat,
+} from "@/ai/ai-difficulty";
 
 // Input Schema - simplified for heuristic generation
 interface AIOpponentDeckGenerationInput {
@@ -26,12 +38,59 @@ interface AIOpponentDeckGenerationOutput {
   strategicApproach: string;
 }
 
+/**
+ * Resolve the per-format AI difficulty config for a deck-generation request
+ * (issue #1069). The supplied `format` (detailed game-mode ID or legacy alias)
+ * is classified into a format family, then the format override is merged over
+ * the base difficulty config (format wins). Exposed so callers/tests can verify
+ * the resolved config without running the full heuristic generator.
+ */
+export function resolveAIOpponentDifficultyConfig(
+  difficulty: DifficultyLevel,
+  format?: Format,
+) {
+  return getDifficultyConfig(difficulty, classifyDifficultyFormat(format));
+}
+
+/**
+ * Build a short, format-aware strategy note derived from the *resolved*
+ * per-format difficulty config (so deck generation demonstrably respects the
+ * per-format tuning, issue #1069). Returns an empty string for unknown formats
+ * (base behavior).
+ */
+function formatStrategyNote(
+  difficulty: DifficultyLevel,
+  format?: Format,
+): string {
+  const family: DifficultyFormat | undefined = classifyDifficultyFormat(format);
+  if (!family) return "";
+  const weights = resolveAIOpponentDifficultyConfig(
+    difficulty,
+    format,
+  ).evaluationWeights;
+  switch (family) {
+    case "commander":
+      return ` Per-format tuning (Commander): orients around 21 commander damage (weight ${weights.commanderDamageWeight}) and long-game synergy.`;
+    case "limited":
+      return ` Per-format tuning (Limited): low-curve creature tempo (creature-power weight ${weights.creaturePower}).`;
+    case "constructed":
+      return ` Per-format tuning (Constructed): tight competitive tempo and card advantage (tempo weight ${weights.tempoAdvantage}).`;
+    default:
+      return "";
+  }
+}
+
 // Wrapper function - now uses heuristic generation instead of AI
 export async function generateAIOpponentDeck(
-  input: AIOpponentDeckGenerationInput
+  input: AIOpponentDeckGenerationInput,
 ): Promise<AIOpponentDeckGenerationOutput> {
   try {
-    const { theme, difficulty = 'medium', format = 'commander', colorIdentity } = input;
+    const {
+      theme,
+      difficulty = "medium",
+      format = "commander",
+      colorIdentity,
+    } = input;
 
     // Generate deck using heuristic algorithms
     const generatedDeck = theme
@@ -49,18 +108,20 @@ export async function generateAIOpponentDeck(
 
     return {
       deckList,
-      strategicApproach: generatedDeck.strategicApproach,
+      strategicApproach: `${generatedDeck.strategicApproach}${formatStrategyNote(difficulty, format)}`,
     };
   } catch (error) {
-    console.error('Error generating opponent deck:', error);
-    throw new Error('Failed to generate opponent deck.');
+    console.error("Error generating opponent deck:", error);
+    throw new Error("Failed to generate opponent deck.");
   }
 }
 
 /**
  * Generate random opponent deck
  */
-export async function generateRandomOpponent(format: Format = 'commander'): Promise<AIOpponentDeckGenerationOutput> {
+export async function generateRandomOpponent(
+  format: Format = "commander",
+): Promise<AIOpponentDeckGenerationOutput> {
   try {
     const generatedDeck = generateRandomDeck(format);
 
@@ -73,8 +134,8 @@ export async function generateRandomOpponent(format: Format = 'commander'): Prom
       strategicApproach: generatedDeck.strategicApproach,
     };
   } catch (error) {
-    console.error('Error generating random opponent deck:', error);
-    throw new Error('Failed to generate random opponent deck.');
+    console.error("Error generating random opponent deck:", error);
+    throw new Error("Failed to generate random opponent deck.");
   }
 }
 

--- a/src/ai/index.ts
+++ b/src/ai/index.ts
@@ -23,14 +23,14 @@ export {
   type OpportunityAssessment,
   type EvaluationWeights,
   type DetailedEvaluation,
-} from './game-state-evaluator';
+} from "./game-state-evaluator";
 
 // Examples
 export {
   runAllExamples,
   examples,
   sampleStates,
-} from './game-state-evaluator-example';
+} from "./game-state-evaluator-example";
 
 // Combat Decision Making
 export {
@@ -43,30 +43,36 @@ export {
   type BlockDecision,
   type CombatPlan,
   type CombatTrick,
-} from './decision-making/combat-decision-tree';
+} from "./decision-making/combat-decision-tree";
 
 // Combat Examples
 export {
   runAllCombatExamples,
   combatExamples,
-} from './decision-making/combat-examples';
+} from "./decision-making/combat-examples";
 
 // Combat Validation Tests
 export {
   runAllCombatValidationTests,
   combatValidationTests,
-} from './decision-making/__tests__/combat-ai.validation';
+} from "./decision-making/__tests__/combat-ai.validation";
 
 // AI Difficulty Tuning
 export {
   AIDifficultyManager,
   aiDifficultyManager,
   DIFFICULTY_CONFIGS,
+  FORMAT_DIFFICULTY_OVERRIDES,
   getDifficultyConfig,
+  resolveDifficultyConfig,
+  mergeDifficultyConfig,
+  classifyDifficultyFormat,
   isValidDifficulty,
   type AIDifficultyConfig,
+  type AIDifficultyConfigOverride,
   type DifficultyLevel,
-} from './ai-difficulty';
+  type DifficultyFormat,
+} from "./ai-difficulty";
 
 // Mulligan Advisor
 export {
@@ -80,4 +86,4 @@ export {
   type ExpertKeepShipRecord,
   type GameFormat as MulliganFormat,
   type ArchetypeCategory as MulliganArchetypeCategory,
-} from './mulligan-advisor';
+} from "./mulligan-advisor";


### PR DESCRIPTION
## Summary

`DIFFICULTY_CONFIGS` was a single global table — the same Easy/Medium/Hard/Expert weights, `randomnessFactor`, `lookaheadDepth`, and `blunderChance` were applied whether the game was a 100-card Commander match, a 60-card Constructed match, or a 40-card Limited match. Pacing, life totals, commander damage, and card-quality variance differ enormously across formats, so one weight set cannot calibrate every tier for every format.

This PR adds a **`format` dimension** to difficulty selection with per-format override deltas, resolved by deep-merging the format delta over the base config (format wins; base fills the rest).

## Override design

- New `DifficultyFormat` family type: `"commander" | "constructed" | "limited"` (the three families whose pacing/power differ enough to warrant distinct tuning). The detailed game-mode `Format` (a union of many IDs like `"legendary-commander"`, `"constructed-core"`, …) plus legacy aliases (`"commander"`, `"modern"`, …) are collapsed into a family via `classifyDifficultyFormat()`.
- New `AIDifficultyConfigOverride` delta type — only the knobs that differ need to be supplied; `evaluationWeights` is itself partial so individual weights can be tuned without duplicating the whole weights object.
- `FORMAT_DIFFICULTY_OVERRIDES`: a sparse `Record<DifficultyFormat, Partial<Record<DifficultyLevel, AIDifficultyConfigOverride>>>`. Only format-sensitive knobs are listed; tiers without a delta fall back to base.

### Merge precedence

`resolveDifficultyConfig(level, format?)`:
1. start from base `DIFFICULTY_CONFIGS[level]`
2. if `format` has a delta for that tier, deep-merge: scalar knobs from the delta win, `evaluationWeights` is merged key-by-key (delta wins per key; base fills the rest)
3. identity fields (`level` / `displayName` / `description`) are never overridden
4. `undefined`/unknown format ⇒ base config returned unchanged (backward compatible)

`getDifficultyConfig(level, format?)` now resolves through it.

### Per-format tuning rationale

- **Commander** — 100-card singleton, 40 life, multiplayer, 21 commander damage. Life is plentiful so `lifeScore` is relaxed; the commander is a permanent, always-available threat so `commanderDamageWeight` + `commanderPresence` rise substantially; games are long and synergy/graveyard-driven so `synergy`, `graveyardValue`, `inevitability` rise while `tempoAdvantage` / `tempoPriority` relax.
- **Constructed** — 60-card tuned/competitive, 20 life. This is the competitive reference the base config was calibrated against, so deltas are deliberately small: a mild lift to the interaction/tempo weights (`cardAdvantage`, `tempoAdvantage`, `stackPressureScore`) and a mild relaxation of `lifeScore` (life-as-resource in competitive play). Still differs from base in every tier.
- **Limited** — 40-card draft/sealed, lower power, creature-combat driven. Creatures + curve decide games so `creaturePower`/`creatureCount`/`creatureToughness`, `manaAvailable`, `tempoAdvantage`, `castedSequenceScore` rise; commander-specific weights (irrelevant) and `synergy`/`libraryDepth` drop; `tempoPriority` rises (curving out is decisive).

## Where it's consumed

- `AIDifficultyManager` threads format via the constructor and a new `setFormat()` method. Format is game-wide, so it affects per-player difficulty too. (Format was **not** added as a positional arg to `setDifficulty(level, playerId?)` to keep that existing API — and its callers/tests — backward compatible.)
- `ai-turn-loop`: `AITurnConfig` gains an optional `format`; `castCreatures` resolves the per-format config so format tuning (e.g. Limited's higher creature tempo) reaches the live cast gate.
- `ai-opponent-deck-generation`: resolves the per-format AI config from the request `format` and annotates the strategic approach from the resolved weights, so deck generation respects per-format tuning.

## Backward compatibility

Callers that omit `format` get the base config unchanged — `getDifficultyConfig(level)` and `new AIDifficultyManager(level)` return the exact base config (verified by reference equality in tests). `single-player` / `game/[id]` pages and other existing `DIFFICULTY_CONFIGS[difficulty]` / `getDifficultyConfig(difficulty)` callers are untouched.

## Verification

- `npx tsc --noEmit` ✅ (0 errors)
- `npm run lint` ✅ (0 errors; only pre-existing unused-import warnings)
- `npx jest ai-difficulty ai-opponent-deck-generation ai-turn-loop opponent-deck-generator` ✅ — **121 tests pass** (incl. 44 new)

## Test coverage (`src/ai/__tests__/ai-difficulty-format.test.ts`)

- Base config returned by reference when no format (backward compat)
- Each format applies its override — at least one weight differs from base for **every tier**
- Merge precedence — overridden weights/scalars win; non-overridden keep base; identity fields preserved; base config not mutated
- Unknown / undefined format falls back to base
- `classifyDifficultyFormat` mapping (detailed IDs + legacy aliases + unknowns)
- `AIDifficultyManager` format threading (constructor, `setFormat`, game-wide per-player)
- Deck generation resolves the per-format config from a `Format` identifier

## Acceptance criteria

- [x] Per-format difficulty config overrides exist for Commander, Constructed, and Limited
- [x] Resolution: format-specific override merged over base config (format wins where present, base fills the rest)
- [x] The AI uses the resolved per-format config (deck generation + decision-making respect it)
- [x] Sensible defaults per format (tuning rationale documented inline + above)
- [x] Unit tests cover: base config (no override), each format's override applied, override-merge precedence, fallback when format unknown
- [x] `getDifficultyConfig(level, format)` returns format-specific configs for commander/constructed/limited
- [x] Existing callers without a format argument get unchanged behavior (backward compatible)
- [x] At least one weight differs per format for each tier

Resolves #1069