### PR TITLE
feat(ai): resolve #1067 — scale combat-trick casting and bluff/hold behavior by difficulty

### DIFF
--- a/src/ai/__tests__/combat-trick-probability.test.ts
+++ b/src/ai/__tests__/combat-trick-probability.test.ts
@@ -2,10 +2,22 @@ import { describe, it, expect } from "@jest/globals";
 import {
   estimateCombatTrickProbability,
   calculateCombatTrickDiscount,
+  decideCombatTrickHold,
+  getDifficultyTrickScaling,
+  resolveTrickScaling,
+  DIFFICULTY_TRICK_SCALING,
   type CombatTrickType,
 } from "../decision-making/combat-trick-probability";
 import { CombatDecisionTree } from "../decision-making/combat-decision-tree";
 import { createTestGameState, createMockPermanent } from "./test-helpers";
+import type { DifficultyLevel } from "../ai-difficulty";
+
+const DIFFICULTY_LEVELS: DifficultyLevel[] = [
+  "easy",
+  "medium",
+  "hard",
+  "expert",
+];
 
 describe("estimateCombatTrickProbability", () => {
   it("should return 0 probability when opponent has no open mana", () => {
@@ -307,5 +319,382 @@ describe("integration: combat trick discount in attack decisions", () => {
 
     const plan = ai.generateAttackPlan();
     expect(plan).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #1067 — difficulty-scaled combat-trick casting + bluff/hold behavior.
+// ---------------------------------------------------------------------------
+
+describe("estimateCombatTrickProbability — difficulty scaling (#1067)", () => {
+  // A fixed, mana-rich board used to compare tiers on identical inputs.
+  const mana = { white: 2, blue: 0, black: 0, red: 2, green: 0, colorless: 1 };
+
+  it("omitting difficulty preserves the legacy (unscaled) behavior", () => {
+    const legacy = estimateCombatTrickProbability(mana, "tempo", 4, 5);
+    const explicit = estimateCombatTrickProbability(
+      mana,
+      "tempo",
+      4,
+      5,
+      undefined,
+    );
+    expect(explicit.probability).toBe(legacy.probability);
+    // The unscaled multipliers are all 1, so expert must match legacy exactly
+    // on the probability term (bluff/freq multipliers both 1 for expert).
+    const expert = estimateCombatTrickProbability(mana, "tempo", 4, 5, "expert");
+    expect(expert.probability).toBeCloseTo(legacy.probability, 10);
+  });
+
+  it("expert estimates a higher trick probability than easy on the same board", () => {
+    const easy = estimateCombatTrickProbability(mana, "tempo", 4, 5, "easy");
+    const expert = estimateCombatTrickProbability(
+      mana,
+      "tempo",
+      4,
+      5,
+      "expert",
+    );
+    expect(expert.probability).toBeGreaterThan(easy.probability);
+  });
+
+  it("is monotonic in skill across every archetype", () => {
+    const archetypes = [
+      "aggro",
+      "control",
+      "midrange",
+      "tempo",
+      "combo",
+      "unknown",
+    ] as const;
+    for (const arch of archetypes) {
+      const probs = DIFFICULTY_LEVELS.map(
+        (d) => estimateCombatTrickProbability(mana, arch, 4, 5, d).probability,
+      );
+      for (let i = 1; i < probs.length; i++) {
+        expect(probs[i]).toBeGreaterThanOrEqual(probs[i - 1]);
+      }
+    }
+  });
+
+  it("easy bluffs are heavily suppressed (bluffWeight ≈ 0)", () => {
+    // Use a control board where bluff contribution is largest; easy should
+    // contribute almost nothing while expert contributes fully.
+    const easy = estimateCombatTrickProbability(mana, "control", 4, 5, "easy");
+    const noBluff = estimateCombatTrickProbability(mana, "control", 4, 5);
+    // Easy's probability is strictly below the unscaled (no-difficulty) one
+    // because both freq and bluff multipliers are < 1 for easy.
+    expect(easy.probability).toBeLessThan(noBluff.probability);
+  });
+
+  it.each(DIFFICULTY_LEVELS)(
+    "includes the difficulty and multipliers in the reasoning (%s)",
+    (level) => {
+      const result = estimateCombatTrickProbability(mana, "tempo", 4, 5, level);
+      expect(result.reasoning).toContain(`difficulty=${level}`);
+    },
+  );
+
+  it("still caps at 0.95 for expert with a saturated board", () => {
+    const saturated = estimateCombatTrickProbability(
+      { white: 3, blue: 3, black: 3, red: 3, green: 3, colorless: 5 },
+      "tempo",
+      7,
+      10,
+      "expert",
+    );
+    expect(saturated.probability).toBeLessThanOrEqual(0.95);
+  });
+});
+
+describe("DIFFICULTY_TRICK_SCALING table (#1067)", () => {
+  it("exposes a monotonic bluff multiplier (easy < ... < expert)", () => {
+    const vals = DIFFICULTY_LEVELS.map(
+      (d) => DIFFICULTY_TRICK_SCALING[d].bluffMultiplier,
+    );
+    for (let i = 1; i < vals.length; i++) {
+      expect(vals[i]).toBeGreaterThan(vals[i - 1]);
+    }
+    expect(DIFFICULTY_TRICK_SCALING.easy.bluffMultiplier).toBeLessThan(0.2);
+    expect(DIFFICULTY_TRICK_SCALING.expert.bluffMultiplier).toBe(1);
+  });
+
+  it("exposes a monotonic optimal-cast frequency (easy < ... < expert)", () => {
+    const vals = DIFFICULTY_LEVELS.map(
+      (d) => DIFFICULTY_TRICK_SCALING[d].trickFrequencyMultiplier,
+    );
+    for (let i = 1; i < vals.length; i++) {
+      expect(vals[i]).toBeGreaterThan(vals[i - 1]);
+    }
+  });
+
+  it("miscastChance decreases monotonically with skill", () => {
+    const vals = DIFFICULTY_LEVELS.map(
+      (d) => DIFFICULTY_TRICK_SCALING[d].miscastChance,
+    );
+    for (let i = 1; i < vals.length; i++) {
+      expect(vals[i]).toBeLessThan(vals[i - 1]);
+    }
+  });
+
+  it("holdDiscipline increases monotonically with skill", () => {
+    const vals = DIFFICULTY_LEVELS.map(
+      (d) => DIFFICULTY_TRICK_SCALING[d].holdDiscipline,
+    );
+    for (let i = 1; i < vals.length; i++) {
+      expect(vals[i]).toBeGreaterThan(vals[i - 1]);
+    }
+  });
+
+  it("getDifficultyTrickScaling returns the table entry by reference", () => {
+    for (const level of DIFFICULTY_LEVELS) {
+      expect(getDifficultyTrickScaling(level)).toBe(
+        DIFFICULTY_TRICK_SCALING[level],
+      );
+    }
+  });
+});
+
+describe("resolveTrickScaling — per-format composition (#1069)", () => {
+  it("returns the base scaling by reference when no format is supplied", () => {
+    for (const level of DIFFICULTY_LEVELS) {
+      expect(resolveTrickScaling(level, undefined)).toBe(
+        DIFFICULTY_TRICK_SCALING[level],
+      );
+    }
+  });
+
+  it("returns the base scaling when the format has no override for the tier", () => {
+    // All three format families declare overrides for every tier in #1069, so
+    // this asserts the fallback path only triggers when blunderChance is
+    // unchanged; if a format's resolved blunderChance equals the base, the
+    // miscastChance (and thus the whole object) is returned unchanged.
+    expect(resolveTrickScaling("medium", "constructed")).toBeDefined();
+  });
+
+  it("folds the per-format blunderChance delta into miscastChance", () => {
+    // Constructed does not override blunderChance for any tier (#1069 only
+    // touches evaluationWeights there), so the ratio is 1 → base unchanged.
+    const base = resolveTrickScaling("hard", undefined);
+    const constructed = resolveTrickScaling("hard", "constructed");
+    expect(constructed.miscastChance).toBeCloseTo(base.miscastChance, 10);
+
+    // Every resolved scaling must keep miscastChance within [0, 1].
+    for (const level of DIFFICULTY_LEVELS) {
+      for (const format of [
+        "commander",
+        "constructed",
+        "limited",
+      ] as const) {
+        const m = resolveTrickScaling(level, format).miscastChance;
+        expect(m).toBeGreaterThanOrEqual(0);
+        expect(m).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+});
+
+describe("decideCombatTrickHold — bluff/hold by difficulty (#1067)", () => {
+  // A seeded RNG factory: a deterministic sequence so tests are reproducible.
+  function makeRng(...rolls: number[]): () => number {
+    let i = 0;
+    return () => {
+      const r = rolls[i % rolls.length];
+      i++;
+      return r;
+    };
+  }
+
+  it("easy mis-times (miscasts) the reveal when the miscast roll hits", () => {
+    // roll 0.3 < easy.miscastChance(0.4) → forced early reveal.
+    const decision = decideCombatTrickHold({
+      difficulty: "easy",
+      evNow: 0.2,
+      evLater: 0.9,
+      rng: makeRng(0.3),
+    });
+    expect(decision.holdForValue).toBe(false);
+    expect(decision.miscast).toBe(true);
+  });
+
+  it("expert holds for value when the discipline roll passes", () => {
+    // First roll 0.9 ≥ expert.miscastChance(0.02) → no miscast.
+    // Second roll 0.5 < expert.holdDiscipline(0.95) → hold.
+    const decision = decideCombatTrickHold({
+      difficulty: "expert",
+      evNow: 0.2,
+      evLater: 0.9,
+      rng: makeRng(0.9, 0.5),
+    });
+    expect(decision.holdForValue).toBe(true);
+    expect(decision.miscast).toBe(false);
+  });
+
+  it("expert reveals now when there is no value gain to holding", () => {
+    const decision = decideCombatTrickHold({
+      difficulty: "expert",
+      evNow: 0.8,
+      evLater: 0.8,
+      rng: makeRng(0.99, 0.0),
+    });
+    expect(decision.holdForValue).toBe(false);
+    expect(decision.miscast).toBe(false);
+  });
+
+  it("easy rarely holds for value even when later EV dominates (low discipline)", () => {
+    // No miscast (0.9 ≥ 0.4) but discipline roll 0.4 ≥ easy.holdDiscipline(0.1)
+    // → easy fails the discipline check and reveals now despite +EV.
+    const decision = decideCombatTrickHold({
+      difficulty: "easy",
+      evNow: 0.1,
+      evLater: 0.9,
+      rng: makeRng(0.9, 0.4),
+    });
+    expect(decision.holdForValue).toBe(false);
+    expect(decision.miscast).toBe(false);
+  });
+
+  it("produces monotonic hold rates across tiers on identical value (aggregated)", () => {
+    // Across many deterministic rolls, the cumulative hold count must be
+    // non-decreasing in skill — easy holds least, expert holds most.
+    const rolls: number[] = [];
+    for (let i = 1; i <= 20; i++) rolls.push(i / 25); // 0.04 .. 0.80 in order
+    const evNow = 0.2;
+    const evLater = 0.8;
+    const holdCounts = DIFFICULTY_LEVELS.map((level) => {
+      let held = 0;
+      // Pair rolls: (miscast, discipline) — reuse the same ladder per tier.
+      for (let i = 0; i < rolls.length - 1; i += 2) {
+        let idx = 0;
+        const rng = () => rolls[i + idx++ % 2];
+        const d = decideCombatTrickHold({
+          difficulty: level,
+          evNow,
+          evLater,
+          rng,
+        });
+        if (d.holdForValue) held++;
+      }
+      return held;
+    });
+    for (let i = 1; i < holdCounts.length; i++) {
+      expect(holdCounts[i]).toBeGreaterThanOrEqual(holdCounts[i - 1]);
+    }
+    expect(holdCounts[0]).toBeLessThan(holdCounts[holdCounts.length - 1]);
+  });
+
+  it("composes with per-format config via the format parameter", () => {
+    // Same tier, different formats must remain valid and within bounds.
+    for (const format of [
+      "commander",
+      "constructed",
+      "limited",
+    ] as const) {
+      const d = decideCombatTrickHold({
+        difficulty: "hard",
+        format,
+        evNow: 0.2,
+        evLater: 0.7,
+        rng: makeRng(0.99, 0.5),
+      });
+      expect(typeof d.holdForValue).toBe("boolean");
+      expect(typeof d.miscast).toBe("boolean");
+      expect(d.reasoning).toContain("hard");
+    }
+  });
+});
+
+describe("CombatDecisionTree — difficulty plumbing into the trick module (#1067)", () => {
+  it("stores and exposes the difficulty tier", () => {
+    const state = createTestGameState(
+      20,
+      20,
+      [createMockPermanent("c1", "Bear", "creature", 2, 2, false, 2)],
+      [],
+    );
+    for (const level of DIFFICULTY_LEVELS) {
+      const ai = new CombatDecisionTree(state, "player1", level);
+      expect(ai.getDifficulty()).toBe(level);
+    }
+  });
+
+  it("decideCombatTrickBluffHold scales hold behavior by the tree's difficulty", () => {
+    const state = createTestGameState(
+      20,
+      20,
+      [createMockPermanent("c1", "Bear", "creature", 2, 2, false, 2)],
+      [],
+    );
+    const easyAi = new CombatDecisionTree(state, "player1", "easy");
+    const expertAi = new CombatDecisionTree(state, "player1", "expert");
+
+    // Deterministic RNG: low roll → easy miscasts, expert survives; next roll
+    // → expert passes discipline, easy fails it.
+    let i = 0;
+    const rng = () => {
+      const v = [0.3, 0.4, 0.9, 0.5][i++ % 4];
+      return v;
+    };
+
+    const easyDecision = easyAi.decideCombatTrickBluffHold(0.2, 0.9, rng);
+    const expertDecision = expertAi.decideCombatTrickBluffHold(0.2, 0.9, rng);
+
+    expect(easyDecision.holdForValue).toBe(false);
+    expect(expertDecision.holdForValue).toBe(true);
+  });
+
+  it("setDifficultyFormat threads per-format config into bluff/hold decisions", () => {
+    const state = createTestGameState(
+      20,
+      20,
+      [createMockPermanent("c1", "Bear", "creature", 2, 2, false, 2)],
+      [],
+    );
+    const ai = new CombatDecisionTree(state, "player1", "hard");
+    expect(ai.getDifficultyFormat()).toBeUndefined();
+    ai.setDifficultyFormat("limited");
+    expect(ai.getDifficultyFormat()).toBe("limited");
+    // Decision still well-formed with a format applied.
+    const d = ai.decideCombatTrickBluffHold(0.3, 0.7, () => 0.99);
+    expect(typeof d.holdForValue).toBe("boolean");
+  });
+
+  it("expert and easy produce different attack EVs against identical open mana", () => {
+    // Same board, same opponent open mana — the only difference is the AI's
+    // tier threading into estimateCombatTrickProbability. Expert discounts its
+    // attack EV at least as much as easy (it reads/plays around tricks more).
+    const buildPlan = (level: DifficultyLevel) => {
+      const state = createTestGameState(
+        20,
+        20,
+        [createMockPermanent("c1", "Bear", "creature", 2, 2, false, 2)],
+        [],
+      );
+      state.players.player2.manaPool = {
+        white: 0,
+        blue: 0,
+        black: 0,
+        red: 2,
+        green: 0,
+        colorless: 1,
+      };
+      state.players.player2.hand = [
+        { cardInstanceId: "h1", name: "Lightning Bolt", type: "Instant", manaValue: 1 },
+      ];
+      const ai = new CombatDecisionTree(state, "player1", level);
+      ai.setConfig({ useCombatTricks: true, opponentArchetype: "tempo" });
+      return ai.generateAttackPlan();
+    };
+
+    const easyPlan = buildPlan("easy");
+    const expertPlan = buildPlan("expert");
+
+    // When both decide to attack, expert (higher perceived trick threat)
+    // cannot assign a HIGHER expected value than easy on the same board.
+    if (easyPlan.attacks.length > 0 && expertPlan.attacks.length > 0) {
+      expect(expertPlan.attacks[0].expectedValue).toBeLessThanOrEqual(
+        easyPlan.attacks[0].expectedValue + 1e-9,
+      );
+    }
   });
 });

--- a/src/ai/decision-making/combat-decision-tree.ts
+++ b/src/ai/decision-making/combat-decision-tree.ts
@@ -37,8 +37,12 @@ import {
 import {
   estimateCombatTrickProbability,
   calculateCombatTrickDiscount,
+  decideCombatTrickHold,
   type OpponentManaState,
+  type CombatTrickHoldDecision,
+  type CombatTrickHoldInput,
 } from "./combat-trick-probability";
+import type { DifficultyFormat, DifficultyLevel } from "../ai-difficulty";
 import {
   LookaheadEngine,
   HeuristicTable,
@@ -311,6 +315,19 @@ export class CombatDecisionTree {
   private lookaheadEngine: LookaheadEngine;
   private archetype: DeckArchetype;
   private opponentArchetype: OpponentArchetype;
+  /**
+   * Skill tier this tree plays at. Threaded into the combat-trick module so
+   * that trick casting probability and bluff/hold behavior scale by difficulty
+   * (issue #1067). Stored separately from {@link config} because the base
+   * {@link CombatAIConfig} shape has no tier field and is overridden wholesale
+   * by {@link setConfig}.
+   */
+  private readonly difficulty: DifficultyLevel;
+  /**
+   * Optional format family used to fold the per-format difficulty overrides
+   * (#1069) into trick bluff/hold decisions. Set via {@link setDifficultyFormat}.
+   */
+  private difficultyFormat?: DifficultyFormat;
   constructor(
     gameState: GameState,
     aiPlayerId: string,
@@ -322,6 +339,7 @@ export class CombatDecisionTree {
     this.aiPlayerId = aiPlayerId;
     this.archetype = archetype;
     this.opponentArchetype = opponentArchetype;
+    this.difficulty = difficulty;
 
     const baseConfig = DefaultCombatConfigs[difficulty];
     // Wire the deck-specific playstyle weights into the live combat config.
@@ -373,6 +391,55 @@ export class CombatDecisionTree {
    */
   getOpponentArchetype(): OpponentArchetype {
     return this.opponentArchetype;
+  }
+
+  /**
+   * The skill tier this tree plays at. Drives difficulty-scaled combat-trick
+   * casting probability and bluff/hold behavior (issue #1067).
+   */
+  getDifficulty(): DifficultyLevel {
+    return this.difficulty;
+  }
+
+  /**
+   * The active format family used to fold per-format difficulty overrides
+   * (#1069) into trick decisions, if any.
+   */
+  getDifficultyFormat(): DifficultyFormat | undefined {
+    return this.difficultyFormat;
+  }
+
+  /**
+   * Set the active format family so trick bluff/hold decisions apply the
+   * per-format overrides (issue #1069). Pass `undefined` to clear overrides.
+   */
+  setDifficultyFormat(format?: DifficultyFormat): void {
+    this.difficultyFormat = format;
+  }
+
+  /**
+   * Decide whether to hold a combat trick for a higher-value window or cast it
+   * now, scaled by this tree's difficulty (issue #1067).
+   *
+   * Easy tiers frequently mis-time reveals (high `miscastChance`) and rarely
+   * hold for value (low `holdDiscipline`); Expert tiers hold for the
+   * highest-EV window and almost never mis-cast. The decision is deterministic
+   * when `rng` is supplied, which is how callers/tests assert per-tier
+   * monotonicity without flakiness.
+   */
+  decideCombatTrickBluffHold(
+    evNow: number,
+    evLater: number,
+    rng?: () => number,
+  ): CombatTrickHoldDecision {
+    const input: CombatTrickHoldInput = {
+      difficulty: this.difficulty,
+      format: this.difficultyFormat,
+      evNow,
+      evLater,
+      rng,
+    };
+    return decideCombatTrickHold(input);
   }
 
   /**
@@ -697,6 +764,7 @@ export class CombatDecisionTree {
         this.config.opponentArchetype,
         opponent.hand?.length,
         this.gameState.turnInfo?.currentTurn,
+        this.difficulty,
       );
 
       if (trickEstimate.probability > 0) {
@@ -744,6 +812,7 @@ export class CombatDecisionTree {
           this.config.opponentArchetype,
           opponent.hand?.length,
           this.gameState.turnInfo?.currentTurn,
+          this.difficulty,
         );
 
         if (trickEstimate.probability > 0) {

--- a/src/ai/decision-making/combat-trick-probability.ts
+++ b/src/ai/decision-making/combat-trick-probability.ts
@@ -1,4 +1,10 @@
 import type { OpponentArchetype } from "./block-prediction";
+import {
+  DIFFICULTY_CONFIGS,
+  resolveDifficultyConfig,
+  type DifficultyFormat,
+  type DifficultyLevel,
+} from "../ai-difficulty";
 
 export interface OpponentManaState {
   white: number;
@@ -77,6 +83,123 @@ const COMMON_TRICK_CMC: Record<CombatTrickType, number> = {
   lifelink: 1,
 };
 
+/**
+ * Per-difficulty scaling for combat-trick casting and bluff/hold behavior
+ * (issue #1067).
+ *
+ * The archetype profiles in {@link ARCHETYPE_TRICK_WEIGHTS} are otherwise
+ * constant across skill tiers, which flattens the difficulty experience: Easy
+ * and Expert would represent bluffs and hold/cast combat tricks identically.
+ * These multipliers reintroduce a skill axis. Every knob is **monotonic in
+ * skill** so a higher tier always casts/bluffs/holds at least as well as the
+ * tier below it:
+ *
+ * - `bluffMultiplier` — scales the archetype `bluffWeight`. Easy ≈ 0 (rarely
+ *   represents a bluff), Expert = 1 (credible bluffs).
+ * - `trickFrequencyMultiplier` — scales the archetype `trickFrequency`,
+ *   interpreted as the rate of *optimal* trick casting. Easy miscasts or
+ *   over-commits so its effective optimal-cast rate is low; Expert casts the
+ *   right trick at the right time.
+ * - `miscastChance` — probability of mis-timing a held trick (forced early
+ *   reveal / wrong window). Easy frequently wastes tricks, Expert almost never.
+ *   Decreasing in skill.
+ * - `holdDiscipline` — probability of holding a trick for a higher-EV window
+ *   when one exists. Easy reveals at the first opportunity, Expert holds for
+ *   maximum value. Increasing in skill.
+ *
+ * Composition with the per-format overrides (#1069): {@link resolveTrickScaling}
+ * folds the resolved per-format `blunderChance` into `miscastChance`, so a
+ * format delta that raises/lowers blunders proportionally scales mis-timing.
+ */
+export interface CombatTrickDifficultyScaling {
+  bluffMultiplier: number;
+  trickFrequencyMultiplier: number;
+  miscastChance: number;
+  holdDiscipline: number;
+}
+
+export const DIFFICULTY_TRICK_SCALING: Record<
+  DifficultyLevel,
+  CombatTrickDifficultyScaling
+> = {
+  easy: {
+    bluffMultiplier: 0.1,
+    trickFrequencyMultiplier: 0.5,
+    miscastChance: 0.4,
+    holdDiscipline: 0.1,
+  },
+  medium: {
+    bluffMultiplier: 0.5,
+    trickFrequencyMultiplier: 0.8,
+    miscastChance: 0.15,
+    holdDiscipline: 0.5,
+  },
+  hard: {
+    bluffMultiplier: 0.85,
+    trickFrequencyMultiplier: 0.95,
+    miscastChance: 0.05,
+    holdDiscipline: 0.8,
+  },
+  expert: {
+    bluffMultiplier: 1.0,
+    trickFrequencyMultiplier: 1.0,
+    miscastChance: 0.02,
+    holdDiscipline: 0.95,
+  },
+};
+
+/**
+ * Baseline multipliers (no scaling) used when no difficulty is supplied,
+ * preserving the pre-#1067 behavior of {@link estimateCombatTrickProbability}.
+ */
+const NO_DIFFICULTY_SCALING: CombatTrickDifficultyScaling = {
+  bluffMultiplier: 1,
+  trickFrequencyMultiplier: 1,
+  miscastChance: 0,
+  holdDiscipline: 0,
+};
+
+/**
+ * Get the base tier-keyed combat-trick scaling.
+ */
+export function getDifficultyTrickScaling(
+  difficulty: DifficultyLevel,
+): CombatTrickDifficultyScaling {
+  return DIFFICULTY_TRICK_SCALING[difficulty];
+}
+
+/**
+ * Resolve the effective combat-trick scaling for a (tier, format) pair,
+ * composing the per-tier base with the per-format difficulty config (#1069).
+ *
+ * The base multipliers come from {@link DIFFICULTY_TRICK_SCALING}. The
+ * `miscastChance` knob is then re-weighted by the ratio of the resolved
+ * per-format `blunderChance` to the base tier `blunderChance`, so a format
+ * override that raises blunders proportionally raises trick mis-timing and
+ * vice-versa. The result is clamped to [0, 1]. When no format is supplied (or
+ * the format has no override for the tier) the base scaling is returned
+ * unchanged — fully backward compatible.
+ */
+export function resolveTrickScaling(
+  difficulty: DifficultyLevel,
+  format?: DifficultyFormat,
+): CombatTrickDifficultyScaling {
+  const base = DIFFICULTY_TRICK_SCALING[difficulty];
+  if (!format) return base;
+  const resolved = resolveDifficultyConfig(difficulty, format);
+  const baseConfig = DIFFICULTY_CONFIGS[difficulty];
+  if (baseConfig.blunderChance <= 0) return base;
+  const ratio = resolved.blunderChance / baseConfig.blunderChance;
+  const miscastChance = clamp01(base.miscastChance * ratio);
+  if (miscastChance === base.miscastChance) return base;
+  return { ...base, miscastChance };
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
 function totalMana(mana: OpponentManaState): number {
   return (
     mana.white +
@@ -107,6 +230,7 @@ export function estimateCombatTrickProbability(
   opponentArchetype: OpponentArchetype,
   cardsInHand?: number,
   turnNumber?: number,
+  difficulty?: DifficultyLevel,
 ): CombatTrickEstimate {
   const total = totalMana(opponentMana);
 
@@ -120,9 +244,16 @@ export function estimateCombatTrickProbability(
   }
 
   const weights = ARCHETYPE_TRICK_WEIGHTS[opponentArchetype];
+  // Issue #1067: scale trick frequency and bluff credibility by difficulty.
+  // When `difficulty` is omitted the multipliers are all 1 (no scaling),
+  // preserving the original behavior for existing callers.
+  const scaling =
+    difficulty === undefined
+      ? NO_DIFFICULTY_SCALING
+      : DIFFICULTY_TRICK_SCALING[difficulty];
 
   const manaFactor = Math.min(1, total / 3);
-  const archetypeFactor = weights.trickFrequency;
+  const archetypeFactor = weights.trickFrequency * scaling.trickFrequencyMultiplier;
 
   let handFactor = 0.5;
   if (cardsInHand !== undefined) {
@@ -154,7 +285,8 @@ export function estimateCombatTrickProbability(
     }
   }
 
-  const bluffBonus = weights.bluffWeight * (total >= 2 ? 0.1 : 0);
+  const bluffBonus =
+    weights.bluffWeight * scaling.bluffMultiplier * (total >= 2 ? 0.1 : 0);
   const probability = Math.min(0.95, baseProbability + bluffBonus);
 
   const hasRedRemoval = hasColors(opponentMana, ["red"]) && total >= 2;
@@ -176,12 +308,17 @@ export function estimateCombatTrickProbability(
   if (hasRedRemoval) colorReasons.push("red mana suggests burn/removal");
   if (hasWhitePump) colorReasons.push("white mana suggests pump/protection");
 
+  const difficultyReason =
+    difficulty === undefined
+      ? ""
+      : `; difficulty=${difficulty} (freq×${scaling.trickFrequencyMultiplier.toFixed(2)}, bluff×${scaling.bluffMultiplier.toFixed(2)})`;
+
   const reasoning = [
     `${total} open mana, archetype=${opponentArchetype}`,
     `base prob=${baseProbability.toFixed(3)}`,
     `expected tricks: [${estimatedTypes.join(", ") || "none"}]`,
     ...colorReasons,
-  ].join("; ");
+  ].join("; ") + difficultyReason;
 
   return {
     probability,
@@ -229,3 +366,84 @@ export function calculateCombatTrickDiscount(
 
   return { discountedEV, riskAdjustment };
 }
+
+/**
+ * Input to {@link decideCombatTrickHold} — the AI's own bluff/hold decision
+ * for a combat trick it is considering (issue #1067).
+ */
+export interface CombatTrickHoldInput {
+  /** Skill tier of the AI holding/casting the trick. */
+  difficulty: DifficultyLevel;
+  /** Active format family, used to fold per-format blunder tuning (#1069). */
+  format?: DifficultyFormat;
+  /** Expected value of casting the trick at the first opportunity. */
+  evNow: number;
+  /** Expected value of holding for the highest-EV window this combat. */
+  evLater: number;
+  /**
+   * Deterministic randomness source for tests. Defaults to `Math.random`.
+   * Each decision consumes up to two rolls (miscast, then discipline).
+   */
+  rng?: () => number;
+}
+
+/**
+ * Result of a combat-trick bluff/hold decision.
+ */
+export interface CombatTrickHoldDecision {
+  /** true = hold the trick for a higher-value window; false = cast now. */
+  holdForValue: boolean;
+  /** true = the early reveal was a mis-timing (forced blunder), not a choice. */
+  miscast: boolean;
+  /** Human-readable explanation including the tier that drove the decision. */
+  reasoning: string;
+}
+
+/**
+ * Decide whether the AI holds a combat trick for a higher-EV window or casts
+ * it now, scaled by difficulty (issue #1067).
+ *
+ * Behavior by tier:
+ * - Easy — high `miscastChance` + low `holdDiscipline` → frequently reveals
+ *   held tricks at the first opportunity (the issue's "Easy reveal held tricks
+ *   by casting them at the first opportunity").
+ * - Expert — low `miscastChance` + high `holdDiscipline` → holds for the
+ *   highest-EV window ("Expert hold until the highest-EV window"), only
+ *   revealing early when there is no value gain or the discipline roll fails.
+ *
+ * The decision is deterministic when a fixed `rng` is supplied, which is how
+ * the unit tests assert monotonic per-tier behavior without flakiness.
+ */
+export function decideCombatTrickHold(
+  input: CombatTrickHoldInput,
+): CombatTrickHoldDecision {
+  const scaling = resolveTrickScaling(input.difficulty, input.format);
+  const rng = input.rng ?? Math.random;
+
+  // 1) Mis-timing blunder: low-skill tiers reveal early by mistake.
+  if (rng() < scaling.miscastChance) {
+    return {
+      holdForValue: false,
+      miscast: true,
+      reasoning: `miscast (diff=${input.difficulty}): mis-timed reveal`,
+    };
+  }
+
+  // 2) Value-hold discipline: hold only when later EV beats now AND the tier's
+  //    discipline passes. Higher tiers hold for value far more reliably.
+  const valueGain = input.evLater - input.evNow;
+  if (valueGain > 0 && rng() < scaling.holdDiscipline) {
+    return {
+      holdForValue: true,
+      miscast: false,
+      reasoning: `hold for value (diff=${input.difficulty}): Δev=+${valueGain.toFixed(3)}`,
+    };
+  }
+
+  return {
+    holdForValue: false,
+    miscast: false,
+    reasoning: `reveal now (diff=${input.difficulty})`,
+  };
+}
+


### PR DESCRIPTION
## Summary

Resolves #1067. Threads `DifficultyLevel` into `combat-trick-probability.ts` and scales combat-trick **casting probability** and **bluff/hold behavior** by difficulty tier. Easy miscasts/over-commits and rarely bluffs; Expert casts optimal tricks and holds/bluffs strategically. Composes with the difficulty tiers (#1070) and the per-format config (#1069).

## Per-difficulty design

A new `DIFFICULTY_TRICK_SCALING` table keys four monotonic knobs by tier:

| tier   | bluff× | trickFreq× | miscastChance | holdDiscipline |
|--------|--------|-----------|---------------|----------------|
| easy   | 0.10   | 0.50      | 0.40          | 0.10           |
| medium | 0.50   | 0.80      | 0.15          | 0.50           |
| hard   | 0.85   | 0.95      | 0.05          | 0.80           |
| expert | 1.00   | 1.00      | 0.02          | 0.95           |

Every knob is **monotonic in skill** (bluff/freq/discipline ↑, miscast ↓).

### Casting probability
`estimateCombatTrickProbability` gains an optional `difficulty` arg that scales the archetype `trickFrequency` (optimal-cast rate) and `bluffWeight` (credible-bluff contribution). Omitting it keeps the legacy unscaled behavior (all multipliers = 1) for full backward compatibility.

### Bluff / hold behavior
New pure function `decideCombatTrickHold({ difficulty, format, evNow, evLater, rng })`:
1. **Miscast roll** — if `rng() < miscastChance`, the tier mis-times the reveal (Easy wastes tricks; Expert almost never). This is the issue's *"Easy reveal held tricks by casting them at the first opportunity"*.
2. **Hold-discipline roll** — if `evLater > evNow` and `rng() < holdDiscipline`, hold for the higher-value window (the issue's *"Expert hold until the highest-EV window"*).
3. Otherwise reveal now.

Deterministic when `rng` is supplied (seeded in tests).

### Per-format composition (#1069)
`resolveTrickScaling(difficulty, format?)` folds the resolved per-format `blunderChance` into `miscastChance` (ratio of resolved/base blunder, clamped to `[0,1]`), so a format delta that raises/lowers blunders proportionally scales trick mis-timing. No format ⇒ base table unchanged (backward compatible).

### Plumbing
`CombatDecisionTree` now stores its `difficulty`, exposes `getDifficulty()` / `getDifficultyFormat()` / `setDifficultyFormat()`, passes the tier into both `estimateCombatTrickProbability` call sites, and exposes `decideCombatTrickBluffHold(evNow, evLater, rng?)` so the AI's own hold/bluff behavior is driven by its tier.

## Files changed
- `src/ai/decision-making/combat-trick-probability.ts` — scaling table, `resolveTrickScaling`, difficulty arg on `estimateCombatTrickProbability`, new `decideCombatTrickHold`.
- `src/ai/decision-making/combat-decision-tree.ts` — stored difficulty + format, accessors, `decideCombatTrickBluffHold`, threaded difficulty into trick-probability calls.
- `src/ai/__tests__/combat-trick-probability.test.ts` — +27 tests: per-difficulty casting, monotonicity (all 4 knobs × all archetypes), per-format composition, bluff/hold (miscast/discipline/hold-rate monotonicity), tree plumbing.

## Acceptance criteria
- [x] Combat-trick casting probability scales by difficulty (expert > easy on identical boards; easy miscasts/overcommits via low `trickFrequencyMultiplier`)
- [x] Bluff/hold behavior scales by difficulty (easy: high miscast + low discipline → reveals immediately; expert: holds for highest-EV window)
- [x] Scaling is smooth/bounded (`[0,1]`) and monotonic in skill (asserted for every knob across all tiers/archetypes)
- [x] Composes with difficulty tiers (#1070) and per-format config (#1069) via `resolveTrickScaling`
- [x] Unit tests cover per-difficulty casting, bluff/hold, monotonicity, and composition
- [x] Difficulty is passed from `combat-decision-tree.ts` into the trick module (both call sites + the new hook)

## Verification
- `jest src/ai/__tests__/combat-trick-probability.test.ts` → **44/44 pass** (17 existing, 27 new)
- Full suite (`jest`) → **5928 passed, 0 failed** (286 suites) — no regressions
- `tsc --noEmit` → 0 new errors (9 pre-existing `next-intl` module-resolution errors are unrelated, present on clean `origin/main`)
- `eslint` on the 3 changed files → 0 errors, 0 new warnings (2 pre-existing warnings in untouched lines of `combat-decision-tree.ts`)

Resolves #1067