### PR TITLE
fix(ai): resolve #994 — tie combat blunder frequency to difficulty

### DIFF
--- a/src/ai/__tests__/combat-decision-tree.test.ts
+++ b/src/ai/__tests__/combat-decision-tree.test.ts
@@ -14,6 +14,11 @@ import {
   type BlockDecision,
 } from "../decision-making/combat-decision-tree";
 import { predictOpponentBlocks } from "../decision-making/block-prediction";
+import {
+  resolveDifficultyConfig,
+  type DifficultyLevel,
+  type DifficultyFormat,
+} from "../ai-difficulty";
 import type {
   AIGameState,
   AIPlayerState,
@@ -907,6 +912,234 @@ describe("CombatDecisionTree", () => {
       expect(aggroPred.predictions[0].blockProbability).not.toBe(
         controlPred.predictions[0].blockProbability,
       );
+    });
+  });
+
+  describe("combat blunder frequency by difficulty (#994)", () => {
+    const TIERS: DifficultyLevel[] = ["easy", "medium", "hard", "expert"];
+
+    // mulberry32 — small, fast, deterministic PRNG so blunder-rate assertions
+    // are reproducible on every CI run (no Math.random flakiness).
+    function seededRng(seed: number): () => number {
+      let s = seed >>> 0;
+      return () => {
+        s = (s + 0x6d2b79f5) | 0;
+        let t = Math.imul(s ^ (s >>> 15), 1 | s);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    }
+
+    it("exposes the per-tier blunder chance from the unified difficulty config", () => {
+      for (const tier of TIERS) {
+        const ai = new CombatDecisionTree(
+          createTestGameState(),
+          "player1",
+          tier,
+        );
+        // Combat reads the SAME knob the rest of the AI uses (composition with
+        // the unified taxonomy #1064/#1192), via resolveDifficultyConfig.
+        expect(ai.getCombatBlunderChance()).toBe(
+          resolveDifficultyConfig(tier).blunderChance,
+        );
+      }
+    });
+
+    it("blunder chance is monotonic in skill: easy > medium > hard > expert", () => {
+      const chances = TIERS.map((tier) =>
+        new CombatDecisionTree(
+          createTestGameState(),
+          "player1",
+          tier,
+        ).getCombatBlunderChance(),
+      );
+      expect(chances[0]).toBeGreaterThan(chances[1]);
+      expect(chances[1]).toBeGreaterThan(chances[2]);
+      expect(chances[2]).toBeGreaterThan(chances[3]);
+    });
+
+    it("composes with per-format difficulty config through resolveDifficultyConfig", () => {
+      const formats: DifficultyFormat[] = [
+        "commander",
+        "constructed",
+        "limited",
+      ];
+      for (const tier of TIERS) {
+        for (const format of formats) {
+          const ai = new CombatDecisionTree(
+            createTestGameState(),
+            "player1",
+            tier,
+          );
+          ai.setDifficultyFormat(format);
+          // The combat path resolves through the same (tier, format) lookup, so
+          // any future per-format blunderChance override is picked up here.
+          expect(ai.getCombatBlunderChance()).toBe(
+            resolveDifficultyConfig(tier, format).blunderChance,
+          );
+        }
+      }
+    });
+
+    // --- Attack decisions: the optimal call is inverted at the per-tier rate ---
+    // Both the direct-EV path (easy) and the block-prediction path (medium+)
+    // run the same blunder roll.
+
+    it("inverts an optimal attack into a hold when the blunder roll fires (easy, direct-EV path)", () => {
+      // Uncontested 4/4 flyer vs an 8-life opponent: aggressive strategy, high
+      // EV (~1.2) -> optimal decision is to attack.
+      const state = createTestGameState(
+        20,
+        8,
+        [
+          createMockPermanent("a1", "Angel", "creature", 4, 4, false, 4, [
+            "flying",
+          ]),
+        ],
+        [],
+      );
+
+      const optimal = new CombatDecisionTree(state, "player1", "easy");
+      optimal.setCombatRng(() => 1); // never fires -> optimal attack stands
+      const optimalPlan = optimal.generateAttackPlan();
+      expect(optimalPlan.attacks).toHaveLength(1);
+      expect(optimalPlan.attacks[0].shouldAttack).toBe(true);
+
+      const ai = new CombatDecisionTree(state, "player1", "easy");
+      ai.setCombatRng(() => 0); // always fires -> attack blundered to hold
+      expect(ai.generateAttackPlan().attacks).toHaveLength(0);
+    });
+
+    it("inverts an optimal hold into an attack when the blunder roll fires (easy)", () => {
+      // 1/1 into a 5/5 blocker at even life: defensive strategy, EV ~-0.8 ->
+      // optimal decision is to hold the attacker back.
+      const state = createTestGameState(
+        20,
+        20,
+        [createMockPermanent("a1", "Llanowar", "creature", 1, 1, false, 1)],
+        [createMockPermanent("b1", "Serra", "creature", 5, 5, false, 5)],
+      );
+
+      const optimal = new CombatDecisionTree(state, "player1", "easy");
+      optimal.setCombatRng(() => 1); // never fires -> doomed attacker held back
+      expect(optimal.generateAttackPlan().attacks).toHaveLength(0);
+
+      const ai = new CombatDecisionTree(state, "player1", "easy");
+      ai.setCombatRng(() => 0); // always fires -> doomed attacker sent in
+      const blundered = ai.generateAttackPlan();
+      expect(blundered.attacks).toHaveLength(1);
+      expect(blundered.attacks[0].shouldAttack).toBe(true);
+    });
+
+    it("applies the blunder on the block-prediction attack path (medium+)", () => {
+      // medium enables useBlockPrediction, so evaluateAttacker resolves via the
+      // predicted-EV branch (buildAttackDecision). The same roll inverts there.
+      const state = createTestGameState(
+        20,
+        8,
+        [
+          createMockPermanent("a1", "Angel", "creature", 4, 4, false, 4, [
+            "flying",
+          ]),
+        ],
+        [],
+      );
+
+      const optimal = new CombatDecisionTree(state, "player1", "medium");
+      optimal.setCombatRng(() => 1);
+      expect(optimal.generateAttackPlan().attacks).toHaveLength(1);
+
+      const ai = new CombatDecisionTree(state, "player1", "medium");
+      ai.setCombatRng(() => 0);
+      expect(ai.generateAttackPlan().attacks).toHaveLength(0);
+    });
+
+    // --- Block decisions: the optimal call is inverted at the per-tier rate ---
+
+    it("inverts an optimal block into a no-block when the blunder roll fires", () => {
+      // 3/3 blocker vs a 2/2 attacker: blocker kills attacker and survives ->
+      // blockValue 0.8 -> optimal decision is to block.
+      const state = createTestGameState(
+        20,
+        20,
+        [createMockPermanent("b1", "Bear", "creature", 3, 3, false, 2)],
+        [],
+      );
+      const attackers = [createMockPermanent("a1", "Goblin", "creature", 2, 2)];
+
+      const optimal = new CombatDecisionTree(state, "player1", "easy");
+      optimal.setCombatRng(() => 1); // never fires -> profitable block made
+      expect(optimal.generateBlockingPlan(attackers).blocks).toHaveLength(1);
+
+      const ai = new CombatDecisionTree(state, "player1", "easy");
+      ai.setCombatRng(() => 0); // always fires -> lethal block missed
+      expect(ai.generateBlockingPlan(attackers).blocks).toHaveLength(0);
+    });
+
+    it("inverts an optimal no-block into a block when the blunder roll fires", () => {
+      // 2/2 blocker (mv 3) vs a 5/5 attacker at 20 life: chump that loses the
+      // blocker without killing the attacker -> blockValue -0.2 -> no block.
+      const state = createTestGameState(
+        20,
+        20,
+        [createMockPermanent("b1", "Bear", "creature", 2, 2, false, 3)],
+        [],
+      );
+      const attackers = [createMockPermanent("a1", "Giant", "creature", 5, 5)];
+
+      const optimal = new CombatDecisionTree(state, "player1", "easy");
+      optimal.setCombatRng(() => 1); // never fires -> harmless attacker ignored
+      expect(optimal.generateBlockingPlan(attackers).blocks).toHaveLength(0);
+
+      const ai = new CombatDecisionTree(state, "player1", "easy");
+      ai.setCombatRng(() => 0); // always fires -> harmless attacker chumped
+      expect(ai.generateBlockingPlan(attackers).blocks).toHaveLength(1);
+    });
+
+    // --- Statistical: the empirical rate scales (and is monotonic) by tier ---
+    // Uses the blocking path: it has no lookahead or tricks, so the decision is
+    // purely optimal + blunder, isolating the per-tier rate.
+
+    it("blunders combat more often as difficulty drops (monotonic, beginner >> expert)", () => {
+      // 3/3 blocker vs a 2/2 attacker -> blockValue 0.8 -> optimal block for
+      // every tier. An inversion = the optimal block is skipped (length 0).
+      const makeState = () =>
+        createTestGameState(
+          20,
+          20,
+          [createMockPermanent("b1", "Bear", "creature", 3, 3, false, 2)],
+          [],
+        );
+      const attackers = [createMockPermanent("a1", "Goblin", "creature", 2, 2)];
+
+      const trials = 400;
+      const countInversions = (tier: DifficultyLevel): number => {
+        let inversions = 0;
+        for (let i = 0; i < trials; i++) {
+          const ai = new CombatDecisionTree(makeState(), "player1", tier);
+          // Same fresh stream per trial index across tiers -> the only thing
+          // that changes is the per-tier blunderChance threshold.
+          ai.setCombatRng(seededRng(0x994 + i));
+          if (ai.generateBlockingPlan(attackers).blocks.length === 0)
+            inversions++;
+        }
+        return inversions;
+      };
+
+      const counts = TIERS.map(countInversions);
+
+      // Monotonic in skill: easy blunders most, expert least.
+      expect(counts[0]).toBeGreaterThan(counts[1]);
+      expect(counts[1]).toBeGreaterThan(counts[2]);
+      expect(counts[2]).toBeGreaterThan(counts[3]);
+
+      // Beginner collapses to easy (LEGACY_DIFFICULTY_ALIASES), so it blunders
+      // as much as easy and far more than expert.
+      expect(countInversions("easy")).toBe(counts[0]);
+
+      // Absolute bounds (issue acceptance: easy >= ~15%, expert <= ~5%).
+      expect(counts[0] / trials).toBeGreaterThanOrEqual(0.15);
+      expect(counts[3] / trials).toBeLessThanOrEqual(0.05);
     });
   });
 });

--- a/src/ai/__tests__/combat-trick-probability.test.ts
+++ b/src/ai/__tests__/combat-trick-probability.test.ts
@@ -207,7 +207,11 @@ describe("calculateCombatTrickDiscount", () => {
   it("should never discount below -0.5", () => {
     const estimate = {
       probability: 0.9,
-      estimatedTypes: ["removal", "pump", "indestructible"] as CombatTrickType[],
+      estimatedTypes: [
+        "removal",
+        "pump",
+        "indestructible",
+      ] as CombatTrickType[],
       confidence: 0.9,
       reasoning: "worst case",
     };
@@ -223,9 +227,7 @@ describe("integration: combat trick discount in attack decisions", () => {
     const noManaState = createTestGameState(
       20,
       20,
-      [
-        createMockPermanent("c1", "Bear", "creature", 2, 2, false, 2),
-      ],
+      [createMockPermanent("c1", "Bear", "creature", 2, 2, false, 2)],
       [],
     );
     noManaState.players.player2.manaPool = {
@@ -241,9 +243,7 @@ describe("integration: combat trick discount in attack decisions", () => {
     const withManaState = createTestGameState(
       20,
       20,
-      [
-        createMockPermanent("c1", "Bear", "creature", 2, 2, false, 2),
-      ],
+      [createMockPermanent("c1", "Bear", "creature", 2, 2, false, 2)],
       [],
     );
     withManaState.players.player2.manaPool = {
@@ -269,11 +269,7 @@ describe("integration: combat trick discount in attack decisions", () => {
       opponentArchetype: "tempo",
     });
 
-    const withManaAI = new CombatDecisionTree(
-      withManaState,
-      "player1",
-      "hard",
-    );
+    const withManaAI = new CombatDecisionTree(withManaState, "player1", "hard");
     withManaAI.setConfig({
       useCombatTricks: true,
       opponentArchetype: "tempo",
@@ -282,10 +278,7 @@ describe("integration: combat trick discount in attack decisions", () => {
     const noManaPlan = noManaAI.generateAttackPlan();
     const withManaPlan = withManaAI.generateAttackPlan();
 
-    if (
-      noManaPlan.attacks.length > 0 &&
-      withManaPlan.attacks.length > 0
-    ) {
+    if (noManaPlan.attacks.length > 0 && withManaPlan.attacks.length > 0) {
       expect(withManaPlan.attacks[0].expectedValue).toBeLessThanOrEqual(
         noManaPlan.attacks[0].expectedValue,
       );
@@ -300,9 +293,7 @@ describe("integration: combat trick discount in attack decisions", () => {
     const state = createTestGameState(
       20,
       20,
-      [
-        createMockPermanent("c1", "Bear", "creature", 2, 2, false, 2),
-      ],
+      [createMockPermanent("c1", "Bear", "creature", 2, 2, false, 2)],
       [],
     );
     state.players.player2.manaPool = {
@@ -342,7 +333,13 @@ describe("estimateCombatTrickProbability — difficulty scaling (#1067)", () => 
     expect(explicit.probability).toBe(legacy.probability);
     // The unscaled multipliers are all 1, so expert must match legacy exactly
     // on the probability term (bluff/freq multipliers both 1 for expert).
-    const expert = estimateCombatTrickProbability(mana, "tempo", 4, 5, "expert");
+    const expert = estimateCombatTrickProbability(
+      mana,
+      "tempo",
+      4,
+      5,
+      "expert",
+    );
     expect(expert.probability).toBeCloseTo(legacy.probability, 10);
   });
 
@@ -481,11 +478,7 @@ describe("resolveTrickScaling — per-format composition (#1069)", () => {
 
     // Every resolved scaling must keep miscastChance within [0, 1].
     for (const level of DIFFICULTY_LEVELS) {
-      for (const format of [
-        "commander",
-        "constructed",
-        "limited",
-      ] as const) {
+      for (const format of ["commander", "constructed", "limited"] as const) {
         const m = resolveTrickScaling(level, format).miscastChance;
         expect(m).toBeGreaterThanOrEqual(0);
         expect(m).toBeLessThanOrEqual(1);
@@ -566,7 +559,7 @@ describe("decideCombatTrickHold — bluff/hold by difficulty (#1067)", () => {
       // Pair rolls: (miscast, discipline) — reuse the same ladder per tier.
       for (let i = 0; i < rolls.length - 1; i += 2) {
         let idx = 0;
-        const rng = () => rolls[i + idx++ % 2];
+        const rng = () => rolls[i + (idx++ % 2)];
         const d = decideCombatTrickHold({
           difficulty: level,
           evNow,
@@ -585,11 +578,7 @@ describe("decideCombatTrickHold — bluff/hold by difficulty (#1067)", () => {
 
   it("composes with per-format config via the format parameter", () => {
     // Same tier, different formats must remain valid and within bounds.
-    for (const format of [
-      "commander",
-      "constructed",
-      "limited",
-    ] as const) {
+    for (const format of ["commander", "constructed", "limited"] as const) {
       const d = decideCombatTrickHold({
         difficulty: "hard",
         format,
@@ -679,10 +668,18 @@ describe("CombatDecisionTree — difficulty plumbing into the trick module (#106
         colorless: 1,
       };
       state.players.player2.hand = [
-        { cardInstanceId: "h1", name: "Lightning Bolt", type: "Instant", manaValue: 1 },
+        {
+          cardInstanceId: "h1",
+          name: "Lightning Bolt",
+          type: "Instant",
+          manaValue: 1,
+        },
       ];
       const ai = new CombatDecisionTree(state, "player1", level);
       ai.setConfig({ useCombatTricks: true, opponentArchetype: "tempo" });
+      // This test isolates trick-EV ordering, not combat blunders (#994). Pin
+      // the combat RNG so the per-difficulty blunder roll never fires here.
+      ai.setCombatRng(() => 1);
       return ai.generateAttackPlan();
     };
 

--- a/src/ai/decision-making/combat-decision-tree.ts
+++ b/src/ai/decision-making/combat-decision-tree.ts
@@ -42,7 +42,11 @@ import {
   type CombatTrickHoldDecision,
   type CombatTrickHoldInput,
 } from "./combat-trick-probability";
-import type { DifficultyFormat, DifficultyLevel } from "../ai-difficulty";
+import {
+  resolveDifficultyConfig,
+  type DifficultyFormat,
+  type DifficultyLevel,
+} from "../ai-difficulty";
 import {
   LookaheadEngine,
   HeuristicTable,
@@ -328,6 +332,12 @@ export class CombatDecisionTree {
    * (#1069) into trick bluff/hold decisions. Set via {@link setDifficultyFormat}.
    */
   private difficultyFormat?: DifficultyFormat;
+  /**
+   * Injectable RNG for the combat blunder roll (issue #994). Defaults to
+   * {@link Math.random}; tests pass a seeded generator so per-difficulty
+   * blunder rates can be asserted deterministically without flakiness.
+   */
+  private combatRng: () => number = Math.random;
   constructor(
     gameState: GameState,
     aiPlayerId: string,
@@ -415,6 +425,40 @@ export class CombatDecisionTree {
    */
   setDifficultyFormat(format?: DifficultyFormat): void {
     this.difficultyFormat = format;
+  }
+
+  /**
+   * Inject a deterministic RNG for the combat blunder roll (issue #994).
+   *
+   * Production code leaves the default {@link Math.random}; tests pass a
+   * seeded generator to assert per-difficulty blunder rates without flakiness.
+   */
+  setCombatRng(rng: () => number): void {
+    this.combatRng = rng;
+  }
+
+  /**
+   * The per-tier probability that a single combat decision is blundered
+   * (issue #994).
+   *
+   * Resolved through {@link resolveDifficultyConfig} so it composes with the
+   * unified difficulty taxonomy (#1064/#1192) and the per-format override
+   * deltas (#1069) — combat blunders scale with exactly the same config the
+   * rest of the AI uses. Monotonic in skill: easy (0.25) > medium (0.10) >
+   * hard (0.05) > expert (0.02), so weaker tiers blunder more often.
+   */
+  getCombatBlunderChance(): number {
+    return resolveDifficultyConfig(this.difficulty, this.difficultyFormat)
+      .blunderChance;
+  }
+
+  /**
+   * Roll whether the current combat decision should be blundered (issue #994).
+   * Uses the injectable {@link combatRng} so the rate is deterministic and
+   * testable.
+   */
+  private shouldCombatBlunder(): boolean {
+    return this.combatRng() < this.getCombatBlunderChance();
   }
 
   /**
@@ -837,7 +881,19 @@ export class CombatDecisionTree {
       );
     }
 
-    if (trickDiscountedValue >= attackThreshold) {
+    // Optimal attack/hold call from the evaluated expected value.
+    let shouldAttackOptimal = trickDiscountedValue >= attackThreshold;
+
+    // Issue #994: lower tiers blunder combat decisions. With probability equal
+    // to the tier's blunderChance, invert the optimal call — easy AI attacks
+    // doomed creatures or holds back profitable attackers most often; expert
+    // almost never deviates. The roll uses the injectable combatRng so the
+    // per-difficulty rate is deterministic and testable.
+    if (this.shouldCombatBlunder()) {
+      shouldAttackOptimal = !shouldAttackOptimal;
+    }
+
+    if (shouldAttackOptimal) {
       shouldAttack = true;
       target = bestTarget!;
       expectedValue = Math.max(0, Math.min(1, trickDiscountedValue));
@@ -895,7 +951,14 @@ export class CombatDecisionTree {
 
     const hasEvasion = evasionBonus > 0;
     const expectedValue = Math.max(0, Math.min(1, predictedEV));
-    const shouldAttack = predictedEV >= attackThreshold;
+    // Optimal attack/hold from the predicted-EV path, then apply the
+    // per-difficulty combat blunder roll (issue #994) — same mechanism and
+    // rate as the non-block-prediction branch in evaluateAttacker, so blunder
+    // frequency is monotonic in skill across both paths.
+    let shouldAttack = predictedEV >= attackThreshold;
+    if (this.shouldCombatBlunder()) {
+      shouldAttack = !shouldAttack;
+    }
     const riskLevel = shouldAttack
       ? this.calculateAttackRisk(creature, opponentAnalyses)
       : 0;
@@ -1396,8 +1459,22 @@ export class CombatDecisionTree {
       }
     }
 
+    // Optimal block/hold call from the evaluated block value.
+    let shouldBlockOptimal = blockValue > 0;
+
+    // Issue #994: lower tiers blunder block decisions too. With probability
+    // equal to the tier's blunderChance, invert the optimal call — easy AI
+    // misses a profitable/lethal block or chump-blocks a harmless attacker;
+    // expert almost never deviates. Same roll + per-tier rate as the attack
+    // path, so combat blunder frequency is monotonic in skill across both
+    // attack and block decisions and composes with the unified difficulty
+    // config (#1064/#1192 + per-format #1069).
+    if (this.shouldCombatBlunder()) {
+      shouldBlockOptimal = !shouldBlockOptimal;
+    }
+
     // Decide whether to block
-    if (blockValue > 0) {
+    if (shouldBlockOptimal) {
       blocks.push({
         blockerId: bestBlocker.id,
         attackerId: attacker.id,


### PR DESCRIPTION
## Summary

`AIDifficultyConfig.blunderChance` already existed per tier (easy `0.25`, medium `0.10`, hard `0.05`, expert `0.02`), but `CombatDecisionTree.generateAttackPlan()` / `generateBlockingPlan()` never consulted it — every tier made the same optimal attack/block call. This ties combat blunder frequency to the difficulty tier so weaker AI makes suboptimal combat decisions more often.

Resolves #994.

## Where blunders are introduced

`src/ai/decision-making/combat-decision-tree.ts` — a single per-difficulty blunder roll applied at the three points a combat decision is finalized:

- **Attack — direct-EV path** (`evaluateAttacker`, the easy/no-block-prediction branch): with probability `blunderChance`, invert the optimal attack/hold call (attack doomed creatures / hold profitable attackers).
- **Attack — block-prediction path** (`buildAttackDecision`, medium+ branch): same roll, same inversion.
- **Block** (`evaluateBlocksForAttacker`): same roll, same inversion (miss a lethal/profitable block / chump-block a harmless attacker).

Inversion only flips the *decision*; the reported `expectedValue`/`riskLevel` still reflect the real evaluated combat, so downstream trick/lookahead logic stays coherent.

## Per-tier rate + composition

- The rate is read via `getCombatBlunderChance()` → `resolveDifficultyConfig(difficulty, difficultyFormat).blunderChance`, so it **composes with the unified difficulty taxonomy (#1064/#1192) and the per-format override deltas (#1069)** — combat blunders scale with exactly the same config the rest of the AI uses. No format currently overrides `blunderChance`; when one does, combat picks it up automatically.
- Monotonic in skill: easy `0.25` > medium `0.10` > hard `0.05` > expert `0.02` (beginner collapses to easy via `LEGACY_DIFFICULTY_ALIASES`).
- Deterministic + testable via a new injectable `setCombatRng(rng)` (mirrors the existing `decideCombatTrickHold` `rng?` pattern from #1067); production defaults to `Math.random`.

## Tests (`src/ai/__tests__/combat-decision-tree.test.ts`)

New `combat blunder frequency by difficulty (#994)` suite:
- per-tier `getCombatBlunderChance()` equals `resolveDifficultyConfig(tier).blunderChance`;
- monotonicity: easy > medium > hard > expert;
- composition with `commander`/`constructed`/`limited` formats via the resolver;
- deterministic inversion of an optimal **attack→hold** and **hold→attack** (easy), plus the block-prediction attack path (medium);
- deterministic inversion of an optimal **block→no-block** and **no-block→block**;
- statistical monotonicity over 400 trials: easy blunders most, expert least, beginner == easy >> expert, with absolute bounds (easy ≥ 15 %, expert ≤ 5 %).

The pre-existing `combat-trick-probability.test.ts` EV-ordering test now pins `setCombatRng(() => 1)` so its trick-EV assertion is isolated from the (correct) new combat blunders.

## Verification
- `npm test -- combat-decision ai-difficulty combat` — 288 passed
- full suite — 6077 passed (3 consecutive runs; the seeded simulation win-rate tests still pass, with monotonicity reinforced)
- `npx tsc --noEmit` — 0 errors
- `npm run lint` — 0 errors