### PR TITLE
feat(rules-engine): resolve #1062 — implement Split Second keyword (CR 702.60)

### DIFF
--- a/src/lib/game-state/__tests__/split-second.test.ts
+++ b/src/lib/game-state/__tests__/split-second.test.ts
@@ -17,10 +17,7 @@
  */
 
 import { describe, it, expect, beforeEach } from "@jest/globals";
-import {
-  canCastSpell,
-  castSpell,
-} from "../spell-casting";
+import { canCastSpell, castSpell } from "../spell-casting";
 import {
   canActivateAbility,
   activateAbility,
@@ -120,8 +117,7 @@ function etfTriggerCreature(): ScryfallCard {
     id: "mock-etb-trigger",
     name: "ETB Trigger",
     type_line: "Creature — Human",
-    oracle_text:
-      "When this creature enters the battlefield, draw a card.",
+    oracle_text: "When this creature enters the battlefield, draw a card.",
     mana_cost: "{1}{U}",
     cmc: 2,
     power: "1",
@@ -210,8 +206,8 @@ function pushSplitSecondSpell(
     sourceCardId: card.id,
     controllerId,
     name: data.name,
-    text: data.oracle_text,
-    manaCost: data.mana_cost,
+    text: data.oracle_text ?? "",
+    manaCost: data.mana_cost ?? null,
     targets: [],
     chosenModes: [],
     variableValues: new Map(),
@@ -224,10 +220,7 @@ function pushSplitSecondSpell(
 }
 
 /** Push a non-split-second spell onto the stack (control case). */
-function pushPlainSpell(
-  state: GameState,
-  controllerId: PlayerId,
-): StackObject {
+function pushPlainSpell(state: GameState, controllerId: PlayerId): StackObject {
   const obj: StackObject = {
     id: "plain-spell-on-stack",
     type: "spell",
@@ -350,9 +343,7 @@ describe("Split second — casting is blocked while active (CR 702.60b)", () => 
 
     // Resolve/counter/remove the split-second spell → stack empties.
     f.state.stack = [];
-    expect(canCastSpell(f.state, f.aliceId, responseCardId).canCast).toBe(
-      true,
-    );
+    expect(canCastSpell(f.state, f.aliceId, responseCardId).canCast).toBe(true);
   });
 });
 

--- a/src/lib/game-state/__tests__/split-second.test.ts
+++ b/src/lib/game-state/__tests__/split-second.test.ts
@@ -1,0 +1,493 @@
+/**
+ * @fileoverview Unit tests for the Split second keyword (CR 702.60).
+ *
+ * Issue #1062 — [Rules Engine] Implement Split Second keyword.
+ *
+ * Split second (CR 702.60):
+ * - 702.60a: static ability that functions only while the spell with split
+ *   second is on the stack.
+ * - 702.60b: while such a spell is on the stack, players can't cast other
+ *   spells or activate abilities that aren't mana abilities. Triggered
+ *   abilities and special actions (e.g. morph face-up) remain legal.
+ * - 702.60c: multiple instances are redundant.
+ *
+ * These tests cover: parsing, cast-blocking, non-mana-ability blocking,
+ * triggered-ability allowance, mana-ability allowance, and restriction
+ * lifting once the spell leaves the stack.
+ */
+
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import {
+  canCastSpell,
+  castSpell,
+} from "../spell-casting";
+import {
+  canActivateAbility,
+  activateAbility,
+  checkTriggeredAbilities,
+} from "../abilities";
+import { createInitialGameState, startGame } from "../game-state";
+import { createCardInstance } from "../card-instance";
+import { addMana } from "../mana";
+import { parseSplitSecond } from "../oracle-text-parser";
+import { hasSplitSecondOnStack } from "../auto-pass-priority";
+import { Phase } from "../types";
+import type {
+  GameState,
+  PlayerId,
+  CardInstanceId,
+  StackObject,
+} from "../types";
+import type { ScryfallCard } from "@/app/actions";
+
+// ---------------------------------------------------------------------------
+// Mock card helpers
+// ---------------------------------------------------------------------------
+
+function makeCard(
+  overrides: Partial<ScryfallCard> & { id: string },
+): ScryfallCard {
+  return {
+    name: "Test Card",
+    type_line: "Instant",
+    oracle_text: "",
+    mana_cost: "{1}{R}",
+    cmc: 2,
+    colors: ["R"],
+    color_identity: ["R"],
+    legalities: { standard: "legal", commander: "legal" },
+    layout: "normal",
+    ...overrides,
+  } as ScryfallCard;
+}
+
+/** A split-second spell (e.g. Sudden Shock). */
+function splitSecondSpell(): ScryfallCard {
+  return makeCard({
+    id: "mock-sudden-shock",
+    name: "Sudden Shock",
+    type_line: "Instant",
+    oracle_text: "Split second (As you cast this spell, ...)",
+    mana_cost: "{1}{R}",
+    cmc: 2,
+  });
+}
+
+/** A generic instant that an opponent might want to cast in response. */
+function vanillaInstant(): ScryfallCard {
+  return makeCard({
+    id: "mock-counterspell",
+    name: "Counterspell",
+    type_line: "Instant",
+    oracle_text: "Draw a card.",
+    mana_cost: "{1}{U}",
+    cmc: 2,
+    colors: ["U"],
+  });
+}
+
+/** Creature whose {T} draws a card (a non-mana activated ability). */
+function tapDrawCreature(): ScryfallCard {
+  return makeCard({
+    id: "mock-tap-draw",
+    name: "Tap Drawer",
+    type_line: "Creature — Human",
+    oracle_text: "{T}: Draw a card.",
+    mana_cost: "{1}{U}",
+    cmc: 2,
+    power: "1",
+    toughness: "1",
+  });
+}
+
+/** Creature whose {T} adds mana (a mana ability — legal under split second). */
+function tapManaCreature(): ScryfallCard {
+  return makeCard({
+    id: "mock-tap-mana",
+    name: "Mana Dude",
+    type_line: "Creature — Elf",
+    oracle_text: "{T}: Add {G}.",
+    mana_cost: "{G}",
+    cmc: 1,
+    power: "0",
+    toughness: "1",
+  });
+}
+
+/** Creature with an "enters the battlefield" triggered ability. */
+function etfTriggerCreature(): ScryfallCard {
+  return makeCard({
+    id: "mock-etb-trigger",
+    name: "ETB Trigger",
+    type_line: "Creature — Human",
+    oracle_text:
+      "When this creature enters the battlefield, draw a card.",
+    mana_cost: "{1}{U}",
+    cmc: 2,
+    power: "1",
+    toughness: "1",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Shared state scaffolding
+// ---------------------------------------------------------------------------
+
+interface Fixture {
+  state: GameState;
+  aliceId: PlayerId;
+  bobId: PlayerId;
+}
+
+function makeFixture(): Fixture {
+  let state = createInitialGameState(["Alice", "Bob"], 20, false);
+  state = startGame(state);
+
+  const ids = Array.from(state.players.keys());
+  const aliceId = ids[0];
+  const bobId = ids[1];
+
+  state.status = "in_progress";
+  state.priorityPlayerId = aliceId;
+  state.turn.activePlayerId = aliceId;
+  state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+  state.stack = [];
+  state.consecutivePasses = 0;
+  state.players.forEach((p) =>
+    state.players.set(p.id, { ...p, hasPassedPriority: false }),
+  );
+
+  return { state, aliceId, bobId };
+}
+
+/** Place a card into a player's hand and the global card map. */
+function putInHand(
+  state: GameState,
+  playerId: PlayerId,
+  cardData: ScryfallCard,
+): CardInstanceId {
+  const card = createCardInstance(cardData, playerId, playerId);
+  state.cards.set(card.id, card);
+  const hand = state.zones.get(`${playerId}-hand`)!;
+  state.zones.set(`${playerId}-hand`, {
+    ...hand,
+    cardIds: [...hand.cardIds, card.id],
+  });
+  return card.id;
+}
+
+/** Place a permanent onto a player's battlefield (summoning-sickness free). */
+function putOnBattlefield(
+  state: GameState,
+  playerId: PlayerId,
+  cardData: ScryfallCard,
+): CardInstanceId {
+  const card = createCardInstance(cardData, playerId, playerId);
+  card.hasSummoningSickness = false;
+  state.cards.set(card.id, card);
+  const bf = state.zones.get(`${playerId}-battlefield`)!;
+  state.zones.set(`${playerId}-battlefield`, {
+    ...bf,
+    cardIds: [...bf.cardIds, card.id],
+  });
+  return card.id;
+}
+
+/**
+ * Push a split-second spell onto the stack, simulating it having been cast.
+ * Mirrors how castSpell stamps the marker (see spell-casting.ts).
+ */
+function pushSplitSecondSpell(
+  state: GameState,
+  controllerId: PlayerId,
+): StackObject {
+  const data = splitSecondSpell();
+  const card = createCardInstance(data, controllerId, controllerId);
+  state.cards.set(card.id, card);
+  const obj: StackObject = {
+    id: "ss-spell-on-stack",
+    type: "spell",
+    sourceCardId: card.id,
+    controllerId,
+    name: data.name,
+    text: data.oracle_text,
+    manaCost: data.mana_cost,
+    targets: [],
+    chosenModes: [],
+    variableValues: new Map(),
+    isCountered: false,
+    timestamp: Date.now(),
+    splitSecond: true,
+  };
+  state.stack = [...state.stack, obj];
+  return obj;
+}
+
+/** Push a non-split-second spell onto the stack (control case). */
+function pushPlainSpell(
+  state: GameState,
+  controllerId: PlayerId,
+): StackObject {
+  const obj: StackObject = {
+    id: "plain-spell-on-stack",
+    type: "spell",
+    sourceCardId: null,
+    controllerId,
+    name: "Plain Instant",
+    text: "",
+    manaCost: "{U}",
+    targets: [],
+    chosenModes: [],
+    variableValues: new Map(),
+    isCountered: false,
+    timestamp: Date.now(),
+  };
+  state.stack = [...state.stack, obj];
+  return obj;
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+describe("Split second — parsing (CR 702.60)", () => {
+  it("detects 'Split second' in oracle text", () => {
+    expect(
+      parseSplitSecond("Split second (As you cast this spell, ...)")
+        .hasSplitSecond,
+    ).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(parseSplitSecond("split second").hasSplitSecond).toBe(true);
+    expect(parseSplitSecond("SPLIT SECOND").hasSplitSecond).toBe(true);
+  });
+
+  it("returns false when the keyword is absent", () => {
+    expect(parseSplitSecond("Draw a card.").hasSplitSecond).toBe(false);
+    expect(parseSplitSecond("").hasSplitSecond).toBe(false);
+  });
+
+  it("does not match substrings inside other words", () => {
+    // word-boundary anchored: must not match "splitsecondish" style noise
+    expect(parseSplitSecond("Some splitsecondish text").hasSplitSecond).toBe(
+      false,
+    );
+  });
+
+  it("produces a description only when present (CR 702.60c redundancy)", () => {
+    const present = parseSplitSecond("Split second");
+    expect(present.description).toBe("Split second");
+    const absent = parseSplitSecond("Flying");
+    expect(absent.description).toBe("");
+  });
+});
+
+describe("Split second — stack presence helper", () => {
+  let f: Fixture;
+  beforeEach(() => {
+    f = makeFixture();
+  });
+
+  it("is false on an empty stack", () => {
+    expect(hasSplitSecondOnStack(f.state)).toBe(false);
+  });
+
+  it("is true when a split-second spell is on the stack", () => {
+    pushSplitSecondSpell(f.state, f.aliceId);
+    expect(hasSplitSecondOnStack(f.state)).toBe(true);
+  });
+
+  it("is false when only a plain spell is on the stack", () => {
+    pushPlainSpell(f.state, f.aliceId);
+    expect(hasSplitSecondOnStack(f.state)).toBe(false);
+  });
+
+  it("lifts as soon as the split-second spell leaves the stack", () => {
+    pushSplitSecondSpell(f.state, f.aliceId);
+    expect(hasSplitSecondOnStack(f.state)).toBe(true);
+    f.state.stack = [];
+    expect(hasSplitSecondOnStack(f.state)).toBe(false);
+  });
+});
+
+describe("Split second — casting is blocked while active (CR 702.60b)", () => {
+  let f: Fixture;
+  let responseCardId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    // Alice has an instant she'd like to cast in response.
+    responseCardId = putInHand(f.state, f.aliceId, vanillaInstant());
+    f.state = addMana(f.state, f.aliceId, {
+      blue: 2,
+      generic: 5,
+    });
+    f.state.priorityPlayerId = f.aliceId;
+  });
+
+  it("canCastSpell rejects while a split-second spell is on the stack", () => {
+    pushSplitSecondSpell(f.state, f.bobId);
+    const result = canCastSpell(f.state, f.aliceId, responseCardId);
+    expect(result.canCast).toBe(false);
+    expect(result.reason).toMatch(/split second/i);
+  });
+
+  it("castSpell is rejected via ValidationService while split second is active", () => {
+    pushSplitSecondSpell(f.state, f.bobId);
+    const result = castSpell(f.state, f.aliceId, responseCardId);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/split second/i);
+    // The response spell must NOT have been added to the stack.
+    expect(result.state.stack.length).toBe(1);
+  });
+
+  it("casting is allowed again once the split-second spell leaves the stack", () => {
+    pushSplitSecondSpell(f.state, f.bobId);
+    expect(canCastSpell(f.state, f.aliceId, responseCardId).canCast).toBe(
+      false,
+    );
+
+    // Resolve/counter/remove the split-second spell → stack empties.
+    f.state.stack = [];
+    expect(canCastSpell(f.state, f.aliceId, responseCardId).canCast).toBe(
+      true,
+    );
+  });
+});
+
+describe("Split second — non-mana abilities are blocked (CR 702.60b)", () => {
+  let f: Fixture;
+  let drawCreatureId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    drawCreatureId = putOnBattlefield(f.state, f.aliceId, tapDrawCreature());
+    f.state.priorityPlayerId = f.aliceId;
+  });
+
+  it("canActivateAbility rejects a non-mana ability while split second is active", () => {
+    pushSplitSecondSpell(f.state, f.bobId);
+    const result = canActivateAbility(f.state, f.aliceId, drawCreatureId, 0);
+    expect(result.canActivate).toBe(false);
+    expect(result.reason).toMatch(/split second/i);
+  });
+
+  it("activateAbility reports failure for a non-mana ability under split second", () => {
+    pushSplitSecondSpell(f.state, f.bobId);
+    const result = activateAbility(f.state, f.aliceId, drawCreatureId, 0);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/split second/i);
+    // No new object added to the stack from this activation.
+    expect(result.state.stack.length).toBe(1);
+  });
+
+  it("the non-mana ability is legal again once the split-second spell leaves", () => {
+    pushSplitSecondSpell(f.state, f.bobId);
+    expect(
+      canActivateAbility(f.state, f.aliceId, drawCreatureId, 0).canActivate,
+    ).toBe(false);
+
+    f.state.stack = [];
+    expect(
+      canActivateAbility(f.state, f.aliceId, drawCreatureId, 0).canActivate,
+    ).toBe(true);
+  });
+});
+
+describe("Split second — mana abilities remain legal (CR 702.60b exception)", () => {
+  let f: Fixture;
+  let manaCreatureId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    manaCreatureId = putOnBattlefield(f.state, f.aliceId, tapManaCreature());
+    f.state.priorityPlayerId = f.aliceId;
+  });
+
+  it("canActivateAbility permits a mana ability under split second", () => {
+    pushSplitSecondSpell(f.state, f.bobId);
+    const result = canActivateAbility(f.state, f.aliceId, manaCreatureId, 0);
+    expect(result.canActivate).toBe(true);
+  });
+
+  it("activateAbility resolves a mana ability (CR 605) without using the stack", () => {
+    pushSplitSecondSpell(f.state, f.bobId);
+    const stackBefore = f.state.stack.length;
+    const result = activateAbility(f.state, f.aliceId, manaCreatureId, 0);
+
+    expect(result.success).toBe(true);
+    // Mana abilities resolve immediately and never add to the stack, so the
+    // split-second spell remains the only object on the stack.
+    expect(result.state.stack.length).toBe(stackBefore);
+    const player = result.state.players.get(f.aliceId);
+    expect(player?.manaPool.green).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("Split second — triggered abilities remain legal (CR 702.60b/c)", () => {
+  let f: Fixture;
+  let etbCreatureId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    etbCreatureId = putOnBattlefield(f.state, f.aliceId, etfTriggerCreature());
+    f.state.priorityPlayerId = f.aliceId;
+  });
+
+  it("a triggered ability still goes on the stack while split second is active", () => {
+    pushSplitSecondSpell(f.state, f.bobId);
+    const stackBefore = f.state.stack.length;
+
+    const result = checkTriggeredAbilities(f.state, "entersBattlefield", {
+      sourceCardId: etbCreatureId,
+    });
+
+    // Triggered abilities are not "cast" or "activated" — they are exempt
+    // from the split-second restriction and must be allowed to go on stack.
+    expect(result.abilities.length).toBeGreaterThan(0);
+    expect(result.state.stack.length).toBeGreaterThan(stackBefore);
+  });
+
+  it("triggered-ability path does not consult split second when the stack is empty", () => {
+    // Control case: trigger works normally with no split-second present.
+    const stackBefore = f.state.stack.length;
+    const result = checkTriggeredAbilities(f.state, "entersBattlefield", {
+      sourceCardId: etbCreatureId,
+    });
+    expect(result.abilities.length).toBeGreaterThan(0);
+    expect(result.state.stack.length).toBeGreaterThan(stackBefore);
+  });
+});
+
+describe("Split second — castSpell stamps the marker onto the stack object", () => {
+  let f: Fixture;
+  let ssCardId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    ssCardId = putInHand(f.state, f.aliceId, splitSecondSpell());
+    f.state = addMana(f.state, f.aliceId, { red: 1, generic: 5 });
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+    f.state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    f.state.stack = [];
+  });
+
+  it("a split-second spell parsed from oracle text carries splitSecond=true on the stack", () => {
+    const result = castSpell(f.state, f.aliceId, ssCardId);
+    expect(result.success).toBe(true);
+    expect(result.state.stack.length).toBe(1);
+    expect(result.state.stack[0].splitSecond).toBe(true);
+    // The helper now sees it.
+    expect(hasSplitSecondOnStack(result.state)).toBe(true);
+  });
+
+  it("a non-split-second spell does not set splitSecond", () => {
+    const plainId = putInHand(f.state, f.aliceId, vanillaInstant());
+    f.state = addMana(f.state, f.aliceId, { blue: 2, generic: 5 });
+    const result = castSpell(f.state, f.aliceId, plainId);
+    expect(result.success).toBe(true);
+    expect(result.state.stack[0].splitSecond).toBeFalsy();
+  });
+});

--- a/src/lib/game-state/abilities.ts
+++ b/src/lib/game-state/abilities.ts
@@ -24,6 +24,7 @@ import {
 } from "./oracle-text-parser";
 import { spendMana, addMana, isManaAbility } from "./mana";
 import { destroyCard, discardCards } from "./keyword-actions";
+import { hasSplitSecondOnStack } from "./auto-pass-priority";
 
 /**
  * Event types that can trigger triggered abilities (CR 603.2)
@@ -233,10 +234,27 @@ export function canActivateAbility(
     return { canActivate: false, reason: "Card is not on the battlefield" };
   }
 
-  // Check for summoning sickness (unless the ability has no tap cost)
+  // Resolve the ability now so we can classify it (e.g. mana ability) for
+  // the Split second restriction below. A missing/invalid index is handled
+  // later by activateAbility; here we only short-circuit when we can.
   const abilities = getActivatedAbilities(card.cardData);
   const ability = abilities[abilityIndex];
 
+  // CR 702.60b - Split second: while a spell with split second is on the
+  // stack, players can't activate abilities that aren't mana abilities.
+  // Triggered abilities and special actions (e.g. turning a face-down
+  // creature face up) are NOT activated abilities and remain legal.
+  if (ability && hasSplitSecondOnStack(state)) {
+    if (!isManaAbility(cardId, ability.effect)) {
+      return {
+        canActivate: false,
+        reason:
+          "A spell with split second is on the stack. Only mana abilities may be activated.",
+      };
+    }
+  }
+
+  // Check for summoning sickness (unless the ability has no tap cost)
   if (ability && !ability.costs.tap && card.hasSummoningSickness) {
     // Some abilities can be activated despite summoning sickness
     // This would need more sophisticated checking

--- a/src/lib/game-state/auto-pass-priority.ts
+++ b/src/lib/game-state/auto-pass-priority.ts
@@ -1,4 +1,4 @@
-import type { GameState, PlayerId } from "./types";
+import type { GameState, PlayerId, StackObject } from "./types";
 import { Phase } from "./types";
 
 /**
@@ -12,6 +12,26 @@ const HUMAN_INTERACTIVE_COMBAT_PHASES: ReadonlySet<Phase> = new Set([
   Phase.COMBAT_DAMAGE,
   Phase.COMBAT_DAMAGE_FIRST_STRIKE,
 ]);
+
+/**
+ * Whether any object currently on the stack grants Split second (CR 702.60).
+ *
+ * Split second is a spell characteristic that functions only while the spell
+ * with split second is on the stack (CR 702.60a). This helper scans the
+ * current stack and returns true if any object carries the `splitSecond`
+ * marker, which is the single source of truth used by the action-validation
+ * path (`ValidationService`, `canActivateAbility`) to reject casts and
+ * non-mana ability activations while such a spell is pending.
+ *
+ * CR 702.60b: players can't cast other spells or activate abilities that
+ * aren't mana abilities. Triggered abilities and special actions (e.g.
+ * turning a face-down creature face up) are NOT affected and remain legal.
+ */
+export function hasSplitSecondOnStack(state: GameState): boolean {
+  return state.stack.some(
+    (obj: StackObject) => obj.splitSecond === true,
+  );
+}
 
 export interface AutoPassContext {
   /** Player whose turn it is (the AI opponent in single-player mode). */
@@ -40,6 +60,10 @@ export function shouldAutoPassPriority(
   if (state.status !== "in_progress") return false;
 
   // Preserve the response window: never yield priority while the stack is live.
+  // This also implicitly handles Split second (CR 702.60): a split-second spell
+  // is itself on the stack, so the stack is non-empty and auto-pass is already
+  // suppressed; the legal-action restriction is enforced separately in
+  // ValidationService / canActivateAbility via hasSplitSecondOnStack().
   if (state.stack.length > 0) return false;
 
   // Only auto-pass on the opponent's turn when the human actually has priority.

--- a/src/lib/game-state/oracle-text-parser.ts
+++ b/src/lib/game-state/oracle-text-parser.ts
@@ -507,6 +507,7 @@ export function extractKeywords(
     "renown",
     "revolt",
     "splice",
+    "split second",
     "storm",
     "support",
     "surge",
@@ -1652,6 +1653,40 @@ export function parseKicker(oracleText: string): KickerInfo {
     description: isMultiKicker
       ? `Multikicker ${costString}`
       : `Kicker ${costString}`,
+  };
+}
+
+/**
+ * Result of detecting Split second (CR 702.60).
+ */
+export interface SplitSecondInfo {
+  hasSplitSecond: boolean;
+  description: string;
+}
+
+/**
+ * Parse the Split second keyword from oracle text.
+ *
+ * CR 702.60: "Split second" is a static ability that functions only while the
+ * spell with split second is on the stack. It has no parameters and no cost,
+ * so a simple, case-insensitive, word-boundary anchored match is sufficient.
+ * The reminder text variant ("(As you cast this spell, ...)") is matched too
+ * because the leading keyword word is always present regardless.
+ *
+ * Example oracle text: "Split second" (Sudden Shock, Krosan Grip, Wipe Away).
+ */
+export function parseSplitSecond(oracleText: string): SplitSecondInfo {
+  if (!oracleText) {
+    return { hasSplitSecond: false, description: "" };
+  }
+
+  // Word-boundary anchored so "split second" matches but a hypothetical
+  // "splitsecondish" would not. Case-insensitive to be tolerant of casing.
+  const hasSplitSecond = /\bsplit second\b/i.test(oracleText);
+
+  return {
+    hasSplitSecond,
+    description: hasSplitSecond ? "Split second" : "",
   };
 }
 

--- a/src/lib/game-state/spell-casting.ts
+++ b/src/lib/game-state/spell-casting.ts
@@ -20,6 +20,7 @@ import { Phase, ZoneType } from "./types";
 import { moveCardBetweenZones } from "./zones";
 import { spendMana, getSpellManaCost } from "./mana";
 import { ValidationService } from "./validation-service";
+import { hasSplitSecondOnStack } from "./auto-pass-priority";
 import { initializePlaneswalkerLoyalty } from "./card-instance";
 import {
   parseKicker,
@@ -27,6 +28,7 @@ import {
   parseBuyback,
   parseFlashback,
   parseBestow,
+  parseSplitSecond,
   isModalSpell,
   getModesForModalSpell,
   hasFuse,
@@ -148,6 +150,17 @@ export function canCastSpell(
     currentPhase === Phase.POSTCOMBAT_MAIN;
   const stackIsEmpty = state.stack.length === 0;
   const isActivePlayer = state.turn.activePlayerId === playerId;
+
+  // CR 702.60b - Split second: while a spell with split second is on the
+  // stack, no other spells may be cast. Reported before sorcery-speed timing
+  // so the operative restriction is surfaced (instants/flash are otherwise
+  // legal timing-wise but are still barred by split second).
+  if (hasSplitSecondOnStack(state)) {
+    return {
+      canCast: false,
+      reason: "A spell with split second is on the stack",
+    };
+  }
 
   // Check if it's an instant
   const typeLine = card.cardData.type_line?.toLowerCase() || "";
@@ -447,6 +460,11 @@ export function castSpell(
     wasKicked: isKicked,
     buybackReturnZone,
     bestowTarget,
+    // CR 702.60 - Split second: parsed from Oracle text and stamped onto the
+    // spell's StackObject so the restriction can be enforced while it's on
+    // the stack (see hasSplitSecondOnStack / ValidationService).
+    splitSecond: parseSplitSecond(card.cardData.oracle_text || "")
+      .hasSplitSecond,
   };
 
   // Move card from hand (or graveyard for flashback) to stack

--- a/src/lib/game-state/types.ts
+++ b/src/lib/game-state/types.ts
@@ -418,6 +418,17 @@ export interface StackObject {
    * in this list causes this spell/ability to be countered.
    */
   wardPaidTargetIds?: string[];
+  /**
+   * Split second (CR 702.60).
+   *
+   * Set on a spell's StackObject when its Oracle text contains "Split second".
+   * Functions only while the spell is on the stack: while any object with
+   * `splitSecond === true` is on the stack, players can't cast other spells or
+   * activate abilities that aren't mana abilities (CR 702.60b). Triggered
+   * abilities and special actions remain legal (CR 702.60b/c). Multiple
+   * instances are redundant (CR 702.60c).
+   */
+  splitSecond?: boolean;
   /** Structured effects to resolve (CR 608) */
   effects?: StackEffect[];
 }

--- a/src/lib/game-state/validation-service.ts
+++ b/src/lib/game-state/validation-service.ts
@@ -10,6 +10,7 @@ import {
   canTarget as canTargetKeyword,
   canBlockProtectedAttacker,
 } from "./evergreen-keywords";
+import { hasSplitSecondOnStack } from "./auto-pass-priority";
 
 /**
  * Validation result structure
@@ -315,6 +316,19 @@ export class ValidationService {
         isValid: false,
         reason: "Card not in hand",
         message: "Card is not in your hand.",
+      };
+    }
+
+    // CR 702.60b - Split second: while a spell with split second is on the
+    // stack, players can't cast other spells. (Triggered abilities and special
+    // actions remain legal.) This is checked before timing/mana so the
+    // restriction is reported as the operative reason.
+    if (hasSplitSecondOnStack(state)) {
+      return {
+        isValid: false,
+        reason: "Split second active",
+        message:
+          "A spell with split second is on the stack. You can't cast other spells.",
       };
     }
 


### PR DESCRIPTION
## Summary

Implements the **Split second** keyword per **CR 702.60** in the rules engine. Split second is a static ability that functions only while the spell with split second is on the stack: while such a spell is pending, players can't cast other spells or activate non-mana abilities. Triggered abilities and special actions (e.g. turning a face-down creature face up) remain legal.

Resolves #1062.

## CR implementation

- **702.60a** — Split second is a spell characteristic modeled as an optional `splitSecond?: boolean` flag on `StackObject`. It is parsed from Oracle text at cast time and stamped onto the spell's stack object, so it is only "active" while that object is on the stack. Once the spell resolves or is countered (leaves the stack), the flag is gone with it.
- **702.60b** — A single stack-scanning helper, `hasSplitSecondOnStack(state)`, is the source of truth. The action-validation path consults it:
  - `ValidationService.validateCastSpell` rejects casting any other spell while a split-second spell is on the stack.
  - `canCastSpell` (UI gating) mirrors the same rejection.
  - `canActivateAbility` rejects activating any ability that is **not** a mana ability (checked via the existing `isManaAbility(cardId, effect)`). Mana abilities remain legal.
  - Triggered abilities go through `checkTriggeredAbilities`, which never consults split second — so triggers (e.g. a morph face-up trigger) still go on the stack, exactly as CR 702.60b/c require.
- **702.60c** — Multiple instances are inherently redundant: the flag is a simple boolean and the helper short-circuits on the first match; stacking more than one changes nothing.

## Enforcement points & exceptions

| Action path | While split second is on the stack |
| --- | --- |
| Cast a spell (`castSpell` → `ValidationService`, and `canCastSpell`) | ❌ Rejected |
| Activate a non-mana ability (`canActivateAbility` / `activateAbility`) | ❌ Rejected |
| Activate a **mana** ability (CR 605) | ✅ Allowed (resolves immediately, no stack) |
| **Triggered** ability (`checkTriggeredAbilities`) | ✅ Allowed (goes on stack) |
| Special actions (morph face-up, etc.) | ✅ Allowed (not cast/activated) |
| Pass priority | ✅ Allowed |

Auto-pass priority (`shouldAutoPassPriority`) already suppresses itself whenever the stack is non-empty, so it is implicitly correct under split second; a clarifying comment was added.

## Files changed

- `src/lib/game-state/types.ts` — add `splitSecond?: boolean` to `StackObject`.
- `src/lib/game-state/oracle-text-parser.ts` — add `parseSplitSecond()` + register `"split second"` keyword.
- `src/lib/game-state/spell-casting.ts` — stamp `splitSecond` onto the stack object in `castSpell`; gate `canCastSpell`.
- `src/lib/game-state/auto-pass-priority.ts` — add exported `hasSplitSecondOnStack()` helper; document the implicit auto-pass guard.
- `src/lib/game-state/validation-service.ts` — reject `cast_spell` under split second.
- `src/lib/game-state/abilities.ts` — reject non-mana ability activation under split second.
- `src/lib/game-state/__tests__/split-second.test.ts` — new test suite (21 tests).

## Acceptance criteria

- [x] "Split second" is parsed from Oracle text onto the spell
- [x] While a Split Second spell is on the stack: casting other spells is rejected; activating non-mana abilities is rejected
- [x] Triggered abilities still trigger and resolve normally during Split Second
- [x] Mana abilities and special actions (e.g. morph face-up) remain allowed
- [x] The restriction lifts once the spell leaves the stack
- [x] Unit tests cover: parse, cast-blocked-during-split-second, non-mana-ability-blocked, triggered-allowed, mana-ability-allowed, restriction-lifts-after-resolve

## Verification

- `npx jest game-state` → 108 suites, 2552 tests passed (no regressions)
- New `split-second.test.ts` → 21/21 passed
- `tsc --noEmit` → clean for all touched files (only pre-existing, unrelated `next-intl` module errors remain)
- `eslint` (project v9) on changed files → 0 errors (13 pre-existing warnings, none introduced)

## Notes / deviations

- The issue's "likely affected files" list mentioned `player-actions.ts` and `trigger-system.ts`. `player-actions.ts` only contains damage/draw/concede helpers — cast/activation validation lives in `validation-service.ts` and `abilities.ts`, so it needed no change. `trigger-system.ts` needed no change because triggered abilities are **exempt** from split second by design (CR 702.60b); they must continue to fire, so leaving that path untouched is the correct behavior.