### PR TITLE
fix(ai): resolve #995 — AI sideboard considerations for best-of-3 play

### DIFF
--- a/src/lib/__tests__/opponent-deck-generator-sideboard.test.ts
+++ b/src/lib/__tests__/opponent-deck-generator-sideboard.test.ts
@@ -1,0 +1,542 @@
+/**
+ * @fileOverview Tests for AI opponent sideboard generation and best-of-3
+ * sideboarding (issue #995).
+ *
+ * Covers:
+ * - Sideboard generation (legal size, color identity, archetype-coherent, deterministic)
+ * - Post-game sideboarding swaps (correct in/out direction by matchup)
+ * - applyAISideboardSwap (maindeck/sideboard size preservation, purity)
+ * - best-of-3 progression via progressAISideboarding
+ * - Role/category helper functions
+ */
+
+import {
+  generateOpponentDeck,
+  generateSideboard,
+  computeAISideboardSwap,
+  applyAISideboardSwap,
+  progressAISideboarding,
+  classifyCardRole,
+  archetypeToCategory,
+  getAISideboardSize,
+  type GeneratedDeck,
+  type MatchupCategory,
+  type AISideboardingStep,
+} from "../opponent-deck-generator";
+
+// ---- helpers -----------------------------------------------------------
+function countCards(
+  list: Array<{ name: string; quantity: number }> | undefined,
+): number {
+  return (list ?? []).reduce((sum, c) => sum + c.quantity, 0);
+}
+
+function namesOf(
+  list: Array<{ name: string; quantity: number }> | undefined,
+): string[] {
+  return (list ?? []).map((c) => c.name);
+}
+
+/** A fixed, deterministic deck fixture used for swap assertions. */
+function controlFixture(
+  difficulty: GeneratedDeck["difficulty"] = "expert",
+): GeneratedDeck {
+  return {
+    name: "UB Control",
+    archetype: "control",
+    theme: "control",
+    description: "",
+    strategicApproach: "",
+    colorIdentity: ["U", "B"],
+    difficulty,
+    format: "constructed-core",
+    cards: [
+      { name: "Counterspell", quantity: 4 }, // disruption (kept vs control)
+      { name: "Doom Blade", quantity: 2 }, // removal (cuttable vs control)
+      { name: "Murder", quantity: 2 }, // removal (cuttable vs control)
+      { name: "Terminate", quantity: 2 }, // removal (cuttable vs control)
+      { name: "Scroll Rack", quantity: 1 }, // other utility (cuttable)
+      { name: "Sheoldred, Whispering One", quantity: 1 }, // threat (kept)
+      { name: "Island", quantity: 14 },
+      { name: "Swamp", quantity: 14 },
+    ],
+    sideboard: [
+      { name: "Batterskull", quantity: 1 }, // threat
+      { name: "Wurmcoil Engine", quantity: 1 }, // threat
+      { name: "Mystic Remora", quantity: 1 }, // cardDraw (U)
+      { name: "Thoughtseize", quantity: 2 }, // disruption (B)
+      { name: "Negate", quantity: 2 }, // disruption (U)
+      { name: "Duress", quantity: 2 }, // disruption (B)
+      { name: "Engineered Explosives", quantity: 1 }, // removal
+      { name: "Pithing Needle", quantity: 1 }, // removal
+    ],
+  };
+}
+
+// ---- tests -------------------------------------------------------------
+
+describe("AI Opponent Sideboard Generation (#995)", () => {
+  describe("Sideboard presence by format", () => {
+    test("constructed formats produce a sideboard", () => {
+      const formats = [
+        "constructed-core",
+        "constructed-legacy",
+        "constructed-pioneer",
+      ] as const;
+      for (const format of formats) {
+        const deck = generateOpponentDeck({
+          format,
+          archetype: "midrange",
+          colorIdentity: ["U", "B"],
+          difficulty: "expert",
+        });
+        expect(deck.sideboard).toBeDefined();
+        expect(deck.sideboard!.length).toBeGreaterThan(0);
+        expect(countCards(deck.sideboard)).toBeLessThanOrEqual(
+          getAISideboardSize(format),
+        );
+      }
+    });
+
+    test("Commander does NOT use a sideboard", () => {
+      const deck = generateOpponentDeck({
+        format: "legendary-commander",
+        archetype: "control",
+        colorIdentity: ["U", "B", "W"],
+        difficulty: "expert",
+      });
+      expect(countCards(deck.sideboard)).toBe(0);
+    });
+
+    test("getAISideboardSize returns 0 for non-sideboard formats", () => {
+      expect(getAISideboardSize("legendary-commander")).toBe(0);
+    });
+
+    test("getAISideboardSize returns 15 for constructed formats", () => {
+      expect(getAISideboardSize("constructed-core")).toBe(15);
+    });
+  });
+
+  describe("Sideboard legality", () => {
+    test("sideboard total never exceeds the format sideboard size", () => {
+      for (const difficulty of ["easy", "medium", "hard", "expert"] as const) {
+        for (const archetype of [
+          "aggro",
+          "control",
+          "midrange",
+          "combo",
+          "ramp",
+        ] as const) {
+          const deck = generateOpponentDeck({
+            format: "constructed-core",
+            archetype,
+            colorIdentity: ["R", "W"],
+            difficulty,
+          });
+          expect(countCards(deck.sideboard)).toBeLessThanOrEqual(15);
+          expect(countCards(deck.sideboard)).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    test("sideboard contains no duplicate card names", () => {
+      const deck = generateOpponentDeck({
+        format: "constructed-core",
+        archetype: "control",
+        colorIdentity: ["U", "B"],
+        difficulty: "expert",
+      });
+      const sbNames = namesOf(deck.sideboard);
+      expect(new Set(sbNames).size).toBe(sbNames.length);
+    });
+
+    test("sideboard cards are not duplicated from the maindeck", () => {
+      const deck = generateOpponentDeck({
+        format: "constructed-core",
+        archetype: "midrange",
+        colorIdentity: ["G", "B"],
+        difficulty: "expert",
+      });
+      const main = new Set(namesOf(deck.cards));
+      for (const name of namesOf(deck.sideboard)) {
+        expect(main.has(name)).toBe(false);
+      }
+    });
+
+    test("sideboard respects color identity", () => {
+      // Mono-red deck: no blue-only sideboard staples should appear.
+      const deck = generateOpponentDeck({
+        format: "constructed-core",
+        archetype: "aggro",
+        colorIdentity: ["R"],
+        difficulty: "expert",
+      });
+      const blueOnly = new Set([
+        "Negate",
+        "Flusterstorm",
+        "Mystic Remora",
+        "Bond of Insight",
+        "Sea Gate Restoration",
+        "Doom Blade",
+        "Path to Exile",
+        "Duress",
+        "Thoughtseize",
+        "Leyline of the Void",
+        "Sylvan Library",
+        "Compost",
+        "Stony Silence",
+        "Fragmentize",
+        "Blood Moon",
+      ]);
+      // Blood Moon is red -> legal; the others are off-color and must be absent.
+      for (const name of namesOf(deck.sideboard)) {
+        if (blueOnly.has(name) && name !== "Blood Moon") {
+          // Any off-color entry would be a violation.
+          expect(["R"]).toContain("R"); // sanity (always true); real check below
+        }
+      }
+      // Explicit: blue-only cards must never appear in a mono-R sideboard.
+      for (const forbidden of [
+        "Negate",
+        "Flusterstorm",
+        "Doom Blade",
+        "Path to Exile",
+      ]) {
+        expect(namesOf(deck.sideboard)).not.toContain(forbidden);
+      }
+    });
+  });
+
+  describe("Sideboard is archetype-coherent (sensible)", () => {
+    test("control sideboard prioritises threats / draw / disruption roles", () => {
+      const deck = generateOpponentDeck({
+        format: "constructed-core",
+        archetype: "control",
+        colorIdentity: ["U", "B", "W"],
+        difficulty: "expert",
+      });
+      const roles = namesOf(deck.sideboard).map((n) => classifyCardRole(n));
+      const wanted = new Set(["threats", "cardDraw", "disruption", "removal"]);
+      // At least one of the priority roles is represented.
+      expect(roles.some((r) => wanted.has(r))).toBe(true);
+    });
+
+    test("aggro sideboard includes interactive roles (removal/disruption)", () => {
+      const deck = generateOpponentDeck({
+        format: "constructed-core",
+        archetype: "aggro",
+        colorIdentity: ["R", "W"],
+        difficulty: "hard",
+      });
+      const roles = namesOf(deck.sideboard).map((n) => classifyCardRole(n));
+      expect(roles).toContain("removal");
+    });
+
+    test("expert packs a fuller sideboard than easy", () => {
+      const easy = generateOpponentDeck({
+        format: "constructed-core",
+        archetype: "midrange",
+        colorIdentity: ["G", "B"],
+        difficulty: "easy",
+      });
+      const expert = generateOpponentDeck({
+        format: "constructed-core",
+        archetype: "midrange",
+        colorIdentity: ["G", "B"],
+        difficulty: "expert",
+      });
+      // Across several generations the expert target should be >= easy target.
+      expect(countCards(expert.sideboard)).toBeGreaterThanOrEqual(
+        countCards(easy.sideboard),
+      );
+    });
+  });
+
+  describe("Sideboard generation is deterministic", () => {
+    test("identical inputs yield identical sideboards", () => {
+      const input = {
+        archetype: "control" as const,
+        colorIdentity: ["U", "B"],
+        difficulty: "expert" as const,
+        format: "constructed-core" as const,
+        maindeckCards: [{ name: "Counterspell", quantity: 4 }],
+      };
+      const a = generateSideboard(input);
+      const b = generateSideboard(input);
+      expect(a).toEqual(b);
+    });
+  });
+});
+
+describe("AI Opponent Post-Game Sideboarding (#995)", () => {
+  describe("Swap direction by matchup", () => {
+    test("vs control: boards IN threats/draw/disruption, boards OUT removal", () => {
+      const deck = controlFixture();
+      const swap = computeAISideboardSwap({
+        deck,
+        opponentCategory: "control",
+        difficulty: "expert",
+        lastGameResult: "loss",
+      });
+      expect(swap.boardIn.length).toBeGreaterThan(0);
+
+      const inRoles = swap.boardIn.map((c) => classifyCardRole(c.name));
+      const outRoles = swap.boardOut.map((c) => classifyCardRole(c.name));
+
+      // In candidates should be the high-value roles vs control.
+      const wantedIn = new Set(["threats", "cardDraw", "disruption"]);
+      expect(inRoles.some((r) => wantedIn.has(r))).toBe(true);
+      // Removal is the most cuttable role vs control.
+      expect(outRoles).toContain("removal");
+    });
+
+    test("vs aggro: boards IN removal/disruption", () => {
+      const deck = controlFixture();
+      const swap = computeAISideboardSwap({
+        deck,
+        opponentCategory: "aggro",
+        difficulty: "expert",
+        lastGameResult: "loss",
+      });
+      expect(swap.boardIn.length).toBeGreaterThan(0);
+      const inRoles = swap.boardIn.map((c) => classifyCardRole(c.name));
+      expect(inRoles).toContain("removal");
+    });
+
+    test("in/out quantities always balance (keeps deck legal)", () => {
+      const deck = controlFixture();
+      for (const opp of [
+        "aggro",
+        "control",
+        "midrange",
+        "combo",
+        "tribal",
+        "special",
+      ] as const) {
+        const swap = computeAISideboardSwap({
+          deck,
+          opponentCategory: opp,
+          difficulty: "expert",
+          lastGameResult: "loss",
+        });
+        expect(countCards(swap.boardIn)).toBe(countCards(swap.boardOut));
+      }
+    });
+
+    test("never boards out lands", () => {
+      const deck = controlFixture();
+      const swap = computeAISideboardSwap({
+        deck,
+        opponentCategory: "midrange",
+        difficulty: "expert",
+        lastGameResult: "loss",
+      });
+      for (const c of swap.boardOut) {
+        expect(classifyCardRole(c.name)).not.toBe("lands");
+        expect(c.name.toLowerCase()).not.toMatch(/island|swamp|plains|land/);
+      }
+    });
+  });
+
+  describe("Difficulty scaling", () => {
+    test("easy boards fewer cards than expert (loss)", () => {
+      const deck = controlFixture();
+      const easy = computeAISideboardSwap({
+        deck,
+        opponentCategory: "control",
+        difficulty: "easy",
+        lastGameResult: "loss",
+      });
+      const expert = computeAISideboardSwap({
+        deck,
+        opponentCategory: "control",
+        difficulty: "expert",
+        lastGameResult: "loss",
+      });
+      expect(countCards(easy.boardIn)).toBeLessThanOrEqual(3);
+      expect(countCards(expert.boardIn)).toBeGreaterThan(
+        countCards(easy.boardIn),
+      );
+      expect(countCards(expert.boardIn)).toBeLessThanOrEqual(10);
+    });
+  });
+
+  describe("Result-aware boarding", () => {
+    test("a win boards conservatively (no more than 3 cards)", () => {
+      const deck = controlFixture();
+      const swap = computeAISideboardSwap({
+        deck,
+        opponentCategory: "control",
+        difficulty: "expert",
+        lastGameResult: "win",
+      });
+      expect(countCards(swap.boardIn)).toBeLessThanOrEqual(3);
+    });
+
+    test("a loss boards at least as much as a win", () => {
+      const deck = controlFixture();
+      const win = computeAISideboardSwap({
+        deck,
+        opponentCategory: "control",
+        difficulty: "expert",
+        lastGameResult: "win",
+      });
+      const loss = computeAISideboardSwap({
+        deck,
+        opponentCategory: "control",
+        difficulty: "expert",
+        lastGameResult: "loss",
+      });
+      expect(countCards(loss.boardIn)).toBeGreaterThanOrEqual(
+        countCards(win.boardIn),
+      );
+    });
+  });
+
+  describe("Determinism", () => {
+    test("identical inputs produce identical swaps", () => {
+      const deck = controlFixture();
+      const a = computeAISideboardSwap({
+        deck,
+        opponentCategory: "combo",
+        difficulty: "hard",
+        lastGameResult: "loss",
+      });
+      const b = computeAISideboardSwap({
+        deck,
+        opponentCategory: "combo",
+        difficulty: "hard",
+        lastGameResult: "loss",
+      });
+      expect(a).toEqual(b);
+    });
+  });
+
+  describe("applyAISideboardSwap", () => {
+    test("preserves maindeck and sideboard size", () => {
+      const deck = controlFixture();
+      const mainBefore = countCards(deck.cards);
+      const sbBefore = countCards(deck.sideboard);
+      const swap = computeAISideboardSwap({
+        deck,
+        opponentCategory: "control",
+        difficulty: "expert",
+        lastGameResult: "loss",
+      });
+      const applied = applyAISideboardSwap(deck, swap);
+      expect(countCards(applied.cards)).toBe(mainBefore);
+      expect(countCards(applied.sideboard)).toBe(sbBefore);
+    });
+
+    test("board-in cards enter the maindeck, board-out cards leave it", () => {
+      const deck = controlFixture();
+      const swap = computeAISideboardSwap({
+        deck,
+        opponentCategory: "control",
+        difficulty: "expert",
+        lastGameResult: "loss",
+      });
+      const applied = applyAISideboardSwap(deck, swap);
+      const mainNames = new Set(namesOf(applied.cards));
+      for (const c of swap.boardIn) expect(mainNames.has(c.name)).toBe(true);
+    });
+
+    test("does not mutate the input deck (pure)", () => {
+      const deck = controlFixture();
+      const snapshot = JSON.stringify(deck);
+      const swap = computeAISideboardSwap({
+        deck,
+        opponentCategory: "midrange",
+        difficulty: "expert",
+        lastGameResult: "loss",
+      });
+      applyAISideboardSwap(deck, swap);
+      expect(JSON.stringify(deck)).toBe(snapshot);
+    });
+  });
+});
+
+describe("AI Opponent Best-of-3 Progression (#995)", () => {
+  test("game 1 (no steps) returns the pre-board deck unchanged", () => {
+    const deck = controlFixture();
+    const game1 = progressAISideboarding(deck, []);
+    expect(game1).toEqual(deck);
+  });
+
+  test("after a game-1 loss, the game-2 deck has been boarded", () => {
+    const deck = controlFixture();
+    const steps: AISideboardingStep[] = [
+      { opponentCategory: "control", result: "loss" },
+    ];
+    const game2 = progressAISideboarding(deck, steps);
+    expect(game2).not.toEqual(deck);
+    // Maindeck size preserved after boarding.
+    expect(countCards(game2.cards)).toBe(countCards(deck.cards));
+    expect(countCards(game2.sideboard)).toBe(countCards(deck.sideboard));
+  });
+
+  test("full best-of-3 keeps every configuration legal", () => {
+    const deck = controlFixture();
+    const steps: AISideboardingStep[] = [
+      { opponentCategory: "control", result: "loss" },
+      { opponentCategory: "control", result: "win" },
+    ];
+    const game3 = progressAISideboarding(deck, steps);
+    expect(countCards(game3.cards)).toBe(countCards(deck.cards));
+    expect(countCards(game3.sideboard)).toBe(countCards(deck.sideboard));
+  });
+
+  test("adapts when the observed opponent category changes between games", () => {
+    const deck = controlFixture();
+    const steps: AISideboardingStep[] = [
+      { opponentCategory: "aggro", result: "loss" },
+      { opponentCategory: "control", result: "loss" },
+    ];
+    const game3 = progressAISideboarding(deck, steps);
+    // Still legal, and the final config reflects re-boarding.
+    expect(countCards(game3.cards)).toBe(countCards(deck.cards));
+    expect(countCards(game3.sideboard)).toBe(countCards(deck.sideboard));
+  });
+});
+
+describe("AI Sideboard helper functions", () => {
+  test("classifyCardRole returns expected roles for known cards", () => {
+    expect(classifyCardRole("Counterspell")).toBe("disruption");
+    expect(classifyCardRole("Doom Blade")).toBe("removal");
+    expect(classifyCardRole("Duress")).toBe("disruption");
+    expect(classifyCardRole("Engineered Explosives")).toBe("removal");
+    expect(classifyCardRole("Batterskull")).toBe("threats");
+    expect(classifyCardRole("Plains")).toBe("lands");
+    expect(classifyCardRole("Sol Ring")).toBe("ramp");
+    expect(classifyCardRole("Birds of Paradise")).toBe("ramp");
+  });
+
+  test("archetypeToCategory maps every archetype to a matchup category", () => {
+    const archetypes = [
+      "aggro",
+      "control",
+      "midrange",
+      "combo",
+      "ramp",
+      "prison",
+      "tempo",
+      "tokens",
+      "aristocrats",
+      "stompy",
+    ] as const;
+    for (const a of archetypes) {
+      const cat: MatchupCategory = archetypeToCategory(a);
+      expect([
+        "aggro",
+        "control",
+        "midrange",
+        "combo",
+        "tribal",
+        "special",
+      ]).toContain(cat);
+    }
+    expect(archetypeToCategory("control")).toBe("control");
+    expect(archetypeToCategory("ramp")).toBe("special");
+    expect(archetypeToCategory("aggro")).toBe("aggro");
+  });
+});

--- a/src/lib/opponent-deck-generator.ts
+++ b/src/lib/opponent-deck-generator.ts
@@ -12,55 +12,55 @@
  * - Strategic synergy evaluation
  */
 
-import { formatRules, Format } from './game-rules';
-import type { MinimalCard } from './card-database';
+import { formatRules, Format } from "./game-rules";
+import type { MinimalCard } from "./card-database";
 
 // Re-export Format type for test imports
 export type { Format };
 
 // Difficulty levels that map to deck quality
-export type DifficultyLevel = 'easy' | 'medium' | 'hard' | 'expert';
+export type DifficultyLevel = "easy" | "medium" | "hard" | "expert";
 
 // Expanded deck archetype definitions
 export type DeckArchetype =
-  | 'aggro'
-  | 'control'
-  | 'midrange'
-  | 'combo'
-  | 'ramp'
-  | 'prison'
-  | 'tempo'
-  | 'tokens'
-  | 'aristocrats'
-  | 'stompy';
+  | "aggro"
+  | "control"
+  | "midrange"
+  | "combo"
+  | "ramp"
+  | "prison"
+  | "tempo"
+  | "tokens"
+  | "aristocrats"
+  | "stompy";
 
 // Strategic themes within archetypes
 export type StrategicTheme =
-  | 'burn'          // Direct damage focus
-  | 'weiss'         // White weenies
-  | 'fairies'       // Blue/white flying
-  | 'zombies'       // Black graveyard synergy
-  | 'dragons'       // Big flying threats
-  | 'tokens'        // Token generation
-  | 'mill'          // Decking opponent
-  | 'lifegain'      // Life gain synergies
-  | 'artifacts'     // Artifact focus
-  | 'enchantments'  // Enchantment focus
-  | 'counters'      // Counterspell-heavy
-  | 'reanimator'    // Graveyard recursion
-  | 'elves'         // Elf tribal
-  | 'goblins'       // Goblin tribal
-  | 'control'       // Traditional control
-  | 'midrange'      // Value-based midrange
-  | 'storm'         // Storm combo
-  | 'scapeshift'    // Land-based combo
-  | 'trample'       // Trample threats
-  | 'haste'         // Haste creatures
-  | 'flash'         // Flash creatures
-  | 'aristocrats'    // Sacrifice synergies
-  | 'tempo'         // Disruptive control
-  | 'toolbox'       // Silver bullet creatures
-  | 'toolbox'       // Silver bullet creatures;
+  | "burn" // Direct damage focus
+  | "weiss" // White weenies
+  | "fairies" // Blue/white flying
+  | "zombies" // Black graveyard synergy
+  | "dragons" // Big flying threats
+  | "tokens" // Token generation
+  | "mill" // Decking opponent
+  | "lifegain" // Life gain synergies
+  | "artifacts" // Artifact focus
+  | "enchantments" // Enchantment focus
+  | "counters" // Counterspell-heavy
+  | "reanimator" // Graveyard recursion
+  | "elves" // Elf tribal
+  | "goblins" // Goblin tribal
+  | "control" // Traditional control
+  | "midrange" // Value-based midrange
+  | "storm" // Storm combo
+  | "scapeshift" // Land-based combo
+  | "trample" // Trample threats
+  | "haste" // Haste creatures
+  | "flash" // Flash creatures
+  | "aristocrats" // Sacrifice synergies
+  | "tempo" // Disruptive control
+  | "toolbox" // Silver bullet creatures
+  | "toolbox"; // Silver bullet creatures;
 
 export interface OpponentDeckGenerationInput {
   format: Format;
@@ -80,6 +80,13 @@ export interface GeneratedDeck {
   colorIdentity: string[];
   difficulty: DifficultyLevel;
   format: Format;
+  /**
+   * Sideboard for best-of-3 (sideboard) play. Issue #995: the AI opponent now
+   * generates a legal sideboard alongside its maindeck for any format whose
+   * construction rules enable one (`formatRules[format].usesSideboard`). Empty
+   * (or `undefined`) for Commander and other non-sideboard formats.
+   */
+  sideboard?: Array<{ name: string; quantity: number }>;
 }
 
 // Difficulty configuration
@@ -139,192 +146,432 @@ interface CardPool {
 
 const CARD_POOL: CardPool = {
   // === WHITE CARDS ===
-  'W_one_drops': [
-    'Soul Warden', 'Champion of the Parish', 'Isamaru, Hound of Konda',
-    'Mother of Runes', 'Thalia, Guardian of Thraben', 'Kytheon, Hero of Akros',
-    'Student of Warfare', 'Steppe Lynx', 'Usher of the Fallen',
+  W_one_drops: [
+    "Soul Warden",
+    "Champion of the Parish",
+    "Isamaru, Hound of Konda",
+    "Mother of Runes",
+    "Thalia, Guardian of Thraben",
+    "Kytheon, Hero of Akros",
+    "Student of Warfare",
+    "Steppe Lynx",
+    "Usher of the Fallen",
   ],
-  'W_two_drops': [
-    'Knight of the White Orchid', 'Thalia\'s Lieutenant', 'Selfless Spirit',
-    'Mentor of the Meek', 'Leonin Arbiter', 'Wall of Omens',
-    'Kytheon\'s Tactics', 'Dauntless Bodyguard', 'Gideon\'s Lawkeeper',
+  W_two_drops: [
+    "Knight of the White Orchid",
+    "Thalia's Lieutenant",
+    "Selfless Spirit",
+    "Mentor of the Meek",
+    "Leonin Arbiter",
+    "Wall of Omens",
+    "Kytheon's Tactics",
+    "Dauntless Bodyguard",
+    "Gideon's Lawkeeper",
   ],
-  'W_three_drops': [
-    'Adanto Vanguard', 'Benevolent Bodyguard', 'Leonin Relic-Warder',
-    'Mirran Crusader', 'Knight of the Holy Nimbus', 'Sun Titan',
-    'Eldrazi Displacer', 'Restoration Angel', 'Flickerwisp',
+  W_three_drops: [
+    "Adanto Vanguard",
+    "Benevolent Bodyguard",
+    "Leonin Relic-Warder",
+    "Mirran Crusader",
+    "Knight of the Holy Nimbus",
+    "Sun Titan",
+    "Eldrazi Displacer",
+    "Restoration Angel",
+    "Flickerwisp",
   ],
-  'W_four_drops': [
-    'Hero of Bladehold', 'Brave the Elements', 'Auriok Champion',
-    'Spectral Procession', 'Cloudgoat Ranger', 'Herald of War',
+  W_four_drops: [
+    "Hero of Bladehold",
+    "Brave the Elements",
+    "Auriok Champion",
+    "Spectral Procession",
+    "Cloudgoat Ranger",
+    "Herald of War",
   ],
-  'W_removal': [
-    'Path to Exile', 'Swords to Plowshares', 'Justice Strike', 'Divine Offering',
-    'Declaration in Stone', 'Oblivion Ring', 'Banishing Light', 'Anguished Unmaking',
+  W_removal: [
+    "Path to Exile",
+    "Swords to Plowshares",
+    "Justice Strike",
+    "Divine Offering",
+    "Declaration in Stone",
+    "Oblivion Ring",
+    "Banishing Light",
+    "Anguished Unmaking",
   ],
-  'W_utility': [
-    'Mana Tithe', 'Apostle\'s Blessing', 'Safety // Grief', 'Selfless Spirit',
-    'Emeria Angel', 'Honor of the Pure', 'Intangible Virtue', 'Anafenza, Kin-Tree Spirit',
+  W_utility: [
+    "Mana Tithe",
+    "Apostle's Blessing",
+    "Safety // Grief",
+    "Selfless Spirit",
+    "Emeria Angel",
+    "Honor of the Pure",
+    "Intangible Virtue",
+    "Anafenza, Kin-Tree Spirit",
   ],
-  'W_lifegain': [
-    'Soul Warden', 'Soul\'s Attendant', 'Auriok Champion', 'Crested Sunmare',
-    'Sphinx\'s Revelation', 'Revitalize', 'Healing Salve', 'Rest for the Weary',
+  W_lifegain: [
+    "Soul Warden",
+    "Soul's Attendant",
+    "Auriok Champion",
+    "Crested Sunmare",
+    "Sphinx's Revelation",
+    "Revitalize",
+    "Healing Salve",
+    "Rest for the Weary",
   ],
 
   // === BLUE CARDS ===
-  'U_one_drops': [
-    'Delver of Secrets', 'Cursecatcher', 'Phantasmal Image', 'Thassa\'s Oracle',
-    'Llanowar Elves', 'Elvish Mystic', 'Birds of Paradise', 'Noble Hierarch',
+  U_one_drops: [
+    "Delver of Secrets",
+    "Cursecatcher",
+    "Phantasmal Image",
+    "Thassa's Oracle",
+    "Llanowar Elves",
+    "Elvish Mystic",
+    "Birds of Paradise",
+    "Noble Hierarch",
   ],
-  'U_two_drops': [
-    'Snapcaster Mage', 'Thing in the Ice', 'Glen Elendra Archmage',
-    'Vendilion Clique', 'Spellstutter Sprite', 'Mystic Remora',
-    'Dark Confidant', 'Grim Lavamancer', 'Sakura-Tribe Elder',
+  U_two_drops: [
+    "Snapcaster Mage",
+    "Thing in the Ice",
+    "Glen Elendra Archmage",
+    "Vendilion Clique",
+    "Spellstutter Sprite",
+    "Mystic Remora",
+    "Dark Confidant",
+    "Grim Lavamancer",
+    "Sakura-Tribe Elder",
   ],
-  'U_three_drops': [
-    'Archmage Emeritus', 'Jace, Vryn\'s Prodigy', 'Teferi, Time Raveler',
-    'Mystic Confluence', 'Narset, Parter of Veils', 'Mulldrifter',
+  U_three_drops: [
+    "Archmage Emeritus",
+    "Jace, Vryn's Prodigy",
+    "Teferi, Time Raveler",
+    "Mystic Confluence",
+    "Narset, Parter of Veils",
+    "Mulldrifter",
   ],
-  'U_four_drops': [
-    'Cryptic Command', 'Tezzeret the Seeker', 'Jace Beleren',
-    'Aetherling', 'Vendilion Clique', 'Batterskull',
+  U_four_drops: [
+    "Cryptic Command",
+    "Tezzeret the Seeker",
+    "Jace Beleren",
+    "Aetherling",
+    "Vendilion Clique",
+    "Batterskull",
   ],
-  'U_counter': [
-    'Counterspell', 'Negate', 'Dispel', 'Neutralize', 'Syncopate',
-    'Mana Leak', 'Spell Pierce', 'Force of Will', 'Daze', 'Arcane Denial',
+  U_counter: [
+    "Counterspell",
+    "Negate",
+    "Dispel",
+    "Neutralize",
+    "Syncopate",
+    "Mana Leak",
+    "Spell Pierce",
+    "Force of Will",
+    "Daze",
+    "Arcane Denial",
   ],
-  'U_draw': [
-    'Brainstorm', 'Ponder', 'Preordain', 'Chart a Course', 'Ancestral Recall',
-    'Cantrip', 'Fact or Fiction', 'Jace\'s Ingenuity', 'Opportunity',
+  U_draw: [
+    "Brainstorm",
+    "Ponder",
+    "Preordain",
+    "Chart a Course",
+    "Ancestral Recall",
+    "Cantrip",
+    "Fact or Fiction",
+    "Jace's Ingenuity",
+    "Opportunity",
   ],
-  'U_tempo': [
-    'Vapor Snag', 'Unsummon', 'Bounce', 'Remand', 'Cryptic Command',
-    'Mystic Confluence', 'Venser, Shaper Savant', 'Peregrine Drake',
+  U_tempo: [
+    "Vapor Snag",
+    "Unsummon",
+    "Bounce",
+    "Remand",
+    "Cryptic Command",
+    "Mystic Confluence",
+    "Venser, Shaper Savant",
+    "Peregrine Drake",
   ],
 
   // === BLACK CARDS ===
-  'B_one_drops': [
-    'Grave Crawler', 'Bloodsoaked Champion', 'Vampire Lacerator',
-    'Goblin Guide', 'Goblin Welder', 'Bloodthrone Vampire',
+  B_one_drops: [
+    "Grave Crawler",
+    "Bloodsoaked Champion",
+    "Vampire Lacerator",
+    "Goblin Guide",
+    "Goblin Welder",
+    "Bloodthrone Vampire",
   ],
-  'B_two_drops': [
-    'Nezumi Prowler', 'Gifted // Willied', 'Phyrexian Rager', 'Pack Rat',
-    'Thoughtseize', 'Inquisition of Kozilek', 'Duress', 'Despise',
+  B_two_drops: [
+    "Nezumi Prowler",
+    "Gifted // Willied",
+    "Phyrexian Rager",
+    "Pack Rat",
+    "Thoughtseize",
+    "Inquisition of Kozilek",
+    "Duress",
+    "Despise",
   ],
-  'B_three_drops': [
-    'Phyrexian Arena', 'Grim Haruspex', 'Liliana of the Veil',
-    'Deathrite Shaman', 'Geralf\'s Messenger', 'Mesmeric Fiend',
+  B_three_drops: [
+    "Phyrexian Arena",
+    "Grim Haruspex",
+    "Liliana of the Veil",
+    "Deathrite Shaman",
+    "Geralf's Messenger",
+    "Mesmeric Fiend",
   ],
-  'B_four_drops': [
-    'Sheoldred, Whispering One', 'Grave Titan', 'Phyrexian Obliterator',
-    'Massacre Wurm', 'Gary', 'Huntmaster of the Fells',
+  B_four_drops: [
+    "Sheoldred, Whispering One",
+    "Grave Titan",
+    "Phyrexian Obliterator",
+    "Massacre Wurm",
+    "Gary",
+    "Huntmaster of the Fells",
   ],
-  'B_kill': [
-    'Innocent Blood', 'Go for the Throat', 'Victim // Night', 'Dead // Gone',
-    'Doom Blade', 'Murder', 'Hero\'s Downfall', 'Ultimate Price', 'Terminate',
-    'Abrupt Decay', 'Maelstrom Pulse', 'Dismember', 'Tragic Slip',
+  B_kill: [
+    "Innocent Blood",
+    "Go for the Throat",
+    "Victim // Night",
+    "Dead // Gone",
+    "Doom Blade",
+    "Murder",
+    "Hero's Downfall",
+    "Ultimate Price",
+    "Terminate",
+    "Abrupt Decay",
+    "Maelstrom Pulse",
+    "Dismember",
+    "Tragic Slip",
   ],
-  'B_reanimate': [
-    'Entomb', 'Unburial Rites', 'Dread Return', 'Animate Dead',
-    'Reanimate', 'Exhume', 'Necromancy', 'Dance of the Dead',
+  B_reanimate: [
+    "Entomb",
+    "Unburial Rites",
+    "Dread Return",
+    "Animate Dead",
+    "Reanimate",
+    "Exhume",
+    "Necromancy",
+    "Dance of the Dead",
   ],
-  'B_discard': [
-    'Thoughtseize', 'Inquisition of Kozilek', 'Duress', 'Despise',
-    'Thought Scour', 'Mind Rot', 'Hymn to Tourach', 'Mind Burst',
+  B_discard: [
+    "Thoughtseize",
+    "Inquisition of Kozilek",
+    "Duress",
+    "Despise",
+    "Thought Scour",
+    "Mind Rot",
+    "Hymn to Tourach",
+    "Mind Burst",
   ],
-  'B_zombies': [
-    'Grave Crawler', 'Geralf\'s Messenger', 'Shepherd of Rot',
-    'Rotlung Reanimator', 'Carrion Feeder', 'Undead Warchief',
-    'Lord of the Undead', 'Zombie Master', 'Cemetery Reaper',
+  B_zombies: [
+    "Grave Crawler",
+    "Geralf's Messenger",
+    "Shepherd of Rot",
+    "Rotlung Reanimator",
+    "Carrion Feeder",
+    "Undead Warchief",
+    "Lord of the Undead",
+    "Zombie Master",
+    "Cemetery Reaper",
   ],
 
   // === RED CARDS ===
-  'R_one_drops': [
-    'Goblin Guide', 'Monastery Swiftspear', 'Goblin Bushwhacker',
-    'Ragavan, Nimble Pilferer', 'Dragon Fodder', 'Krenko\'s Buzzbrew',
+  R_one_drops: [
+    "Goblin Guide",
+    "Monastery Swiftspear",
+    "Goblin Bushwhacker",
+    "Ragavan, Nimble Pilferer",
+    "Dragon Fodder",
+    "Krenko's Buzzbrew",
   ],
-  'R_two_drops': [
-    'Eidolon of the Great Revel', 'Goblin Piledriver', 'Goblin Matron',
-    'Young Pyromancer', 'Mogg War Marshal', 'Feldon\'s Cane',
+  R_two_drops: [
+    "Eidolon of the Great Revel",
+    "Goblin Piledriver",
+    "Goblin Matron",
+    "Young Pyromancer",
+    "Mogg War Marshal",
+    "Feldon's Cane",
   ],
-  'R_three_drops': [
-    'Hazoret the Fervent', 'Blood Moon', 'Kiki-Jiki, Mirror Breaker',
-    'Molten Rain', 'Stormbreath Dragon', 'Glorybringer',
+  R_three_drops: [
+    "Hazoret the Fervent",
+    "Blood Moon",
+    "Kiki-Jiki, Mirror Breaker",
+    "Molten Rain",
+    "Stormbreath Dragon",
+    "Glorybringer",
   ],
-  'R_four_drops': [
-    'Chandra, Torch of Defiance', 'Krenko, Mob Boss', 'Pia and Kiran Nalaar',
-    'Hazardous Conditions', 'Siege-Gang Commander', 'Hellrider',
+  R_four_drops: [
+    "Chandra, Torch of Defiance",
+    "Krenko, Mob Boss",
+    "Pia and Kiran Nalaar",
+    "Hazardous Conditions",
+    "Siege-Gang Commander",
+    "Hellrider",
   ],
-  'R_burn': [
-    'Lightning Bolt', 'Lightning Strike', 'Burst Lightning', 'Searing Blaze',
-    'Chain Lightning', 'Lava Spike', 'Skullcrack', 'Boros Charm',
-    'Fireblast', 'Flame Slash', 'Searing Blood', 'Vexing Devil',
+  R_burn: [
+    "Lightning Bolt",
+    "Lightning Strike",
+    "Burst Lightning",
+    "Searing Blaze",
+    "Chain Lightning",
+    "Lava Spike",
+    "Skullcrack",
+    "Boros Charm",
+    "Fireblast",
+    "Flame Slash",
+    "Searing Blood",
+    "Vexing Devil",
   ],
-  'R_utility': [
-    'Fire // Ice', 'Collision // Colossus', 'Faithless Looting', 'Wheel of Fortune',
-    'Chaos Warp', 'Chandra\'s Pyrohelix', 'Pyrokinesis', 'Price of Progress',
+  R_utility: [
+    "Fire // Ice",
+    "Collision // Colossus",
+    "Faithless Looting",
+    "Wheel of Fortune",
+    "Chaos Warp",
+    "Chandra's Pyrohelix",
+    "Pyrokinesis",
+    "Price of Progress",
   ],
-  'R_goblins': [
-    'Goblin Guide', 'Goblin Piledriver', 'Goblin Matron', 'Goblin Warchief',
-    'Krenko, Mob Boss', 'Siege-Gang Commander', 'Goblin Chieftain', 'Mogg Fanatic',
+  R_goblins: [
+    "Goblin Guide",
+    "Goblin Piledriver",
+    "Goblin Matron",
+    "Goblin Warchief",
+    "Krenko, Mob Boss",
+    "Siege-Gang Commander",
+    "Goblin Chieftain",
+    "Mogg Fanatic",
   ],
 
   // === GREEN CARDS ===
-  'G_one_drops': [
-    'Llanowar Elves', 'Elvish Mystic', 'Fyndhorn Elves', 'Heritage Druid',
-    'Arbor Elf', 'Birds of Paradise', 'Noble Hierarch', 'Deathrite Shaman',
+  G_one_drops: [
+    "Llanowar Elves",
+    "Elvish Mystic",
+    "Fyndhorn Elves",
+    "Heritage Druid",
+    "Arbor Elf",
+    "Birds of Paradise",
+    "Noble Hierarch",
+    "Deathrite Shaman",
   ],
-  'G_two_drops': [
-    'Sakura-Tribe Elder', 'Wall of Roots', 'Eternal Witness', 'Courser of Kruphix',
-    'Scavenging Ooze', 'Questing Beast', 'Strangleroot Geist', 'Kitchen Finks',
+  G_two_drops: [
+    "Sakura-Tribe Elder",
+    "Wall of Roots",
+    "Eternal Witness",
+    "Courser of Kruphix",
+    "Scavenging Ooze",
+    "Questing Beast",
+    "Strangleroot Geist",
+    "Kitchen Finks",
   ],
-  'G_three_drops': [
-    'Knight of the Reliquary', 'Eternal Witness', 'Voice of Resurgence',
-    'Fierce Empath', 'Courser of Kruphix', 'Thrun, the Last Troll',
+  G_three_drops: [
+    "Knight of the Reliquary",
+    "Eternal Witness",
+    "Voice of Resurgence",
+    "Fierce Empath",
+    "Courser of Kruphix",
+    "Thrun, the Last Troll",
   ],
-  'G_four_drops': [
-    'Craterhoof Behemoth', 'Worldspine Wurm', 'Terastodon', 'Avenger of Zendikar',
-    'Primal Command', 'Polukranos, Unchained', 'Thragtusk',
+  G_four_drops: [
+    "Craterhoof Behemoth",
+    "Worldspine Wurm",
+    "Terastodon",
+    "Avenger of Zendikar",
+    "Primal Command",
+    "Polukranos, Unchained",
+    "Thragtusk",
   ],
-  'G_ramp': [
-    'Rampant Growth', 'Farseek', 'Nature\'s Lore', 'Cultivate', 'Kodama\'s Reach',
-    'Sol Ring', 'Birds of Paradise', 'Noble Hierarch', 'Deathrite Shaman',
+  G_ramp: [
+    "Rampant Growth",
+    "Farseek",
+    "Nature's Lore",
+    "Cultivate",
+    "Kodama's Reach",
+    "Sol Ring",
+    "Birds of Paradise",
+    "Noble Hierarch",
+    "Deathrite Shaman",
   ],
-  'G_big': [
-    'Craterhoof Behemoth', 'Worldspine Wurm', 'Terastodon', 'Avenger of Zendikar',
-    'Primal Command', 'Polukranos, Unchained', 'Thragtusk', 'Vorinclex, Voice of Hunger',
+  G_big: [
+    "Craterhoof Behemoth",
+    "Worldspine Wurm",
+    "Terastodon",
+    "Avenger of Zendikar",
+    "Primal Command",
+    "Polukranos, Unchained",
+    "Thragtusk",
+    "Vorinclex, Voice of Hunger",
   ],
-  'G_elves': [
-    'Llanowar Elves', 'Elvish Mystic', 'Fyndhorn Elves', 'Heritage Druid',
-    'Arbor Elf', 'Elvish Archdruid', 'Ezuri, Renegade Leader', 'Elvish Champion',
-    'Imperious Perfect', 'Timberwatch Elf', 'Jagged-Scar Archers',
+  G_elves: [
+    "Llanowar Elves",
+    "Elvish Mystic",
+    "Fyndhorn Elves",
+    "Heritage Druid",
+    "Arbor Elf",
+    "Elvish Archdruid",
+    "Ezuri, Renegade Leader",
+    "Elvish Champion",
+    "Imperious Perfect",
+    "Timberwatch Elf",
+    "Jagged-Scar Archers",
   ],
-  'G_trample': [
-    'Questing Beast', 'Thrun, the Last Troll', 'Polukranos, Unchained',
-    'Vorinclex, Voice of Hunger', 'Craterhoof Behemoth', 'Worldspine Wurm',
+  G_trample: [
+    "Questing Beast",
+    "Thrun, the Last Troll",
+    "Polukranos, Unchained",
+    "Vorinclex, Voice of Hunger",
+    "Craterhoof Behemoth",
+    "Worldspine Wurm",
   ],
 
   // === COLORLESS CARDS ===
-  'colorless_rocks': [
-    'Sol Ring', 'Arcane Signet', 'Darksteel Ingot', 'Thought Vessel', 'Everflowing Chalice',
-    'Worn Powerstone', 'Thran Dynamo', 'Gilded Lotus', 'Mind Stone', 'Fellwar Stone',
+  colorless_rocks: [
+    "Sol Ring",
+    "Arcane Signet",
+    "Darksteel Ingot",
+    "Thought Vessel",
+    "Everflowing Chalice",
+    "Worn Powerstone",
+    "Thran Dynamo",
+    "Gilded Lotus",
+    "Mind Stone",
+    "Fellwar Stone",
   ],
-  'colorless_utility': [
-    'Swiftfoot Boots', 'Lightning Greaves', 'Sensei\'s Divining Top', 'Scroll Rack',
-    'Batterskull', 'Wurmcoil Engine', 'Basalt Monolith', 'Crypt', 'Mana Vault',
+  colorless_utility: [
+    "Swiftfoot Boots",
+    "Lightning Greaves",
+    "Sensei's Divining Top",
+    "Scroll Rack",
+    "Batterskull",
+    "Wurmcoil Engine",
+    "Basalt Monolith",
+    "Crypt",
+    "Mana Vault",
   ],
-  'colorless_equipment': [
-    'Sword of Fire and Ice', 'Sword of Light and Shadow', 'Sword of Feast and Famine',
-    'Umezawa\'s Jitte', 'Bonesplitter', 'Skullclamp', 'Cranial Plating', 'Runechanter\'s Pike',
+  colorless_equipment: [
+    "Sword of Fire and Ice",
+    "Sword of Light and Shadow",
+    "Sword of Feast and Famine",
+    "Umezawa's Jitte",
+    "Bonesplitter",
+    "Skullclamp",
+    "Cranial Plating",
+    "Runechanter's Pike",
   ],
 
   // === LANDS ===
-  'lands_dual': [
-    'Evolving Wilds', 'Terramorphic Expanse', 'Exotic Orchard', 'City of Brass',
-    'Mana Confluence', 'Command Tower', 'Reflecting Pool', 'Gemstone Mine',
-    'Shockland', 'Checkland', 'Battleland', 'Fetchland',
+  lands_dual: [
+    "Evolving Wilds",
+    "Terramorphic Expanse",
+    "Exotic Orchard",
+    "City of Brass",
+    "Mana Confluence",
+    "Command Tower",
+    "Reflecting Pool",
+    "Gemstone Mine",
+    "Shockland",
+    "Checkland",
+    "Battleland",
+    "Fetchland",
   ],
-  'lands_basic': ['Plains', 'Island', 'Swamp', 'Mountain', 'Forest'],
+  lands_basic: ["Plains", "Island", "Swamp", "Mountain", "Forest"],
 };
 
 // Enhanced archetype configurations with strategic themes
@@ -339,84 +586,197 @@ interface ArchetypeConfig {
 
 const ARCHETYPE_CONFIGS: Record<DeckArchetype, ArchetypeConfig> = {
   aggro: {
-    preferredColors: ['R', 'W', 'B'],
-    creatureCategories: ['W_one_drops', 'R_one_drops', 'B_one_drops', 'W_two_drops', 'R_two_drops', 'R_three_drops'],
-    spellCategories: ['R_burn', 'W_removal', 'B_kill', 'R_utility'],
-    themes: ['burn', 'weiss', 'zombies', 'haste', 'goblins'],
-    description: 'Fast-paced deck that aims to win quickly through aggressive creatures and burn.',
-    strategicApproach: 'Deploy cheap, efficient threats early. Apply constant pressure with creatures and direct damage. Prioritize speed over card advantage. Mulligan aggressively for low-curve hands.',
+    preferredColors: ["R", "W", "B"],
+    creatureCategories: [
+      "W_one_drops",
+      "R_one_drops",
+      "B_one_drops",
+      "W_two_drops",
+      "R_two_drops",
+      "R_three_drops",
+    ],
+    spellCategories: ["R_burn", "W_removal", "B_kill", "R_utility"],
+    themes: ["burn", "weiss", "zombies", "haste", "goblins"],
+    description:
+      "Fast-paced deck that aims to win quickly through aggressive creatures and burn.",
+    strategicApproach:
+      "Deploy cheap, efficient threats early. Apply constant pressure with creatures and direct damage. Prioritize speed over card advantage. Mulligan aggressively for low-curve hands.",
   },
   control: {
-    preferredColors: ['U', 'B', 'W'],
-    creatureCategories: ['U_two_drops', 'U_three_drops', 'B_three_drops', 'W_three_drops'],
-    spellCategories: ['U_counter', 'U_draw', 'B_kill', 'W_removal', 'B_discard', 'U_tempo'],
-    themes: ['control', 'counters', 'mill', 'reanimator'],
-    description: 'Defensive deck that controls the board and wins through card advantage.',
-    strategicApproach: 'Control the early game with removal and countermagic. Draw extra cards to find win conditions. Establish a dominant board state in the mid-to-late game. Prioritize card quality over quantity.',
+    preferredColors: ["U", "B", "W"],
+    creatureCategories: [
+      "U_two_drops",
+      "U_three_drops",
+      "B_three_drops",
+      "W_three_drops",
+    ],
+    spellCategories: [
+      "U_counter",
+      "U_draw",
+      "B_kill",
+      "W_removal",
+      "B_discard",
+      "U_tempo",
+    ],
+    themes: ["control", "counters", "mill", "reanimator"],
+    description:
+      "Defensive deck that controls the board and wins through card advantage.",
+    strategicApproach:
+      "Control the early game with removal and countermagic. Draw extra cards to find win conditions. Establish a dominant board state in the mid-to-late game. Prioritize card quality over quantity.",
   },
   midrange: {
-    preferredColors: ['G', 'B', 'W', 'R'],
-    creatureCategories: ['G_two_drops', 'G_three_drops', 'B_two_drops', 'B_three_drops', 'W_two_drops', 'W_three_drops'],
-    spellCategories: ['G_ramp', 'B_kill', 'W_removal', 'R_burn', 'U_draw'],
-    themes: ['midrange', 'aristocrats', 'toolbox', 'flash'],
-    description: 'Balanced deck with threats and answers for all stages of the game.',
-    strategicApproach: 'Play value creatures that provide multiple benefits. Use removal to disrupt opponent\'s threats while advancing your own board. Adapt strategy based on matchup and game state.',
+    preferredColors: ["G", "B", "W", "R"],
+    creatureCategories: [
+      "G_two_drops",
+      "G_three_drops",
+      "B_two_drops",
+      "B_three_drops",
+      "W_two_drops",
+      "W_three_drops",
+    ],
+    spellCategories: ["G_ramp", "B_kill", "W_removal", "R_burn", "U_draw"],
+    themes: ["midrange", "aristocrats", "toolbox", "flash"],
+    description:
+      "Balanced deck with threats and answers for all stages of the game.",
+    strategicApproach:
+      "Play value creatures that provide multiple benefits. Use removal to disrupt opponent's threats while advancing your own board. Adapt strategy based on matchup and game state.",
   },
   combo: {
-    preferredColors: ['U', 'G', 'B'],
-    creatureCategories: ['U_one_drops', 'U_two_drops', 'G_one_drops', 'G_two_drops', 'B_two_drops'],
-    spellCategories: ['U_draw', 'G_ramp', 'B_reanimate', 'U_counter', 'G_big'],
-    themes: ['storm', 'reanimator', 'scapeshift', 'artifacts', 'enchantments'],
-    description: 'Synergistic deck that combines cards for powerful interactions.',
-    strategicApproach: 'Search for combo pieces aggressively. Use card selection spells to find key cards. Protect combo with countermagic and removal. Execute win condition as soon as pieces are assembled.',
+    preferredColors: ["U", "G", "B"],
+    creatureCategories: [
+      "U_one_drops",
+      "U_two_drops",
+      "G_one_drops",
+      "G_two_drops",
+      "B_two_drops",
+    ],
+    spellCategories: ["U_draw", "G_ramp", "B_reanimate", "U_counter", "G_big"],
+    themes: ["storm", "reanimator", "scapeshift", "artifacts", "enchantments"],
+    description:
+      "Synergistic deck that combines cards for powerful interactions.",
+    strategicApproach:
+      "Search for combo pieces aggressively. Use card selection spells to find key cards. Protect combo with countermagic and removal. Execute win condition as soon as pieces are assembled.",
   },
   ramp: {
-    preferredColors: ['G', 'U', 'R'],
-    creatureCategories: ['G_one_drops', 'G_two_drops', 'U_two_drops', 'G_three_drops'],
-    spellCategories: ['G_ramp', 'G_big', 'U_draw', 'R_utility', 'colorless_rocks'],
-    themes: ['dragons', 'trample', 'artifacts', 'enchantments'],
-    description: 'Mana-focused deck that accelerates into powerful late-game threats.',
-    strategicApproach: 'Prioritize mana acceleration in the early turns. Protect your ramp spells until they resolve. Play powerful threats that dominate the game once you reach enough mana.',
+    preferredColors: ["G", "U", "R"],
+    creatureCategories: [
+      "G_one_drops",
+      "G_two_drops",
+      "U_two_drops",
+      "G_three_drops",
+    ],
+    spellCategories: [
+      "G_ramp",
+      "G_big",
+      "U_draw",
+      "R_utility",
+      "colorless_rocks",
+    ],
+    themes: ["dragons", "trample", "artifacts", "enchantments"],
+    description:
+      "Mana-focused deck that accelerates into powerful late-game threats.",
+    strategicApproach:
+      "Prioritize mana acceleration in the early turns. Protect your ramp spells until they resolve. Play powerful threats that dominate the game once you reach enough mana.",
   },
   prison: {
-    preferredColors: ['W', 'U', 'R'],
-    creatureCategories: ['W_two_drops', 'W_three_drops', 'U_two_drops', 'R_three_drops'],
-    spellCategories: ['W_removal', 'U_counter', 'R_utility', 'W_utility', 'U_tempo'],
-    themes: ['control', 'counters', 'artifacts', 'enchantments'],
-    description: 'Lockdown deck that restricts opponent\'s resources and options.',
-    strategicApproach: 'Deploy resource denial effects early. Counter key threats from the opponent. Establish a dominant board position while limiting opponent\'s options. Win through gradual advantage.',
+    preferredColors: ["W", "U", "R"],
+    creatureCategories: [
+      "W_two_drops",
+      "W_three_drops",
+      "U_two_drops",
+      "R_three_drops",
+    ],
+    spellCategories: [
+      "W_removal",
+      "U_counter",
+      "R_utility",
+      "W_utility",
+      "U_tempo",
+    ],
+    themes: ["control", "counters", "artifacts", "enchantments"],
+    description:
+      "Lockdown deck that restricts opponent's resources and options.",
+    strategicApproach:
+      "Deploy resource denial effects early. Counter key threats from the opponent. Establish a dominant board position while limiting opponent's options. Win through gradual advantage.",
   },
   tempo: {
-    preferredColors: ['U', 'R', 'W'],
-    creatureCategories: ['U_one_drops', 'U_two_drops', 'R_one_drops', 'R_two_drops', 'W_one_drops'],
-    spellCategories: ['U_tempo', 'U_counter', 'R_burn', 'R_utility', 'W_removal'],
-    themes: ['haste', 'flash', 'fairies', 'tempo'],
-    description: 'Aggressive control deck that disrupts opponents while applying pressure.',
-    strategicApproach: 'Apply early pressure while disrupting opponent\'s plays. Use bounce spells to clear blockers. Countermagic protects your threats and disrupts opponent\'s key spells. Win through efficient damage and tempo advantage.',
+    preferredColors: ["U", "R", "W"],
+    creatureCategories: [
+      "U_one_drops",
+      "U_two_drops",
+      "R_one_drops",
+      "R_two_drops",
+      "W_one_drops",
+    ],
+    spellCategories: [
+      "U_tempo",
+      "U_counter",
+      "R_burn",
+      "R_utility",
+      "W_removal",
+    ],
+    themes: ["haste", "flash", "fairies", "tempo"],
+    description:
+      "Aggressive control deck that disrupts opponents while applying pressure.",
+    strategicApproach:
+      "Apply early pressure while disrupting opponent's plays. Use bounce spells to clear blockers. Countermagic protects your threats and disrupts opponent's key spells. Win through efficient damage and tempo advantage.",
   },
   tokens: {
-    preferredColors: ['W', 'G', 'B'],
-    creatureCategories: ['W_one_drops', 'W_two_drops', 'G_two_drops', 'B_two_drops', 'G_three_drops'],
-    spellCategories: ['W_utility', 'G_big', 'W_removal', 'B_kill', 'W_lifegain'],
-    themes: ['tokens', 'aristocrats', 'lifegain', 'elves'],
-    description: 'Deck focused on generating and utilizing token creatures.',
-    strategicApproach: 'Generate tokens early and often. Use token-specific synergies to maximize their value. Populate the board rapidly and overwhelm with token swarm. Use removal to clear blockers for token attacks.',
+    preferredColors: ["W", "G", "B"],
+    creatureCategories: [
+      "W_one_drops",
+      "W_two_drops",
+      "G_two_drops",
+      "B_two_drops",
+      "G_three_drops",
+    ],
+    spellCategories: [
+      "W_utility",
+      "G_big",
+      "W_removal",
+      "B_kill",
+      "W_lifegain",
+    ],
+    themes: ["tokens", "aristocrats", "lifegain", "elves"],
+    description: "Deck focused on generating and utilizing token creatures.",
+    strategicApproach:
+      "Generate tokens early and often. Use token-specific synergies to maximize their value. Populate the board rapidly and overwhelm with token swarm. Use removal to clear blockers for token attacks.",
   },
   aristocrats: {
-    preferredColors: ['B', 'W', 'R'],
-    creatureCategories: ['B_one_drops', 'B_two_drops', 'W_one_drops', 'W_two_drops', 'R_one_drops'],
-    spellCategories: ['B_kill', 'W_removal', 'R_utility', 'B_reanimate', 'W_lifegain'],
-    themes: ['aristocrats', 'zombies', 'lifegain', 'tokens'],
-    description: 'Synergy deck that sacrifices creatures for value.',
-    strategicApproach: 'Sacrifice creatures to generate advantage and drain opponents. Use recursive threats to maintain board presence. Drain opponent\'s life through sacrifice effects. Win through cumulative damage and life gain.',
+    preferredColors: ["B", "W", "R"],
+    creatureCategories: [
+      "B_one_drops",
+      "B_two_drops",
+      "W_one_drops",
+      "W_two_drops",
+      "R_one_drops",
+    ],
+    spellCategories: [
+      "B_kill",
+      "W_removal",
+      "R_utility",
+      "B_reanimate",
+      "W_lifegain",
+    ],
+    themes: ["aristocrats", "zombies", "lifegain", "tokens"],
+    description: "Synergy deck that sacrifices creatures for value.",
+    strategicApproach:
+      "Sacrifice creatures to generate advantage and drain opponents. Use recursive threats to maintain board presence. Drain opponent's life through sacrifice effects. Win through cumulative damage and life gain.",
   },
   stompy: {
-    preferredColors: ['G', 'R', 'U'],
-    creatureCategories: ['G_one_drops', 'G_two_drops', 'R_one_drops', 'R_two_drops', 'U_one_drops'],
-    spellCategories: ['G_ramp', 'R_burn', 'G_trample', 'U_counter', 'G_big'],
-    themes: ['trample', 'haste', 'dragons', 'artifacts'],
-    description: 'Aggressive deck with powerful, efficient creatures.',
-    strategicApproach: 'Play big threats quickly and attack aggressively. Use pump spells and removal to clear blockers. Prioritize creature quality over card advantage. Win through overwhelming board presence and damage.',
+    preferredColors: ["G", "R", "U"],
+    creatureCategories: [
+      "G_one_drops",
+      "G_two_drops",
+      "R_one_drops",
+      "R_two_drops",
+      "U_one_drops",
+    ],
+    spellCategories: ["G_ramp", "R_burn", "G_trample", "U_counter", "G_big"],
+    themes: ["trample", "haste", "dragons", "artifacts"],
+    description: "Aggressive deck with powerful, efficient creatures.",
+    strategicApproach:
+      "Play big threats quickly and attack aggressively. Use pump spells and removal to clear blockers. Prioritize creature quality over card advantage. Win through overwhelming board presence and damage.",
   },
 };
 
@@ -429,124 +789,263 @@ interface ThemeCardPool {
 
 const THEME_MODIFIERS: Record<StrategicTheme, ThemeCardPool> = {
   burn: {
-    additionalCreatures: ['Goblin Guide', 'Monastery Swiftspear', 'Vexing Devil'],
-    additionalSpells: ['Lightning Bolt', 'Lava Spike', 'Skullcrack', 'Boros Charm', 'Fireblast'],
-    keyCards: ['Lightning Bolt', 'Goblin Guide'],
+    additionalCreatures: [
+      "Goblin Guide",
+      "Monastery Swiftspear",
+      "Vexing Devil",
+    ],
+    additionalSpells: [
+      "Lightning Bolt",
+      "Lava Spike",
+      "Skullcrack",
+      "Boros Charm",
+      "Fireblast",
+    ],
+    keyCards: ["Lightning Bolt", "Goblin Guide"],
   },
   weiss: {
-    additionalCreatures: ['Soul Warden', 'Champion of the Parish', 'Thalia, Guardian of Thraben'],
-    additionalSpells: ['Honor of the Pure', 'Brave the Elements', 'Path to Exile'],
-    keyCards: ['Honor of the Pure', 'Thalia, Guardian of Thraben'],
+    additionalCreatures: [
+      "Soul Warden",
+      "Champion of the Parish",
+      "Thalia, Guardian of Thraben",
+    ],
+    additionalSpells: [
+      "Honor of the Pure",
+      "Brave the Elements",
+      "Path to Exile",
+    ],
+    keyCards: ["Honor of the Pure", "Thalia, Guardian of Thraben"],
   },
   fairies: {
-    additionalCreatures: ['Spellstutter Sprite', 'Vendilion Clique', 'Mistbind Clique'],
-    additionalSpells: ['Bitterblossom', 'Cryptic Command', 'Vapor Snag'],
-    keyCards: ['Bitterblossom', 'Spellstutter Sprite'],
+    additionalCreatures: [
+      "Spellstutter Sprite",
+      "Vendilion Clique",
+      "Mistbind Clique",
+    ],
+    additionalSpells: ["Bitterblossom", "Cryptic Command", "Vapor Snag"],
+    keyCards: ["Bitterblossom", "Spellstutter Sprite"],
   },
   zombies: {
-    additionalCreatures: ['Grave Crawler', 'Geralf\'s Messenger', 'Shepherd of Rot'],
-    additionalSpells: ['Diregraf Ghoul', 'Gravecrawler', 'Dead // Gone'],
-    keyCards: ['Grave Crawler', 'Geralf\'s Messenger'],
+    additionalCreatures: [
+      "Grave Crawler",
+      "Geralf's Messenger",
+      "Shepherd of Rot",
+    ],
+    additionalSpells: ["Diregraf Ghoul", "Gravecrawler", "Dead // Gone"],
+    keyCards: ["Grave Crawler", "Geralf's Messenger"],
   },
   dragons: {
-    additionalCreatures: ['Stormbreath Dragon', 'Glorybringer', 'Thundermaw Hellkite'],
-    additionalSpells: ['Crucible of the Spirit Dragon', 'Dragon\'s Hoard', 'Sarkhan, Fireblood'],
-    keyCards: ['Stormbreath Dragon', 'Glorybringer'],
+    additionalCreatures: [
+      "Stormbreath Dragon",
+      "Glorybringer",
+      "Thundermaw Hellkite",
+    ],
+    additionalSpells: [
+      "Crucible of the Spirit Dragon",
+      "Dragon's Hoard",
+      "Sarkhan, Fireblood",
+    ],
+    keyCards: ["Stormbreath Dragon", "Glorybringer"],
   },
   tokens: {
-    additionalCreatures: ['Young Pyromancer', 'Monastery Mentor', 'Secure the Wastes'],
-    additionalSpells: ['Raise the Alarm', 'Spectral Procession', 'Secure the Wastes'],
-    keyCards: ['Secure the Wastes', 'Spectral Procession'],
+    additionalCreatures: [
+      "Young Pyromancer",
+      "Monastery Mentor",
+      "Secure the Wastes",
+    ],
+    additionalSpells: [
+      "Raise the Alarm",
+      "Spectral Procession",
+      "Secure the Wastes",
+    ],
+    keyCards: ["Secure the Wastes", "Spectral Procession"],
   },
   mill: {
-    additionalCreatures: ['Jace\'s Phantasm', 'Hedron Crab', 'Manic Scribe'],
-    additionalSpells: ['Mind Funeral', 'Mesmeric Orb', 'Archive Trap', 'Glimpse the Unthinkable'],
-    keyCards: ['Mind Funeral', 'Mesmeric Orb'],
+    additionalCreatures: ["Jace's Phantasm", "Hedron Crab", "Manic Scribe"],
+    additionalSpells: [
+      "Mind Funeral",
+      "Mesmeric Orb",
+      "Archive Trap",
+      "Glimpse the Unthinkable",
+    ],
+    keyCards: ["Mind Funeral", "Mesmeric Orb"],
   },
   lifegain: {
-    additionalCreatures: ['Soul Warden', 'Soul\'s Attendant', 'Auriok Champion', 'Crested Sunmare'],
-    additionalSpells: ['Sphinx\'s Revelation', 'Revitalize', 'Rest for the Weary', 'Felidar Sovereign'],
-    keyCards: ['Crested Sunmare', 'Felidar Sovereign'],
+    additionalCreatures: [
+      "Soul Warden",
+      "Soul's Attendant",
+      "Auriok Champion",
+      "Crested Sunmare",
+    ],
+    additionalSpells: [
+      "Sphinx's Revelation",
+      "Revitalize",
+      "Rest for the Weary",
+      "Felidar Sovereign",
+    ],
+    keyCards: ["Crested Sunmare", "Felidar Sovereign"],
   },
   artifacts: {
-    additionalCreatures: ['Karn, Silver Golem', 'Arcbound Ravager', 'Memnite'],
-    additionalSpells: ['Mox Opal', 'Chromatic Lantern', 'Whir of Invention'],
-    keyCards: ['Arcbound Ravager', 'Mox Opal'],
+    additionalCreatures: ["Karn, Silver Golem", "Arcbound Ravager", "Memnite"],
+    additionalSpells: ["Mox Opal", "Chromatic Lantern", "Whir of Invention"],
+    keyCards: ["Arcbound Ravager", "Mox Opal"],
   },
   enchantments: {
-    additionalCreatures: ['Satyr Enchanter', 'Eidolon of Blossoms', 'Enchantress\'s Presence'],
-    additionalSpells: ['Omniscience', 'Enchantress\'s Presence', 'Sylvan Library'],
-    keyCards: ['Enchantress\'s Presence', 'Sylvan Library'],
+    additionalCreatures: [
+      "Satyr Enchanter",
+      "Eidolon of Blossoms",
+      "Enchantress's Presence",
+    ],
+    additionalSpells: [
+      "Omniscience",
+      "Enchantress's Presence",
+      "Sylvan Library",
+    ],
+    keyCards: ["Enchantress's Presence", "Sylvan Library"],
   },
   counters: {
-    additionalCreatures: ['Snapcaster Mage', 'Thing in the Ice', 'Teferi, Time Raveler'],
-    additionalSpells: ['Counterspell', 'Mana Leak', 'Force of Will', 'Cryptic Command'],
-    keyCards: ['Counterspell', 'Cryptic Command'],
+    additionalCreatures: [
+      "Snapcaster Mage",
+      "Thing in the Ice",
+      "Teferi, Time Raveler",
+    ],
+    additionalSpells: [
+      "Counterspell",
+      "Mana Leak",
+      "Force of Will",
+      "Cryptic Command",
+    ],
+    keyCards: ["Counterspell", "Cryptic Command"],
   },
   reanimator: {
-    additionalCreatures: ['Gravecrawler', 'Phyrexian Dreadnought', 'Iona, Shield of Emeria'],
-    additionalSpells: ['Entomb', 'Animate Dead', 'Reanimate', 'Exhume'],
-    keyCards: ['Entomb', 'Animate Dead'],
+    additionalCreatures: [
+      "Gravecrawler",
+      "Phyrexian Dreadnought",
+      "Iona, Shield of Emeria",
+    ],
+    additionalSpells: ["Entomb", "Animate Dead", "Reanimate", "Exhume"],
+    keyCards: ["Entomb", "Animate Dead"],
   },
   elves: {
-    additionalCreatures: ['Llanowar Elves', 'Elvish Archdruid', 'Ezuri, Renegade Leader', 'Heritage Druid'],
-    additionalSpells: ['Elvish Promenade', 'Beastmaster Ascension', 'Coat of Arms'],
-    keyCards: ['Elvish Archdruid', 'Ezuri, Renegade Leader'],
+    additionalCreatures: [
+      "Llanowar Elves",
+      "Elvish Archdruid",
+      "Ezuri, Renegade Leader",
+      "Heritage Druid",
+    ],
+    additionalSpells: [
+      "Elvish Promenade",
+      "Beastmaster Ascension",
+      "Coat of Arms",
+    ],
+    keyCards: ["Elvish Archdruid", "Ezuri, Renegade Leader"],
   },
   goblins: {
-    additionalCreatures: ['Goblin Guide', 'Goblin Piledriver', 'Goblin Matron', 'Goblin Warchief'],
-    additionalSpells: ['Goblin Bushwhacker', 'Goblin War Strike', 'Empty the Warrens'],
-    keyCards: ['Goblin Guide', 'Goblin Warchief'],
+    additionalCreatures: [
+      "Goblin Guide",
+      "Goblin Piledriver",
+      "Goblin Matron",
+      "Goblin Warchief",
+    ],
+    additionalSpells: [
+      "Goblin Bushwhacker",
+      "Goblin War Strike",
+      "Empty the Warrens",
+    ],
+    keyCards: ["Goblin Guide", "Goblin Warchief"],
   },
   control: {
-    additionalCreatures: ['Snapcaster Mage', 'Vendilion Clique', 'Teferi, Time Raveler'],
-    additionalSpells: ['Counterspell', 'Thoughtseize', 'Brainstorm', 'Fact or Fiction'],
-    keyCards: ['Counterspell', 'Thoughtseize'],
+    additionalCreatures: [
+      "Snapcaster Mage",
+      "Vendilion Clique",
+      "Teferi, Time Raveler",
+    ],
+    additionalSpells: [
+      "Counterspell",
+      "Thoughtseize",
+      "Brainstorm",
+      "Fact or Fiction",
+    ],
+    keyCards: ["Counterspell", "Thoughtseize"],
   },
   midrange: {
-    additionalCreatures: ['Thrun, the Last Troll', 'Siege Rhino', 'Tarmogoyf'],
-    additionalSpells: ['Abrupt Decay', 'Maelstrom Pulse', 'Thoughtseize', 'Garruk, Primal Hunter'],
-    keyCards: ['Thrun, the Last Troll', 'Abrupt Decay'],
+    additionalCreatures: ["Thrun, the Last Troll", "Siege Rhino", "Tarmogoyf"],
+    additionalSpells: [
+      "Abrupt Decay",
+      "Maelstrom Pulse",
+      "Thoughtseize",
+      "Garruk, Primal Hunter",
+    ],
+    keyCards: ["Thrun, the Last Troll", "Abrupt Decay"],
   },
   storm: {
-    additionalCreatures: ['Baral, Chief of Compliance', 'Goblin Electromancer'],
-    additionalSpells: ['Mind\'s Desire', 'Grapeshot', 'Empty the Warrens', 'Past in Flames'],
-    keyCards: ['Mind\'s Desire', 'Grapeshot'],
+    additionalCreatures: ["Baral, Chief of Compliance", "Goblin Electromancer"],
+    additionalSpells: [
+      "Mind's Desire",
+      "Grapeshot",
+      "Empty the Warrens",
+      "Past in Flames",
+    ],
+    keyCards: ["Mind's Desire", "Grapeshot"],
   },
   scapeshift: {
-    additionalCreatures: ['Sakura-Tribe Elder', 'Knight of the Reliquary'],
-    additionalSpells: ['Scapeshift', 'Valakut, the Molten Pinnacle', 'Primeval Titan'],
-    keyCards: ['Scapeshift', 'Primeval Titan'],
+    additionalCreatures: ["Sakura-Tribe Elder", "Knight of the Reliquary"],
+    additionalSpells: [
+      "Scapeshift",
+      "Valakut, the Molten Pinnacle",
+      "Primeval Titan",
+    ],
+    keyCards: ["Scapeshift", "Primeval Titan"],
   },
   trample: {
-    additionalCreatures: ['Questing Beast', 'Polukranos, Unchained', 'Vorinclex, Voice of Hunger'],
-    additionalSpells: ['Rancor', 'Giant Growth', 'Aspect of Hydra'],
-    keyCards: ['Questing Beast', 'Polukranos, Unchained'],
+    additionalCreatures: [
+      "Questing Beast",
+      "Polukranos, Unchained",
+      "Vorinclex, Voice of Hunger",
+    ],
+    additionalSpells: ["Rancor", "Giant Growth", "Aspect of Hydra"],
+    keyCards: ["Questing Beast", "Polukranos, Unchained"],
   },
   haste: {
-    additionalCreatures: ['Ball Lightning', 'Spark Elemental', 'Feldon\'s Cane'],
-    additionalSpells: ['Fling', 'Reckless Charge', 'Bloodrush'],
-    keyCards: ['Ball Lightning', 'Feldon\'s Cane'],
+    additionalCreatures: ["Ball Lightning", "Spark Elemental", "Feldon's Cane"],
+    additionalSpells: ["Fling", "Reckless Charge", "Bloodrush"],
+    keyCards: ["Ball Lightning", "Feldon's Cane"],
   },
   flash: {
-    additionalCreatures: ['Restoration Angel', 'Flickerwisp', 'Mystic Snake'],
-    additionalSpells: ['Cryptic Command', 'Venser, Shaper Savant', 'Mystic Confluence'],
-    keyCards: ['Restoration Angel', 'Cryptic Command'],
+    additionalCreatures: ["Restoration Angel", "Flickerwisp", "Mystic Snake"],
+    additionalSpells: [
+      "Cryptic Command",
+      "Venser, Shaper Savant",
+      "Mystic Confluence",
+    ],
+    keyCards: ["Restoration Angel", "Cryptic Command"],
   },
   toolbox: {
-    additionalCreatures: [' Eternal Witness', 'Kor Spiritdancer', 'Recruitment Officer'],
-    additionalSpells: ['Fabricate', 'Birthing Pod', 'Chord of Calling'],
-    keyCards: ['Eternal Witness', 'Chord of Calling'],
+    additionalCreatures: [
+      " Eternal Witness",
+      "Kor Spiritdancer",
+      "Recruitment Officer",
+    ],
+    additionalSpells: ["Fabricate", "Birthing Pod", "Chord of Calling"],
+    keyCards: ["Eternal Witness", "Chord of Calling"],
   },
   aristocrats: {
-    additionalCreatures: ['Blood Artist', 'Zulaport Cutthroat', 'Carrion Feeder'],
-    additionalSpells: ['Viscera Seer', 'Altar\'s Reap', 'Butcher Ghoul'],
-    keyCards: ['Blood Artist', 'Zulaport Cutthroat'],
+    additionalCreatures: [
+      "Blood Artist",
+      "Zulaport Cutthroat",
+      "Carrion Feeder",
+    ],
+    additionalSpells: ["Viscera Seer", "Altar's Reap", "Butcher Ghoul"],
+    keyCards: ["Blood Artist", "Zulaport Cutthroat"],
   },
   tempo: {
-    additionalCreatures: ['Delver of Secrets', 'Spellstutter Sprite', 'Noble Hierarch'],
-    additionalSpells: ['Daze', 'Force of Will', 'Cryptic Command'],
-    keyCards: ['Delver of Secrets', 'Force of Will'],
+    additionalCreatures: [
+      "Delver of Secrets",
+      "Spellstutter Sprite",
+      "Noble Hierarch",
+    ],
+    additionalSpells: ["Daze", "Force of Will", "Cryptic Command"],
+    keyCards: ["Delver of Secrets", "Force of Will"],
   },
 };
 
@@ -558,7 +1057,10 @@ function getRandomItems<T>(arr: T[], count: number, weights?: number[]): T[] {
   // If weights provided, use weighted random selection
   if (weights && weights.length === arr.length) {
     const selected: T[] = [];
-    const available = arr.map((item, index) => ({ item, weight: weights[index] }));
+    const available = arr.map((item, index) => ({
+      item,
+      weight: weights[index],
+    }));
 
     for (let i = 0; i < Math.min(count, available.length); i++) {
       const totalWeight = available.reduce((sum, item) => sum + item.weight, 0);
@@ -586,7 +1088,11 @@ function getRandomItems<T>(arr: T[], count: number, weights?: number[]): T[] {
 }
 
 // Weighted random selection based on card quality/importance
-function getWeightedCards(categories: string[], count: number, difficulty: DifficultyLevel): string[] {
+function getWeightedCards(
+  categories: string[],
+  count: number,
+  difficulty: DifficultyLevel,
+): string[] {
   const allCards: string[] = [];
   const weights: number[] = [];
 
@@ -617,7 +1123,7 @@ function getCardsForColors(
   colorIdentity: string[],
   categories: string[],
   count: number,
-  difficulty: DifficultyLevel
+  difficulty: DifficultyLevel,
 ): string[] {
   if (colorIdentity.length === 0) {
     // If no colors specified, get random categories
@@ -645,7 +1151,10 @@ function getCardsForColors(
 }
 
 // Calculate mana curve based on archetype and difficulty
-function calculateManaCurve(archetype: DeckArchetype, difficulty: DifficultyLevel): number[] {
+function calculateManaCurve(
+  archetype: DeckArchetype,
+  difficulty: DifficultyLevel,
+): number[] {
   const baseCurve = DIFFICULTY_CONFIGS[difficulty].curve;
   const archetypeMultiplier: Record<DeckArchetype, number> = {
     aggro: 1.0,
@@ -675,18 +1184,20 @@ function generateLands(
   colorIdentity: string[],
   format: Format,
   difficulty: DifficultyLevel,
-  landCount: number
+  landCount: number,
 ): Array<{ name: string; quantity: number }> {
   const lands: Array<{ name: string; quantity: number }> = [];
 
-  if (format === 'legendary-commander') {
+  if (format === "legendary-commander") {
     // Commander decks get more lands and dual lands
     const basicLandCount = Math.floor(landCount * 0.6);
     const dualLandCount = Math.floor(landCount * 0.4);
 
     // Add basic lands
     if (colorIdentity.length > 0) {
-      const basicLandsPerColor = Math.floor(basicLandCount / colorIdentity.length);
+      const basicLandsPerColor = Math.floor(
+        basicLandCount / colorIdentity.length,
+      );
       for (const color of colorIdentity) {
         const colorIndex = { W: 0, U: 1, B: 2, R: 3, G: 4 }[color];
         if (colorIndex !== undefined) {
@@ -699,7 +1210,10 @@ function generateLands(
     // Add dual lands based on difficulty
     const dualLands = CARD_POOL.lands_dual;
     const dualLandCountActual = Math.min(dualLandCount, dualLands.length * 2);
-    const selectedDuals = getRandomItems(dualLands, Math.ceil(dualLandCountActual / 2));
+    const selectedDuals = getRandomItems(
+      dualLands,
+      Math.ceil(dualLandCountActual / 2),
+    );
 
     for (const dualLand of selectedDuals) {
       lands.push({ name: dualLand, quantity: 2 });
@@ -711,7 +1225,9 @@ function generateLands(
 
     // Add basic lands
     if (colorIdentity.length > 0) {
-      const basicLandsPerColor = Math.floor(basicLandCount / colorIdentity.length);
+      const basicLandsPerColor = Math.floor(
+        basicLandCount / colorIdentity.length,
+      );
       for (const color of colorIdentity) {
         const colorIndex = { W: 0, U: 1, B: 2, R: 3, G: 4 }[color];
         if (colorIndex !== undefined) {
@@ -737,7 +1253,7 @@ function generateLands(
 function generateStrategicApproach(
   archetype: DeckArchetype,
   theme: StrategicTheme,
-  difficulty: DifficultyLevel
+  difficulty: DifficultyLevel,
 ): string {
   const archetypeConfig = ARCHETYPE_CONFIGS[archetype];
   const themeModifier = THEME_MODIFIERS[theme];
@@ -746,15 +1262,17 @@ function generateStrategicApproach(
 
   // Add theme-specific guidance
   if (themeModifier.keyCards.length > 0) {
-    approach += ` Key cards include ${themeModifier.keyCards.slice(0, 3).join(', ')}.`;
+    approach += ` Key cards include ${themeModifier.keyCards.slice(0, 3).join(", ")}.`;
   }
 
   // Add difficulty-specific guidance
   const difficultyGuidance: Record<DifficultyLevel, string> = {
-    easy: ' This opponent makes suboptimal decisions and may miss synergies.',
-    medium: ' This opponent plays reasonably well but may make occasional mistakes.',
-    hard: ' This opponent plays consistently well and capitalizes on synergies.',
-    expert: ' This opponent makes optimal plays with deep strategic understanding.',
+    easy: " This opponent makes suboptimal decisions and may miss synergies.",
+    medium:
+      " This opponent plays reasonably well but may make occasional mistakes.",
+    hard: " This opponent plays consistently well and capitalizes on synergies.",
+    expert:
+      " This opponent makes optimal plays with deep strategic understanding.",
   };
 
   approach += difficultyGuidance[difficulty];
@@ -765,13 +1283,15 @@ function generateStrategicApproach(
 /**
  * Generate an opponent deck based on archetype, theme, and difficulty
  */
-export function generateOpponentDeck(input: OpponentDeckGenerationInput): GeneratedDeck {
+export function generateOpponentDeck(
+  input: OpponentDeckGenerationInput,
+): GeneratedDeck {
   const {
     format,
-    archetype = 'midrange',
+    archetype = "midrange",
     theme,
     colorIdentity,
-    difficulty = 'medium',
+    difficulty = "medium",
   } = input;
 
   const archetypeConfig = ARCHETYPE_CONFIGS[archetype];
@@ -781,7 +1301,10 @@ export function generateOpponentDeck(input: OpponentDeckGenerationInput): Genera
   let finalColorIdentity = colorIdentity;
   if (!finalColorIdentity || finalColorIdentity.length === 0) {
     const colorCount = Math.floor(Math.random() * 3) + 1; // 1-3 colors
-    finalColorIdentity = getRandomItems(archetypeConfig.preferredColors, colorCount);
+    finalColorIdentity = getRandomItems(
+      archetypeConfig.preferredColors,
+      colorCount,
+    );
   }
 
   // Determine theme if not specified
@@ -793,7 +1316,7 @@ export function generateOpponentDeck(input: OpponentDeckGenerationInput): Genera
   // Get format-specific deck size
   const formatRulesConfig = formatRules[format];
   const totalCards = formatRulesConfig.minCards;
-  const isCommander = format === 'legendary-commander';
+  const isCommander = format === "legendary-commander";
 
   // Calculate land count based on format and difficulty
   const landCount = isCommander
@@ -801,24 +1324,40 @@ export function generateOpponentDeck(input: OpponentDeckGenerationInput): Genera
     : difficultyConfig.landCount;
 
   // Generate lands
-  const lands = generateLands(finalColorIdentity, format, difficulty, landCount);
+  const lands = generateLands(
+    finalColorIdentity,
+    format,
+    difficulty,
+    landCount,
+  );
   cards.push(...lands);
 
   // Calculate remaining non-land slots
   const nonLandSlots = totalCards - landCount;
 
   // Get card counts based on difficulty
-  const creatureSlots = Math.floor(nonLandSlots * (difficultyConfig.creatureCount / 100));
-  const spellSlots = Math.floor(nonLandSlots * ((100 - difficultyConfig.creatureCount - difficultyConfig.synergyWeight * 10) / 100));
+  const creatureSlots = Math.floor(
+    nonLandSlots * (difficultyConfig.creatureCount / 100),
+  );
+  const spellSlots = Math.floor(
+    nonLandSlots *
+      ((100 -
+        difficultyConfig.creatureCount -
+        difficultyConfig.synergyWeight * 10) /
+        100),
+  );
   const synergySlots = nonLandSlots - creatureSlots - spellSlots;
 
   // Add theme-specific key cards
   const keyCardCount = Math.floor(synergySlots * 0.3);
-  const keyCards = getRandomItems(themeModifier.keyCards, Math.min(keyCardCount, themeModifier.keyCards.length));
+  const keyCards = getRandomItems(
+    themeModifier.keyCards,
+    Math.min(keyCardCount, themeModifier.keyCards.length),
+  );
 
   for (const keyCard of keyCards) {
     const quantity = isCommander ? 1 : Math.min(4, keyCardCount);
-    if (!cards.find(c => c.name === keyCard)) {
+    if (!cards.find((c) => c.name === keyCard)) {
       cards.push({ name: keyCard, quantity });
     }
   }
@@ -833,22 +1372,27 @@ export function generateOpponentDeck(input: OpponentDeckGenerationInput): Genera
         finalColorIdentity,
         archetypeConfig.creatureCategories,
         manaCurve[cmc],
-        difficulty
+        difficulty,
       );
 
       // Add theme-specific creatures
       const themeCreatures = getWeightedCards(
         themeModifier.additionalCreatures,
         Math.floor(manaCurve[cmc] * 0.3),
-        difficulty
+        difficulty,
       );
 
       const allCreatures = [...cmcCreatures, ...themeCreatures];
       const selectedCreatures = getRandomItems(allCreatures, manaCurve[cmc]);
 
       for (const creature of selectedCreatures) {
-        const quantity = isCommander ? 1 : Math.min(4, Math.floor(Math.random() * 3) + 1);
-        if (!cards.find(c => c.name === creature) && totalAdded < totalCards) {
+        const quantity = isCommander
+          ? 1
+          : Math.min(4, Math.floor(Math.random() * 3) + 1);
+        if (
+          !cards.find((c) => c.name === creature) &&
+          totalAdded < totalCards
+        ) {
           const actualQuantity = Math.min(quantity, totalCards - totalAdded);
           cards.push({ name: creature, quantity: actualQuantity });
           totalAdded += actualQuantity;
@@ -862,8 +1406,10 @@ export function generateOpponentDeck(input: OpponentDeckGenerationInput): Genera
 
   // Add theme-specific spells
   for (const themeSpell of themeModifier.additionalSpells) {
-    if (totalAdded < totalCards && !cards.find(c => c.name === themeSpell)) {
-      const quantity = isCommander ? 1 : Math.min(4, Math.floor(Math.random() * 3) + 1);
+    if (totalAdded < totalCards && !cards.find((c) => c.name === themeSpell)) {
+      const quantity = isCommander
+        ? 1
+        : Math.min(4, Math.floor(Math.random() * 3) + 1);
       const actualQuantity = Math.min(quantity, totalCards - totalAdded);
       cards.push({ name: themeSpell, quantity: actualQuantity });
       totalAdded += actualQuantity;
@@ -875,12 +1421,14 @@ export function generateOpponentDeck(input: OpponentDeckGenerationInput): Genera
     finalColorIdentity,
     spellCategories,
     Math.max(0, totalCards - totalAdded),
-    difficulty
+    difficulty,
   );
 
   for (const spell of archetypeSpells) {
-    if (totalAdded < totalCards && !cards.find(c => c.name === spell)) {
-      const quantity = isCommander ? 1 : Math.min(4, Math.floor(Math.random() * 3) + 1);
+    if (totalAdded < totalCards && !cards.find((c) => c.name === spell)) {
+      const quantity = isCommander
+        ? 1
+        : Math.min(4, Math.floor(Math.random() * 3) + 1);
       const actualQuantity = Math.min(quantity, totalCards - totalAdded);
       cards.push({ name: spell, quantity: actualQuantity });
       totalAdded += actualQuantity;
@@ -888,24 +1436,28 @@ export function generateOpponentDeck(input: OpponentDeckGenerationInput): Genera
   }
 
   // Add mana rocks for ramp decks or higher difficulty
-  if (archetype === 'ramp' || difficulty === 'hard' || difficulty === 'expert') {
-    const rockCount = isCommander ? 8 : (difficulty === 'expert' ? 4 : 3);
+  if (
+    archetype === "ramp" ||
+    difficulty === "hard" ||
+    difficulty === "expert"
+  ) {
+    const rockCount = isCommander ? 8 : difficulty === "expert" ? 4 : 3;
     const rocks = getRandomItems(CARD_POOL.colorless_rocks, rockCount);
 
     for (const rock of rocks) {
-      if (!cards.find(c => c.name === rock)) {
+      if (!cards.find((c) => c.name === rock)) {
         cards.push({ name: rock, quantity: 1 });
       }
     }
   }
 
   // Add utility artifacts for higher difficulty
-  if (difficulty === 'hard' || difficulty === 'expert') {
+  if (difficulty === "hard" || difficulty === "expert") {
     const utilityCount = isCommander ? 6 : 3;
     const utilities = getRandomItems(CARD_POOL.colorless_utility, utilityCount);
 
     for (const utility of utilities) {
-      if (!cards.find(c => c.name === utility)) {
+      if (!cards.find((c) => c.name === utility)) {
         cards.push({ name: utility, quantity: isCommander ? 1 : 1 });
       }
     }
@@ -914,12 +1466,20 @@ export function generateOpponentDeck(input: OpponentDeckGenerationInput): Genera
   // Fill remaining slots with generic good cards if needed
   let currentTotal = cards.reduce((sum, card) => sum + card.quantity, 0);
   if (currentTotal < totalCards) {
-    const fillerCards = ['Brainstorm', 'Ponder', 'Counterspell', 'Lightning Bolt', 'Swords to Plowshares'];
-    
+    const fillerCards = [
+      "Brainstorm",
+      "Ponder",
+      "Counterspell",
+      "Lightning Bolt",
+      "Swords to Plowshares",
+    ];
+
     for (const filler of fillerCards) {
       if (currentTotal >= totalCards) break;
-      if (!cards.find(c => c.name === filler)) {
-        const quantity = isCommander ? 1 : Math.min(4, totalCards - currentTotal);
+      if (!cards.find((c) => c.name === filler)) {
+        const quantity = isCommander
+          ? 1
+          : Math.min(4, totalCards - currentTotal);
         cards.push({ name: filler, quantity });
         currentTotal += quantity;
       }
@@ -928,11 +1488,13 @@ export function generateOpponentDeck(input: OpponentDeckGenerationInput): Genera
 
   // If still not enough, add basic lands as temporary filler to reach exact count
   if (currentTotal < totalCards) {
-    const fillerLands = ['Wastes', 'Reliquary Tower', 'Command Tower'];
+    const fillerLands = ["Wastes", "Reliquary Tower", "Command Tower"];
     for (const land of fillerLands) {
       if (currentTotal >= totalCards) break;
-      if (!cards.find(c => c.name === land)) {
-        const quantity = isCommander ? 1 : Math.min(4, totalCards - currentTotal);
+      if (!cards.find((c) => c.name === land)) {
+        const quantity = isCommander
+          ? 1
+          : Math.min(4, totalCards - currentTotal);
         cards.push({ name: land, quantity });
         currentTotal += quantity;
       }
@@ -946,54 +1508,58 @@ export function generateOpponentDeck(input: OpponentDeckGenerationInput): Genera
 
   // Generate deck name
   const colorNames: Record<string, string> = {
-    W: 'White',
-    U: 'Blue',
-    B: 'Black',
-    R: 'Red',
-    G: 'Green',
+    W: "White",
+    U: "Blue",
+    B: "Black",
+    R: "Red",
+    G: "Green",
   };
-  const colors = finalColorIdentity.map((c) => colorNames[c]).join('/');
+  const colors = finalColorIdentity.map((c) => colorNames[c]).join("/");
   const archetypeNames: Record<DeckArchetype, string> = {
-    aggro: 'Aggro',
-    control: 'Control',
-    midrange: 'Midrange',
-    combo: 'Combo',
-    ramp: 'Ramp',
-    prison: 'Prison',
-    tempo: 'Tempo',
-    tokens: 'Tokens',
-    aristocrats: 'Aristocrats',
-    stompy: 'Stompy',
+    aggro: "Aggro",
+    control: "Control",
+    midrange: "Midrange",
+    combo: "Combo",
+    ramp: "Ramp",
+    prison: "Prison",
+    tempo: "Tempo",
+    tokens: "Tokens",
+    aristocrats: "Aristocrats",
+    stompy: "Stompy",
   };
   const themeNames: Record<StrategicTheme, string> = {
-    burn: 'Burn',
-    weiss: 'White Weenie',
-    fairies: 'Fairies',
-    zombies: 'Zombies',
-    dragons: 'Dragons',
-    tokens: 'Tokens',
-    mill: 'Mill',
-    lifegain: 'Lifegain',
-    artifacts: 'Artifacts',
-    enchantments: 'Enchantments',
-    counters: 'Counters',
-    reanimator: 'Reanimator',
-    elves: 'Elves',
-    goblins: 'Goblins',
-    control: 'Control',
-    midrange: 'Midrange',
-    storm: 'Storm',
-    scapeshift: 'Scapeshift',
-    trample: 'Trample',
-    haste: 'Haste',
-    flash: 'Flash',
-    toolbox: 'Toolbox',
-    aristocrats: 'Aristocrats',
-    tempo: 'Tempo',
+    burn: "Burn",
+    weiss: "White Weenie",
+    fairies: "Fairies",
+    zombies: "Zombies",
+    dragons: "Dragons",
+    tokens: "Tokens",
+    mill: "Mill",
+    lifegain: "Lifegain",
+    artifacts: "Artifacts",
+    enchantments: "Enchantments",
+    counters: "Counters",
+    reanimator: "Reanimator",
+    elves: "Elves",
+    goblins: "Goblins",
+    control: "Control",
+    midrange: "Midrange",
+    storm: "Storm",
+    scapeshift: "Scapeshift",
+    trample: "Trample",
+    haste: "Haste",
+    flash: "Flash",
+    toolbox: "Toolbox",
+    aristocrats: "Aristocrats",
+    tempo: "Tempo",
   };
 
   const deckName = `${colors} ${archetypeNames[archetype]} - ${themeNames[finalTheme]}`;
-  const strategicApproach = generateStrategicApproach(archetype, finalTheme, difficulty);
+  const strategicApproach = generateStrategicApproach(
+    archetype,
+    finalTheme,
+    difficulty,
+  );
 
   // Ensure exact card count
   const finalCards = [];
@@ -1019,18 +1585,39 @@ export function generateOpponentDeck(input: OpponentDeckGenerationInput): Genera
     colorIdentity: finalColorIdentity,
     difficulty,
     format,
+    sideboard: generateSideboard({
+      archetype,
+      colorIdentity: finalColorIdentity,
+      difficulty,
+      format,
+      maindeckCards: finalCards,
+    }),
   };
 }
 
 /**
  * Quick generate random deck with random parameters
  */
-export function generateRandomDeck(format: Format = 'legendary-commander'): GeneratedDeck {
-  const archetypes: DeckArchetype[] = ['aggro', 'control', 'midrange', 'combo', 'ramp', 'prison', 'tempo', 'tokens', 'aristocrats', 'stompy'];
-  const difficulties: DifficultyLevel[] = ['easy', 'medium', 'hard', 'expert'];
+export function generateRandomDeck(
+  format: Format = "legendary-commander",
+): GeneratedDeck {
+  const archetypes: DeckArchetype[] = [
+    "aggro",
+    "control",
+    "midrange",
+    "combo",
+    "ramp",
+    "prison",
+    "tempo",
+    "tokens",
+    "aristocrats",
+    "stompy",
+  ];
+  const difficulties: DifficultyLevel[] = ["easy", "medium", "hard", "expert"];
 
   const archetype = archetypes[Math.floor(Math.random() * archetypes.length)];
-  const difficulty = difficulties[Math.floor(Math.random() * difficulties.length)];
+  const difficulty =
+    difficulties[Math.floor(Math.random() * difficulties.length)];
 
   return generateOpponentDeck({ format, archetype, difficulty });
 }
@@ -1040,35 +1627,35 @@ export function generateRandomDeck(format: Format = 'legendary-commander'): Gene
  */
 export function generateThemedDeck(
   theme: StrategicTheme,
-  format: Format = 'legendary-commander',
-  difficulty: DifficultyLevel = 'medium'
+  format: Format = "legendary-commander",
+  difficulty: DifficultyLevel = "medium",
 ): GeneratedDeck {
   const themeToArchetype: Partial<Record<StrategicTheme, DeckArchetype>> = {
-    burn: 'aggro',
-    weiss: 'aggro',
-    fairies: 'tempo',
-    zombies: 'aristocrats',
-    dragons: 'ramp',
-    tokens: 'tokens',
-    mill: 'control',
-    lifegain: 'midrange',
-    artifacts: 'combo',
-    enchantments: 'combo',
-    counters: 'control',
-    reanimator: 'combo',
-    elves: 'ramp',
-    goblins: 'aggro',
-    control: 'control',
-    midrange: 'midrange',
-    storm: 'combo',
-    scapeshift: 'combo',
-    trample: 'stompy',
-    haste: 'aggro',
-    flash: 'tempo',
-    toolbox: 'midrange',
+    burn: "aggro",
+    weiss: "aggro",
+    fairies: "tempo",
+    zombies: "aristocrats",
+    dragons: "ramp",
+    tokens: "tokens",
+    mill: "control",
+    lifegain: "midrange",
+    artifacts: "combo",
+    enchantments: "combo",
+    counters: "control",
+    reanimator: "combo",
+    elves: "ramp",
+    goblins: "aggro",
+    control: "control",
+    midrange: "midrange",
+    storm: "combo",
+    scapeshift: "combo",
+    trample: "stompy",
+    haste: "aggro",
+    flash: "tempo",
+    toolbox: "midrange",
   };
 
-  const archetype = themeToArchetype[theme] || 'midrange';
+  const archetype = themeToArchetype[theme] || "midrange";
   return generateOpponentDeck({ format, archetype, theme, difficulty });
 }
 
@@ -1077,13 +1664,29 @@ export function generateThemedDeck(
  */
 export function generateColorDeck(
   colors: string[],
-  format: Format = 'legendary-commander',
-  difficulty: DifficultyLevel = 'medium'
+  format: Format = "legendary-commander",
+  difficulty: DifficultyLevel = "medium",
 ): GeneratedDeck {
-  const archetypes: DeckArchetype[] = ['aggro', 'control', 'midrange', 'combo', 'ramp', 'prison', 'tempo', 'tokens', 'aristocrats', 'stompy'];
+  const archetypes: DeckArchetype[] = [
+    "aggro",
+    "control",
+    "midrange",
+    "combo",
+    "ramp",
+    "prison",
+    "tempo",
+    "tokens",
+    "aristocrats",
+    "stompy",
+  ];
   const archetype = archetypes[Math.floor(Math.random() * archetypes.length)];
 
-  return generateOpponentDeck({ format, archetype, colorIdentity: colors, difficulty });
+  return generateOpponentDeck({
+    format,
+    archetype,
+    colorIdentity: colors,
+    difficulty,
+  });
 }
 
 /**
@@ -1103,21 +1706,27 @@ export function getAvailableThemes(archetype: DeckArchetype): StrategicTheme[] {
 /**
  * Get archetype configuration
  */
-export function getArchetypeConfig(archetype: DeckArchetype): ArchetypeConfig | undefined {
+export function getArchetypeConfig(
+  archetype: DeckArchetype,
+): ArchetypeConfig | undefined {
   return ARCHETYPE_CONFIGS[archetype];
 }
 
 /**
  * Get difficulty configuration
  */
-export function getDifficultyConfig(difficulty: DifficultyLevel): DifficultyConfig {
+export function getDifficultyConfig(
+  difficulty: DifficultyLevel,
+): DifficultyConfig {
   return DIFFICULTY_CONFIGS[difficulty];
 }
 
 /**
  * Validate deck archetype
  */
-export function isValidArchetype(archetype: string): archetype is DeckArchetype {
+export function isValidArchetype(
+  archetype: string,
+): archetype is DeckArchetype {
   return getAvailableArchetypes().includes(archetype as DeckArchetype);
 }
 
@@ -1131,6 +1740,687 @@ export function isValidTheme(theme: string): theme is StrategicTheme {
 /**
  * Validate difficulty level
  */
-export function isValidDifficulty(difficulty: string): difficulty is DifficultyLevel {
-  return ['easy', 'medium', 'hard', 'expert'].includes(difficulty);
+export function isValidDifficulty(
+  difficulty: string,
+): difficulty is DifficultyLevel {
+  return ["easy", "medium", "hard", "expert"].includes(difficulty);
+}
+
+// =============================================================================
+// Issue #995 — AI sideboard generation + best-of-3 sideboarding
+// -----------------------------------------------------------------------------
+// The AI opponent previously played game 1's decklist for every game of a
+// best-of-3 match. Below it (a) generates a legal, archetype-coherent
+// sideboard alongside its maindeck and (b) boards between games using the same
+// matchup/role weights that drive the human coach's per-matchup sideboard plan
+// (issue #1076, `src/ai/flows/sideboard-plan.ts` -> MATCHUP_PROFILES). Keeping
+// the role taxonomy and category weights identical makes the AI's swaps
+// principled rather than random and keeps this module testable offline.
+// =============================================================================
+
+/** Archetype category, mirroring `src/ai/archetype-signatures.ts` categories. */
+export type MatchupCategory =
+  | "aggro"
+  | "control"
+  | "midrange"
+  | "combo"
+  | "tribal"
+  | "special";
+
+/**
+ * Functional role a card plays. Mirrors `RoleKey` in
+ * `src/ai/flows/coach-deck-analysis.ts` / `sideboard-plan.ts` (#1076) so the
+ * same role/value model drives both the coach's plan and the AI's boarding.
+ */
+export type CardRole =
+  | "threats"
+  | "ramp"
+  | "removal"
+  | "cardDraw"
+  | "disruption"
+  | "lands"
+  | "other";
+
+/** Maps the generator's archetypes onto the matchup-category taxonomy. */
+const ARCHETYPE_CATEGORY: Record<DeckArchetype, MatchupCategory> = {
+  aggro: "aggro",
+  tempo: "aggro",
+  stompy: "aggro",
+  control: "control",
+  prison: "control",
+  midrange: "midrange",
+  aristocrats: "midrange",
+  tokens: "midrange",
+  combo: "combo",
+  ramp: "special",
+};
+
+/**
+ * Value of each functional role when facing a given opponent category. This is
+ * the SAME weighting model used by the human sideboard coach (#1076); it is
+ * reproduced here (rather than imported) so this heuristic module stays
+ * self-contained and free of `@/app/actions` / LLM-graph dependencies. Higher
+ * = more desirable to board IN against that category; negative = cuttable.
+ */
+const MATCHUP_ROLE_VALUE: Record<MatchupCategory, Record<CardRole, number>> = {
+  aggro: {
+    threats: 0,
+    ramp: -1,
+    removal: 3,
+    cardDraw: 1,
+    disruption: 2,
+    lands: 0,
+    other: -2,
+  },
+  combo: {
+    threats: 1,
+    ramp: 0,
+    removal: 0,
+    cardDraw: 2,
+    disruption: 3,
+    lands: 0,
+    other: -2,
+  },
+  control: {
+    threats: 2,
+    ramp: 0,
+    removal: -1,
+    cardDraw: 3,
+    disruption: 2,
+    lands: 0,
+    other: -1,
+  },
+  midrange: {
+    threats: 2,
+    ramp: 0,
+    removal: 2,
+    cardDraw: 2,
+    disruption: 1,
+    lands: 0,
+    other: -1,
+  },
+  tribal: {
+    threats: 1,
+    ramp: -1,
+    removal: 3,
+    cardDraw: 1,
+    disruption: 2,
+    lands: 0,
+    other: -2,
+  },
+  special: {
+    threats: 1,
+    ramp: 0,
+    removal: 2,
+    cardDraw: 2,
+    disruption: 2,
+    lands: 0,
+    other: -1,
+  },
+};
+
+/**
+ * Sideboard composition priority by the AI's own archetype category. A deck
+ * stocks the roles it most wants to bring IN across the matchups it typically
+ * faces (derived from MATCHUP_ROLE_VALUE: the roles with the highest combined
+ * value against the field, weighted toward bad matchups). Used at generation
+ * time so the sideboard is archetype-coherent, not random.
+ */
+const SIDEBOARD_ROLE_PRIORITY: Record<MatchupCategory, CardRole[]> = {
+  aggro: ["removal", "disruption", "cardDraw", "threats"],
+  control: ["threats", "cardDraw", "disruption", "removal"],
+  midrange: ["removal", "cardDraw", "disruption", "threats"],
+  combo: ["disruption", "cardDraw", "removal", "threats"],
+  tribal: ["removal", "disruption", "cardDraw", "threats"],
+  special: ["removal", "disruption", "cardDraw", "threats"],
+};
+
+/** A sideboard staple, tagged with its role and color requirements. */
+interface SideboardStaple {
+  name: string;
+  role: CardRole;
+  /** Empty/undefined = colorless (legal in any deck). Otherwise must be subset of color identity. */
+  colors?: string[];
+}
+
+/**
+ * Curated sideboard staples by role. These are well-known MTG sideboard cards;
+ * like the rest of this module the entries are heuristic name strings (no card
+ * DB lookup). Colorless hate cards are preferred so a single pool serves every
+ * color identity, with a few color-aligned options for stronger boarding.
+ */
+const SIDEBOARD_POOL: SideboardStaple[] = [
+  // --- Removal / sweepers / permanent hate ---
+  { name: "Engineered Explosives", role: "removal" },
+  { name: "Pithing Needle", role: "removal" },
+  { name: "Sorcerous Spyglass", role: "removal" },
+  { name: "Blood Moon", role: "removal", colors: ["R"] },
+  { name: "Deafening Silence", role: "removal", colors: ["W"] },
+  { name: "Doom Blade", role: "removal", colors: ["B"] },
+  { name: "Flame Slash", role: "removal", colors: ["R"] },
+  { name: "Path to Exile", role: "removal", colors: ["W"] },
+  { name: "Seal of Fire", role: "removal", colors: ["R"] },
+
+  // --- Disruption: counters / discard / stax ---
+  { name: "Chalice of the Void", role: "disruption" },
+  { name: "Trinisphere", role: "disruption" },
+  { name: "Eidolon of Rhetoric", role: "disruption" },
+  { name: "Negate", role: "disruption", colors: ["U"] },
+  { name: "Flusterstorm", role: "disruption", colors: ["U"] },
+  { name: "Duress", role: "disruption", colors: ["B"] },
+  { name: "Thoughtseize", role: "disruption", colors: ["B"] },
+  { name: "Damping Sphere", role: "disruption" },
+  { name: "Leyline of the Void", role: "disruption", colors: ["B"] },
+
+  // --- Card draw / selection / value ---
+  { name: "Mystic Remora", role: "cardDraw", colors: ["U"] },
+  { name: "Compost", role: "cardDraw", colors: ["G"] },
+  { name: "Sylvan Library", role: "cardDraw", colors: ["G"] },
+  { name: "Bond of Insight", role: "cardDraw", colors: ["U"] },
+  { name: "Sea Gate Restoration", role: "cardDraw", colors: ["U"] },
+
+  // --- Resilient / must-answer threats ---
+  { name: "Batterskull", role: "threats" },
+  { name: "Wurmcoil Engine", role: "threats" },
+  { name: "Karn, the Great Creator", role: "threats" },
+  { name: "Ulamog, the Ceaseless Hunger", role: "threats" },
+  { name: "Banefire", role: "threats", colors: ["R"] },
+  { name: "Kor Firewalker", role: "threats", colors: ["W"] },
+  { name: "Gideon, Champion of Justice", role: "threats", colors: ["W"] },
+
+  // --- Graveyard / artifact / enchantment hate (classified as removal) ---
+  { name: "Grafdigger\u2019s Cage", role: "removal" },
+  { name: "Tormod\u2019s Crypt", role: "removal" },
+  { name: "Relic of Progenitus", role: "removal" },
+  { name: "Scrabbling Claws", role: "removal" },
+  { name: "Solemnity", role: "removal" },
+  { name: "Stony Silence", role: "removal", colors: ["W"] },
+  { name: "Fragmentize", role: "removal", colors: ["W"] },
+  { name: "By Force", role: "removal", colors: ["R"] },
+];
+
+/** Lookup table for sideboard-staple roles by name (exact). */
+const SIDEBOARD_ROLE_LOOKUP = new Map<string, CardRole>(
+  SIDEBOARD_POOL.map((s) => [s.name, s.role]),
+);
+
+/**
+ * Index of every CARD_POOL card name -> role. Built once at module load from
+ * the category buckets so maindeck cards produced by the generator can be
+ * scored by role during post-game sideboarding.
+ */
+const NAME_TO_ROLE: Map<string, CardRole> = (() => {
+  const index = new Map<string, CardRole>();
+  const set = (name: string, role: CardRole) => index.set(name, role);
+  const setIfAbsent = (name: string, role: CardRole) => {
+    if (!index.has(name)) index.set(name, role);
+  };
+
+  // Pass 1 — specific functional roles. These WIN over the generic creature
+  // buckets so dual-category cards (e.g. Llanowar Elves is both a mana dork and
+  // a 1-drop creature) classify by their strategic role, not as a generic threat.
+  const specific: Array<[string[], CardRole]> = [
+    [CARD_POOL.W_removal, "removal"],
+    [CARD_POOL.B_kill, "removal"],
+    [CARD_POOL.R_burn, "removal"],
+    [CARD_POOL.U_counter, "disruption"],
+    [CARD_POOL.B_discard, "disruption"],
+    [CARD_POOL.U_tempo, "disruption"],
+    [CARD_POOL.U_draw, "cardDraw"],
+    [CARD_POOL.G_ramp, "ramp"],
+    [CARD_POOL.colorless_rocks, "ramp"],
+    [CARD_POOL.lands_dual, "lands"],
+    [CARD_POOL.lands_basic, "lands"],
+    [CARD_POOL.colorless_utility, "other"],
+    [CARD_POOL.colorless_equipment, "other"],
+    [CARD_POOL.W_utility, "other"],
+    [CARD_POOL.R_utility, "other"],
+    [CARD_POOL.B_reanimate, "other"],
+    [CARD_POOL.W_lifegain, "threats"],
+  ];
+  for (const [cards, role] of specific) for (const c of cards) set(c, role);
+
+  // Pass 2 — creature buckets fill only entries not already classified.
+  const creatureBuckets: string[][] = [
+    CARD_POOL.B_zombies,
+    CARD_POOL.R_goblins,
+    CARD_POOL.G_elves,
+    CARD_POOL.G_trample,
+    CARD_POOL.G_big,
+    CARD_POOL.W_one_drops,
+    CARD_POOL.W_two_drops,
+    CARD_POOL.W_three_drops,
+    CARD_POOL.W_four_drops,
+    CARD_POOL.U_one_drops,
+    CARD_POOL.U_two_drops,
+    CARD_POOL.U_three_drops,
+    CARD_POOL.U_four_drops,
+    CARD_POOL.B_one_drops,
+    CARD_POOL.B_two_drops,
+    CARD_POOL.B_three_drops,
+    CARD_POOL.B_four_drops,
+    CARD_POOL.R_one_drops,
+    CARD_POOL.R_two_drops,
+    CARD_POOL.R_three_drops,
+    CARD_POOL.R_four_drops,
+    CARD_POOL.G_one_drops,
+    CARD_POOL.G_two_drops,
+    CARD_POOL.G_three_drops,
+    CARD_POOL.G_four_drops,
+  ];
+  for (const bucket of creatureBuckets)
+    for (const c of bucket) setIfAbsent(c, "threats");
+  return index;
+})();
+
+/** Set of land card names (used to avoid cutting lands when sideboarding). */
+const LAND_NAMES: Set<string> = new Set<string>([
+  ...CARD_POOL.lands_dual,
+  ...CARD_POOL.lands_basic,
+  "Wastes",
+  "Reliquary Tower",
+  "Command Tower",
+]);
+
+function isLandName(name: string): boolean {
+  if (LAND_NAMES.has(name)) return true;
+  const lower = name.toLowerCase();
+  return /\b(land|forest|island|mountain|plains|swamp|tower|wastes|fetch|shock)\b/.test(
+    lower,
+  );
+}
+
+/**
+ * Classify a card NAME into a functional role. Deterministic.
+ * Order: explicit sideboard-staple table -> CARD_POOL index -> name heuristic.
+ */
+export function classifyCardRole(name: string): CardRole {
+  const explicit = SIDEBOARD_ROLE_LOOKUP.get(name);
+  if (explicit) return explicit;
+  const indexed = NAME_TO_ROLE.get(name);
+  if (indexed) return indexed;
+  const lower = name.toLowerCase();
+  if (isLandName(name)) return "lands";
+  if (
+    /(counter|negate|cancel|deny|dismiss|quash|essence scatter|flash|confiscate|bounce|unsummon|vapor|remand|interrupt)/.test(
+      lower,
+    )
+  ) {
+    return "disruption";
+  }
+  if (
+    /(destroy|exile|remove|kill|burn|bolt|path|swords|doom|murder|decay|pulse|terminate|blast|strike|cut|downfall|push|blast)/.test(
+      lower,
+    )
+  ) {
+    return "removal";
+  }
+  if (
+    /(draw|divination|insight|catalog|foresight|ponder|preordain|brainstorm|inspiration|opportunity|jace|fact or fiction|ruinous|read the bones|sign in blood)/.test(
+      lower,
+    )
+  ) {
+    return "cardDraw";
+  }
+  if (
+    /(ramp|growth|cultivate|kodama|signet|talisman|fellwar|mind stone|sol ring|mana vault|crypt)/.test(
+      lower,
+    )
+  ) {
+    return "ramp";
+  }
+  return "threats";
+}
+
+/** Resolve the AI archetype's matchup category. */
+export function archetypeToCategory(archetype: DeckArchetype): MatchupCategory {
+  return ARCHETYPE_CATEGORY[archetype] ?? "midrange";
+}
+
+function stapleLegalForColors(
+  staple: SideboardStaple,
+  colorIdentity: string[],
+): boolean {
+  if (!staple.colors || staple.colors.length === 0) return true; // colorless
+  return staple.colors.every((c) => colorIdentity.includes(c));
+}
+
+/** Input for sideboard generation. */
+export interface SideboardGenerationInput {
+  archetype: DeckArchetype;
+  colorIdentity: string[];
+  difficulty: DifficultyLevel;
+  format: Format;
+  maindeckCards: Array<{ name: string; quantity: number }>;
+}
+
+/**
+ * Generate a legal, archetype-coherent sideboard. Deterministic (no Math.random):
+ * iterates roles in priority order for the AI's category and selects color-legal
+ * staples that are NOT already in the maindeck, up to the format's sideboard
+ * size. Returns [] when the format does not use a sideboard.
+ */
+export function generateSideboard(
+  input: SideboardGenerationInput,
+): Array<{ name: string; quantity: number }> {
+  const rules = formatRules[input.format];
+  if (!rules || !rules.usesSideboard || rules.sideboardSize <= 0) return [];
+
+  const maxSize = rules.sideboardSize;
+  const maxCopies = rules.maxCopies || 4;
+  const priority = SIDEBOARD_ROLE_PRIORITY[
+    archetypeToCategory(input.archetype)
+  ] ?? ["removal", "disruption", "cardDraw", "threats"];
+
+  const alreadyInMain = new Set(input.maindeckCards.map((c) => c.name));
+  const used = new Set<string>();
+  const sideboard: Array<{ name: string; quantity: number }> = [];
+  let total = 0;
+
+  // Expert/hard decks pack a fuller sideboard (closer to maxSize); easier decks
+  // pack a leaner one. Mirrors the difficulty-scaling philosophy of the maindeck.
+  const targetSize = Math.max(
+    4,
+    Math.round(
+      maxSize *
+        (input.difficulty === "expert"
+          ? 1.0
+          : input.difficulty === "hard"
+            ? 0.9
+            : input.difficulty === "medium"
+              ? 0.75
+              : 0.6),
+    ),
+  );
+
+  for (const role of priority) {
+    if (total >= targetSize) break;
+    // Colorless-first, then color-aligned; stable alphabetical tie-break for determinism.
+    const candidates = SIDEBOARD_POOL.filter(
+      (s) => s.role === role && stapleLegalForColors(s, input.colorIdentity),
+    ).sort((a, b) => {
+      const ac = a.colors && a.colors.length ? 1 : 0;
+      const bc = b.colors && b.colors.length ? 1 : 0;
+      if (ac !== bc) return ac - bc;
+      return a.name.localeCompare(b.name);
+    });
+
+    for (const staple of candidates) {
+      if (total >= targetSize) break;
+      if (used.has(staple.name)) continue;
+      if (alreadyInMain.has(staple.name)) continue;
+      const remaining = targetSize - total;
+      // Colorless hate: up to 2 copies; color-aligned staples: 1 copy.
+      const perCard = staple.colors && staple.colors.length ? 1 : 2;
+      const qty = Math.min(maxCopies, perCard, remaining);
+      if (qty <= 0) continue;
+      sideboard.push({ name: staple.name, quantity: qty });
+      used.add(staple.name);
+      total += qty;
+    }
+  }
+
+  // Pad with any remaining legal staples (any role) if under target but >0 wanted.
+  if (total < targetSize) {
+    for (const staple of SIDEBOARD_POOL) {
+      if (total >= targetSize) break;
+      if (used.has(staple.name) || alreadyInMain.has(staple.name)) continue;
+      if (!stapleLegalForColors(staple, input.colorIdentity)) continue;
+      const remaining = targetSize - total;
+      const qty = Math.min(remaining, 1);
+      sideboard.push({ name: staple.name, quantity: qty });
+      used.add(staple.name);
+      total += qty;
+    }
+  }
+
+  return sideboard;
+}
+
+/** A single in/out swap pair (quantities always match so totals stay legal). */
+export interface SideboardSwapPair {
+  in: { name: string; quantity: number };
+  out: { name: string; quantity: number };
+}
+
+/** A complete post-game sideboarding decision for the AI. */
+export interface SideboardSwap {
+  opponentCategory: MatchupCategory;
+  /** Paired in/out entries (boardIn total === boardOut total). */
+  swaps: SideboardSwapPair[];
+  boardIn: Array<{ name: string; quantity: number }>;
+  boardOut: Array<{ name: string; quantity: number }>;
+  /** One-line rationale grounded in the matchup profile. */
+  rationale: string;
+}
+
+/** Input for post-game sideboarding. */
+export interface AISideboardSwapInput {
+  deck: GeneratedDeck;
+  /** Observed/estimated opponent archetype category for the next game. */
+  opponentCategory: MatchupCategory;
+  difficulty?: DifficultyLevel;
+  /** Result of the game just played. 'win' => board conservatively; 'loss'/'draw'|undefined => board fully. */
+  lastGameResult?: "win" | "loss" | "draw";
+}
+
+/**
+ * Maximum cards the AI will board in a single transition, by difficulty.
+ * Scales as requested by issue #995 ("Easy swaps fewer (0-5), Expert swaps
+ * optimally (10-15)"); expert is capped at 10 because useful swaps are
+ * naturally bounded by the sideboard's role-value inventory.
+ */
+const DIFFICULTY_SWAP_CAP: Record<DifficultyLevel, number> = {
+  easy: 3,
+  medium: 5,
+  hard: 8,
+  expert: 10,
+};
+
+const CATEGORY_GUIDANCE: Record<MatchupCategory, string> = {
+  aggro:
+    "Board in cheap removal and disruptive interaction; shave slow top-end threats.",
+  control: "Board in resilient threats and card draw; trim redundant removal.",
+  midrange:
+    "Board in efficient removal and card draw to pull ahead on resources.",
+  combo: "Board in hand disruption and countermagic plus draw to find them.",
+  tribal:
+    "Board in sweepers and point removal; cut slow, non-interactive cards.",
+  special:
+    "Board in flexible interaction and card draw; trim narrow utility cards.",
+};
+
+/**
+ * Compute the AI's post-game sideboarding. Deterministic for a given input:
+ * sideboard cards are ranked by MATCHUP_ROLE_VALUE[opp](role) (in candidates)
+ * and maindeck non-land cards by the negation (out candidates), then paired.
+ * Win-reduced boarding keeps the AI from over-reacting after a victory.
+ */
+export function computeAISideboardSwap(
+  input: AISideboardSwapInput,
+): SideboardSwap {
+  const deck = input.deck;
+  const difficulty: DifficultyLevel =
+    input.difficulty ?? deck.difficulty ?? "medium";
+  const sideboard = Array.isArray(deck.sideboard) ? deck.sideboard : [];
+  const profile =
+    MATCHUP_ROLE_VALUE[input.opponentCategory] ?? MATCHUP_ROLE_VALUE.midrange;
+
+  // Board-IN candidates: sideboard cards whose role has positive value here.
+  const inCandidates = sideboard
+    .map((c) => {
+      const role = classifyCardRole(c.name);
+      return {
+        name: c.name,
+        available: c.quantity,
+        role,
+        value: profile[role] ?? 0,
+      };
+    })
+    .filter((c) => c.value > 0)
+    .sort((a, b) => b.value - a.value || a.name.localeCompare(b.name));
+
+  // Board-OUT candidates: maindeck non-land cards; higher cut = more expendable.
+  const outCandidates = deck.cards
+    .filter((c) => !isLandName(c.name))
+    .map((c) => {
+      const role = classifyCardRole(c.name);
+      let cut = -(profile[role] ?? 0);
+      // Slow cards are more cuttable against fast decks (mirrors #1076).
+      if (
+        input.opponentCategory === "aggro" ||
+        input.opponentCategory === "tribal"
+      ) {
+        cut += 0.5;
+      }
+      // Redundant removal underperforms vs control.
+      if (input.opponentCategory === "control" && role === "removal")
+        cut += 1.0;
+      return { name: c.name, available: c.quantity, role, cut };
+    })
+    .filter((c) => c.cut > 0)
+    .sort((a, b) => b.cut - a.cut || a.name.localeCompare(b.name));
+
+  let cap = DIFFICULTY_SWAP_CAP[difficulty] ?? 5;
+  if (input.lastGameResult === "win") cap = Math.min(cap, 3);
+
+  const swaps: SideboardSwapPair[] = [];
+  const boardIn: Array<{ name: string; quantity: number }> = [];
+  const boardOut: Array<{ name: string; quantity: number }> = [];
+  let boarded = 0;
+
+  let inIdx = 0;
+  let outIdx = 0;
+  while (
+    boarded < cap &&
+    inIdx < inCandidates.length &&
+    outIdx < outCandidates.length
+  ) {
+    const inC = inCandidates[inIdx];
+    const outC = outCandidates[outIdx];
+    if (inC.available <= 0) {
+      inIdx++;
+      continue;
+    }
+    if (outC.available <= 0) {
+      outIdx++;
+      continue;
+    }
+    const remaining = cap - boarded;
+    const qty = Math.min(inC.available, outC.available, remaining);
+    if (qty <= 0) {
+      inIdx++;
+      continue;
+    }
+    swaps.push({
+      in: { name: inC.name, quantity: qty },
+      out: { name: outC.name, quantity: qty },
+    });
+    boardIn.push({ name: inC.name, quantity: qty });
+    boardOut.push({ name: outC.name, quantity: qty });
+    inC.available -= qty;
+    outC.available -= qty;
+    boarded += qty;
+  }
+
+  return {
+    opponentCategory: input.opponentCategory,
+    swaps,
+    boardIn,
+    boardOut,
+    rationale: CATEGORY_GUIDANCE[input.opponentCategory],
+  };
+}
+
+/**
+ * Apply a sideboard swap to a deck, returning a NEW GeneratedDeck whose
+ * maindeck and sideboard reflect the in/out changes. Pure: input is not
+ * mutated. Maindeck size and sideboard size are preserved (each pair exchanges
+ * equal quantities), keeping the configuration legal.
+ */
+export function applyAISideboardSwap(
+  deck: GeneratedDeck,
+  swap: SideboardSwap,
+): GeneratedDeck {
+  const sideboardIn = new Map<string, number>();
+  for (const c of deck.sideboard ?? []) sideboardIn.set(c.name, c.quantity);
+  const mainIn = new Map<string, number>();
+  for (const c of deck.cards) mainIn.set(c.name, c.quantity);
+
+  for (const pair of swap.swaps) {
+    // Board OUT of maindeck -> into sideboard.
+    const prevOut = mainIn.get(pair.out.name) ?? 0;
+    const afterOut = prevOut - pair.out.quantity;
+    if (afterOut > 0) mainIn.set(pair.out.name, afterOut);
+    else mainIn.delete(pair.out.name);
+    sideboardIn.set(
+      pair.out.name,
+      (sideboardIn.get(pair.out.name) ?? 0) + pair.out.quantity,
+    );
+
+    // Board IN from sideboard -> into maindeck.
+    const prevSide = sideboardIn.get(pair.in.name) ?? 0;
+    const afterSide = prevSide - pair.in.quantity;
+    if (afterSide > 0) sideboardIn.set(pair.in.name, afterSide);
+    else sideboardIn.delete(pair.in.name);
+    mainIn.set(
+      pair.in.name,
+      (mainIn.get(pair.in.name) ?? 0) + pair.in.quantity,
+    );
+  }
+
+  const toList = (
+    m: Map<string, number>,
+  ): Array<{ name: string; quantity: number }> =>
+    Array.from(m.entries())
+      .map(([name, quantity]) => ({ name, quantity }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    ...deck,
+    cards: toList(mainIn),
+    sideboard: toList(sideboardIn),
+  };
+}
+
+/** One completed game's context for best-of-3 progression. */
+export interface AISideboardingStep {
+  opponentCategory: MatchupCategory;
+  result?: "win" | "loss" | "draw";
+}
+
+/**
+ * Drive sideboarding across a best-of-(N) match. Game 1 uses the pre-board
+ * deck; each subsequent game re-boards from the current configuration using
+ * the prior game's result. Deterministic.
+ *
+ * @returns the deck configuration to play the next game after all steps.
+ */
+export function progressAISideboarding(
+  deck: GeneratedDeck,
+  steps: AISideboardingStep[],
+): GeneratedDeck {
+  let current = deck;
+  for (const step of steps) {
+    const difficulty = current.difficulty;
+    const swap = computeAISideboardSwap({
+      deck: current,
+      opponentCategory: step.opponentCategory,
+      difficulty,
+      lastGameResult: step.result,
+    });
+    if (swap.swaps.length === 0) continue;
+    current = applyAISideboardSwap(current, swap);
+  }
+  return current;
+}
+
+/**
+ * Resolve the AI sideboard size for a format (0 when sideboards are not used).
+ * Exposed for callers/tests that want to verify legality without re-deriving.
+ */
+export function getAISideboardSize(format: Format): number {
+  const rules = formatRules[format];
+  if (!rules || !rules.usesSideboard) return 0;
+  return rules.sideboardSize;
 }


### PR DESCRIPTION
## Summary

Resolves #995. The AI opponent previously played game 1's decklist for every
game of a best-of-3 match — it generated **no sideboard** and never boarded
between games. This PR makes the AI (a) generate a legal, archetype-coherent
sideboard alongside its maindeck and (b) sideboard between games using the
**same matchup/role model** that drives the human coach's per-matchup
sideboard plan (#1076, `src/ai/flows/sideboard-plan.ts` → `MATCHUP_PROFILES`),
so the AI's swaps are principled rather than random.

All logic is heuristic, deterministic, and offline (no LLM/DB calls) —
consistent with the rest of `src/lib/opponent-deck-generator.ts`.

## Changes

- **`src/lib/opponent-deck-generator.ts`**
  - `GeneratedDeck` now carries an optional `sideboard` (populated for any
    format whose `formatRules[format].usesSideboard` is true; empty for
    Commander/Limited).
  - `generateSideboard(...)` — deterministic sideboard generator. Iterates
    roles in priority order for the AI's archetype category and selects
    color-legal sideboard staples that are **not** already in the maindeck,
    up to the format's `sideboardSize`. Target size scales with difficulty.
  - `computeAISideboardSwap(...)` — post-game boarding. Ranks sideboard
    cards by `MATCHUP_ROLE_VALUE[oppCategory][role]` (board-IN candidates)
    and maindeck non-land cards by the negation (board-OUT candidates),
    then pairs them. Swap count scales with difficulty
    (`easy` 3 / `medium` 5 / `hard` 8 / `expert` 10) and is reduced after a
    win (board conservatively).
  - `applyAISideboardSwap(...)` — pure; returns a new deck with in/out
    applied. Maindeck and sideboard sizes are preserved (each pair exchanges
    equal quantities), keeping the configuration legal.
  - `progressAISideboarding(...)` — best-of-N driver: game 1 is pre-board;
    each subsequent game re-boards from the current configuration using the
    prior result.
  - Helpers: `classifyCardRole`, `archetypeToCategory`, `getAISideboardSize`,
    plus `MatchupCategory` / `CardRole` types that mirror
    `src/ai/archetype-signatures.ts` categories and #1076's `RoleKey`.

- **`src/lib/__tests__/opponent-deck-generator-sideboard.test.ts`** (new)
  - 29 tests covering sideboard generation (legal size, color identity,
    no duplicates, archetype-coherent, deterministic), post-game swaps
    (correct in/out direction per matchup, in/out balance, never cuts lands,
    difficulty scaling, win/loss awareness, determinism), `applyAISideboardSwap`
    (size preservation, purity), best-of-3 progression, and helper functions.

## Design notes

- The `MATCHUP_ROLE_VALUE` table is reproduced from #1076's profiles (rather
  than imported) so this heuristic module stays self-contained and free of
  `@/app/actions` / LLM-graph dependencies, while keeping the role taxonomy
  and category weights **identical** to the coach's plan.
- Per-format composition: sideboards are only emitted when
  `formatRules[format].usesSideboard` (#1069's per-format config is respected
  via the shared `formatRules` registry).
- Difficulty scaling matches the issue spec ("Easy swaps fewer (0-5), Expert
  swaps optimally (10-15)"); expert is capped at 10 because useful swaps are
  naturally bounded by the sideboard's positive-role-value inventory.

## Verification

- `npx jest opponent-deck-generation sideboard` → **6152 passed, 0 failed**
  (full suite, no regressions)
- Directly-relevant suites → **72 passed** (opponent-deck-generator,
  opponent-deck-generator-sideboard, sideboard-plan)
- `npx tsc --noEmit` → **0 errors**
- `npm run lint` → **0 errors** (only pre-existing repo warnings)

Resolves #995