### PR TITLE
feat(ai): resolve #1063 — wire difficulty-scaled mulligan decisions into the opponent turn loop

### DIFF
--- a/src/ai/__tests__/ai-turn-loop.test.ts
+++ b/src/ai/__tests__/ai-turn-loop.test.ts
@@ -13,6 +13,7 @@ import {
   detectPlayerArchetype,
   detectOpponentArchetype,
   runAITurn,
+  runOpeningHandMulligan,
   computeAdaptiveTempoRisk,
   adaptiveStrength,
   ADAPTIVE_MIN_MULT,
@@ -77,7 +78,7 @@ import {
 import { passPriority, drawCard } from "@/lib/game-state/game-state";
 import { advancePhase } from "@/lib/game-state/turn-phases";
 import { engineToAIState } from "@/lib/game-state/serialization";
-import { getMaxHandSize } from "@/lib/game-rules";
+import { getMaxHandSize, getMulliganRules } from "@/lib/game-rules";
 
 const canPlayLandMock = canPlayLand as unknown as jest.Mock;
 const playLandMock = playLand as unknown as jest.Mock;
@@ -92,6 +93,7 @@ const drawCardMock = drawCard as unknown as jest.Mock;
 const advancePhaseMock = advancePhase as unknown as jest.Mock;
 const engineToAIStateMock = engineToAIState as unknown as jest.Mock;
 const getMaxHandSizeMock = getMaxHandSize as unknown as jest.Mock;
+const getMulliganRulesMock = getMulliganRules as unknown as jest.Mock;
 
 const AI: PlayerId = "player1";
 const OPP: PlayerId = "player2";
@@ -972,9 +974,15 @@ describe("computeAdaptiveTempoRisk (issue #1068) — bounds", () => {
   }
 
   it("exposes the documented per-tier strength curve (easy loudest, expert subtlest)", () => {
-    expect(adaptiveStrength("easy")).toBeGreaterThan(adaptiveStrength("medium"));
-    expect(adaptiveStrength("medium")).toBeGreaterThan(adaptiveStrength("hard"));
-    expect(adaptiveStrength("hard")).toBeGreaterThan(adaptiveStrength("expert"));
+    expect(adaptiveStrength("easy")).toBeGreaterThan(
+      adaptiveStrength("medium"),
+    );
+    expect(adaptiveStrength("medium")).toBeGreaterThan(
+      adaptiveStrength("hard"),
+    );
+    expect(adaptiveStrength("hard")).toBeGreaterThan(
+      adaptiveStrength("expert"),
+    );
   });
 });
 
@@ -1025,7 +1033,9 @@ describe("computeAdaptiveTempoRisk (issue #1068) — composition with difficulty
     const expert = computeAdaptiveTempoRisk(swing, { difficulty: "expert" });
 
     expect(easy.riskMultiplier - 1).toBeGreaterThan(expert.riskMultiplier - 1);
-    expect(easy.tempoMultiplier - 1).toBeGreaterThan(expert.tempoMultiplier - 1);
+    expect(easy.tempoMultiplier - 1).toBeGreaterThan(
+      expert.tempoMultiplier - 1,
+    );
   });
 });
 
@@ -1033,9 +1043,13 @@ describe("computeAdaptiveTempoRisk (issue #1068) — hysteresis / no oscillation
   it("does not move when the target change is inside the deadband", () => {
     const prev = { tempoMultiplier: 1.0, riskMultiplier: 1.0 };
     // Tiny shift in standing → target barely moves → multiplier frozen.
-    const r = computeAdaptiveTempoRisk(swingOf(0.01, 0), {
-      difficulty: "medium",
-    }, prev);
+    const r = computeAdaptiveTempoRisk(
+      swingOf(0.01, 0),
+      {
+        difficulty: "medium",
+      },
+      prev,
+    );
 
     expect(r.tempoMultiplier).toBe(prev.tempoMultiplier);
     expect(r.riskMultiplier).toBe(prev.riskMultiplier);
@@ -1046,12 +1060,20 @@ describe("computeAdaptiveTempoRisk (issue #1068) — hysteresis / no oscillation
     // would jump between ~0.82 and ~1.18; with smoothing (factor 0.5) the
     // amplitude must shrink and every step stay within the global bounds.
     let prev = { tempoMultiplier: 1, riskMultiplier: 1 };
-    const swings = [swingOf(-1, 0), swingOf(1, 0), swingOf(-1, 0), swingOf(1, 0)];
+    const swings = [
+      swingOf(-1, 0),
+      swingOf(1, 0),
+      swingOf(-1, 0),
+      swingOf(1, 0),
+    ];
     const tempoValues: number[] = [];
     for (const s of swings) {
       const r = computeAdaptiveTempoRisk(s, { difficulty: "medium" }, prev);
       tempoValues.push(r.tempoMultiplier);
-      prev = { tempoMultiplier: r.tempoMultiplier, riskMultiplier: r.riskMultiplier };
+      prev = {
+        tempoMultiplier: r.tempoMultiplier,
+        riskMultiplier: r.riskMultiplier,
+      };
     }
 
     // All within bounds.
@@ -1075,11 +1097,18 @@ describe("computeAdaptiveTempoRisk (issue #1068) — hysteresis / no oscillation
     let prevTempo = -Infinity;
     const tempoValues: number[] = [];
     for (let i = 0; i < 5; i++) {
-      const r = computeAdaptiveTempoRisk(swingOf(-1, 0), {
-        difficulty: "hard",
-      }, prev);
+      const r = computeAdaptiveTempoRisk(
+        swingOf(-1, 0),
+        {
+          difficulty: "hard",
+        },
+        prev,
+      );
       tempoValues.push(r.tempoMultiplier);
-      prev = { tempoMultiplier: r.tempoMultiplier, riskMultiplier: r.riskMultiplier };
+      prev = {
+        tempoMultiplier: r.tempoMultiplier,
+        riskMultiplier: r.riskMultiplier,
+      };
     }
     // Monotonic non-decreasing toward the (higher) press target.
     for (const v of tempoValues) {
@@ -1134,5 +1163,250 @@ describe("computeAdaptiveTempoRisk (issue #1068) — AdaptiveTempoRisk shape", (
       expect(r).toHaveProperty(key);
       expect(typeof r[key]).toBe("number");
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #1063 — opponent opening-hand mulligan wired into the turn loop.
+//
+// `runOpeningHandMulligan` is the game-start step the orchestrator runs before
+// the first `runAITurn`. These tests exercise the REAL loop (decision via
+// decideOpponentMulligan + mechanical executeOpponentMulligan) against a real
+// engine state, controlling the blunder roll through the injected `rng` and
+// pinning the redraw shuffle via a Math.random spy so every assertion is
+// deterministic.
+// ---------------------------------------------------------------------------
+
+describe("runOpeningHandMulligan (issue #1063 wiring)", () => {
+  function mkCard(
+    id: string,
+    name: string,
+    typeLine: string,
+    cmc: number,
+    colors: string[],
+    oracleText = "",
+  ): CardInstance {
+    return {
+      id,
+      oracleId: id,
+      cardData: {
+        name,
+        type_line: typeLine,
+        cmc,
+        mana_cost: `{${cmc}}`,
+        colors,
+        oracle_text: oracleText,
+      } as any,
+      currentFaceIndex: 0,
+      isFaceDown: false,
+      controllerId: AI,
+      ownerId: AI,
+      isTapped: false,
+      isFlipped: false,
+      isTurnedFaceUp: false,
+      isPhasedOut: false,
+      hasSummoningSickness: false,
+    } as unknown as CardInstance;
+  }
+
+  /** A strong 3-land + low-curve opener the expert engine keeps. */
+  function strongOpener(prefix: string): CardInstance[] {
+    return [
+      mkCard(`${prefix}-h1`, "Forest", "Basic Land", 0, ["G"]),
+      mkCard(`${prefix}-h2`, "Plains", "Basic Land", 0, ["W"]),
+      mkCard(`${prefix}-h3`, "Mountain", "Basic Land", 0, ["R"]),
+      mkCard(`${prefix}-h4`, "Savannah Lions", "Creature", 1, ["W"]),
+      mkCard(`${prefix}-h5`, "Grizzly Bears", "Creature", 2, ["G"]),
+      mkCard(
+        `${prefix}-h6`,
+        "Lightning Bolt",
+        "Instant",
+        1,
+        ["R"],
+        "deals 3 damage",
+      ),
+      mkCard(`${prefix}-h7`, "Raging Goblin", "Creature", 1, ["R"]),
+    ];
+  }
+
+  /** A zero-land opener the expert engine ships. */
+  function zeroLandOpener(prefix: string): CardInstance[] {
+    return [
+      mkCard(`${prefix}-b1`, "Hill Giant", "Creature", 4, ["R"]),
+      mkCard(`${prefix}-b2`, "Air Elemental", "Creature", 4, ["U"]),
+      mkCard(`${prefix}-b3`, "Serra Angel", "Creature", 5, ["W"]),
+      mkCard(`${prefix}-b4`, "Craw Wurm", "Creature", 6, ["G"]),
+      mkCard(`${prefix}-b5`, "War Mammoth", "Creature", 3, ["G"]),
+      mkCard(`${prefix}-b6`, "Grizzly Bears", "Creature", 2, ["G"]),
+      mkCard(`${prefix}-b7`, "Gray Ogre", "Creature", 2, ["R"]),
+    ];
+  }
+
+  function buildMulliganState(opts: {
+    hand: CardInstance[];
+    library?: CardInstance[];
+  }): EngineGameState {
+    const cards = new Map<string, CardInstance>();
+    const handIds: string[] = [];
+    for (const c of opts.hand) {
+      cards.set(c.id, c);
+      handIds.push(c.id);
+    }
+    const libIds: string[] = [];
+    for (const c of opts.library ?? []) {
+      cards.set(c.id, c);
+      libIds.push(c.id);
+    }
+    const zones = new Map<string, { cardIds: string[] }>();
+    zones.set(`${AI}-hand`, { cardIds: handIds });
+    zones.set(`${AI}-library`, { cardIds: libIds });
+    zones.set(`${AI}-battlefield`, { cardIds: [] });
+    zones.set(`${OPP}-battlefield`, { cardIds: [] });
+    const players = new Map<PlayerId, unknown>();
+    players.set(AI, { id: AI });
+    players.set(OPP, { id: OPP });
+    return {
+      cards,
+      zones,
+      players,
+      turn: {
+        activePlayerId: AI,
+        currentPhase: "untap" as any,
+        turnNumber: 0,
+        extraTurns: 0,
+        isFirstTurn: true,
+        startedAt: 0,
+      },
+      combat: {
+        inCombatPhase: false,
+        attackers: [],
+        blockers: new Map(),
+        remainingCombatPhases: 0,
+      } as any,
+      priorityPlayerId: AI,
+    } as unknown as EngineGameState;
+  }
+
+  beforeEach(() => {
+    // game-rules is auto-mocked at the file level; supply the mulligan rules.
+    getMulliganRulesMock.mockReturnValue({ type: "london", minHandSize: 0 });
+  });
+
+  it("keeps a strong opener with zero mulligans (expert, no blunder)", async () => {
+    const state = buildMulliganState({ hand: strongOpener("keep") });
+    const result = await runOpeningHandMulligan(
+      state,
+      AI,
+      baseConfig({ difficulty: "expert" }),
+      () => 0.99, // above expert's 0.02 blunderChance -> never blunders
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.mulligansTaken).toBe(0);
+    expect(result.finalHandSize).toBe(7);
+    expect(result.decisions).toHaveLength(1);
+    expect(result.decisions[0].decision?.decision).toBe("keep");
+    expect(result.decisions[0].decision?.blundered).toBe(false);
+  });
+
+  it("a forced blunder chain mulligans down to the keep floor and stops", async () => {
+    // Easy + rng always blunders: every expert "keep" inverts to "ship", so the
+    // loop mulligans 7->6->5->4->3, where the floor forces a keep. The redraw
+    // shuffle is pinned so the count is deterministic.
+    const library: CardInstance[] = [];
+    for (let i = 0; i < 14; i++) {
+      library.push(
+        mkCard(`lib-${i}`, i % 2 ? "Forest" : "Plains", "Basic Land", 0, [
+          i % 2 ? "G" : "W",
+        ]),
+      );
+    }
+    const state = buildMulliganState({ hand: strongOpener("chain"), library });
+    const spy = jest.spyOn(Math, "random").mockReturnValue(0.5);
+
+    const result = await runOpeningHandMulligan(
+      state,
+      AI,
+      baseConfig({ difficulty: "easy" }),
+      () => 0, // always under easy's 0.45 blunderChance -> always blunders
+    );
+
+    spy.mockRestore();
+
+    expect(result.success).toBe(true);
+    expect(result.mulligansTaken).toBe(4);
+    expect(result.finalHandSize).toBe(3);
+    const last = result.decisions[result.decisions.length - 1];
+    expect(last.forcedKeep).toBe(true);
+    // Every non-forced step shipped (blunder on a keepable hand).
+    for (const step of result.decisions) {
+      if (step.forcedKeep) continue;
+      expect(step.decision?.decision).toBe("ship");
+      expect(step.decision?.blundered).toBe(true);
+    }
+  });
+
+  it("ships a zero-land opener, re-evaluates, and terminates", async () => {
+    const library: CardInstance[] = [];
+    for (let i = 0; i < 10; i++) {
+      library.push(
+        mkCard(`gd-${i}`, i % 2 ? "Forest" : "Plains", "Basic Land", 0, [
+          i % 2 ? "G" : "W",
+        ]),
+      );
+    }
+    const state = buildMulliganState({
+      hand: zeroLandOpener("bad"),
+      library,
+    });
+    const spy = jest.spyOn(Math, "random").mockReturnValue(0.5);
+
+    const result = await runOpeningHandMulligan(
+      state,
+      AI,
+      baseConfig({ difficulty: "expert" }),
+      () => 0.99, // no blunder -> expert follows the advisor
+    );
+
+    spy.mockRestore();
+
+    expect(result.success).toBe(true);
+    expect(result.mulligansTaken).toBeGreaterThanOrEqual(1);
+    expect(result.finalHandSize).toBeLessThanOrEqual(6);
+    expect(result.finalHandSize).toBeGreaterThanOrEqual(3);
+    // The opener was correctly identified as a ship by the expert engine.
+    expect(result.decisions[0].decision?.expertDecision).toBe("ship");
+    expect(result.decisions[0].decision?.decision).toBe("ship");
+    expect(result.decisions[0].decision?.blundered).toBe(false);
+  });
+
+  it("expert mulligans a strong opener far less often than easy (per-difficulty)", async () => {
+    const N = 40;
+    const spy = jest.spyOn(Math, "random").mockReturnValue(0.5);
+    let easyMulligans = 0;
+    let expertMulligans = 0;
+    for (let i = 0; i < N; i++) {
+      const roll = (i + 1) / (N + 1); // deterministic, spread across (0,1)
+      const easyRes = await runOpeningHandMulligan(
+        buildMulliganState({ hand: strongOpener(`e${i}`) }),
+        AI,
+        baseConfig({ difficulty: "easy" }),
+        () => roll,
+      );
+      if (easyRes.mulligansTaken > 0) easyMulligans++;
+      const expertRes = await runOpeningHandMulligan(
+        buildMulliganState({ hand: strongOpener(`x${i}`) }),
+        AI,
+        baseConfig({ difficulty: "expert" }),
+        () => roll,
+      );
+      if (expertRes.mulligansTaken > 0) expertMulligans++;
+    }
+    spy.mockRestore();
+
+    // Easy (blunderChance 0.45) mulligans the strong opener far more than
+    // Expert (0.02). The wiring therefore scales mulligan quality by difficulty.
+    expect(easyMulligans).toBeGreaterThan(expertMulligans);
+    expect(expertMulligans).toBeLessThan(N * 0.15);
   });
 });

--- a/src/ai/__tests__/mulligan-advisor.test.ts
+++ b/src/ai/__tests__/mulligan-advisor.test.ts
@@ -2,233 +2,311 @@
  * @fileOverview Tests for mulligan advisor
  */
 
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect } from "@jest/globals";
 import {
   analyzeMulligan,
+  decideOpponentMulligan,
+  DIFFICULTY_MULLIGAN_SCALING,
+  getDifficultyMulliganScaling,
+  resolveMulliganScaling,
   getMatchingExpertRecords,
   KEEP_SHIP_DATABASE,
   type MulliganInput,
+  type OpponentMulliganInput,
   type Card,
-} from '../mulligan-advisor';
+} from "../mulligan-advisor";
+import {
+  DIFFICULTY_LEVELS,
+  type DifficultyLevel,
+  type DifficultyFormat,
+} from "../ai-difficulty";
 
 function makeCard(overrides: Partial<Card> & { name: string }): Card {
   return {
     name: overrides.name,
-    type_line: overrides.type_line || 'Creature',
+    type_line: overrides.type_line || "Creature",
     cmc: overrides.cmc ?? 0,
     colors: overrides.colors ?? [],
-    oracle_text: overrides.oracle_text ?? '',
+    oracle_text: overrides.oracle_text ?? "",
     mana_cost: overrides.mana_cost,
     power: overrides.power,
     toughness: overrides.toughness,
   };
 }
 
-function land(name: string, color: string = ''): Card {
-  return makeCard({ name, type_line: 'Basic Land', colors: color ? [color] : [] });
+function land(name: string, color: string = ""): Card {
+  return makeCard({
+    name,
+    type_line: "Basic Land",
+    colors: color ? [color] : [],
+  });
 }
 
-function creature(name: string, cmc: number, color: string = '', oracleText: string = ''): Card {
-  return makeCard({ name, type_line: 'Creature', cmc, colors: color ? [color] : [], oracle_text: oracleText });
+function creature(
+  name: string,
+  cmc: number,
+  color: string = "",
+  oracleText: string = "",
+): Card {
+  return makeCard({
+    name,
+    type_line: "Creature",
+    cmc,
+    colors: color ? [color] : [],
+    oracle_text: oracleText,
+  });
 }
 
-function spell(name: string, cmc: number, typeLine: string = 'Instant', color: string = '', oracleText: string = ''): Card {
-  return makeCard({ name, type_line: typeLine, cmc, colors: color ? [color] : [], oracle_text: oracleText });
+function spell(
+  name: string,
+  cmc: number,
+  typeLine: string = "Instant",
+  color: string = "",
+  oracleText: string = "",
+): Card {
+  return makeCard({
+    name,
+    type_line: typeLine,
+    cmc,
+    colors: color ? [color] : [],
+    oracle_text: oracleText,
+  });
 }
 
-describe('mulligan-advisor', () => {
-  describe('KEEP_SHIP_DATABASE', () => {
-    it('should have at least 50 expert records', () => {
+describe("mulligan-advisor", () => {
+  describe("KEEP_SHIP_DATABASE", () => {
+    it("should have at least 50 expert records", () => {
       expect(KEEP_SHIP_DATABASE.length).toBeGreaterThanOrEqual(50);
     });
 
-    it('should cover land count rules', () => {
-      const patterns = KEEP_SHIP_DATABASE.map(r => r.handComposition);
-      expect(patterns).toContain('0-land');
-      expect(patterns.some(p => p.includes('1-land'))).toBe(true);
-      expect(patterns.some(p => p.includes('2-land'))).toBe(true);
-      expect(patterns.some(p => p.includes('3-land'))).toBe(true);
-      expect(patterns.some(p => p.includes('5-land'))).toBe(true);
+    it("should cover land count rules", () => {
+      const patterns = KEEP_SHIP_DATABASE.map((r) => r.handComposition);
+      expect(patterns).toContain("0-land");
+      expect(patterns.some((p) => p.includes("1-land"))).toBe(true);
+      expect(patterns.some((p) => p.includes("2-land"))).toBe(true);
+      expect(patterns.some((p) => p.includes("3-land"))).toBe(true);
+      expect(patterns.some((p) => p.includes("5-land"))).toBe(true);
     });
 
-    it('should cover archetype-specific rules', () => {
-      const archetypes = KEEP_SHIP_DATABASE.map(r => r.archetype);
-      expect(archetypes).toContain('aggro');
-      expect(archetypes).toContain('control');
-      expect(archetypes).toContain('combo');
-      expect(archetypes).toContain('tribal');
+    it("should cover archetype-specific rules", () => {
+      const archetypes = KEEP_SHIP_DATABASE.map((r) => r.archetype);
+      expect(archetypes).toContain("aggro");
+      expect(archetypes).toContain("control");
+      expect(archetypes).toContain("combo");
+      expect(archetypes).toContain("tribal");
     });
   });
 
-  describe('analyzeMulligan', () => {
-    describe('no-lander', () => {
-      it('should always ship a 0-land hand', () => {
+  describe("analyzeMulligan", () => {
+    describe("no-lander", () => {
+      it("should always ship a 0-land hand", () => {
         const hand: Card[] = [
-          creature('Grizzly Bears', 2, 'G'),
-          creature(' Savannah Lions', 1, 'W'),
-          creature(' Hill Giant', 4, 'R'),
-          creature(' Serra Angel', 5, 'W'),
-          creature(' War Mammoth', 3, 'G'),
-          spell('Lightning Bolt', 1, 'Instant', 'R', 'deals 3 damage'),
-          spell('Giant Growth', 1, 'Instant', 'G'),
+          creature("Grizzly Bears", 2, "G"),
+          creature(" Savannah Lions", 1, "W"),
+          creature(" Hill Giant", 4, "R"),
+          creature(" Serra Angel", 5, "W"),
+          creature(" War Mammoth", 3, "G"),
+          spell("Lightning Bolt", 1, "Instant", "R", "deals 3 damage"),
+          spell("Giant Growth", 1, "Instant", "G"),
         ];
 
-        const result = analyzeMulligan({ hand, format: 'limited' });
-        expect(result.decision).toBe('ship');
+        const result = analyzeMulligan({ hand, format: "limited" });
+        expect(result.decision).toBe("ship");
         expect(result.analysis.landCount).toBe(0);
-        expect(result.reasoning.some(r => r.includes('No lands'))).toBe(true);
+        expect(result.reasoning.some((r) => r.includes("No lands"))).toBe(true);
       });
     });
 
-    describe('1-lander aggro', () => {
-      it('should lean keep for a 1-land aggro hand on the play in constructed', () => {
+    describe("1-lander aggro", () => {
+      it("should lean keep for a 1-land aggro hand on the play in constructed", () => {
         const hand: Card[] = [
-          land('Mountain', 'R'),
-          creature('Goblin Guide', 1, 'R'),
-          creature('Monastery Swiftspear', 1, 'R'),
-          creature('Raging Goblin', 1, 'R'),
-          spell('Lightning Bolt', 1, 'Instant', 'R', 'deals 3 damage'),
-          spell('Shock', 1, 'Instant', 'R', 'deals 2 damage'),
-          creature('Jackal Pup', 1, 'R'),
+          land("Mountain", "R"),
+          creature("Goblin Guide", 1, "R"),
+          creature("Monastery Swiftspear", 1, "R"),
+          creature("Raging Goblin", 1, "R"),
+          spell("Lightning Bolt", 1, "Instant", "R", "deals 3 damage"),
+          spell("Shock", 1, "Instant", "R", "deals 2 damage"),
+          creature("Jackal Pup", 1, "R"),
         ];
 
-        const result = analyzeMulligan({ hand, archetype: 'aggro', format: 'constructed', onThePlay: true });
-        expect(result.decision).toBe('keep');
+        const result = analyzeMulligan({
+          hand,
+          archetype: "aggro",
+          format: "constructed",
+          onThePlay: true,
+        });
+        expect(result.decision).toBe("keep");
       });
     });
 
-    describe('1-lander control', () => {
-      it('should ship a 1-land control hand', () => {
+    describe("1-lander control", () => {
+      it("should ship a 1-land control hand", () => {
         const hand: Card[] = [
-          land('Island', 'U'),
-          spell('Cancel', 3, 'Instant', 'U', 'counter target spell'),
-          spell('Essence Scatter', 2, 'Instant', 'U', 'counter target creature spell'),
-          spell('Divination', 3, 'Sorcery', 'U', 'draw two cards'),
-          creature('Air Elemental', 4, 'U'),
-          creature('Serra Angel', 5, 'W'),
-          spell('Concentrate', 4, 'Sorcery', 'U', 'draw three cards'),
+          land("Island", "U"),
+          spell("Cancel", 3, "Instant", "U", "counter target spell"),
+          spell(
+            "Essence Scatter",
+            2,
+            "Instant",
+            "U",
+            "counter target creature spell",
+          ),
+          spell("Divination", 3, "Sorcery", "U", "draw two cards"),
+          creature("Air Elemental", 4, "U"),
+          creature("Serra Angel", 5, "W"),
+          spell("Concentrate", 4, "Sorcery", "U", "draw three cards"),
         ];
 
-        const result = analyzeMulligan({ hand, archetype: 'control', format: 'limited' });
-        expect(result.decision).toBe('ship');
+        const result = analyzeMulligan({
+          hand,
+          archetype: "control",
+          format: "limited",
+        });
+        expect(result.decision).toBe("ship");
       });
     });
 
-    describe('5-lander control', () => {
-      it('should ship a 5-land hand with few spells', () => {
+    describe("5-lander control", () => {
+      it("should ship a 5-land hand with few spells", () => {
         const hand: Card[] = [
-          land('Island', 'U'),
-          land('Island', 'U'),
-          land('Swamp', 'B'),
-          land('Plains', 'W'),
-          land('Mountain', 'R'),
-          spell('Cancel', 3, 'Instant', 'U', 'counter target spell'),
-          creature('Air Elemental', 4, 'U'),
+          land("Island", "U"),
+          land("Island", "U"),
+          land("Swamp", "B"),
+          land("Plains", "W"),
+          land("Mountain", "R"),
+          spell("Cancel", 3, "Instant", "U", "counter target spell"),
+          creature("Air Elemental", 4, "U"),
         ];
 
-        const result = analyzeMulligan({ hand, archetype: 'control', format: 'limited' });
-        expect(result.decision).toBe('ship');
-        expect(result.reasoning.some(r => r.includes('flood'))).toBe(true);
+        const result = analyzeMulligan({
+          hand,
+          archetype: "control",
+          format: "limited",
+        });
+        expect(result.decision).toBe("ship");
+        expect(result.reasoning.some((r) => r.includes("flood"))).toBe(true);
       });
     });
 
-    describe('3-land good curve', () => {
-      it('should keep an ideal 3-land curve hand', () => {
+    describe("3-land good curve", () => {
+      it("should keep an ideal 3-land curve hand", () => {
         const hand: Card[] = [
-          land('Forest', 'G'),
-          land('Plains', 'W'),
-          creature('Savannah Lions', 1, 'W'),
-          creature('Grizzly Bears', 2, 'G'),
-          creature('Glory Seeker', 2, 'W'),
-          spell('Giant Growth', 1, 'Instant', 'G'),
-          spell('Lightning Bolt', 1, 'Instant', 'R', 'deals 3 damage'),
+          land("Forest", "G"),
+          land("Plains", "W"),
+          creature("Savannah Lions", 1, "W"),
+          creature("Grizzly Bears", 2, "G"),
+          creature("Glory Seeker", 2, "W"),
+          spell("Giant Growth", 1, "Instant", "G"),
+          spell("Lightning Bolt", 1, "Instant", "R", "deals 3 damage"),
         ];
 
-        const result = analyzeMulligan({ hand, format: 'limited' });
+        const result = analyzeMulligan({ hand, format: "limited" });
         expect(result.handQualityScore).toBeGreaterThanOrEqual(40);
       });
     });
 
-    describe('combo hand with pieces', () => {
-      it('should have a good score for a combo hand with both pieces', () => {
+    describe("combo hand with pieces", () => {
+      it("should have a good score for a combo hand with both pieces", () => {
         const hand: Card[] = [
-          land('Island', 'U'),
-          land('Volcanic Island', ''),
-          spell('Ponder', 1, 'Sorcery', 'U', 'look at the top three cards'),
-          spell('Preordain', 1, 'Instant', 'U', 'scry 2'),
-          spell('Splinter Twin', 4, 'Enchantment', 'R'),
-          creature('Deceiver Exarch', 3, 'U'),
-          creature('Pestermite', 2, 'U'),
+          land("Island", "U"),
+          land("Volcanic Island", ""),
+          spell("Ponder", 1, "Sorcery", "U", "look at the top three cards"),
+          spell("Preordain", 1, "Instant", "U", "scry 2"),
+          spell("Splinter Twin", 4, "Enchantment", "R"),
+          creature("Deceiver Exarch", 3, "U"),
+          creature("Pestermite", 2, "U"),
         ];
 
-        const result = analyzeMulligan({ hand, archetype: 'combo', format: 'constructed' });
+        const result = analyzeMulligan({
+          hand,
+          archetype: "combo",
+          format: "constructed",
+        });
         expect(result.handQualityScore).toBeGreaterThan(50);
       });
     });
 
-    describe('combo hand without pieces', () => {
-      it('should ship a combo hand with no combo pieces', () => {
+    describe("combo hand without pieces", () => {
+      it("should ship a combo hand with no combo pieces", () => {
         const hand: Card[] = [
-          land('Island', 'U'),
-          land('Island', 'U'),
-          land('Forest', 'G'),
-          land('Plains', 'W'),
-          creature('Grizzly Bears', 2, 'G'),
-          creature('Hill Giant', 4, 'R'),
-          spell('Cancel', 3, 'Instant', 'U', 'counter target spell'),
-          creature('Air Elemental', 4, 'U'),
+          land("Island", "U"),
+          land("Island", "U"),
+          land("Forest", "G"),
+          land("Plains", "W"),
+          creature("Grizzly Bears", 2, "G"),
+          creature("Hill Giant", 4, "R"),
+          spell("Cancel", 3, "Instant", "U", "counter target spell"),
+          creature("Air Elemental", 4, "U"),
         ];
 
-        const result = analyzeMulligan({ hand, archetype: 'combo', format: 'constructed' });
-        expect(result.decision).toBe('ship');
+        const result = analyzeMulligan({
+          hand,
+          archetype: "combo",
+          format: "constructed",
+        });
+        expect(result.decision).toBe("ship");
       });
     });
 
-    describe('empty hand', () => {
-      it('should ship an empty hand', () => {
+    describe("empty hand", () => {
+      it("should ship an empty hand", () => {
         const result = analyzeMulligan({ hand: [] });
-        expect(result.decision).toBe('ship');
+        expect(result.decision).toBe("ship");
         expect(result.confidence).toBe(1.0);
       });
     });
 
-    describe('non-7-card hand', () => {
-      it('should return ship for non-7-card hands', () => {
-        const hand: Card[] = [land('Forest', 'G'), land('Forest', 'G'), creature('Grizzly Bears', 2, 'G')];
+    describe("non-7-card hand", () => {
+      it("should return ship for non-7-card hands", () => {
+        const hand: Card[] = [
+          land("Forest", "G"),
+          land("Forest", "G"),
+          creature("Grizzly Bears", 2, "G"),
+        ];
         const result = analyzeMulligan({ hand });
-        expect(result.decision).toBe('ship');
+        expect(result.decision).toBe("ship");
       });
     });
 
-    describe('game number adjustments', () => {
-      it('should be more conservative in game 3+', () => {
+    describe("game number adjustments", () => {
+      it("should be more conservative in game 3+", () => {
         const marginalHand: Card[] = [
-          land('Forest', 'G'),
-          land('Forest', 'G'),
-          creature('Savannah Lions', 1, 'W'),
-          creature('Grizzly Bears', 2, 'G'),
-          creature('Hill Giant', 4, 'R'),
-          creature('Gray Ogre', 2, 'R'),
-          land('Mountain', 'R'),
+          land("Forest", "G"),
+          land("Forest", "G"),
+          creature("Savannah Lions", 1, "W"),
+          creature("Grizzly Bears", 2, "G"),
+          creature("Hill Giant", 4, "R"),
+          creature("Gray Ogre", 2, "R"),
+          land("Mountain", "R"),
         ];
 
-        const g1Result = analyzeMulligan({ hand: marginalHand, format: 'limited', gameNumber: 1 });
-        const g3Result = analyzeMulligan({ hand: marginalHand, format: 'limited', gameNumber: 3 });
+        const g1Result = analyzeMulligan({
+          hand: marginalHand,
+          format: "limited",
+          gameNumber: 1,
+        });
+        const g3Result = analyzeMulligan({
+          hand: marginalHand,
+          format: "limited",
+          gameNumber: 3,
+        });
 
-        expect(g3Result.handQualityScore).toBeGreaterThanOrEqual(g1Result.handQualityScore);
+        expect(g3Result.handQualityScore).toBeGreaterThanOrEqual(
+          g1Result.handQualityScore,
+        );
       });
     });
 
-    describe('hand analysis', () => {
-      it('should correctly count lands, creatures, and spells', () => {
+    describe("hand analysis", () => {
+      it("should correctly count lands, creatures, and spells", () => {
         const hand: Card[] = [
-          land('Forest', 'G'),
-          land('Island', 'U'),
-          land('Plains', 'W'),
-          creature('Grizzly Bears', 2, 'G'),
-          creature('Savannah Lions', 1, 'W'),
-          creature('Air Elemental', 4, 'U'),
-          spell('Lightning Bolt', 1, 'Instant', 'R', 'deals 3 damage'),
+          land("Forest", "G"),
+          land("Island", "U"),
+          land("Plains", "W"),
+          creature("Grizzly Bears", 2, "G"),
+          creature("Savannah Lions", 1, "W"),
+          creature("Air Elemental", 4, "U"),
+          spell("Lightning Bolt", 1, "Instant", "R", "deals 3 damage"),
         ];
 
         const result = analyzeMulligan({ hand });
@@ -237,16 +315,16 @@ describe('mulligan-advisor', () => {
         expect(result.analysis.spellCount).toBe(4);
       });
 
-      it('should detect removal spells', () => {
+      it("should detect removal spells", () => {
         const hand: Card[] = [
-          land('Mountain', 'R'),
-          land('Mountain', 'R'),
-          spell('Lightning Bolt', 1, 'Instant', 'R', 'deals 3 damage'),
-          spell('Murder', 3, 'Instant', 'B', 'destroy target creature'),
-          spell('Shock', 1, 'Instant', 'R', 'deals 2 damage'),
-          creature('Raging Goblin', 1, 'R'),
-          creature('Jackal Pup', 1, 'R'),
-          creature('Goblin Guide', 1, 'R'),
+          land("Mountain", "R"),
+          land("Mountain", "R"),
+          spell("Lightning Bolt", 1, "Instant", "R", "deals 3 damage"),
+          spell("Murder", 3, "Instant", "B", "destroy target creature"),
+          spell("Shock", 1, "Instant", "R", "deals 2 damage"),
+          creature("Raging Goblin", 1, "R"),
+          creature("Jackal Pup", 1, "R"),
+          creature("Goblin Guide", 1, "R"),
         ];
 
         const result = analyzeMulligan({ hand });
@@ -254,32 +332,38 @@ describe('mulligan-advisor', () => {
         expect(result.analysis.removalCount).toBeGreaterThanOrEqual(2);
       });
 
-      it('should detect card draw', () => {
+      it("should detect card draw", () => {
         const hand: Card[] = [
-          land('Island', 'U'),
-          land('Island', 'U'),
-          land('Island', 'U'),
-          spell('Divination', 3, 'Sorcery', 'U', 'draw two cards'),
-          spell('Ponder', 1, 'Sorcery', 'U', 'look at the top three cards'),
-          creature('Air Elemental', 4, 'U'),
-          creature('Serra Angel', 5, 'W'),
-          spell('Cancel', 3, 'Instant', 'U', 'counter target spell'),
+          land("Island", "U"),
+          land("Island", "U"),
+          land("Island", "U"),
+          spell("Divination", 3, "Sorcery", "U", "draw two cards"),
+          spell("Ponder", 1, "Sorcery", "U", "look at the top three cards"),
+          creature("Air Elemental", 4, "U"),
+          creature("Serra Angel", 5, "W"),
+          spell("Cancel", 3, "Instant", "U", "counter target spell"),
         ];
 
         const result = analyzeMulligan({ hand });
         expect(result.analysis.hasCardDraw).toBe(true);
       });
 
-      it('should detect ramp', () => {
+      it("should detect ramp", () => {
         const hand: Card[] = [
-          land('Forest', 'G'),
-          land('Forest', 'G'),
-          creature('Llanowar Elves', 1, 'G', 'tap: add G'),
-          spell('Cultivate', 3, 'Sorcery', 'G', 'search your library for a land'),
-          spell('Farseek', 2, 'Sorcery', 'G', 'search your library for a land'),
-          creature('Stampeding Rhino', 4, 'G'),
-          creature('Hill Giant', 4, 'R'),
-          spell('Giant Growth', 1, 'Instant', 'G'),
+          land("Forest", "G"),
+          land("Forest", "G"),
+          creature("Llanowar Elves", 1, "G", "tap: add G"),
+          spell(
+            "Cultivate",
+            3,
+            "Sorcery",
+            "G",
+            "search your library for a land",
+          ),
+          spell("Farseek", 2, "Sorcery", "G", "search your library for a land"),
+          creature("Stampeding Rhino", 4, "G"),
+          creature("Hill Giant", 4, "R"),
+          spell("Giant Growth", 1, "Instant", "G"),
         ];
 
         const result = analyzeMulligan({ hand });
@@ -287,96 +371,111 @@ describe('mulligan-advisor', () => {
       });
     });
 
-    describe('confidence scoring', () => {
-      it('should have reasonable confidence for clear decisions', () => {
+    describe("confidence scoring", () => {
+      it("should have reasonable confidence for clear decisions", () => {
         const clearShip: Card[] = [
-          land('Forest', 'G'),
-          creature('Grizzly Bears', 2, 'G'),
-          creature('Hill Giant', 4, 'R'),
-          creature('Air Elemental', 4, 'U'),
-          creature('Serra Angel', 5, 'W'),
-          creature('Craw Wurm', 6, 'G'),
-          creature('War Mammoth', 3, 'G'),
+          land("Forest", "G"),
+          creature("Grizzly Bears", 2, "G"),
+          creature("Hill Giant", 4, "R"),
+          creature("Air Elemental", 4, "U"),
+          creature("Serra Angel", 5, "W"),
+          creature("Craw Wurm", 6, "G"),
+          creature("War Mammoth", 3, "G"),
         ];
 
         const clearKeep: Card[] = [
-          land('Forest', 'G'),
-          land('Plains', 'W'),
-          land('Mountain', 'R'),
-          creature('Savannah Lions', 1, 'W'),
-          creature('Grizzly Bears', 2, 'G'),
-          spell('Lightning Bolt', 1, 'Instant', 'R', 'deals 3 damage'),
-          creature('Raging Goblin', 1, 'R'),
+          land("Forest", "G"),
+          land("Plains", "W"),
+          land("Mountain", "R"),
+          creature("Savannah Lions", 1, "W"),
+          creature("Grizzly Bears", 2, "G"),
+          spell("Lightning Bolt", 1, "Instant", "R", "deals 3 damage"),
+          creature("Raging Goblin", 1, "R"),
         ];
 
-        const shipResult = analyzeMulligan({ hand: clearShip, format: 'limited' });
-        const keepResult = analyzeMulligan({ hand: clearKeep, format: 'limited' });
+        const shipResult = analyzeMulligan({
+          hand: clearShip,
+          format: "limited",
+        });
+        const keepResult = analyzeMulligan({
+          hand: clearKeep,
+          format: "limited",
+        });
 
-        expect(shipResult.decision).toBe('ship');
-        expect(keepResult.decision).toBe('keep');
+        expect(shipResult.decision).toBe("ship");
+        expect(keepResult.decision).toBe("keep");
       });
     });
 
-    describe('color consistency', () => {
-      it('should penalize 3+ color hands in limited', () => {
+    describe("color consistency", () => {
+      it("should penalize 3+ color hands in limited", () => {
         const fiveColorHand: Card[] = [
-          land('Forest', 'G'),
-          land('Island', 'U'),
-          land('Mountain', 'R'),
-          land('Swamp', 'B'),
-          land('Plains', 'W'),
-          creature('Grizzly Bears', 2, 'G'),
-          spell('Cancel', 3, 'Instant', 'U', 'counter target spell'),
+          land("Forest", "G"),
+          land("Island", "U"),
+          land("Mountain", "R"),
+          land("Swamp", "B"),
+          land("Plains", "W"),
+          creature("Grizzly Bears", 2, "G"),
+          spell("Cancel", 3, "Instant", "U", "counter target spell"),
         ];
 
-        const result = analyzeMulligan({ hand: fiveColorHand, format: 'limited' });
+        const result = analyzeMulligan({
+          hand: fiveColorHand,
+          format: "limited",
+        });
         expect(result.handQualityScore).toBeLessThan(50);
       });
 
-      it('should be more lenient with colors in constructed', () => {
+      it("should be more lenient with colors in constructed", () => {
         const threeColorHand: Card[] = [
-          land('Temple Garden', ''),
-          land('Sacred Foundry', ''),
-          land('Steam Vents', ''),
-          creature('Savannah Lions', 1, 'W'),
-          creature('Grizzly Bears', 2, 'G'),
-          creature('Snapcaster Mage', 2, 'U'),
-          spell('Lightning Helix', 2, 'Instant', 'R', 'deals 3 damage'),
+          land("Temple Garden", ""),
+          land("Sacred Foundry", ""),
+          land("Steam Vents", ""),
+          creature("Savannah Lions", 1, "W"),
+          creature("Grizzly Bears", 2, "G"),
+          creature("Snapcaster Mage", 2, "U"),
+          spell("Lightning Helix", 2, "Instant", "R", "deals 3 damage"),
         ];
 
-        const result = analyzeMulligan({ hand: threeColorHand, format: 'constructed' });
+        const result = analyzeMulligan({
+          hand: threeColorHand,
+          format: "constructed",
+        });
         expect(result.handQualityScore).toBeGreaterThanOrEqual(35);
       });
     });
 
-    describe('constructed vs limited thresholds', () => {
-      it('should have lower threshold for constructed mulligans', () => {
+    describe("constructed vs limited thresholds", () => {
+      it("should have lower threshold for constructed mulligans", () => {
         const twoLandHighCurve: Card[] = [
-          land('Mountain', 'R'),
-          land('Swamp', 'B'),
-          creature('Glory Seeker', 2, 'W'),
-          spell('Terminate', 2, 'Instant', 'B', 'destroy target creature'),
-          spell('Damnation', 4, 'Sorcery', 'B', 'destroy all creatures'),
-          creature('Grave Titan', 6, 'B'),
-          spell('Sign in Blood', 2, 'Sorcery', 'B', 'draw two cards'),
+          land("Mountain", "R"),
+          land("Swamp", "B"),
+          creature("Glory Seeker", 2, "W"),
+          spell("Terminate", 2, "Instant", "B", "destroy target creature"),
+          spell("Damnation", 4, "Sorcery", "B", "destroy all creatures"),
+          creature("Grave Titan", 6, "B"),
+          spell("Sign in Blood", 2, "Sorcery", "B", "draw two cards"),
         ];
 
-        const constructedResult = analyzeMulligan({ hand: twoLandHighCurve, format: 'constructed' });
+        const constructedResult = analyzeMulligan({
+          hand: twoLandHighCurve,
+          format: "constructed",
+        });
         expect(constructedResult.handQualityScore).toBeGreaterThanOrEqual(30);
       });
     });
   });
 
-  describe('getMatchingExpertRecords', () => {
-    it('should return 0-land records for 0-land hands', () => {
+  describe("getMatchingExpertRecords", () => {
+    it("should return 0-land records for 0-land hands", () => {
       const hand: Card[] = [
-        creature('Grizzly Bears', 2, 'G'),
-        creature('Savannah Lions', 1, 'W'),
-        creature('Hill Giant', 4, 'R'),
-        creature('Serra Angel', 5, 'W'),
-        creature('War Mammoth', 3, 'G'),
-        creature('Air Elemental', 4, 'U'),
-        spell('Lightning Bolt', 1, 'Instant', 'R', 'deals 3 damage'),
+        creature("Grizzly Bears", 2, "G"),
+        creature("Savannah Lions", 1, "W"),
+        creature("Hill Giant", 4, "R"),
+        creature("Serra Angel", 5, "W"),
+        creature("War Mammoth", 3, "G"),
+        creature("Air Elemental", 4, "U"),
+        spell("Lightning Bolt", 1, "Instant", "R", "deals 3 damage"),
       ];
 
       const analysis = {
@@ -396,10 +495,10 @@ describe('mulligan-advisor', () => {
 
       const records = getMatchingExpertRecords(analysis);
       expect(records.length).toBeGreaterThan(0);
-      expect(records[0].handComposition).toBe('0-land');
+      expect(records[0].handComposition).toBe("0-land");
     });
 
-    it('should filter by format', () => {
+    it("should filter by format", () => {
       const analysis = {
         landCount: 0,
         spellCount: 7,
@@ -415,8 +514,16 @@ describe('mulligan-advisor', () => {
         hasLands: false,
       };
 
-      const constructedRecords = getMatchingExpertRecords(analysis, undefined, 'constructed');
-      const limitedRecords = getMatchingExpertRecords(analysis, undefined, 'limited');
+      const constructedRecords = getMatchingExpertRecords(
+        analysis,
+        undefined,
+        "constructed",
+      );
+      const limitedRecords = getMatchingExpertRecords(
+        analysis,
+        undefined,
+        "limited",
+      );
 
       expect(constructedRecords.length).toBeGreaterThan(0);
       expect(limitedRecords.length).toBeGreaterThan(0);
@@ -424,3 +531,337 @@ describe('mulligan-advisor', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Issue #1063 — difficulty-scaled opponent mulligan decisions.
+// ---------------------------------------------------------------------------
+
+const TIERS: DifficultyLevel[] = ["easy", "medium", "hard", "expert"];
+const FORMATS: DifficultyFormat[] = ["limited", "constructed", "commander"];
+
+/** Deterministic seeded PRNG so per-tier blunder statistics are reproducible. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// A hand the expert engine clearly KEEPS (3 lands + smooth 1-2 curve). The
+// existing `analyzeMulligan` confidence test asserts this exact hand is 'keep'.
+function clearKeepHand(): Card[] {
+  return [
+    land("Forest", "G"),
+    land("Plains", "W"),
+    land("Mountain", "R"),
+    creature("Savannah Lions", 1, "W"),
+    creature("Grizzly Bears", 2, "G"),
+    spell("Lightning Bolt", 1, "Instant", "R", "deals 3 damage"),
+    creature("Raging Goblin", 1, "R"),
+  ];
+}
+
+// A hand the expert engine clearly SHIPS (zero lands — cannot cast anything).
+function clearShipHand(): Card[] {
+  return [
+    creature("Grizzly Bears", 2, "G"),
+    creature("Hill Giant", 4, "R"),
+    creature("Air Elemental", 4, "U"),
+    creature("Serra Angel", 5, "W"),
+    creature("Craw Wurm", 6, "G"),
+    creature("War Mammoth", 3, "G"),
+    spell("Lightning Bolt", 1, "Instant", "R", "deals 3 damage"),
+  ];
+}
+
+describe("DIFFICULTY_MULLIGAN_SCALING (issue #1063)", () => {
+  it("is keyed over the canonical 4-tier taxonomy", () => {
+    for (const tier of TIERS) {
+      expect(DIFFICULTY_MULLIGAN_SCALING[tier]).toBeDefined();
+      expect(getDifficultyMulliganScaling(tier)).toBe(
+        DIFFICULTY_MULLIGAN_SCALING[tier],
+      );
+    }
+  });
+
+  it("blunderChance is monotonic DECREASING in skill (easy worst, expert best)", () => {
+    const chances = TIERS.map(
+      (t) => DIFFICULTY_MULLIGAN_SCALING[t].blunderChance,
+    );
+    for (let i = 0; i < chances.length - 1; i++) {
+      expect(chances[i]).toBeGreaterThan(chances[i + 1]);
+    }
+    // Bounded to [0, 1].
+    for (const c of chances) {
+      expect(c).toBeGreaterThanOrEqual(0);
+      expect(c).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe("resolveMulliganScaling (issue #1063, per-format composition)", () => {
+  it("returns the base scaling when no format is supplied", () => {
+    for (const tier of TIERS) {
+      expect(resolveMulliganScaling(tier)).toEqual(
+        DIFFICULTY_MULLIGAN_SCALING[tier],
+      );
+    }
+  });
+
+  it("preserves the tier ordering for every format family (no format inversion)", () => {
+    for (const fmt of FORMATS) {
+      const chances = TIERS.map(
+        (t) => resolveMulliganScaling(t, fmt).blunderChance,
+      );
+      for (let i = 0; i < chances.length - 1; i++) {
+        expect(chances[i]).toBeGreaterThanOrEqual(chances[i + 1]);
+      }
+    }
+  });
+
+  it("composes with the per-format blunderChance ratio (bounded, smooth)", () => {
+    // The current FORMAT_DIFFICULTY_OVERRIDES do not change blunderChance, so
+    // the resolved mulligan blunderChance equals the base. This asserts the
+    // composition contract: it tracks the resolved difficulty blunderChance
+    // ratio without drifting from the base when the ratio is 1.
+    for (const tier of TIERS) {
+      for (const fmt of FORMATS) {
+        const resolved = resolveMulliganScaling(tier, fmt).blunderChance;
+        const base = DIFFICULTY_MULLIGAN_SCALING[tier].blunderChance;
+        expect(resolved).toBeGreaterThanOrEqual(0);
+        expect(resolved).toBeLessThanOrEqual(1);
+        // With no blunderChance overrides present, resolved === base.
+        expect(resolved).toBeCloseTo(base, 10);
+      }
+    }
+  });
+});
+
+describe("decideOpponentMulligan (issue #1063)", () => {
+  it("expert follows the advisor: keeps a good hand, ships a bad hand", () => {
+    const keep = decideOpponentMulligan({
+      hand: clearKeepHand(),
+      difficulty: "expert",
+      format: "limited",
+      rng: () => 0.99, // above expert's 0.02 blunderChance → no blunder
+    });
+    expect(keep.expertDecision).toBe("keep");
+    expect(keep.decision).toBe("keep");
+    expect(keep.blundered).toBe(false);
+
+    const ship = decideOpponentMulligan({
+      hand: clearShipHand(),
+      difficulty: "expert",
+      format: "limited",
+      rng: () => 0.99,
+    });
+    expect(ship.expertDecision).toBe("ship");
+    expect(ship.decision).toBe("ship");
+    expect(ship.blundered).toBe(false);
+  });
+
+  it("the expert read is difficulty-agnostic (only the blunder scales)", () => {
+    // On the identical hand every tier computes the SAME expert decision.
+    const hand = clearKeepHand();
+    const reads = TIERS.map(
+      (t) =>
+        decideOpponentMulligan({
+          hand,
+          difficulty: t,
+          format: "limited",
+          rng: () => 0.99,
+        }).expertDecision,
+    );
+    expect(new Set(reads).size).toBe(1);
+    expect(reads[0]).toBe("keep");
+  });
+
+  it("easy blunders (inverts the expert call) when the roll lands under blunderChance", () => {
+    // roll 0 < easy's 0.45 → blunder inverts keep → ship on a good hand.
+    const keepHandBlundered = decideOpponentMulligan({
+      hand: clearKeepHand(),
+      difficulty: "easy",
+      format: "limited",
+      rng: () => 0,
+    });
+    expect(keepHandBlundered.expertDecision).toBe("keep");
+    expect(keepHandBlundered.decision).toBe("ship");
+    expect(keepHandBlundered.blundered).toBe(true);
+
+    // roll 0 → blunder inverts ship → keep on a bad hand.
+    const shipHandBlundered = decideOpponentMulligan({
+      hand: clearShipHand(),
+      difficulty: "easy",
+      format: "limited",
+      rng: () => 0,
+    });
+    expect(shipHandBlundered.expertDecision).toBe("ship");
+    expect(shipHandBlundered.decision).toBe("keep");
+    expect(shipHandBlundered.blundered).toBe(true);
+  });
+
+  it("never blunders when the roll is above every tier blunderChance", () => {
+    for (const tier of TIERS) {
+      const d = decideOpponentMulligan({
+        hand: clearShipHand(),
+        difficulty: tier,
+        format: "limited",
+        rng: () => 0.99,
+      });
+      expect(d.blundered).toBe(false);
+      expect(d.decision).toBe(d.expertDecision);
+    }
+  });
+
+  it("a mid-range roll blunders easy/medium but not hard/expert", () => {
+    // 0.10 < easy(0.45) and medium(0.18), but > hard(0.07) and expert(0.02).
+    const expectBlunder: Record<DifficultyLevel, boolean> = {
+      easy: true,
+      medium: true,
+      hard: false,
+      expert: false,
+    };
+    for (const tier of TIERS) {
+      const d = decideOpponentMulligan({
+        hand: clearKeepHand(),
+        difficulty: tier,
+        format: "limited",
+        rng: () => 0.1,
+      });
+      expect(d.blundered).toBe(expectBlunder[tier]);
+    }
+  });
+
+  it("ships an empty hand without blundering", () => {
+    const d = decideOpponentMulligan({
+      hand: [],
+      difficulty: "easy",
+      format: "limited",
+      rng: () => 0,
+    });
+    expect(d.decision).toBe("ship");
+    expect(d.blundered).toBe(false);
+  });
+
+  // ---- Headline acceptance: per-difficulty decision quality + monotonicity ----
+
+  it("on identical bad hands, Easy keeps (blunders) more often than Expert", () => {
+    const N = 200;
+    const hand = clearShipHand(); // expert ships; a blunder keeps the bad hand
+    const keepCounts = TIERS.map((tier) => {
+      const rng = mulberry32(20240626); // identical stream per tier
+      let keeps = 0;
+      for (let i = 0; i < N; i++) {
+        if (
+          decideOpponentMulligan({
+            hand,
+            difficulty: tier,
+            format: "limited",
+            rng,
+          }).decision === "keep"
+        ) {
+          keeps++;
+        }
+      }
+      return keeps;
+    });
+
+    // Easy keeps the bad hand far more often than Expert.
+    expect(keepCounts[0]).toBeGreaterThan(keepCounts[3]);
+    // Strong separation: Easy blunders ~45% (its blunderChance), Expert ~2%.
+    expect(keepCounts[0]).toBeGreaterThan(N * 0.3);
+    expect(keepCounts[3]).toBeLessThan(N * 0.1);
+  });
+
+  it("on identical good hands, Easy ships (blunders) more often than Expert", () => {
+    const N = 200;
+    const hand = clearKeepHand(); // expert keeps; a blunder ships the good hand
+    const shipCounts = TIERS.map((tier) => {
+      const rng = mulberry32(98765);
+      let ships = 0;
+      for (let i = 0; i < N; i++) {
+        if (
+          decideOpponentMulligan({
+            hand,
+            difficulty: tier,
+            format: "limited",
+            rng,
+          }).decision === "ship"
+        ) {
+          ships++;
+        }
+      }
+      return ships;
+    });
+
+    expect(shipCounts[0]).toBeGreaterThan(shipCounts[3]);
+    // Strong separation: Easy blunders ~45%, Expert ~2%.
+    expect(shipCounts[0]).toBeGreaterThan(N * 0.3);
+    expect(shipCounts[3]).toBeLessThan(N * 0.1);
+  });
+
+  it("blunder rate is monotonic in skill over an identical rng stream", () => {
+    const N = 300;
+    const hand = clearShipHand();
+    const blundersByTier = TIERS.map((tier) => {
+      const rng = mulberry32(424242);
+      let b = 0;
+      for (let i = 0; i < N; i++) {
+        if (
+          decideOpponentMulligan({
+            hand,
+            difficulty: tier,
+            format: "limited",
+            rng,
+          }).blundered
+        ) {
+          b++;
+        }
+      }
+      return b;
+    });
+
+    // easy >= medium >= hard >= expert
+    for (let i = 0; i < blundersByTier.length - 1; i++) {
+      expect(blundersByTier[i]).toBeGreaterThanOrEqual(blundersByTier[i + 1]);
+    }
+    expect(blundersByTier[0]).toBeGreaterThan(blundersByTier[3]);
+  });
+
+  it("relaxes the keep bar for smaller post-mulligan hands (bounded)", () => {
+    // A zero-land 6-card hand is still unkeepable — relief never rescues garbage.
+    const zeroLandSix: Card[] = clearShipHand().slice(0, 6);
+    const d = decideOpponentMulligan({
+      hand: zeroLandSix,
+      difficulty: "expert",
+      format: "limited",
+      rng: () => 0.99,
+    });
+    expect(d.expertDecision).toBe("ship");
+    expect(d.decision).toBe("ship");
+
+    // A reasonable 6-card hand (2 lands + a low curve) IS kept under the
+    // relaxed 6-card bar (>= 33) where it would be far closer to the 7-card
+    // bar (>= 40). The relaxation keeps post-mulligan hands playable.
+    const playableSix: Card[] = [
+      land("Plains", "W"),
+      land("Mountain", "R"),
+      creature("Savannah Lions", 1, "W"),
+      creature("Grizzly Bears", 2, "G"),
+      spell("Lightning Bolt", 1, "Instant", "R", "deals 3 damage"),
+      creature("Raging Goblin", 1, "R"),
+    ];
+    const kept = decideOpponentMulligan({
+      hand: playableSix,
+      difficulty: "expert",
+      format: "limited",
+      rng: () => 0.99,
+    });
+    expect(kept.handQualityScore).toBeGreaterThanOrEqual(33);
+    expect(kept.expertDecision).toBe("keep");
+    expect(kept.decision).toBe("keep");
+  });
+});

--- a/src/ai/ai-action-executor.ts
+++ b/src/ai/ai-action-executor.ts
@@ -30,6 +30,11 @@ import {
   untapCardAction,
 } from "@/lib/game-state/keyword-actions";
 import { passPriority } from "@/lib/game-state/game-state";
+import {
+  moveCardBetweenZones,
+  shuffleZone,
+  drawCards,
+} from "@/lib/game-state/zones";
 import { quickScore } from "./game-state-evaluator";
 import type { GameState } from "./game-state-evaluator";
 
@@ -699,4 +704,98 @@ export async function evaluateLookahead(
   // For depth === 1, just evaluate the resulting state
   const aiState = getAIGameState(result.newState);
   return quickScore(aiState as unknown as GameState, playerId, "medium");
+}
+
+// ---------------------------------------------------------------------------
+// Issue #1063 — opponent opening-hand mulligan mechanics.
+//
+// The engine's `"mulligan"` ActionType is an event/log descriptor, not a full
+// mechanic, so the opponent turn loop needs a dedicated executor that performs
+// the actual card movement: ship the current hand back into the library,
+// shuffle, and draw one fewer card. This keeps the mechanical action in the
+// executor module alongside every other engine action the AI performs.
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of mechanically executing one opponent mulligan.
+ */
+export interface OpponentMulliganResult {
+  success: boolean;
+  state: EngineGameState;
+  /** Hand size before the mulligan. */
+  fromHandSize: number;
+  /** Hand size after the mulligan (expected `fromHandSize - 1`). */
+  toHandSize: number;
+  error?: string;
+}
+
+/**
+ * Mechanically execute a single mulligan for the AI opponent: return the
+ * current hand to the library, shuffle, and draw one fewer card (issue #1063).
+ *
+ * This is the action half of the keep/ship decision made by
+ * {@link decideOpponentMulligan}; the decision/wiring lives in the turn loop.
+ * The function is a pure-ish state transform (it only shuffles, using
+ * `Math.random`) and never throws — degenerate states produce a failed result
+ * the caller can skip. It does not route through {@link executeAIAction}'s
+ * switch because `"mulligan"` is an event/log type there, not an AI action.
+ */
+export function executeOpponentMulligan(
+  state: EngineGameState,
+  playerId: PlayerId,
+): OpponentMulliganResult {
+  const handKey = `${playerId}-hand`;
+  const libraryKey = `${playerId}-library`;
+  const zones = new Map(state.zones);
+  const handZone = zones.get(handKey);
+  const libraryZone = zones.get(libraryKey);
+
+  if (!handZone || !libraryZone) {
+    return {
+      success: false,
+      state,
+      fromHandSize: handZone?.cardIds.length ?? 0,
+      toHandSize: handZone?.cardIds.length ?? 0,
+      error: `Missing ${playerId} hand or library zone`,
+    };
+  }
+
+  const fromHandSize = handZone.cardIds.length;
+  if (fromHandSize <= 0) {
+    return { success: true, state, fromHandSize: 0, toHandSize: 0 };
+  }
+
+  // 1) Put every hand card back into the library.
+  let hand = handZone;
+  let library = libraryZone;
+  for (const cardId of [...hand.cardIds]) {
+    const moved = moveCardBetweenZones(hand, library, cardId);
+    hand = moved.from;
+    library = moved.to;
+  }
+
+  // 2) Shuffle the library so the redraw is randomized.
+  library = shuffleZone(library);
+
+  // 3) Draw one fewer card than we shipped.
+  const toDraw = Math.max(0, fromHandSize - 1);
+  const drawn = drawCards(library, hand, toDraw);
+  library = drawn.library;
+  hand = drawn.hand;
+
+  zones.set(handKey, hand);
+  zones.set(libraryKey, library);
+
+  const newState: EngineGameState = {
+    ...state,
+    zones,
+    lastModifiedAt: Date.now(),
+  };
+
+  return {
+    success: true,
+    state: newState,
+    fromHandSize,
+    toHandSize: hand.cardIds.length,
+  };
 }

--- a/src/ai/ai-turn-loop.ts
+++ b/src/ai/ai-turn-loop.ts
@@ -17,10 +17,16 @@ import type {
 import { Phase } from "@/lib/game-state/types";
 import {
   executeAIAction,
+  executeOpponentMulligan,
   type AIAction,
   getAvailableAttackers,
   getAIGameState,
 } from "./ai-action-executor";
+import {
+  decideOpponentMulligan,
+  type OpponentMulliganDecision,
+  type Card,
+} from "./mulligan-advisor";
 import {
   getDifficultyConfig,
   resolveDifficultyConfig,
@@ -30,7 +36,7 @@ import {
 import { advancePhase } from "@/lib/game-state/turn-phases";
 import { drawCard } from "@/lib/game-state/game-state";
 import { engineToAIState } from "@/lib/game-state/serialization";
-import { getMaxHandSize } from "@/lib/game-rules";
+import { getMaxHandSize, getMulliganRules } from "@/lib/game-rules";
 import { discardCards } from "@/lib/game-state/keyword-actions";
 import {
   classifyArchetypeName,
@@ -168,10 +174,7 @@ const clampMult = (v: number): number =>
  *   previous value (deadband, kills micro-oscillation).
  * - Otherwise move a `(1 - ADAPTIVE_SMOOTHING)` fraction toward the target.
  */
-function smoothMultiplier(
-  prev: number | undefined,
-  target: number,
-): number {
+function smoothMultiplier(prev: number | undefined, target: number): number {
   if (prev === undefined) return target;
   if (Math.abs(target - prev) < ADAPTIVE_DEADBAND) return prev;
   return prev + (target - prev) * (1 - ADAPTIVE_SMOOTHING);
@@ -199,7 +202,10 @@ export function computeAdaptiveTempoRisk(
   // Standing (who is ahead) dominates; momentum amplifies it.
   const pressure = Math.max(
     -1,
-    Math.min(1, -(swing.normalizedAdvantage * 0.7 + swing.normalizedDelta * 0.3)),
+    Math.min(
+      1,
+      -(swing.normalizedAdvantage * 0.7 + swing.normalizedDelta * 0.3),
+    ),
   );
 
   // Risk reaches slightly further than tempo when digging out (commit harder),
@@ -396,6 +402,152 @@ function advanceToNextPhase(
     priorityPlayerId: aiPlayerId,
     lastModifiedAt: Date.now(),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Issue #1063 — opponent opening-hand mulligan, wired into the game-start path.
+//
+// Mulliganing happens before turn 1 (and after every mulligan), so it lives in
+// this module as a dedicated game-start step the orchestrator runs before the
+// first {@link runAITurn}. Each iteration evaluates the current hand with the
+// difficulty-scaled {@link decideOpponentMulligan}: a "keep" ends the loop; a
+// "ship" is executed mechanically ({@link executeOpponentMulligan}) and the
+// smaller hand is re-evaluated, exactly as the issue specifies.
+// ---------------------------------------------------------------------------
+
+/**
+ * One step of the opening-hand mulligan loop.
+ */
+export interface OpeningMulliganDecisionStep {
+  /** Hand size evaluated at this step. */
+  handSizeBefore: number;
+  /** The difficulty-scaled keep/ship decision (absent on a forced floor keep). */
+  decision?: OpponentMulliganDecision;
+  /** True when the loop stopped because the hand reached the keep-floor. */
+  forcedKeep?: boolean;
+}
+
+/**
+ * Result of the opponent's opening-hand mulligan sequence.
+ */
+export interface OpeningMulliganResult {
+  success: boolean;
+  state: EngineGameState;
+  /** Number of mulligans taken (0 = kept the opener). */
+  mulligansTaken: number;
+  /** One entry per hand evaluated, in order (the last is the keep). */
+  decisions: OpeningMulliganDecisionStep[];
+  /** Final opening hand size after all mulligans. */
+  finalHandSize: number;
+  error?: string;
+}
+
+/**
+ * Hard floor below which the opponent always keeps. Real players almost never
+ * mulligan below this; it also guarantees the loop terminates even if a
+ * degenerate hand kept scoring "ship".
+ */
+const MIN_KEEP_HAND_SIZE = 3;
+
+/**
+ * Pull the AI opponent's current hand out of the engine state as advisor
+ * {@link Card}s (the advisor reads the same fields the engine stores on
+ * `cardData`). Returns an empty array when the hand zone is missing.
+ */
+function extractOpponentHand(
+  state: EngineGameState,
+  playerId: PlayerId,
+): Card[] {
+  const handZone = state.zones.get(`${playerId}-hand`);
+  if (!handZone) return [];
+  const hand: Card[] = [];
+  for (const cardId of handZone.cardIds) {
+    const inst = state.cards.get(cardId);
+    if (inst?.cardData) hand.push(inst.cardData as unknown as Card);
+  }
+  return hand;
+}
+
+/**
+ * Run the AI opponent's opening-hand mulligan sequence (issue #1063).
+ *
+ * Invoked at game start (before turn 1) and after every mulligan: the current
+ * hand is evaluated by the difficulty-scaled {@link decideOpponentMulligan};
+ * a "keep" ends the loop, a "ship" is executed mechanically and the new,
+ * smaller hand is re-evaluated. Decision quality therefore scales by
+ * difficulty — Expert keeps/ships near-optimally while Easy blunders (keeping
+ * bad hands / shipping good ones) at a higher rate.
+ *
+ * The loop always terminates: the keep bar relaxes for smaller hands (see
+ * {@link decideOpponentMulligan}), a hard floor forces a keep, and a step cap
+ * guards against any degenerate cycle.
+ *
+ * @param rng Optional deterministic randomness source for the blunder rolls,
+ *   forwarded to {@link decideOpponentMulligan}. Defaults to `Math.random`.
+ */
+export async function runOpeningHandMulligan(
+  gameState: EngineGameState,
+  aiPlayerId: PlayerId,
+  config: AITurnConfig,
+  rng: () => number = Math.random,
+): Promise<OpeningMulliganResult> {
+  const decisions: OpeningMulliganDecisionStep[] = [];
+  let state = gameState;
+  let mulligansTaken = 0;
+
+  const minHandSize = getMulliganRules().minHandSize;
+  const floor = Math.max(minHandSize ?? 0, MIN_KEEP_HAND_SIZE);
+  const archetypeName = config.archetype;
+
+  // Step cap is a safety net only — the relaxing threshold + floor already
+  // guarantee termination.
+  for (let step = 0; step < 8; step++) {
+    const hand = extractOpponentHand(state, aiPlayerId);
+    const handSizeBefore = hand.length;
+
+    if (handSizeBefore <= floor) {
+      decisions.push({ handSizeBefore, forcedKeep: true });
+      break;
+    }
+
+    const decision = decideOpponentMulligan({
+      hand,
+      archetype: archetypeName,
+      difficulty: config.difficulty,
+      format: config.format,
+      onThePlay: true,
+      gameNumber: 1,
+      rng,
+    });
+    decisions.push({ handSizeBefore, decision });
+
+    config.onCommentary?.(
+      decision.decision === "keep"
+        ? `Keeps opening hand (${handSizeBefore})`
+        : `Mulligans to ${handSizeBefore - 1}`,
+    );
+
+    if (decision.decision === "keep") break;
+
+    const res = executeOpponentMulligan(state, aiPlayerId);
+    if (!res.success || !res.state) {
+      return {
+        success: false,
+        state,
+        mulligansTaken,
+        decisions,
+        finalHandSize: handSizeBefore,
+        error: res.error,
+      };
+    }
+    state = res.state;
+    mulligansTaken++;
+  }
+
+  const finalHandZone = state.zones.get(`${aiPlayerId}-hand`);
+  const finalHandSize = finalHandZone?.cardIds.length ?? 0;
+
+  return { success: true, state, mulligansTaken, decisions, finalHandSize };
 }
 
 /**

--- a/src/ai/mulligan-advisor.ts
+++ b/src/ai/mulligan-advisor.ts
@@ -7,20 +7,26 @@
  * archetype-aware weighting.
  */
 
-import type { Card } from './types';
+import type { Card } from "./types";
 export type { Card };
+import {
+  DIFFICULTY_CONFIGS,
+  resolveDifficultyConfig,
+  type DifficultyFormat,
+  type DifficultyLevel,
+} from "./ai-difficulty";
 
-export type MulliganDecision = 'keep' | 'ship';
+export type MulliganDecision = "keep" | "ship";
 
 export type ArchetypeCategory =
-  | 'aggro'
-  | 'control'
-  | 'midrange'
-  | 'combo'
-  | 'tribal'
-  | 'special';
+  | "aggro"
+  | "control"
+  | "midrange"
+  | "combo"
+  | "tribal"
+  | "special";
 
-export type GameFormat = 'limited' | 'constructed' | '*';
+export type GameFormat = "limited" | "constructed" | "*";
 
 export interface MulliganInput {
   hand: Card[];
@@ -64,86 +70,544 @@ export interface ExpertKeepShipRecord {
 
 const KEEP_SHIP_DATABASE: ExpertKeepShipRecord[] = [
   // === LAND COUNT RULES (Universal) ===
-  { handComposition: '0-land', archetype: '*', format: 'limited', gameNumber: 1, decision: 'ship', reason: 'Zero lands means you cannot play any spells. Ship and hope for a land in the top 6.' },
-  { handComposition: '0-land', archetype: '*', format: 'constructed', gameNumber: 1, decision: 'ship', reason: 'Zero lands is unkeepable in any format.' },
-  { handComposition: '1-land-bomb', archetype: 'aggro', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'Aggressive decks can keep 1-lander if it has cheap threats and the land produces the right color for early plays.' },
-  { handComposition: '1-land-bomb', archetype: 'aggro', format: 'constructed', gameNumber: 1, decision: 'keep', reason: 'Constructed aggro with a 1-drop and a land that casts it is a fine keep on the play.' },
-  { handComposition: '1-land-no-action', archetype: 'control', format: 'limited', gameNumber: 1, decision: 'ship', reason: 'Control needs to hit land drops consistently. One land with no early action spells is a mulligan.' },
-  { handComposition: '1-land-no-action', archetype: 'control', format: 'limited', gameNumber: 2, decision: 'ship', reason: 'Even on the draw, control decks cannot afford to miss land drops.' },
-  { handComposition: '1-land-no-action', archetype: 'control', format: 'constructed', gameNumber: 1, decision: 'ship', reason: 'Constructed control with 1 land and no cheap interaction is unkeepable.' },
-  { handComposition: '2-land-curve', archetype: '*', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'Two lands with a reasonable curve (spells at 2-3-4 CMC) is a fine keep in limited.' },
-  { handComposition: '2-land-curve', archetype: '*', format: 'limited', gameNumber: 2, decision: 'keep', reason: 'Two lands with a curve is acceptable on the draw.' },
-  { handComposition: '2-land-high-curve', archetype: '*', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'Two lands with only 4+ CMC spells is risky. Keep only if the cards are individually very powerful.' },
-  { handComposition: '5-land-few-spells', archetype: '*', format: 'limited', gameNumber: 1, decision: 'ship', reason: 'Five lands and only two spells is land-flooded. Ship to find more action.' },
-  { handComposition: '5-land-few-spells', archetype: 'control', format: 'constructed', gameNumber: 1, decision: 'ship', reason: 'Even control decks need more than two action spells. This is land-flooded.' },
-  { handComposition: '6-land', archetype: '*', format: 'limited', gameNumber: 1, decision: 'ship', reason: 'Six or more lands in a 7-card hand is always a mulligan. You need action.' },
-  { handComposition: '7-land', archetype: '*', format: '*', gameNumber: 1, decision: 'ship', reason: 'All lands is an automatic mulligan.' },
-  { handComposition: '3-land-curve', archetype: '*', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'Three lands with a good curve is the ideal opening hand in limited.' },
-  { handComposition: '3-land-curve', archetype: '*', format: 'constructed', gameNumber: 1, decision: 'keep', reason: 'Three lands with curve is generally a keep in constructed too.' },
-  { handComposition: '4-land-curve', archetype: '*', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'Four lands is on the edge but fine if you have enough action spells at different CMCs.' },
-  { handComposition: '4-land-few-spells', archetype: 'aggro', format: 'limited', gameNumber: 1, decision: 'ship', reason: 'Aggressive decks cannot afford to flood on lands. Too few threats.' },
+  {
+    handComposition: "0-land",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 1,
+    decision: "ship",
+    reason:
+      "Zero lands means you cannot play any spells. Ship and hope for a land in the top 6.",
+  },
+  {
+    handComposition: "0-land",
+    archetype: "*",
+    format: "constructed",
+    gameNumber: 1,
+    decision: "ship",
+    reason: "Zero lands is unkeepable in any format.",
+  },
+  {
+    handComposition: "1-land-bomb",
+    archetype: "aggro",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Aggressive decks can keep 1-lander if it has cheap threats and the land produces the right color for early plays.",
+  },
+  {
+    handComposition: "1-land-bomb",
+    archetype: "aggro",
+    format: "constructed",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Constructed aggro with a 1-drop and a land that casts it is a fine keep on the play.",
+  },
+  {
+    handComposition: "1-land-no-action",
+    archetype: "control",
+    format: "limited",
+    gameNumber: 1,
+    decision: "ship",
+    reason:
+      "Control needs to hit land drops consistently. One land with no early action spells is a mulligan.",
+  },
+  {
+    handComposition: "1-land-no-action",
+    archetype: "control",
+    format: "limited",
+    gameNumber: 2,
+    decision: "ship",
+    reason: "Even on the draw, control decks cannot afford to miss land drops.",
+  },
+  {
+    handComposition: "1-land-no-action",
+    archetype: "control",
+    format: "constructed",
+    gameNumber: 1,
+    decision: "ship",
+    reason:
+      "Constructed control with 1 land and no cheap interaction is unkeepable.",
+  },
+  {
+    handComposition: "2-land-curve",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Two lands with a reasonable curve (spells at 2-3-4 CMC) is a fine keep in limited.",
+  },
+  {
+    handComposition: "2-land-curve",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 2,
+    decision: "keep",
+    reason: "Two lands with a curve is acceptable on the draw.",
+  },
+  {
+    handComposition: "2-land-high-curve",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Two lands with only 4+ CMC spells is risky. Keep only if the cards are individually very powerful.",
+  },
+  {
+    handComposition: "5-land-few-spells",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 1,
+    decision: "ship",
+    reason:
+      "Five lands and only two spells is land-flooded. Ship to find more action.",
+  },
+  {
+    handComposition: "5-land-few-spells",
+    archetype: "control",
+    format: "constructed",
+    gameNumber: 1,
+    decision: "ship",
+    reason:
+      "Even control decks need more than two action spells. This is land-flooded.",
+  },
+  {
+    handComposition: "6-land",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 1,
+    decision: "ship",
+    reason:
+      "Six or more lands in a 7-card hand is always a mulligan. You need action.",
+  },
+  {
+    handComposition: "7-land",
+    archetype: "*",
+    format: "*",
+    gameNumber: 1,
+    decision: "ship",
+    reason: "All lands is an automatic mulligan.",
+  },
+  {
+    handComposition: "3-land-curve",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Three lands with a good curve is the ideal opening hand in limited.",
+  },
+  {
+    handComposition: "3-land-curve",
+    archetype: "*",
+    format: "constructed",
+    gameNumber: 1,
+    decision: "keep",
+    reason: "Three lands with curve is generally a keep in constructed too.",
+  },
+  {
+    handComposition: "4-land-curve",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Four lands is on the edge but fine if you have enough action spells at different CMCs.",
+  },
+  {
+    handComposition: "4-land-few-spells",
+    archetype: "aggro",
+    format: "limited",
+    gameNumber: 1,
+    decision: "ship",
+    reason:
+      "Aggressive decks cannot afford to flood on lands. Too few threats.",
+  },
 
   // === AGGRO SPECIFIC ===
-  { handComposition: 'aggro-fast-start', archetype: 'aggro', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'Aggro hands with 1-2 drop creatures and 2 lands are ideal keeps. Speed is king.' },
-  { handComposition: 'aggro-slow-hand', archetype: 'aggro', format: 'limited', gameNumber: 1, decision: 'ship', reason: 'Aggro hands with only 4+ CMC creatures are too slow. Ship to find early pressure.' },
-  { handComposition: 'aggro-no-1-drop', archetype: 'aggro', format: 'constructed', gameNumber: 1, decision: 'ship', reason: 'Constructed aggro without a 1-drop on the play is often a mulligan. You need early pressure.' },
-  { handComposition: 'aggro-no-1-drop', archetype: 'aggro', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'In limited, aggro decks may not have enough 1-drops to require them. A strong 2-3 curve is acceptable.' },
-  { handComposition: 'aggro-no-1-drop', archetype: 'aggro', format: 'limited', gameNumber: 2, decision: 'keep', reason: 'On the draw, a 2-3 curve aggro hand is perfectly fine in limited.' },
-  { handComposition: 'aggro-burn-heavy', archetype: 'burn', format: 'constructed', gameNumber: 1, decision: 'keep', reason: 'Burn decks keep hands with 2-3 burn spells and 1-2 lands. Curve is less important than raw damage output.' },
-  { handComposition: 'aggro-1-land-2drop', archetype: 'aggro', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'One land with a 2-drop and a 3-drop on the play is a reasonable aggro keep in limited.' },
+  {
+    handComposition: "aggro-fast-start",
+    archetype: "aggro",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Aggro hands with 1-2 drop creatures and 2 lands are ideal keeps. Speed is king.",
+  },
+  {
+    handComposition: "aggro-slow-hand",
+    archetype: "aggro",
+    format: "limited",
+    gameNumber: 1,
+    decision: "ship",
+    reason:
+      "Aggro hands with only 4+ CMC creatures are too slow. Ship to find early pressure.",
+  },
+  {
+    handComposition: "aggro-no-1-drop",
+    archetype: "aggro",
+    format: "constructed",
+    gameNumber: 1,
+    decision: "ship",
+    reason:
+      "Constructed aggro without a 1-drop on the play is often a mulligan. You need early pressure.",
+  },
+  {
+    handComposition: "aggro-no-1-drop",
+    archetype: "aggro",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "In limited, aggro decks may not have enough 1-drops to require them. A strong 2-3 curve is acceptable.",
+  },
+  {
+    handComposition: "aggro-no-1-drop",
+    archetype: "aggro",
+    format: "limited",
+    gameNumber: 2,
+    decision: "keep",
+    reason: "On the draw, a 2-3 curve aggro hand is perfectly fine in limited.",
+  },
+  {
+    handComposition: "aggro-burn-heavy",
+    archetype: "burn",
+    format: "constructed",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Burn decks keep hands with 2-3 burn spells and 1-2 lands. Curve is less important than raw damage output.",
+  },
+  {
+    handComposition: "aggro-1-land-2drop",
+    archetype: "aggro",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "One land with a 2-drop and a 3-drop on the play is a reasonable aggro keep in limited.",
+  },
 
   // === CONTROL SPECIFIC ===
-  { handComposition: 'control-removal-heavy', archetype: 'control', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'Control hands with removal and a solid land base are fine. Early interaction is key.' },
-  { handComposition: 'control-no-early-action', archetype: 'control', format: 'limited', gameNumber: 1, decision: 'ship', reason: 'Control with only 5+ CMC spells and 2-3 lands cannot interact early. Ship to find removal or counters.' },
-  { handComposition: 'control-no-early-action', archetype: 'control', format: 'constructed', gameNumber: 1, decision: 'ship', reason: 'Constructed control needs early interaction or card selection. Pure late-game hands are unkeepable.' },
-  { handComposition: 'control-draw-and-lands', archetype: 'control', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'Card draw plus lands is a solid control opening. Drawing into interaction is the plan.' },
-  { handComposition: 'control-4-land-counters', archetype: 'control', format: 'constructed', gameNumber: 1, decision: 'keep', reason: 'Four lands with counterspells and card draw is a premium control hand.' },
-  { handComposition: 'control-2-land-bomb', archetype: 'control', format: 'limited', gameNumber: 1, decision: 'ship', reason: 'Two lands with only a single expensive threat is too risky for control. Need more interaction or lands.' },
+  {
+    handComposition: "control-removal-heavy",
+    archetype: "control",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Control hands with removal and a solid land base are fine. Early interaction is key.",
+  },
+  {
+    handComposition: "control-no-early-action",
+    archetype: "control",
+    format: "limited",
+    gameNumber: 1,
+    decision: "ship",
+    reason:
+      "Control with only 5+ CMC spells and 2-3 lands cannot interact early. Ship to find removal or counters.",
+  },
+  {
+    handComposition: "control-no-early-action",
+    archetype: "control",
+    format: "constructed",
+    gameNumber: 1,
+    decision: "ship",
+    reason:
+      "Constructed control needs early interaction or card selection. Pure late-game hands are unkeepable.",
+  },
+  {
+    handComposition: "control-draw-and-lands",
+    archetype: "control",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Card draw plus lands is a solid control opening. Drawing into interaction is the plan.",
+  },
+  {
+    handComposition: "control-4-land-counters",
+    archetype: "control",
+    format: "constructed",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Four lands with counterspells and card draw is a premium control hand.",
+  },
+  {
+    handComposition: "control-2-land-bomb",
+    archetype: "control",
+    format: "limited",
+    gameNumber: 1,
+    decision: "ship",
+    reason:
+      "Two lands with only a single expensive threat is too risky for control. Need more interaction or lands.",
+  },
 
   // === MIDRANGE SPECIFIC ===
-  { handComposition: 'midrange-balanced', archetype: 'midrange', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'Midrange hands with a mix of creatures, removal, and 3 lands are ideal keeps.' },
-  { handComposition: 'midrange-no-removal', archetype: 'midrange', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'Midrange can keep creature-heavy hands since creatures provide both offense and defense.' },
-  { handComposition: 'midrange-all-removal', archetype: 'midrange', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'Too much removal without threats means no win condition. Keep only if removal is very versatile.' },
+  {
+    handComposition: "midrange-balanced",
+    archetype: "midrange",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Midrange hands with a mix of creatures, removal, and 3 lands are ideal keeps.",
+  },
+  {
+    handComposition: "midrange-no-removal",
+    archetype: "midrange",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Midrange can keep creature-heavy hands since creatures provide both offense and defense.",
+  },
+  {
+    handComposition: "midrange-all-removal",
+    archetype: "midrange",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Too much removal without threats means no win condition. Keep only if removal is very versatile.",
+  },
 
   // === COMBO SPECIFIC ===
-  { handComposition: 'combo-has-pieces', archetype: 'combo', format: 'constructed', gameNumber: 1, decision: 'keep', reason: 'If a combo hand has both pieces (or a tutor + piece) and the mana to execute, always keep.' },
-  { handComposition: 'combo-half-pieces', archetype: 'combo', format: 'constructed', gameNumber: 1, decision: 'keep', reason: 'One combo piece with card selection (cantrips, tutors) is a reasonable keep.' },
-  { handComposition: 'combo-no-pieces', archetype: 'combo', format: 'constructed', gameNumber: 1, decision: 'ship', reason: 'No combo pieces and no tutors/cantrips means no route to the combo. Ship.' },
-  { handComposition: 'combo-1-land-tutor', archetype: 'combo', format: 'constructed', gameNumber: 1, decision: 'keep', reason: 'One land with a tutor (like Vampiric Tutor) to find the second land or a combo piece is a classic keep.' },
+  {
+    handComposition: "combo-has-pieces",
+    archetype: "combo",
+    format: "constructed",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "If a combo hand has both pieces (or a tutor + piece) and the mana to execute, always keep.",
+  },
+  {
+    handComposition: "combo-half-pieces",
+    archetype: "combo",
+    format: "constructed",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "One combo piece with card selection (cantrips, tutors) is a reasonable keep.",
+  },
+  {
+    handComposition: "combo-no-pieces",
+    archetype: "combo",
+    format: "constructed",
+    gameNumber: 1,
+    decision: "ship",
+    reason:
+      "No combo pieces and no tutors/cantrips means no route to the combo. Ship.",
+  },
+  {
+    handComposition: "combo-1-land-tutor",
+    archetype: "combo",
+    format: "constructed",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "One land with a tutor (like Vampiric Tutor) to find the second land or a combo piece is a classic keep.",
+  },
 
   // === TRIBAL SPECIFIC ===
-  { handComposition: 'tribal-lord-and-tribe', archetype: 'tribal', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'A tribal hand with a lord and 2+ tribe members plus lands is an excellent keep.' },
-  { handComposition: 'tribal-tribe-no-lord', archetype: 'tribal', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'Multiple tribal creatures with lands is fine even without a lord. The synergy is inherent.' },
-  { handComposition: 'tribal-no-tribe', archetype: 'tribal', format: 'limited', gameNumber: 1, decision: 'ship', reason: 'Tribal deck with no tribal members in the opening hand is weak. Ship to find your tribe.' },
+  {
+    handComposition: "tribal-lord-and-tribe",
+    archetype: "tribal",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "A tribal hand with a lord and 2+ tribe members plus lands is an excellent keep.",
+  },
+  {
+    handComposition: "tribal-tribe-no-lord",
+    archetype: "tribal",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Multiple tribal creatures with lands is fine even without a lord. The synergy is inherent.",
+  },
+  {
+    handComposition: "tribal-no-tribe",
+    archetype: "tribal",
+    format: "limited",
+    gameNumber: 1,
+    decision: "ship",
+    reason:
+      "Tribal deck with no tribal members in the opening hand is weak. Ship to find your tribe.",
+  },
 
   // === COLOR/CONSISTENCY ===
-  { handComposition: 'color-screw-risk', archetype: '*', format: 'limited', gameNumber: 1, decision: 'ship', reason: 'Multiple colored spells requiring different colors with no fixing is a mulligan in limited.' },
-  { handComposition: 'color-screw-risk', archetype: '*', format: 'constructed', gameNumber: 1, decision: 'keep', reason: 'In constructed, mana bases are better. A hand with playable spells even if not all colors is often keepable.' },
-  { handComposition: 'mono-color-good-curve', archetype: '*', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'Mono-color hands with a good curve and correct lands are always keeps. Maximum consistency.' },
+  {
+    handComposition: "color-screw-risk",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 1,
+    decision: "ship",
+    reason:
+      "Multiple colored spells requiring different colors with no fixing is a mulligan in limited.",
+  },
+  {
+    handComposition: "color-screw-risk",
+    archetype: "*",
+    format: "constructed",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "In constructed, mana bases are better. A hand with playable spells even if not all colors is often keepable.",
+  },
+  {
+    handComposition: "mono-color-good-curve",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Mono-color hands with a good curve and correct lands are always keeps. Maximum consistency.",
+  },
 
   // === GAME NUMBER ADJUSTMENTS ===
-  { handComposition: 'mediocre-g1', archetype: '*', format: 'limited', gameNumber: 1, decision: 'ship', reason: 'On the play in game 1, be more willing to mulligan marginal hands to maximize your chance of a strong start.' },
-  { handComposition: 'mediocre-g2', archetype: '*', format: 'limited', gameNumber: 2, decision: 'keep', reason: 'On the draw in game 2, keep slightly worse hands since you have the draw step advantage.' },
-  { handComposition: 'mediocre-g3', archetype: '*', format: 'limited', gameNumber: 3, decision: 'keep', reason: 'In game 3+, be more cautious about mulliganing to 6 since you cannot afford to fall further behind on cards.' },
+  {
+    handComposition: "mediocre-g1",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 1,
+    decision: "ship",
+    reason:
+      "On the play in game 1, be more willing to mulligan marginal hands to maximize your chance of a strong start.",
+  },
+  {
+    handComposition: "mediocre-g2",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 2,
+    decision: "keep",
+    reason:
+      "On the draw in game 2, keep slightly worse hands since you have the draw step advantage.",
+  },
+  {
+    handComposition: "mediocre-g3",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 3,
+    decision: "keep",
+    reason:
+      "In game 3+, be more cautious about mulliganing to 6 since you cannot afford to fall further behind on cards.",
+  },
 
   // === CURVE QUALITY ===
-  { handComposition: 'good-curve-2-3-4', archetype: '*', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'A smooth curve with plays at 2, 3, and 4 CMC plus lands is the gold standard in limited.' },
-  { handComposition: 'good-curve-1-2-3', archetype: '*', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'A low curve with plays at 1, 2, and 3 CMC is excellent for aggro and tempo strategies.' },
-  { handComposition: 'bad-curve-gap', archetype: '*', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'A hand with only 1-drops and 6-drops has a gap. Keep only if the 1-drops are strong enough to buy time.' },
-  { handComposition: 'bad-curve-no-early', archetype: '*', format: 'limited', gameNumber: 1, decision: 'ship', reason: 'A hand with nothing playable before turn 4 is a mulligan. You will fall too far behind.' },
+  {
+    handComposition: "good-curve-2-3-4",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "A smooth curve with plays at 2, 3, and 4 CMC plus lands is the gold standard in limited.",
+  },
+  {
+    handComposition: "good-curve-1-2-3",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "A low curve with plays at 1, 2, and 3 CMC is excellent for aggro and tempo strategies.",
+  },
+  {
+    handComposition: "bad-curve-gap",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "A hand with only 1-drops and 6-drops has a gap. Keep only if the 1-drops are strong enough to buy time.",
+  },
+  {
+    handComposition: "bad-curve-no-early",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 1,
+    decision: "ship",
+    reason:
+      "A hand with nothing playable before turn 4 is a mulligan. You will fall too far behind.",
+  },
 
   // === RAMP / ACCELERATION ===
-  { handComposition: 'ramp-2-land-ramp-spell', archetype: 'midrange', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'Two lands plus a ramp spell and a payoff (big creature) is an excellent midrange keep.' },
-  { handComposition: 'ramp-2-land-no-payoff', archetype: 'midrange', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'Ramp without a payoff in hand is risky. Keep only if the rest of the hand has enough action.' },
+  {
+    handComposition: "ramp-2-land-ramp-spell",
+    archetype: "midrange",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Two lands plus a ramp spell and a payoff (big creature) is an excellent midrange keep.",
+  },
+  {
+    handComposition: "ramp-2-land-no-payoff",
+    archetype: "midrange",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Ramp without a payoff in hand is risky. Keep only if the rest of the hand has enough action.",
+  },
 
   // === CARD DRAW / SELECTION ===
-  { handComposition: 'selection-2-land-cantrip', archetype: '*', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'Card selection (cantrips, scry) smooths out draws. Two lands plus selection is a safe keep.' },
-  { handComposition: 'selection-1-land-cantrip', archetype: '*', format: 'constructed', gameNumber: 1, decision: 'keep', reason: 'In constructed, a cantrip with one land is keepable because selection compensates for the land shortage.' },
-  { handComposition: 'selection-1-land-cantrip', archetype: '*', format: 'limited', gameNumber: 1, decision: 'keep', reason: 'In limited, one land plus a cantrip is risky. The cantrip may not find a land.' },
+  {
+    handComposition: "selection-2-land-cantrip",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "Card selection (cantrips, scry) smooths out draws. Two lands plus selection is a safe keep.",
+  },
+  {
+    handComposition: "selection-1-land-cantrip",
+    archetype: "*",
+    format: "constructed",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "In constructed, a cantrip with one land is keepable because selection compensates for the land shortage.",
+  },
+  {
+    handComposition: "selection-1-land-cantrip",
+    archetype: "*",
+    format: "limited",
+    gameNumber: 1,
+    decision: "keep",
+    reason:
+      "In limited, one land plus a cantrip is risky. The cantrip may not find a land.",
+  },
 
   // === SPECIAL SITUATIONS ===
-  { handComposition: 'sideboard-knowledge', archetype: '*', format: 'constructed', gameNumber: 2, decision: 'keep', reason: 'After sideboarding, your deck is tuned for the matchup. Keep hands that align with your post-board plan.' },
-  { handComposition: 'hate-card-in-opener', archetype: '*', format: 'constructed', gameNumber: 2, decision: 'keep', reason: 'A hand with a key sideboard hate card is usually a keep, even if slightly below average.' },
+  {
+    handComposition: "sideboard-knowledge",
+    archetype: "*",
+    format: "constructed",
+    gameNumber: 2,
+    decision: "keep",
+    reason:
+      "After sideboarding, your deck is tuned for the matchup. Keep hands that align with your post-board plan.",
+  },
+  {
+    handComposition: "hate-card-in-opener",
+    archetype: "*",
+    format: "constructed",
+    gameNumber: 2,
+    decision: "keep",
+    reason:
+      "A hand with a key sideboard hate card is usually a keep, even if slightly below average.",
+  },
 ];
 
 function analyzeHand(hand: Card[]): HandAnalysis {
@@ -161,12 +625,12 @@ function analyzeHand(hand: Card[]): HandAnalysis {
   const spellTypes = new Set<string>();
 
   for (const card of hand) {
-    const typeLine = (card.type_line || '').toLowerCase();
-    const oracleText = (card.oracle_text || '').toLowerCase();
-    const name = (card.name || '').toLowerCase();
+    const typeLine = (card.type_line || "").toLowerCase();
+    const oracleText = (card.oracle_text || "").toLowerCase();
+    const name = (card.name || "").toLowerCase();
     const cmc = card.cmc ?? 0;
 
-    if (typeLine.includes('land') || typeLine === 'basic land') {
+    if (typeLine.includes("land") || typeLine === "basic land") {
       landCount++;
       hasLands = true;
       continue;
@@ -175,7 +639,7 @@ function analyzeHand(hand: Card[]): HandAnalysis {
     spellCount++;
     totalCmc += cmc;
 
-    if (typeLine.includes('creature')) {
+    if (typeLine.includes("creature")) {
       creatureCount++;
     }
 
@@ -187,51 +651,51 @@ function analyzeHand(hand: Card[]): HandAnalysis {
     }
 
     if (
-      oracleText.includes('destroy') ||
-      oracleText.includes('exile') ||
-      oracleText.includes('counter') ||
-      oracleText.includes('sacrifice') ||
-      name.includes('bolt') ||
-      name.includes('terminate') ||
-      name.includes('murder') ||
-      name.includes('shock') ||
-      name.includes('path to exile') ||
-      oracleText.includes('deals') && oracleText.includes('damage') ||
-      oracleText.includes('remove') ||
-      oracleText.includes('return') ||
-      name.includes('bounce')
+      oracleText.includes("destroy") ||
+      oracleText.includes("exile") ||
+      oracleText.includes("counter") ||
+      oracleText.includes("sacrifice") ||
+      name.includes("bolt") ||
+      name.includes("terminate") ||
+      name.includes("murder") ||
+      name.includes("shock") ||
+      name.includes("path to exile") ||
+      (oracleText.includes("deals") && oracleText.includes("damage")) ||
+      oracleText.includes("remove") ||
+      oracleText.includes("return") ||
+      name.includes("bounce")
     ) {
       removalCount++;
       hasRemoval = true;
     }
 
     if (
-      oracleText.includes('draw') ||
-      oracleText.includes('scry') ||
-      oracleText.includes('look at the top') ||
-      oracleText.includes('surveil') ||
-      oracleText.includes('explore') ||
-      name.includes('cantrip') ||
-      name.includes('ponder') ||
-      name.includes('brainstorm') ||
-      name.includes('divination') ||
-      name.includes('opt') ||
-      name.includes('preordain')
+      oracleText.includes("draw") ||
+      oracleText.includes("scry") ||
+      oracleText.includes("look at the top") ||
+      oracleText.includes("surveil") ||
+      oracleText.includes("explore") ||
+      name.includes("cantrip") ||
+      name.includes("ponder") ||
+      name.includes("brainstorm") ||
+      name.includes("divination") ||
+      name.includes("opt") ||
+      name.includes("preordain")
     ) {
       cardDrawCount++;
       hasCardDraw = true;
     }
 
     if (
-      oracleText.includes('search your library for a land') ||
-      oracleText.includes('put a land') ||
-      name.includes('ramp') ||
-      name.includes('cultivate') ||
-      name.includes('kodama') ||
-      name.includes('farseek') ||
-      name.includes('birds of paradise') ||
-      name.includes('llanowar elves') ||
-      name.includes('elvish mystic')
+      oracleText.includes("search your library for a land") ||
+      oracleText.includes("put a land") ||
+      name.includes("ramp") ||
+      name.includes("cultivate") ||
+      name.includes("kodama") ||
+      name.includes("farseek") ||
+      name.includes("birds of paradise") ||
+      name.includes("llanowar elves") ||
+      name.includes("elvish mystic")
     ) {
       hasRamp = true;
     }
@@ -254,63 +718,80 @@ function analyzeHand(hand: Card[]): HandAnalysis {
 }
 
 function classifyArchetype(archetype?: string): ArchetypeCategory {
-  if (!archetype) return 'midrange';
+  if (!archetype) return "midrange";
 
   const lower = archetype.toLowerCase();
-  if (['burn', 'zoo', 'sligh', 'aggro-midrange'].some(a => lower.includes(a))) return 'aggro';
-  if (['draw-go', 'stax', 'prison', 'tempo-control', 'control-midrange'].some(a => lower.includes(a))) return 'control';
-  if (['storm', 'reanimator', 'infinite'].some(a => lower.includes(a))) return 'combo';
-  if (['elves', 'goblins', 'zombies', 'dragons'].some(a => lower.includes(a))) return 'tribal';
-  if (['lands', 'superfriends'].some(a => lower.includes(a))) return 'special';
-  return 'midrange';
+  if (["burn", "zoo", "sligh", "aggro-midrange"].some((a) => lower.includes(a)))
+    return "aggro";
+  if (
+    ["draw-go", "stax", "prison", "tempo-control", "control-midrange"].some(
+      (a) => lower.includes(a),
+    )
+  )
+    return "control";
+  if (["storm", "reanimator", "infinite"].some((a) => lower.includes(a)))
+    return "combo";
+  if (["elves", "goblins", "zombies", "dragons"].some((a) => lower.includes(a)))
+    return "tribal";
+  if (["lands", "superfriends"].some((a) => lower.includes(a)))
+    return "special";
+  return "midrange";
 }
 
-function scoreHandQuality(analysis: HandAnalysis, archetype: ArchetypeCategory, format: GameFormat, gameNumber: number, onThePlay: boolean): { score: number; reasons: string[] } {
+function scoreHandQuality(
+  analysis: HandAnalysis,
+  archetype: ArchetypeCategory,
+  format: GameFormat,
+  gameNumber: number,
+  onThePlay: boolean,
+): { score: number; reasons: string[] } {
   const reasons: string[] = [];
   let score = 50;
 
   // === LAND COUNT SCORING ===
   if (analysis.landCount === 0) {
     score -= 60;
-    reasons.push('No lands — cannot cast any spells');
+    reasons.push("No lands — cannot cast any spells");
   } else if (analysis.landCount === 1) {
-    if (archetype === 'aggro' && analysis.avgCmc <= 2.0 && onThePlay) {
+    if (archetype === "aggro" && analysis.avgCmc <= 2.0 && onThePlay) {
       score -= 10;
-      reasons.push('Only 1 land, but low curve and aggro archetype make it acceptable');
-    } else if (analysis.hasCardDraw && format === 'constructed' && onThePlay) {
+      reasons.push(
+        "Only 1 land, but low curve and aggro archetype make it acceptable",
+      );
+    } else if (analysis.hasCardDraw && format === "constructed" && onThePlay) {
       score -= 8;
-      reasons.push('Only 1 land, but card selection can find more');
+      reasons.push("Only 1 land, but card selection can find more");
     } else {
       score -= 35;
-      reasons.push('Only 1 land — high risk of missing land drops');
+      reasons.push("Only 1 land — high risk of missing land drops");
     }
   } else if (analysis.landCount === 2) {
     if (analysis.avgCmc <= 2.5 && analysis.spellCount >= 3) {
       score += 5;
-      reasons.push('2 lands with a low curve is workable');
+      reasons.push("2 lands with a low curve is workable");
     } else if (analysis.avgCmc <= 3.5 && analysis.spellCount >= 3) {
       score += 0;
-      reasons.push('2 lands with a reasonable curve is acceptable');
+      reasons.push("2 lands with a reasonable curve is acceptable");
     } else if (analysis.avgCmc > 4.0) {
       score -= 20;
-      reasons.push('2 lands with only expensive spells is risky');
+      reasons.push("2 lands with only expensive spells is risky");
     } else {
       score -= 5;
-      reasons.push('2 lands — slightly below ideal but acceptable');
+      reasons.push("2 lands — slightly below ideal but acceptable");
     }
   } else if (analysis.landCount === 3) {
     score += 10;
-    reasons.push('3 lands — ideal land count for an opening hand');
+    reasons.push("3 lands — ideal land count for an opening hand");
   } else if (analysis.landCount === 4) {
     if (analysis.spellCount >= 3) {
       score += 5;
-      reasons.push('4 lands with enough action is fine');
+      reasons.push("4 lands with enough action is fine");
     } else if (analysis.spellCount === 2) {
       score -= 5;
-      reasons.push('4 lands with only 2 spells is slightly flooded');
+      reasons.push("4 lands with only 2 spells is slightly flooded");
     } else {
       score -= 25;
-      reasons.push('4+ lands with too few action spells');
+      reasons.push("4+ lands with too few action spells");
     }
   } else if (analysis.landCount >= 5) {
     score -= 40;
@@ -320,83 +801,92 @@ function scoreHandQuality(analysis: HandAnalysis, archetype: ArchetypeCategory, 
   // === CURVE SCORING ===
   if (analysis.spellCount === 0) {
     score -= 50;
-    reasons.push('No non-land cards — no action');
+    reasons.push("No non-land cards — no action");
   } else {
     if (analysis.avgCmc >= 1.5 && analysis.avgCmc <= 3.5) {
       score += 10;
-      reasons.push('Good average mana value in the hand');
+      reasons.push("Good average mana value in the hand");
     } else if (analysis.avgCmc < 1.5) {
       score += 5;
-      reasons.push('Very low curve — good for aggro, may lack late-game');
+      reasons.push("Very low curve — good for aggro, may lack late-game");
     } else if (analysis.avgCmc > 4.5) {
       score -= 25;
-      reasons.push('Very high average CMC — will not have early plays');
+      reasons.push("Very high average CMC — will not have early plays");
     } else if (analysis.avgCmc > 3.5) {
       score -= 10;
-      reasons.push('Above-average CMC — may be slow to start');
+      reasons.push("Above-average CMC — may be slow to start");
     }
   }
 
   // === CREATURE COUNT ===
-  if (archetype === 'aggro' && analysis.creatureCount >= 3) {
+  if (archetype === "aggro" && analysis.creatureCount >= 3) {
     score += 10;
-    reasons.push('Multiple early creatures for aggressive start');
-  } else if (archetype === 'aggro' && analysis.creatureCount === 0) {
+    reasons.push("Multiple early creatures for aggressive start");
+  } else if (archetype === "aggro" && analysis.creatureCount === 0) {
     score -= 20;
-    reasons.push('Aggro hand with no creatures has no pressure');
-  } else if (archetype === 'control' && analysis.creatureCount <= 1) {
+    reasons.push("Aggro hand with no creatures has no pressure");
+  } else if (archetype === "control" && analysis.creatureCount <= 1) {
     score += 5;
-    reasons.push('Few creatures — appropriate for control strategy');
+    reasons.push("Few creatures — appropriate for control strategy");
   } else if (analysis.creatureCount >= 2 && analysis.creatureCount <= 4) {
     score += 5;
-    reasons.push('Good creature count for general play');
+    reasons.push("Good creature count for general play");
   }
 
   // === REMOVAL ===
   if (analysis.hasRemoval) {
     score += 5;
-    reasons.push('Hand has removal for early interaction');
+    reasons.push("Hand has removal for early interaction");
   }
 
   // === CARD DRAW ===
   if (analysis.hasCardDraw) {
     score += 8;
-    reasons.push('Card draw/selection helps smooth future draws');
+    reasons.push("Card draw/selection helps smooth future draws");
   }
 
   // === RAMP ===
-  if (analysis.hasRamp && (archetype === 'midrange' || archetype === 'control' || archetype === 'combo')) {
+  if (
+    analysis.hasRamp &&
+    (archetype === "midrange" ||
+      archetype === "control" ||
+      archetype === "combo")
+  ) {
     score += 8;
-    reasons.push('Ramp helps accelerate into powerful plays');
+    reasons.push("Ramp helps accelerate into powerful plays");
   }
 
   // === COLOR CONSISTENCY ===
-  if (analysis.colorCount >= 3 && format === 'limited') {
+  if (analysis.colorCount >= 3 && format === "limited") {
     score -= 15;
     reasons.push(`${analysis.colorCount} colors with limited fixing is risky`);
   } else if (analysis.colorCount <= 1) {
     score += 5;
-    reasons.push('Mono-color — excellent mana consistency');
+    reasons.push("Mono-color — excellent mana consistency");
   }
 
   // === ARCHETYPE-SPECIFIC BONUSES ===
-  if (archetype === 'combo') {
+  if (archetype === "combo") {
     if (analysis.hasCardDraw) {
       score += 5;
-      reasons.push('Card selection helps find combo pieces');
+      reasons.push("Card selection helps find combo pieces");
     }
   }
 
-  if (archetype === 'tribal' && analysis.creatureCount >= 3) {
+  if (archetype === "tribal" && analysis.creatureCount >= 3) {
     score += 5;
-    reasons.push('Multiple creatures support tribal synergies');
+    reasons.push("Multiple creatures support tribal synergies");
   }
 
   // === FORMAT ADJUSTMENTS ===
-  if (format === 'limited') {
-    if (analysis.spellCount >= 4 && analysis.landCount >= 2 && analysis.landCount <= 4) {
+  if (format === "limited") {
+    if (
+      analysis.spellCount >= 4 &&
+      analysis.landCount >= 2 &&
+      analysis.landCount <= 4
+    ) {
       score += 5;
-      reasons.push('Solid spell-to-land ratio for limited');
+      reasons.push("Solid spell-to-land ratio for limited");
     }
   }
 
@@ -404,17 +894,23 @@ function scoreHandQuality(analysis: HandAnalysis, archetype: ArchetypeCategory, 
   if (gameNumber >= 3) {
     if (score < 60 && score >= 35) {
       score += 10;
-      reasons.push('In game 3+, more conservative with mulligans (cannot afford to fall further behind on cards)');
+      reasons.push(
+        "In game 3+, more conservative with mulligans (cannot afford to fall further behind on cards)",
+      );
     }
   } else if (gameNumber === 2 && !onThePlay) {
     if (score < 60 && score >= 30) {
       score += 5;
-      reasons.push('On the draw in game 2, slightly more willing to keep marginal hands');
+      reasons.push(
+        "On the draw in game 2, slightly more willing to keep marginal hands",
+      );
     }
   } else if (gameNumber === 1 && onThePlay) {
     if (score >= 55 && score <= 65) {
       score -= 5;
-      reasons.push('On the play in game 1, slightly stricter with mulligans for optimal start');
+      reasons.push(
+        "On the play in game 1, slightly stricter with mulligans for optimal start",
+      );
     }
   }
 
@@ -422,30 +918,67 @@ function scoreHandQuality(analysis: HandAnalysis, archetype: ArchetypeCategory, 
   const earlyPlays = analysis.spellCount - countExpensiveOnly(analysis);
   if (earlyPlays === 0 && analysis.landCount < 4) {
     score -= 10;
-    reasons.push('No early plays available before turn 4');
+    reasons.push("No early plays available before turn 4");
   }
 
   // === LOW LAND + HIGH CURVE PENALTY ===
   if (analysis.landCount <= 1 && analysis.avgCmc >= 3.0) {
     score -= 15;
-    reasons.push('Very few lands with expensive spells — unlikely to cast anything on time');
+    reasons.push(
+      "Very few lands with expensive spells — unlikely to cast anything on time",
+    );
   }
 
   return { score, reasons };
 }
 
 function countExpensiveOnly(analysis: HandAnalysis): number {
-  return analysis.spellCount > 0 && analysis.avgCmc > 4.0 ? analysis.spellCount : 0;
+  return analysis.spellCount > 0 && analysis.avgCmc > 4.0
+    ? analysis.spellCount
+    : 0;
+}
+
+/**
+ * Analyze a hand and score its keep quality (shared by {@link analyzeMulligan}
+ * and the difficulty-scaled {@link decideOpponentMulligan}).
+ *
+ * Extracted so the expert read of a hand can be reused for the smaller,
+ * post-mulligan hands the opponent loop re-evaluates (issue #1063) without
+ * duplicating the scoring logic.
+ */
+function scoreHand(
+  hand: Card[],
+  archetype: string | undefined,
+  format: GameFormat,
+  gameNumber: number,
+  onThePlay: boolean,
+): { analysis: HandAnalysis; score: number; reasons: string[] } {
+  const analysis = analyzeHand(hand);
+  const archetypeCategory = classifyArchetype(archetype);
+  const { score, reasons } = scoreHandQuality(
+    analysis,
+    archetypeCategory,
+    format,
+    gameNumber,
+    onThePlay,
+  );
+  return { analysis, score, reasons };
 }
 
 export function analyzeMulligan(input: MulliganInput): MulliganAdvice {
-  const { hand, archetype, format = 'limited', gameNumber = 1, onThePlay = true } = input;
+  const {
+    hand,
+    archetype,
+    format = "limited",
+    gameNumber = 1,
+    onThePlay = true,
+  } = input;
 
   if (hand.length === 0) {
     return {
-      decision: 'ship',
+      decision: "ship",
       confidence: 1.0,
-      reasoning: ['Empty hand is not a valid opening hand'],
+      reasoning: ["Empty hand is not a valid opening hand"],
       analysis: createEmptyAnalysis(),
       handQualityScore: 0,
     };
@@ -453,20 +986,24 @@ export function analyzeMulligan(input: MulliganInput): MulliganAdvice {
 
   if (hand.length !== 7) {
     return {
-      decision: 'ship',
+      decision: "ship",
       confidence: 0.5,
-      reasoning: ['Mulligan advisor expects a 7-card opening hand'],
+      reasoning: ["Mulligan advisor expects a 7-card opening hand"],
       analysis: analyzeHand(hand),
       handQualityScore: 0,
     };
   }
 
-  const analysis = analyzeHand(hand);
-  const archetypeCategory = classifyArchetype(archetype);
-  const { score, reasons } = scoreHandQuality(analysis, archetypeCategory, format, gameNumber, onThePlay);
+  const { analysis, score, reasons } = scoreHand(
+    hand,
+    archetype,
+    format,
+    gameNumber,
+    onThePlay,
+  );
 
-  const threshold = format === 'limited' ? 40 : 35;
-  const decision: MulliganDecision = score >= threshold ? 'keep' : 'ship';
+  const threshold = format === "limited" ? 40 : 35;
+  const decision: MulliganDecision = score >= threshold ? "keep" : "ship";
   const confidence = Math.min(1, Math.max(0, Math.abs(score - threshold) / 50));
 
   return {
@@ -478,23 +1015,47 @@ export function analyzeMulligan(input: MulliganInput): MulliganAdvice {
   };
 }
 
-export function getMatchingExpertRecords(analysis: HandAnalysis, archetype?: string, format?: GameFormat): ExpertKeepShipRecord[] {
-  return KEEP_SHIP_DATABASE.filter(record => {
-    if (record.format !== '*' && format && record.format !== format) return false;
-    if (record.archetype !== '*' && archetype) {
+export function getMatchingExpertRecords(
+  analysis: HandAnalysis,
+  archetype?: string,
+  format?: GameFormat,
+): ExpertKeepShipRecord[] {
+  return KEEP_SHIP_DATABASE.filter((record) => {
+    if (record.format !== "*" && format && record.format !== format)
+      return false;
+    if (record.archetype !== "*" && archetype) {
       const archetypeLower = archetype.toLowerCase();
       if (!archetypeLower.includes(record.archetype)) return false;
     }
-    if (record.handComposition === '0-land' && analysis.landCount !== 0) return false;
-    if (record.handComposition === '1-land-bomb' && analysis.landCount !== 1) return false;
-    if (record.handComposition === '1-land-no-action' && analysis.landCount !== 1) return false;
-    if (record.handComposition === '5-land-few-spells' && analysis.landCount < 5) return false;
-    if (record.handComposition === '6-land' && analysis.landCount < 6) return false;
-    if (record.handComposition === '7-land' && analysis.landCount < 7) return false;
-    if (record.handComposition === '2-land-curve' && analysis.landCount !== 2) return false;
-    if (record.handComposition === '3-land-curve' && analysis.landCount !== 3) return false;
-    if (record.handComposition === '4-land-curve' && analysis.landCount !== 4) return false;
-    if (record.handComposition === '4-land-few-spells' && analysis.landCount !== 4) return false;
+    if (record.handComposition === "0-land" && analysis.landCount !== 0)
+      return false;
+    if (record.handComposition === "1-land-bomb" && analysis.landCount !== 1)
+      return false;
+    if (
+      record.handComposition === "1-land-no-action" &&
+      analysis.landCount !== 1
+    )
+      return false;
+    if (
+      record.handComposition === "5-land-few-spells" &&
+      analysis.landCount < 5
+    )
+      return false;
+    if (record.handComposition === "6-land" && analysis.landCount < 6)
+      return false;
+    if (record.handComposition === "7-land" && analysis.landCount < 7)
+      return false;
+    if (record.handComposition === "2-land-curve" && analysis.landCount !== 2)
+      return false;
+    if (record.handComposition === "3-land-curve" && analysis.landCount !== 3)
+      return false;
+    if (record.handComposition === "4-land-curve" && analysis.landCount !== 4)
+      return false;
+    if (
+      record.handComposition === "4-land-few-spells" &&
+      analysis.landCount !== 4
+    )
+      return false;
     return true;
   });
 }
@@ -517,3 +1078,255 @@ function createEmptyAnalysis(): HandAnalysis {
 }
 
 export { KEEP_SHIP_DATABASE };
+
+// ---------------------------------------------------------------------------
+// Issue #1063 — difficulty-scaled opponent mulligan decisions.
+//
+// `analyzeMulligan` above is the expert keep/ship engine the *player* coach
+// consumes; it is entirely difficulty-agnostic. The opponent turn loop needs
+// the same evaluation, but the quality of the call must SCALE BY DIFFICULTY:
+// Expert follows the advisor (mirroring the same KEEP_SHIP_DATABASE the coach
+// teaches), while Easy blunders — keeping unkeepable hands and shipping
+// keepable ones — at a bounded, monotonic rate.
+//
+// The shape mirrors the per-difficulty combat-trick scaling from #1067/#1188:
+// a tier-keyed table of monotonic knobs, a `resolveMulliganScaling` that folds
+// in the per-format difficulty override (#1069/#1187), and a pure
+// `decideOpponentMulligan` that accepts an injectable `rng` for deterministic
+// unit tests.
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-difficulty knobs for opponent mulligan decision quality.
+ */
+export interface MulliganDifficultyScaling {
+  /**
+   * Probability the opponent blunders its mulligan decision by *inverting* the
+   * expert keep/ship call. A blunder on an expert-"ship" hand keeps a bad
+   * hand; a blunder on an expert-"keep" hand ships a good one. Monotonic
+   * *decreasing* in skill: Easy blunders most, Expert almost never.
+   */
+  blunderChance: number;
+}
+
+/**
+ * Tier-keyed mulligan decision-quality scaling (issue #1063).
+ *
+ * `blunderChance` is monotonic decreasing in skill so a higher tier always
+ * mulligans at least as well as the tier below it. The absolute values run
+ * *higher* than {@link DIFFICULTY_CONFIGS.blunderChance} because mulligan
+ * decisions are high-leverage and low-skill players visibly misjudge them far
+ * more often than they blunder a single combat step — but the ordering is
+ * consistent with the canonical taxonomy (#1064).
+ */
+export const DIFFICULTY_MULLIGAN_SCALING: Record<
+  DifficultyLevel,
+  MulliganDifficultyScaling
+> = {
+  easy: { blunderChance: 0.45 },
+  medium: { blunderChance: 0.18 },
+  hard: { blunderChance: 0.07 },
+  expert: { blunderChance: 0.02 },
+};
+
+/**
+ * Look up the base mulligan decision-quality scaling for a difficulty tier.
+ */
+export function getDifficultyMulliganScaling(
+  difficulty: DifficultyLevel,
+): MulliganDifficultyScaling {
+  return DIFFICULTY_MULLIGAN_SCALING[difficulty];
+}
+
+function clampMulligan01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+/**
+ * Resolve the effective mulligan scaling for a (tier, format) pair, composing
+ * the per-tier base with the per-format difficulty override (#1069/#1187).
+ *
+ * The base `blunderChance` comes from {@link DIFFICULTY_MULLIGAN_SCALING}. It
+ * is then re-weighted by the ratio of the resolved per-format
+ * `blunderChance` to the base tier `blunderChance`, so a format override that
+ * raises blunders proportionally raises mulligan blunders and vice-versa. The
+ * result is clamped to `[0, 1]`. When no format is supplied (or the format has
+ * no override for the tier) the base scaling is returned unchanged — fully
+ * backward compatible. This mirrors {@code resolveTrickScaling} from
+ * #1067/#1188.
+ */
+export function resolveMulliganScaling(
+  difficulty: DifficultyLevel,
+  format?: DifficultyFormat,
+): MulliganDifficultyScaling {
+  const base = DIFFICULTY_MULLIGAN_SCALING[difficulty];
+  if (!format) return base;
+  const resolved = resolveDifficultyConfig(difficulty, format);
+  const baseConfig = DIFFICULTY_CONFIGS[difficulty];
+  if (baseConfig.blunderChance <= 0) return base;
+  const ratio = resolved.blunderChance / baseConfig.blunderChance;
+  const blunderChance = clampMulligan01(base.blunderChance * ratio);
+  if (blunderChance === base.blunderChance) return base;
+  return { ...base, blunderChance };
+}
+
+/**
+ * Points of keep-bar relief applied per card already lost to a mulligan. A
+ * 7-card hand uses the full expert threshold; each subsequent, smaller hand
+ * lowers the bar by this much so the opponent does not spiral into infinite
+ * mulligans (mulliganing to n-1 has already cost a card).
+ */
+const MULLIGAN_HAND_SIZE_RELIEF = 7;
+
+/**
+ * Expert keep threshold for a hand of `handSize` cards. The base (40 limited /
+ * 35 constructed) matches {@link analyzeMulligan} for a 7-card opener; it
+ * relaxes by {@link MULLIGAN_HAND_SIZE_RELIEF} per missing card, floored at 0.
+ */
+function expertKeepThreshold(handSize: number, format: GameFormat): number {
+  const base = format === "limited" ? 40 : 35;
+  return Math.max(
+    0,
+    base - MULLIGAN_HAND_SIZE_RELIEF * Math.max(0, 7 - handSize),
+  );
+}
+
+/** Map an AI difficulty format family onto the advisor's {@link GameFormat}. */
+function difficultyFormatToGameFormat(format?: DifficultyFormat): GameFormat {
+  if (format === "limited") return "limited";
+  if (format === "constructed" || format === "commander") return "constructed";
+  return "*";
+}
+
+function invertMulliganDecision(decision: MulliganDecision): MulliganDecision {
+  return decision === "keep" ? "ship" : "keep";
+}
+
+/**
+ * Input to {@link decideOpponentMulligan} — the opponent's difficulty-scaled
+ * keep/ship decision for an opening (or post-mulligan) hand.
+ *
+ * `format` is re-typed to the AI {@link DifficultyFormat} family (which
+ * includes `commander`) rather than the advisor's coarser {@link GameFormat};
+ * {@link decideOpponentMulligan} maps it internally.
+ */
+export interface OpponentMulliganInput extends Omit<MulliganInput, "format"> {
+  /** Skill tier driving the decision quality. */
+  difficulty: DifficultyLevel;
+  /** Active format family; folds in per-format overrides (#1069). */
+  format?: DifficultyFormat;
+  /**
+   * Deterministic randomness source for the blunder roll. Defaults to
+   * `Math.random`. Each decision consumes exactly one roll.
+   */
+  rng?: () => number;
+}
+
+/**
+ * Result of a difficulty-scaled opponent mulligan decision.
+ */
+export interface OpponentMulliganDecision {
+  /** The decision the opponent acts on (possibly a difficulty blunder). */
+  decision: MulliganDecision;
+  /** The expert (correct) decision before difficulty scaling. */
+  expertDecision: MulliganDecision;
+  /** True when a difficulty blunder inverted the expert call. */
+  blundered: boolean;
+  /** Tier that drove the decision (for inspection / tests). */
+  difficulty: DifficultyLevel;
+  /** Effective blunder chance used (post per-format composition). */
+  blunderChance: number;
+  confidence: number;
+  reasoning: string[];
+  analysis: HandAnalysis;
+  handQualityScore: number;
+}
+
+/**
+ * Decide whether the AI opponent keeps or ships a hand, scaled by difficulty
+ * (issue #1063).
+ *
+ * The expert keep/ship read comes from the same engine the player coach uses
+ * ({@link scoreHandQuality} over the {@link KEEP_SHIP_DATABASE} heuristics), so
+ * an Expert opponent mirrors the advice the coach teaches. Lower-skill tiers
+ * blunder — inverting the expert call with probability
+ * {@link MulliganDifficultyScaling.blunderChance} — which directly produces
+ * "keeps unkeepable hands" (blunder on an expert-ship hand) and "ships
+ * keepable hands" (blunder on an expert-keep hand).
+ *
+ * For 7-card openers the expert decision is identical to {@link analyzeMulligan}.
+ * For the smaller hands seen after a mulligan the keep bar relaxes (see
+ * {@link expertKeepThreshold}) so the opponent keeps progressively more readily
+ * rather than mulliganing forever.
+ *
+ * Deterministic when a fixed `rng` is supplied.
+ */
+export function decideOpponentMulligan(
+  input: OpponentMulliganInput,
+): OpponentMulliganDecision {
+  const {
+    hand,
+    archetype,
+    difficulty,
+    format,
+    gameNumber = 1,
+    onThePlay = true,
+    rng = Math.random,
+  } = input;
+
+  const gameFormat = difficultyFormatToGameFormat(format);
+
+  if (hand.length === 0) {
+    return {
+      decision: "ship",
+      expertDecision: "ship",
+      blundered: false,
+      difficulty,
+      blunderChance: resolveMulliganScaling(difficulty, format).blunderChance,
+      confidence: 1.0,
+      reasoning: ["Empty hand — no mulligan decision to make"],
+      analysis: createEmptyAnalysis(),
+      handQualityScore: 0,
+    };
+  }
+
+  const { analysis, score, reasons } = scoreHand(
+    hand,
+    archetype,
+    gameFormat,
+    gameNumber,
+    onThePlay,
+  );
+  const threshold = expertKeepThreshold(hand.length, gameFormat);
+  const expertDecision: MulliganDecision = score >= threshold ? "keep" : "ship";
+
+  const scaling = resolveMulliganScaling(difficulty, format);
+  const blundered = rng() < scaling.blunderChance;
+  const decision: MulliganDecision = blundered
+    ? invertMulliganDecision(expertDecision)
+    : expertDecision;
+
+  const confidence = Math.min(1, Math.max(0, Math.abs(score - threshold) / 50));
+  const reasoning = blundered
+    ? [
+        ...reasons,
+        `blunder (diff=${difficulty}): inverted expert "${expertDecision}" -> "${decision}" (blunderChance=${scaling.blunderChance.toFixed(3)})`,
+      ]
+    : [
+        ...reasons,
+        `follows expert ${expertDecision} (diff=${difficulty}, blunderChance=${scaling.blunderChance.toFixed(3)})`,
+      ];
+
+  return {
+    decision,
+    expertDecision,
+    blundered,
+    difficulty,
+    blunderChance: scaling.blunderChance,
+    confidence,
+    reasoning,
+    analysis,
+    handQualityScore: Math.max(0, Math.min(100, score)),
+  };
+}


### PR DESCRIPTION
## Summary

The AI opponent had **no mulligan step at all** — `analyzeMulligan()` (the expert keep/ship engine) was consumed only by the *player* coach, never by the opponent turn loop, and was entirely difficulty-agnostic. This wires a difficulty-scaled mulligan decision into the opponent game-start path so higher-skilled AI mulligans near-optimally while lower-skilled AI blunders (keeps unkeepable hands / ships keepable ones) at a bounded, monotonic rate.

Resolves #1063.

## Design

**1. `mulligan-advisor.ts` — difficulty-scaled decision (`decideOpponentMulligan`)**
- The expert keep/ship read now comes from the same engine the coach teaches (`scoreHandQuality` over `KEEP_SHIP_DATABASE` heuristics), so **Expert mirrors the advice the coach gives the player**.
- Added a tier-keyed `DIFFICULTY_MULLIGAN_SCALING` table with one monotonic knob — `blunderChance` — decreasing in skill (`easy 0.45 → medium 0.18 → hard 0.07 → expert 0.02`). A blunder **inverts** the expert call, directly producing “keeps a bad hand” (blunder on expert-`ship`) and “ships a good hand” (blunder on expert-`keep`).
- `resolveMulliganScaling(tier, format)` composes the per-format difficulty override (#1069/#1187) via the resolved `blunderChance` ratio — mirroring the proven `resolveTrickScaling` pattern from #1067/#1188 — so it builds on the **unified taxonomy** (#1064/#1192) and per-format config.
- For the smaller hands seen after a mulligan, the keep bar relaxes (`-7` per missing card, floored) so the AI keeps progressively more readily instead of spiraling into infinite mulligans; 7-card openers use the exact `analyzeMulligan` threshold.
- Pure & deterministic: an injectable `rng` drives the blunder roll (defaults to `Math.random`).

**2. `ai-action-executor.ts — mechanical action (`executeOpponentMulligan`)**
- Performs the London-mulligan card movement: return the hand to the library, shuffle, draw one fewer. Routed as a dedicated executor (the engine’s `"mulligan"` ActionType is an event/log descriptor, not a mechanic).

**3. `ai-turn-loop.ts — game-start wiring (`runOpeningHandMulligan`)**
- The orchestrator’s pre-turn-1 step. Each iteration evaluates the current hand with `decideOpponentMulligan`; `keep` ends the loop, `ship` is executed mechanically and the new hand is re-evaluated — exactly the issue’s “before turn 1 and after every mulligan”. Guaranteed to terminate (relaxing threshold + hard keep-floor + step cap).

## Per-difficulty scaling (bounded, smooth, monotonic)

| Tier | blunderChance | Behavior |
|------|--------------|----------|
| easy | 0.45 | Frequently keeps bad hands / ships good ones |
| medium | 0.18 | Occasional mulligan blunders |
| hard | 0.07 | Rarely misjudges |
| expert | 0.02 | ≈ optimal — follows the advisor |

`blunderChance` is monotonic decreasing and bounded in `[0, 1]`; per-format composition never inverts the tier ordering.

## Acceptance criteria

- [x] AI opponent executes a mulligan decision before turn 1 and after every mulligan, wired through `ai-turn-loop.ts` (`runOpeningHandMulligan`)
- [x] `mulligan-advisor.ts` accepts a `DifficultyLevel` and outputs vary measurably by tier (`decideOpponentMulligan`)
- [x] On identical opening hands, Easy keeps bad hands / ships good hands more often than Expert (parameterized over the 4 tiers)
- [x] Scaling is bounded/smooth and monotonic in skill; composes with the unified taxonomy (#1064/#1192) and per-format config (#1069/#1187)
- [x] Tests added in `src/ai/__tests__/mulligan-advisor.test.ts` (+ loop-wiring tests in `ai-turn-loop.test.ts`)

## Tests

- **`mulligan-advisor.test.ts`**: scaling-table monotonicity; `resolveMulliganScaling` per-format composition + ordering preservation; `decideOpponentMulligan` expert-follows-advisor; easy blunders (inverts) under a forced roll; headline per-difficulty quality (Easy keeps bad / ships good hands ≫ Expert, over an identical seeded rng stream); blunder-rate monotonicity `easy ≥ medium ≥ hard ≥ expert`; bounded hand-size relaxation.
- **`ai-turn-loop.test.ts`**: `runOpeningHandMulligan` keeps a strong opener (0 mulligans); a forced blunder chain mulligans down to the keep floor and stops; a zero-land opener is shipped, re-evaluated, and terminates; Expert mulligans a strong opener far less often than Easy.

## Verify

- `npm test -- mulligan ai-turn-loop ai-action-executor` → 6087 passed, 0 failed
- `npm run typecheck` → clean
- `npm run lint` → 0 errors (no new warnings introduced)