### PR TITLE
feat(rules-engine): resolve #1060 — implement Foretell alternate-cast mechanic (CR 702.142)

### DIFF
--- a/src/lib/game-state/__tests__/foretell.test.ts
+++ b/src/lib/game-state/__tests__/foretell.test.ts
@@ -1,0 +1,558 @@
+/**
+ * @fileoverview Unit tests for the Foretell keyword (CR 702.142).
+ *
+ * Issue #1060 — [Rules Engine] Implement Foretell alternate-cast mechanic
+ * (CR 702.142).
+ *
+ * Foretell is a two-step mechanic:
+ * - CR 702.142b (keyword action): Once per turn, on your turn, during a main
+ *   phase while the stack is empty, you may pay {2} and exile a card from your
+ *   hand face down. It becomes "foretold" — hidden from opponents, visible to
+ *   you.
+ * - CR 702.142c (alternate cast): On a later turn you may cast a foretold card
+ *   from exile by paying its printed foretell cost (an alternative cost),
+ *   revealing it as you cast it. The spell's mana value is unchanged.
+ *
+ * These tests cover: parsing (parseForetell / parseAlternativeCost), the
+ * foretell action (exile face down, pay {2}, once-per-turn, timing, illegal
+ * rejection), the zone helpers, the cast-for-foretell action (cast from exile,
+ * pay foretell cost, reveal, later-turn restriction), and illegal-cast
+ * rejection.
+ */
+
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import { castSpell, resolveTopOfStack } from "../spell-casting";
+import { createInitialGameState, startGame } from "../game-state";
+import { createCardInstance } from "../card-instance";
+import { addMana } from "../mana";
+import {
+  parseForetell,
+  parseAlternativeCost,
+  extractKeywords,
+  AlternativeCostType,
+} from "../oracle-text-parser";
+import { foretellCard, castForetoldCard } from "../keyword-actions";
+import { isForetoldCard, getForetoldCardIds } from "../zones";
+import { Phase, ZoneType } from "../types";
+import type { GameState, PlayerId, CardInstanceId } from "../types";
+import type { ScryfallCard } from "@/app/actions";
+
+// ---------------------------------------------------------------------------
+// Mock card helpers
+// ---------------------------------------------------------------------------
+
+function makeCard(
+  overrides: Partial<ScryfallCard> & { id: string },
+): ScryfallCard {
+  return {
+    name: "Test Card",
+    type_line: "Creature — Goblin",
+    oracle_text: "",
+    mana_cost: "{4}{R}{R}",
+    cmc: 6,
+    colors: ["R"],
+    color_identity: ["R"],
+    legalities: { standard: "legal", commander: "legal" },
+    layout: "normal",
+    power: "4",
+    toughness: "4",
+    ...overrides,
+  } as ScryfallCard;
+}
+
+/**
+ * A card with Foretell. Printed mana cost {2}{U}{U} (mana value 4); foretell
+ * cost {1}{U}. Used across the parsing, action, and casting tests.
+ */
+function foretellInstant(): ScryfallCard {
+  return makeCard({
+    id: "mock-foretell-instant",
+    name: "Saw It Coming",
+    type_line: "Instant",
+    oracle_text: "Foretell {1}{U}",
+    mana_cost: "{2}{U}{U}",
+    cmc: 4,
+    colors: ["U"],
+    color_identity: ["U"],
+  });
+}
+
+/** A card WITHOUT Foretell, used to assert illegal-action rejection. */
+function plainInstant(): ScryfallCard {
+  return makeCard({
+    id: "mock-plain-instant",
+    name: "Cancel",
+    type_line: "Instant",
+    oracle_text: "Counter target spell.",
+    mana_cost: "{1}{U}{U}",
+    cmc: 3,
+    colors: ["U"],
+    color_identity: ["U"],
+  });
+}
+
+/** A cheap card used to populate a drawable library. */
+function basicIsland(idSuffix: string): ScryfallCard {
+  return makeCard({
+    id: `island-${idSuffix}`,
+    name: "Island",
+    type_line: "Basic Land — Island",
+    oracle_text: "({T}: Add {U}.)",
+    mana_cost: "",
+    cmc: 0,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Shared state scaffolding
+// ---------------------------------------------------------------------------
+
+interface Fixture {
+  state: GameState;
+  aliceId: PlayerId;
+  bobId: PlayerId;
+}
+
+function makeFixture(): Fixture {
+  let state = createInitialGameState(["Alice", "Bob"], 20, false);
+  state = startGame(state);
+
+  const ids = Array.from(state.players.keys());
+  const aliceId = ids[0];
+  const bobId = ids[1];
+
+  state.status = "in_progress";
+  state.priorityPlayerId = aliceId;
+  state.turn.activePlayerId = aliceId;
+  state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+  state.stack = [];
+  state.consecutivePasses = 0;
+  state.players.forEach((p) =>
+    state.players.set(p.id, { ...p, hasPassedPriority: false }),
+  );
+
+  return { state, aliceId, bobId };
+}
+
+/** Place a card into a player's hand and the global card map. */
+function putInHand(
+  state: GameState,
+  playerId: PlayerId,
+  cardData: ScryfallCard,
+): CardInstanceId {
+  const card = createCardInstance(cardData, playerId, playerId);
+  state.cards.set(card.id, card);
+  const hand = state.zones.get(`${playerId}-hand`)!;
+  state.zones.set(`${playerId}-hand`, {
+    ...hand,
+    cardIds: [...hand.cardIds, card.id],
+  });
+  return card.id;
+}
+
+/** Hand size for a player. */
+function handSize(state: GameState, playerId: PlayerId): number {
+  return state.zones.get(`${playerId}-hand`)!.cardIds.length;
+}
+
+/** Exile IDs for a player. */
+function exileIds(state: GameState, playerId: PlayerId): CardInstanceId[] {
+  return state.zones.get(`${playerId}-exile`)!.cardIds;
+}
+
+// ===========================================================================
+// Parsing (CR 702.142)
+// ===========================================================================
+
+describe("Foretell — parsing (CR 702.142)", () => {
+  it("parseForetell detects 'Foretell {cost}' and parses the cost", () => {
+    const r = parseForetell("Foretell {1}{U}");
+    expect(r.hasForetell).toBe(true);
+    expect(r.foretellCost).not.toBeNull();
+    expect(r.foretellCost!.generic).toBe(1);
+    expect(r.foretellCost!.blue).toBe(1);
+    expect(r.description).toBe("Foretell {1}{U}");
+  });
+
+  it("parseForetell is case-insensitive", () => {
+    expect(parseForetell("foretell {2}{B}").hasForetell).toBe(true);
+    expect(parseForetell("FORETELL {3}").hasForetell).toBe(true);
+  });
+
+  it("parseForetell returns false when the keyword is absent", () => {
+    expect(parseForetell("Flying").hasForetell).toBe(false);
+    expect(parseForetell("Flashback {2}{R}").hasForetell).toBe(false);
+    expect(parseForetell("").hasForetell).toBe(false);
+    expect(parseForetell("").foretellCost).toBeNull();
+  });
+
+  it("parseForetell does not match 'foretell' inside other words", () => {
+    expect(parseForetell("foretelling").hasForetell).toBe(false);
+  });
+
+  it("parseAlternativeCost recognizes foretell as an alternative cost", () => {
+    const r = parseAlternativeCost("Foretell {1}{U}");
+    expect(r.hasAlternativeCost).toBe(true);
+    expect(r.costType).toBe(AlternativeCostType.FORETELL);
+    expect(r.manaCost).not.toBeNull();
+    expect(r.manaCost!.blue).toBe(1);
+    expect(r.description).toContain("Foretell");
+  });
+
+  it("extractKeywords detects the foretell mechanic keyword", () => {
+    const parsed = extractKeywords("Foretell {1}{U}", "Instant");
+    expect(parsed.some((k) => k.keyword.includes("foretell"))).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Foretell keyword action (CR 702.142b)
+// ===========================================================================
+
+describe("Foretell — keyword action: exile face down (CR 702.142b)", () => {
+  let f: Fixture;
+  let cardId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    cardId = putInHand(f.state, f.aliceId, foretellInstant());
+    // Enough generic mana to pay the {2} foretell cost.
+    f.state = addMana(f.state, f.aliceId, { generic: 5 });
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+    f.state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    f.state.stack = [];
+  });
+
+  it("foretellCard succeeds, pays {2}, and exiles the card face down", () => {
+    const before = f.state.players.get(f.aliceId)!.manaPool;
+    const beforeHand = handSize(f.state, f.aliceId);
+
+    const result = foretellCard(f.state, f.aliceId, cardId);
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+
+    // Card left the hand.
+    expect(handSize(result.state, f.aliceId)).toBe(beforeHand - 1);
+    // Card is now in Alice's exile.
+    expect(exileIds(result.state, f.aliceId)).toContain(cardId);
+
+    // The foretold marker and face-down flag are set, and the foretell turn is
+    // recorded (for the later-turn cast restriction).
+    const card = result.state.cards.get(cardId)!;
+    expect(card.foretold).toBe(true);
+    expect(card.isFaceDown).toBe(true);
+    expect(card.foretoldTurn).toBe(f.state.turn.turnNumber);
+
+    // Exactly {2} generic was spent.
+    const after = result.state.players.get(f.aliceId)!.manaPool;
+    expect(before.generic - after.generic).toBe(2);
+
+    // The once-per-turn allowance was consumed.
+    expect(result.state.players.get(f.aliceId)!.foretoldThisTurn).toBe(1);
+  });
+
+  it("isForetoldCard / getForetoldCardIds identify the foretold card", () => {
+    const result = foretellCard(f.state, f.aliceId, cardId);
+    expect(result.success).toBe(true);
+
+    const card = result.state.cards.get(cardId)!;
+    expect(isForetoldCard(card)).toBe(true);
+    // A plain exiled card is not foretold.
+    const plainId = putInHand(result.state, f.aliceId, plainInstant());
+    // Move it to exile face up via the generic exile helper path.
+    const exileZone = result.state.zones.get(`${f.aliceId}-exile`)!;
+    result.state.zones.set(`${f.aliceId}-exile`, {
+      ...exileZone,
+      cardIds: [...exileZone.cardIds, plainId],
+    });
+    expect(isForetoldCard(result.state.cards.get(plainId))).toBe(false);
+
+    const foretoldIds = getForetoldCardIds(
+      result.state.zones.get(`${f.aliceId}-exile`)!,
+      result.state.cards,
+    );
+    expect(foretoldIds).toEqual([cardId]);
+  });
+
+  it("is limited to once per turn (CR 702.142b)", () => {
+    const first = foretellCard(f.state, f.aliceId, cardId);
+    expect(first.success).toBe(true);
+
+    // Foretell a second card the same turn — must be rejected.
+    const secondId = putInHand(first.state, f.aliceId, foretellInstant());
+    const second = foretellCard(first.state, f.aliceId, secondId);
+    expect(second.success).toBe(false);
+    expect(second.error).toMatch(/already foretold/i);
+  });
+
+  it("is rejected for a card without Foretell", () => {
+    const plainId = putInHand(f.state, f.aliceId, plainInstant());
+    const result = foretellCard(f.state, f.aliceId, plainId);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/foretell/i);
+  });
+
+  it("is rejected when it is not your turn", () => {
+    f.state.turn.activePlayerId = f.bobId;
+    const result = foretellCard(f.state, f.aliceId, cardId);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/your turn/i);
+  });
+
+  it("is rejected outside a main phase", () => {
+    f.state.turn.currentPhase = Phase.BEGIN_COMBAT;
+    const result = foretellCard(f.state, f.aliceId, cardId);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/main phase/i);
+  });
+
+  it("is rejected when the stack is not empty", () => {
+    f.state.stack = [
+      {
+        id: "dummy-stack-object",
+        type: "spell",
+        sourceCardId: null,
+        controllerId: f.aliceId,
+        name: "Dummy",
+        text: "",
+        manaCost: null,
+        targets: [],
+        chosenModes: [],
+        variableValues: new Map(),
+        isCountered: false,
+        timestamp: Date.now(),
+      },
+    ];
+    const result = foretellCard(f.state, f.aliceId, cardId);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/stack/i);
+  });
+
+  it("is rejected when there is not enough mana to pay {2}", () => {
+    const poor: GameState = {
+      ...f.state,
+      players: new Map(f.state.players).set(f.aliceId, {
+        ...f.state.players.get(f.aliceId)!,
+        manaPool: {
+          colorless: 0,
+          white: 0,
+          blue: 0,
+          black: 0,
+          red: 0,
+          green: 0,
+          generic: 1,
+        },
+      }),
+    };
+    const result = foretellCard(poor, f.aliceId, cardId);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/mana/i);
+  });
+
+  it("is rejected when the player does not have priority", () => {
+    f.state.priorityPlayerId = f.bobId;
+    const result = foretellCard(f.state, f.aliceId, cardId);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/priority/i);
+  });
+});
+
+// ===========================================================================
+// Cast a foretold card for its foretell cost (CR 702.142c)
+// ===========================================================================
+
+describe("Foretell — cast for the foretell cost (CR 702.142c)", () => {
+  let f: Fixture;
+  let cardId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    cardId = putInHand(f.state, f.aliceId, foretellInstant());
+    f.state = addMana(f.state, f.aliceId, { generic: 5, blue: 5 });
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+    f.state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    f.state.stack = [];
+  });
+
+  /** Foretell `cardId` on the current turn, returning the post-foretell state. */
+  function foretellOnCurrentTurn(): GameState {
+    const r = foretellCard(f.state, f.aliceId, cardId);
+    expect(r.success).toBe(true);
+    return r.state;
+  }
+
+  /** Advance to a strictly later turn (CR 702.142c). */
+  function advanceTurn(state: GameState): GameState {
+    return {
+      ...state,
+      turn: { ...state.turn, turnNumber: state.turn.turnNumber + 1 },
+    };
+  }
+
+  it("castForetoldCard casts from exile for the foretell cost and reveals it", () => {
+    let state = foretellOnCurrentTurn();
+    state = advanceTurn(state);
+    // Fresh mana on the later turn (foretell cost {1}{U} = 1 generic + 1 blue).
+    state = addMana(state, f.aliceId, { generic: 1, blue: 1 });
+    state.priorityPlayerId = f.aliceId;
+    state.turn.activePlayerId = f.aliceId;
+    state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    state.stack = [];
+
+    const before = state.players.get(f.aliceId)!.manaPool;
+    const result = castForetoldCard(state, f.aliceId, cardId);
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(result.state.stack.length).toBe(1);
+    expect(result.state.stack[0].alternativeCostsUsed).toContain("foretell");
+    expect(result.state.stack[0].sourceCardId).toBe(cardId);
+
+    // The spell is announced revealed: face up and no longer foretold.
+    const card = result.state.cards.get(cardId)!;
+    expect(card.isFaceDown).toBe(false);
+    expect(card.foretold).toBe(false);
+
+    // Paid the foretell cost ({1}{U}), not the printed mana cost ({2}{U}{U}).
+    const after = result.state.players.get(f.aliceId)!.manaPool;
+    expect(before.generic - after.generic).toBe(1);
+    expect(before.blue - after.blue).toBe(1);
+
+    // The card moved from exile onto the stack.
+    expect(exileIds(result.state, f.aliceId)).not.toContain(cardId);
+  });
+
+  it("the spell's mana value (printed mana_cost / cmc) is unchanged (CR 702.142c)", () => {
+    let state = foretellOnCurrentTurn();
+    state = advanceTurn(state);
+    state = addMana(state, f.aliceId, { generic: 5, blue: 5 });
+    state.priorityPlayerId = f.aliceId;
+    state.turn.activePlayerId = f.aliceId;
+    state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    state.stack = [];
+
+    const result = castForetoldCard(state, f.aliceId, cardId);
+    expect(result.success).toBe(true);
+    expect(result.state.stack[0].manaCost).toBe("{2}{U}{U}");
+    expect(result.state.cards.get(cardId)!.cardData.cmc).toBe(4);
+  });
+
+  it("the foretell cast can be cast directly via castSpell with the foretell alt cost", () => {
+    let state = foretellOnCurrentTurn();
+    state = advanceTurn(state);
+    state = addMana(state, f.aliceId, { generic: 5, blue: 5 });
+    state.priorityPlayerId = f.aliceId;
+    state.turn.activePlayerId = f.aliceId;
+    state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    state.stack = [];
+
+    const result = castSpell(state, f.aliceId, cardId, [], [], 0, false, {
+      type: "foretell",
+    });
+    expect(result.success).toBe(true);
+    expect(result.state.stack[0].alternativeCostsUsed).toContain("foretell");
+    expect(result.state.cards.get(cardId)!.foretold).toBe(false);
+    expect(result.state.cards.get(cardId)!.isFaceDown).toBe(false);
+  });
+
+  it("a foretold instant resolves normally after being cast", () => {
+    let state = foretellOnCurrentTurn();
+    state = advanceTurn(state);
+    state = addMana(state, f.aliceId, { generic: 5, blue: 5 });
+    state.priorityPlayerId = f.aliceId;
+    state.turn.activePlayerId = f.aliceId;
+    state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    state.stack = [];
+
+    const cast = castForetoldCard(state, f.aliceId, cardId);
+    expect(cast.success).toBe(true);
+
+    // Resolve the top of the stack — the instant should leave the stack and go
+    // to its owner's graveyard (standard spell resolution).
+    const resolved = resolveTopOfStack(cast.state);
+    expect(resolved.stack.length).toBe(0);
+    expect(resolved.zones.get(`${f.aliceId}-graveyard`)!.cardIds).toContain(
+      cardId,
+    );
+  });
+
+  it("cannot be cast the same turn it was foretold (CR 702.142c)", () => {
+    const state = foretellOnCurrentTurn();
+    // Do NOT advance the turn.
+    const result = castForetoldCard(state, f.aliceId, cardId);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/later turn/i);
+  });
+
+  it("is rejected for a card that is not foretold", () => {
+    // A plain card in hand (not foretold, not in exile).
+    const result = castForetoldCard(f.state, f.aliceId, cardId);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not foretold/i);
+  });
+
+  it("is rejected when the foretell cost cannot be paid", () => {
+    let state = foretellOnCurrentTurn();
+    state = advanceTurn(state);
+    // Only 1 generic, no blue — cannot pay foretell cost {1}{U}.
+    const broke: GameState = {
+      ...state,
+      players: new Map(state.players).set(f.aliceId, {
+        ...state.players.get(f.aliceId)!,
+        manaPool: {
+          colorless: 0,
+          white: 0,
+          blue: 0,
+          black: 0,
+          red: 0,
+          green: 0,
+          generic: 1,
+        },
+      }),
+    };
+    broke.priorityPlayerId = f.aliceId;
+    broke.turn.activePlayerId = f.aliceId;
+    broke.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    broke.stack = [];
+    const result = castForetoldCard(broke, f.aliceId, cardId);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ===========================================================================
+// Sanity: unrelated mechanics are untouched
+// ===========================================================================
+
+describe("Foretell — does not interfere with non-foretell cards", () => {
+  it("a non-foretell card is not flagged foretold after being exiled normally", () => {
+    const f = makeFixture();
+    const plainId = putInHand(f.state, f.aliceId, plainInstant());
+    // Manually exile it the normal (face-up) way.
+    const hand = f.state.zones.get(`${f.aliceId}-hand`)!;
+    const exile = f.state.zones.get(`${f.aliceId}-exile`)!;
+    f.state.zones.set(`${f.aliceId}-hand`, {
+      ...hand,
+      cardIds: hand.cardIds.filter((id) => id !== plainId),
+    });
+    f.state.zones.set(`${f.aliceId}-exile`, {
+      ...exile,
+      cardIds: [...exile.cardIds, plainId],
+    });
+    expect(isForetoldCard(f.state.cards.get(plainId))).toBe(false);
+    expect(
+      getForetoldCardIds(
+        f.state.zones.get(`${f.aliceId}-exile`)!,
+        f.state.cards,
+      ),
+    ).toEqual([]);
+  });
+
+  it("basicIsland helper still produces a land card (scaffold sanity)", () => {
+    const island = basicIsland("1");
+    expect(island.type_line).toContain("Land");
+    // Reference ZoneType to keep the import meaningful for readers.
+    expect(ZoneType.EXILE).toBe("exile");
+  });
+});

--- a/src/lib/game-state/game-state.ts
+++ b/src/lib/game-state/game-state.ts
@@ -80,6 +80,7 @@ function createPlayer(
     lossReason: null,
     landsPlayedThisTurn: 0,
     maxLandsPerTurn: 1,
+    foretoldThisTurn: 0,
     manaPool: {
       colorless: 0,
       white: 0,
@@ -563,7 +564,11 @@ function advanceToNextPhase(state: GameState): GameState {
     // Reset land plays for all players at the start of a new turn
     for (const playerId of updatedPlayers.keys()) {
       const player = updatedPlayers.get(playerId)!;
-      updatedPlayers.set(playerId, { ...player, landsPlayedThisTurn: 0 });
+      updatedPlayers.set(playerId, {
+        ...player,
+        landsPlayedThisTurn: 0,
+        foretoldThisTurn: 0,
+      });
     }
 
     // Reset Boast tracking (CR 702.131) - clear attackedLastTurn for all creatures

--- a/src/lib/game-state/keyword-actions.ts
+++ b/src/lib/game-state/keyword-actions.ts
@@ -20,10 +20,11 @@ import type {
   CardInstance,
   CardInstanceId,
   PlayerId,
+  Target,
   Zone,
   ScryfallCard,
 } from "./types";
-import { ZoneType } from "./types";
+import { ZoneType, Phase } from "./types";
 import {
   createToken,
   getToughness,
@@ -32,6 +33,10 @@ import {
   hasCounter,
   initializePlaneswalkerLoyalty,
 } from "./card-instance";
+import { moveCardBetweenZones, isForetoldCard } from "./zones";
+import { spendMana } from "./mana";
+import { parseForetell } from "./oracle-text-parser";
+import { castSpell } from "./spell-casting";
 import {
   hasPersist,
   canPersistTrigger,
@@ -363,6 +368,297 @@ export function applyBlitzEndStepSacrifice(
   }
 
   return { state: currentState, affectedIds: sacrificed, applied: true };
+}
+
+// ---------------------------------------------------------------------------
+// Foretell (CR 702.142)
+//
+// Foretell is a two-step mechanic:
+//   1. CR 702.142b — the keyword ACTION: a player may, once per turn, on their
+//      turn, during a main phase while the stack is empty (sorcery timing), pay
+//      {2} and exile a card from their hand FACE DOWN. It becomes "foretold":
+//      hidden from other players, visible to its owner.
+//   2. CR 702.142c — the ALTERNATE CAST: on a later turn, that player may cast
+//      the foretold card FROM EXILE by paying its printed foretell cost
+//      (revealing it as it is announced). Casting otherwise follows normal
+//      timing/stack rules.
+//
+// A foretold card is modelled as a normal card in its owner's exile zone that
+// is flagged `foretold === true` and `isFaceDown === true` (see zones.ts). The
+// per-turn limit is tracked on the player as `foretoldThisTurn` (reset each
+// turn alongside `landsPlayedThisTurn`).
+// ---------------------------------------------------------------------------
+
+/** The constant {2} generic mana cost to exile a card face down (CR 702.142b). */
+const FORETELL_EXILE_COST = 2;
+
+/**
+ * CR 702.142b — the Foretell keyword action (a special action).
+ *
+ * Validates and performs foretelling a card from `playerId`'s hand: pay {2},
+ * exile the card face down, flag it foretold, record the foretell turn, and
+ * consume the once-per-turn allowance. Returns a failing `KeywordActionResult`
+ * for any illegal invocation (wrong zone, no Foretell ability, not your turn,
+ * non-main phase, non-empty stack, no priority, already foretold this turn, or
+ * insufficient mana).
+ */
+export function foretellCard(
+  state: GameState,
+  playerId: PlayerId,
+  cardId: CardInstanceId,
+): KeywordActionResult {
+  const card = state.cards.get(cardId);
+  if (!card) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: `Card ${cardId} not found`,
+    };
+  }
+
+  // CR 702.142a/b: Foretell functions from a player's hand. The card must be in
+  // this player's hand.
+  const handZone = state.zones.get(`${playerId}-hand`);
+  if (!handZone || !handZone.cardIds.includes(cardId)) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: "Card is not in your hand.",
+    };
+  }
+
+  // The card must actually have the Foretell ability and a parseable cost.
+  const foretellInfo = parseForetell(card.cardData.oracle_text || "");
+  if (!foretellInfo.hasForetell || !foretellInfo.foretellCost) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: `${card.cardData.name} does not have Foretell.`,
+    };
+  }
+
+  const player = state.players.get(playerId);
+  if (!player) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: `Player ${playerId} not found`,
+    };
+  }
+
+  // CR 702.142b: only on your turn.
+  if (state.turn.activePlayerId !== playerId) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: "You can foretell only on your turn.",
+    };
+  }
+
+  // Sorcery timing: a main phase (CR 702.142b / 117).
+  if (
+    state.turn.currentPhase !== Phase.PRECOMBAT_MAIN &&
+    state.turn.currentPhase !== Phase.POSTCOMBAT_MAIN
+  ) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: "Foretell can be used only during a main phase.",
+    };
+  }
+
+  // The stack must be empty (sorcery speed).
+  if (state.stack.length > 0) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: "Foretell can be used only when the stack is empty.",
+    };
+  }
+
+  // The player must have priority.
+  if (state.priorityPlayerId !== playerId) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: "You do not have priority.",
+    };
+  }
+
+  // CR 702.142b: at most one card foretold each turn.
+  if ((player.foretoldThisTurn ?? 0) >= 1) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: "You have already foretold a card this turn.",
+    };
+  }
+
+  // CR 702.142b: pay {2} (generic) to exile the card face down.
+  const spendResult = spendMana(state, playerId, {
+    generic: FORETELL_EXILE_COST,
+  });
+  if (!spendResult.success) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: "Not enough mana to foretell (costs {2}).",
+    };
+  }
+
+  let currentState = spendResult.state;
+
+  // Exile the card face down as foretold: hand -> owner's exile.
+  const exileZoneKey = `${playerId}-exile`;
+  const exileZone = currentState.zones.get(exileZoneKey);
+  if (!exileZone) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: "Exile zone not found.",
+    };
+  }
+
+  const moved = moveCardBetweenZones(handZone, exileZone, cardId);
+
+  const updatedZones = new Map(currentState.zones);
+  updatedZones.set(`${playerId}-hand`, moved.from);
+  updatedZones.set(exileZoneKey, moved.to);
+
+  // Flag the card foretold + face down and record the foretell turn so the
+  // later-turn cast restriction (CR 702.142c) can be enforced.
+  const updatedCards = new Map(currentState.cards);
+  updatedCards.set(cardId, {
+    ...card,
+    isFaceDown: true,
+    foretold: true,
+    foretoldTurn: currentState.turn.turnNumber,
+    currentZoneKey: exileZoneKey,
+  });
+
+  // Consume the once-per-turn foretell allowance.
+  const updatedPlayers = new Map(currentState.players);
+  const spendingPlayer = currentState.players.get(playerId)!;
+  updatedPlayers.set(playerId, {
+    ...spendingPlayer,
+    foretoldThisTurn: (spendingPlayer.foretoldThisTurn ?? 0) + 1,
+  });
+
+  currentState = {
+    ...currentState,
+    zones: updatedZones,
+    cards: updatedCards,
+    players: updatedPlayers,
+    lastModifiedAt: Date.now(),
+  };
+
+  return {
+    success: true,
+    state: currentState,
+    description: `${player.name} foretells a card (pays {2}).`,
+    affectedCards: [cardId],
+  };
+}
+
+/**
+ * CR 702.142c — Cast a foretold card from exile for its printed foretell cost.
+ *
+ * Validates that the card is foretold, in this player's exile, owned by them,
+ * has a foretell cost, and is being cast on a later turn (not the turn it was
+ * foretold), then delegates to the spell-casting machinery via the `foretell`
+ * alternative cost. The reveal (face up, foretold cleared) is applied as the
+ * card is announced on the stack inside `castSpell`.
+ */
+export function castForetoldCard(
+  state: GameState,
+  playerId: PlayerId,
+  cardId: CardInstanceId,
+  targets: Target[] = [],
+  chosenModes: string[] = [],
+  xValue: number = 0,
+): { success: boolean; state: GameState; error?: string } {
+  const card = state.cards.get(cardId);
+  if (!card) {
+    return { success: false, state, error: `Card ${cardId} not found` };
+  }
+
+  // Must currently be foretold (face down in exile, flagged).
+  if (!isForetoldCard(card)) {
+    return {
+      success: false,
+      state,
+      error: "That card is not foretold.",
+    };
+  }
+
+  // CR 702.142c: cast from exile. The card must be in this player's exile.
+  const exileZoneKey = `${playerId}-exile`;
+  const exileZone = state.zones.get(exileZoneKey);
+  if (!exileZone || !exileZone.cardIds.includes(cardId)) {
+    return {
+      success: false,
+      state,
+      error: "Foretold card is not in your exile.",
+    };
+  }
+
+  // Only the owner who foretold it may cast it.
+  if (card.ownerId !== playerId) {
+    return {
+      success: false,
+      state,
+      error: "You can cast only your own foretold cards.",
+    };
+  }
+
+  // CR 702.142c: not the turn it was foretold — only a strictly later turn.
+  if (
+    card.foretoldTurn !== undefined &&
+    state.turn.turnNumber <= card.foretoldTurn
+  ) {
+    return {
+      success: false,
+      state,
+      error: "A foretold card can be cast only on a later turn.",
+    };
+  }
+
+  // Must have a foretell cost to pay.
+  const foretellInfo = parseForetell(card.cardData.oracle_text || "");
+  if (!foretellInfo.hasForetell || !foretellInfo.foretellCost) {
+    return {
+      success: false,
+      state,
+      error: "That card has no foretell cost.",
+    };
+  }
+
+  // Delegate to the casting machinery using the foretell alternative cost.
+  // castSpell handles the exile source zone, the foretell-cost replacement, and
+  // the on-cast reveal (CR 702.142c).
+  return castSpell(
+    state,
+    playerId,
+    cardId,
+    targets,
+    chosenModes,
+    xValue,
+    false,
+    {
+      type: "foretell",
+    },
+  );
 }
 
 /**

--- a/src/lib/game-state/oracle-text-parser.ts
+++ b/src/lib/game-state/oracle-text-parser.ts
@@ -591,6 +591,7 @@ export function extractKeywords(
     // Deciduous mechanics
     "cycling",
     "flashback",
+    "foretell", // CR 702.142
     "kicker",
     "convoke",
     "proliferate",
@@ -1807,6 +1808,7 @@ export enum AlternativeCostType {
   SPECTACLE = "spectacle",
   BLAZE = "blaze",
   BLITZ = "blitz",
+  FORETELL = "foretell",
   OTHER = "other",
 }
 
@@ -1909,6 +1911,28 @@ export function parseAlternativeCost(oracleText: string): AlternativeCostInfo {
       additionalRequirement: "Gains haste, dies-draw, and is sacrificed at EOT",
       isAvailable: true,
       description: `Blitz ${blitzMatch[1]}`,
+    };
+  }
+
+  // Check for Foretell (CR 702.142)
+  // "Foretell [cost]" — the printed foretell cost is the alternative cost for
+  // casting a foretold card from exile. Foretell itself is a two-step mechanic:
+  // pay {2} to exile the card face down (CR 702.142b), then later cast it from
+  // exile for [cost] (CR 702.142c). This parser surfaces [cost]; the {2} exile
+  // cost is a constant of the keyword action, not part of this cost.
+  const foretellMatch = oracleText.match(
+    /foretell\s*(\{[^}]+\}(?:\{[^}]+\})*)/i,
+  );
+  if (foretellMatch) {
+    const manaCost = parseManaCost(foretellMatch[1]);
+    return {
+      hasAlternativeCost: true,
+      costType: AlternativeCostType.FORETELL,
+      manaCost,
+      additionalRequirement:
+        "Cast from exile (must be foretold); revealed on cast",
+      isAvailable: true,
+      description: `Foretell ${foretellMatch[1]}`,
     };
   }
 
@@ -2104,5 +2128,44 @@ export function parseBlitz(oracleText: string): {
     hasBlitz: true,
     blitzCost,
     description: `Blitz ${blitzMatch[1]}`,
+  };
+}
+
+/**
+ * Parse the Foretell keyword from oracle text.
+ *
+ * CR 702.142: "Foretell [cost]" is a static ability. The printed [cost] is the
+ * alternative cost for casting a foretold card from exile on a later turn
+ * (CR 702.142c) — the spell's mana value is unchanged and other costs/taxes
+ * still apply. The {2} paid to exile the card face down (CR 702.142b) is a
+ * constant of the keyword action and is NOT part of this cost.
+ *
+ * Example oracle text: "Foretell {1}{U}" (e.g. Saw It Coming). The reminder
+ * text ("During your turn, you may pay {2} and exile this card from your hand
+ * face down...") is not part of the parsed cost.
+ */
+export function parseForetell(oracleText: string): {
+  hasForetell: boolean;
+  foretellCost: ParsedManaCost | null;
+  description: string;
+} {
+  if (!oracleText) {
+    return { hasForetell: false, foretellCost: null, description: "" };
+  }
+
+  const foretellMatch = oracleText.match(
+    /foretell\s*(\{[^}]+\}(?:\{[^}]+\})*)/i,
+  );
+
+  if (!foretellMatch) {
+    return { hasForetell: false, foretellCost: null, description: "" };
+  }
+
+  const foretellCost = parseManaCost(foretellMatch[1]);
+
+  return {
+    hasForetell: true,
+    foretellCost,
+    description: `Foretell ${foretellMatch[1]}`,
   };
 }

--- a/src/lib/game-state/spell-casting.ts
+++ b/src/lib/game-state/spell-casting.ts
@@ -29,6 +29,7 @@ import {
   parseFlashback,
   parseBestow,
   parseBlitz,
+  parseForetell,
   parseSplitSecond,
   isModalSpell,
   getModesForModalSpell,
@@ -238,7 +239,14 @@ export function castSpell(
   xValue: number = 0,
   isKicked: boolean = false,
   alternativeCost?: {
-    type: "buyback" | "flashback" | "bestow" | "escape" | "spectacle" | "blitz";
+    type:
+      | "buyback"
+      | "flashback"
+      | "bestow"
+      | "escape"
+      | "spectacle"
+      | "blitz"
+      | "foretell";
     buybackReturnToHand?: boolean;
     bestowTarget?: CardInstanceId;
   },
@@ -267,10 +275,12 @@ export function castSpell(
     return { success: false, state, error: "Card not found." };
   }
 
-  // Verify the card is in player's hand (or graveyard for Flashback)
+  // Verify the card is in player's hand (or graveyard for Flashback, or exile
+  // for a foretold card cast via Foretell — CR 702.142c).
   let sourceZone: string | null = null;
   const handZone = state.zones.get(`${playerId}-hand`);
   const graveZone = state.zones.get(`${playerId}-graveyard`);
+  const exileZone = state.zones.get(`${playerId}-exile`);
 
   if (handZone && handZone.cardIds.includes(cardId)) {
     sourceZone = `${playerId}-hand`;
@@ -280,6 +290,13 @@ export function castSpell(
     graveZone.cardIds.includes(cardId)
   ) {
     sourceZone = `${playerId}-graveyard`;
+  } else if (
+    alternativeCost?.type === "foretell" &&
+    exileZone &&
+    exileZone.cardIds.includes(cardId)
+  ) {
+    // CR 702.142c: a foretold card is cast from its owner's exile.
+    sourceZone = `${playerId}-exile`;
   } else if (!handZone || !handZone.cardIds.includes(cardId)) {
     return { success: false, state, error: "Card not in hand." };
   }
@@ -414,6 +431,25 @@ export function castSpell(
         }
         break;
       }
+      case "foretell": {
+        // CR 702.142c - Foretell: an alternative cost that REPLACES the mana
+        // cost (not an additional cost). The printed foretell cost is paid
+        // instead of the mana cost; the spell's mana value is unchanged and
+        // other additional costs/taxes still apply on top. Subtract the printed
+        // mana-cost component and add the foretell-cost component so additional
+        // costs are preserved (same treatment as Blitz).
+        const foretellInfo = parseForetell(card.cardData.oracle_text || "");
+        if (foretellInfo.hasForetell && foretellInfo.foretellCost) {
+          totalGeneric += foretellInfo.foretellCost.generic - manaCost.generic;
+          totalWhite += foretellInfo.foretellCost.white - manaCost.white;
+          totalBlue += foretellInfo.foretellCost.blue - manaCost.blue;
+          totalBlack += foretellInfo.foretellCost.black - manaCost.black;
+          totalRed += foretellInfo.foretellCost.red - manaCost.red;
+          totalGreen += foretellInfo.foretellCost.green - manaCost.green;
+          alternativeCostsUsed.push("foretell");
+        }
+        break;
+      }
     }
   }
 
@@ -504,6 +540,20 @@ export function castSpell(
   }
   updatedZones.set("stack", moved.to);
 
+  // CR 702.142c - Foretell: reveal the card as it is announced on the stack.
+  // Turn it face up and clear the foretold marker so it is visible to everyone
+  // and no longer treated as a foretold card while on the stack / resolving.
+  let updatedCards = currentState.cards;
+  if (alternativeCost?.type === "foretell") {
+    updatedCards = new Map(currentState.cards);
+    updatedCards.set(cardId, {
+      ...card,
+      isFaceDown: false,
+      foretold: false,
+      currentZoneKey: "stack",
+    });
+  }
+
   // Add stack object to stack
   const updatedStack = [...currentState.stack, stackObject];
 
@@ -539,6 +589,7 @@ export function castSpell(
     state: {
       ...currentState,
       zones: updatedZones,
+      cards: updatedCards,
       stack: updatedStack,
       players: updatedPlayers,
       priorityPlayerId: playerIds[nextIndex],

--- a/src/lib/game-state/types.ts
+++ b/src/lib/game-state/types.ts
@@ -121,6 +121,22 @@ export interface CardInstance {
    */
   blitz?: boolean;
 
+  // Foretell-specific (CR 702.142)
+  /**
+   * Whether this card is currently foretold: exiled face down by its owner via
+   * the Foretell keyword action (CR 702.142b). While true the card lives in its
+   * owner's exile zone, face down (`isFaceDown === true`), hidden from other
+   * players but visible to its owner, and may be cast for its foretell cost on a
+   * later turn (CR 702.142c). Cleared when the card is cast or leaves exile.
+   */
+  foretold?: boolean;
+  /**
+   * The turn number on which this card was foretold (CR 702.142b). Used to
+   * enforce that a foretold card cannot be cast for its foretell cost on the
+   * same turn it was foretold — only on a later turn (CR 702.142c).
+   */
+  foretoldTurn?: number;
+
   // Prototype-specific (CR 702.152)
   /** Whether this permanent is currently in prototype form */
   isPrototype: boolean;
@@ -281,6 +297,15 @@ export interface Player {
   landsPlayedThisTurn: number;
   /** Maximum lands that can be played this turn */
   maxLandsPerTurn: number;
+
+  // Foretell tracking (CR 702.142b)
+  /**
+   * Number of cards this player has foretold this turn. CR 702.142b allows a
+   * player to foretell at most one card each turn. Reset to 0 at the start of
+   * each turn (mirrors `landsPlayedThisTurn`). Optional so legacy Player
+   * literals default to "no foretells yet" (read with `?? 0`).
+   */
+  foretoldThisTurn?: number;
 
   // Mana pool (internally tracked, displayed as "energy" to users)
   /** Available mana in each color */

--- a/src/lib/game-state/validation-service.ts
+++ b/src/lib/game-state/validation-service.ts
@@ -290,7 +290,10 @@ export class ValidationService {
     }
 
     // Get the card
-    const data = action.data as { cardId?: string };
+    const data = action.data as {
+      cardId?: string;
+      alternativeCost?: { type?: string };
+    };
     const cardId = data.cardId;
     if (!cardId) {
       return {
@@ -309,14 +312,23 @@ export class ValidationService {
       };
     }
 
-    // Verify the card is in player's hand
+    // Verify the card is in a zone the player may cast from. Default: hand.
+    // CR 702.142c - Foretell: a foretold card is cast from its owner's exile.
+    const altType = data.alternativeCost?.type;
     const handZone = state.zones.get(`${action.playerId}-hand`);
-    if (!handZone || !handZone.cardIds.includes(cardId)) {
-      return {
-        isValid: false,
-        reason: "Card not in hand",
-        message: "Card is not in your hand.",
-      };
+    const inHand = handZone?.cardIds.includes(cardId) ?? false;
+    if (!inHand) {
+      const exileZone = state.zones.get(`${action.playerId}-exile`);
+      const inExile = exileZone?.cardIds.includes(cardId) ?? false;
+      const isForetold =
+        inExile && card.foretold === true && card.isFaceDown === true;
+      if (!(altType === "foretell" && isForetold)) {
+        return {
+          isValid: false,
+          reason: "Card not in hand",
+          message: "Card is not in your hand.",
+        };
+      }
     }
 
     // CR 702.60b - Split second: while a spell with split second is on the
@@ -332,10 +344,15 @@ export class ValidationService {
       };
     }
 
-    // Validate mana costs are paid (check player has enough mana)
-    const manaValidation = this.validateManaCost(state, player, card);
-    if (!manaValidation.isValid) {
-      return manaValidation;
+    // Validate mana costs are paid (check player has enough mana). Foretell
+    // (CR 702.142c) REPLACES the mana cost with the printed foretell cost, so
+    // the printed-cost check here is not authoritative — castSpell recomputes
+    // and charges the foretell cost. Skip it to avoid a false rejection.
+    if (altType !== "foretell") {
+      const manaValidation = this.validateManaCost(state, player, card);
+      if (!manaValidation.isValid) {
+        return manaValidation;
+      }
     }
 
     // Check timing rules (Sorcery vs Instant)

--- a/src/lib/game-state/zones.ts
+++ b/src/lib/game-state/zones.ts
@@ -2,7 +2,7 @@
  * Zone management for Magic: The Gathering game state
  */
 
-import type { CardInstanceId, PlayerId, Zone } from "./types";
+import type { CardInstance, CardInstanceId, PlayerId, Zone } from "./types";
 import { ZoneType, getZoneKey } from "./types";
 
 /**
@@ -355,4 +355,36 @@ export function exileCards(
     exile: updatedExile,
     exiledCards: cardIds,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Foretell zone representation (CR 702.142 / CR 713)
+//
+// A foretold card lives in its owner's public exile zone but is kept FACE DOWN
+// (`isFaceDown === true`) and flagged `foretold === true`. It is hidden from
+// other players but visible to its owner, who may cast it for its foretell cost
+// on a later turn (CR 702.142c). We model "foretold" as per-card markers rather
+// than a separate zone so the existing exile machinery (move/reveal/cleanup) is
+// reused unchanged.
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether a card is currently foretold (CR 702.142b): exiled face down by its
+ * owner via the Foretell keyword action. The owner may look at it; it is hidden
+ * from other players. A card that is merely exiled (not face down, or not
+ * flagged) is NOT foretold.
+ */
+export function isForetoldCard(card: CardInstance | undefined): boolean {
+  return card?.foretold === true && card.isFaceDown === true;
+}
+
+/**
+ * Return the IDs of all foretold cards currently in the given exile zone.
+ * CR 702.142b: a foretold card is exiled face down and flagged `foretold`.
+ */
+export function getForetoldCardIds(
+  exileZone: Zone,
+  cards: Map<CardInstanceId, CardInstance>,
+): CardInstanceId[] {
+  return exileZone.cardIds.filter((id) => isForetoldCard(cards.get(id)));
 }


### PR DESCRIPTION
Resolves #1060

## Summary

Implements the **Foretell** alternate-cast mechanic per **CR 702.142**, exercising the zones, alternate-cost casting, and reveal-on-cast subsystems together. Modeled on the recently-merged Blitz (#1061/#1194) and Split Second (#1062/#1191) work.

Foretell is a **two-step** mechanic; both steps are implemented:

1. **CR 702.142b — keyword action (`foretellCard`)**: Once per turn, on your turn, during a main phase while the stack is empty (sorcery timing) and with priority, you may pay `{2}` and exile a card from your hand **face down**. It becomes "foretold" — hidden from opponents, visible to its owner.
2. **CR 702.142c — alternate cast (`castForetoldCard`)**: On a **later turn** you may cast a foretold card **from exile** by paying its printed foretell cost (an alternative cost that replaces the mana cost), **revealing** it as it is announced. The spell's mana value is unchanged and other costs/taxes still apply.

## CR details implemented

- **702.142a/b** — Foretell functions from the hand; foretelling is a once-per-turn special action at sorcery speed that costs `{2}` and exiles the card face down.
- **702.142c** — A foretold card is cast from exile for its printed foretell cost; it is revealed on cast and cannot be cast the turn it was foretold (only a strictly later turn).
- The `{2}` exile cost is a constant of the keyword action; the printed `Foretell [cost]` is the alternate cast cost (mirrors Blitz's replace-cost handling so mana value is preserved).

## Zone / state handling

A foretold card lives in its **owner's public exile zone** but is kept **face down** (`isFaceDown === true`) and flagged `foretold === true` — modelled as per-card markers rather than a separate zone so the existing exile machinery is reused unchanged (per the issue's proposed approach). Only the owner may look at it.

- `types.ts` — `foretold` / `foretoldTurn` on `CardInstance`; `foretoldThisTurn` on `Player` (optional, defaults to 0).
- `game-state.ts` — initializes and resets `foretoldThisTurn` each turn (mirrors `landsPlayedThisTurn`).
- `zones.ts` — `isForetoldCard` / `getForetoldCardIds` helpers.
- The once-per-turn limit is enforced via `Player.foretoldThisTurn`; the later-turn cast restriction via `CardInstance.foretoldTurn`.

## Files changed

- `src/lib/game-state/oracle-text-parser.ts` — `FORETELL` alt-cost type, `parseForetell`, `parseAlternativeCost` recognition, keyword-list entry.
- `src/lib/game-state/keyword-actions.ts` — `foretellCard` (keyword action) + `castForetoldCard` (alternate cast) with full validation.
- `src/lib/game-state/spell-casting.ts` — `castSpell` `"foretell"` alt cost: exile source zone, foretell-cost replacement, on-cast reveal.
- `src/lib/game-state/zones.ts` — foretell zone helpers.
- `src/lib/game-state/types.ts` — `foretold` / `foretoldTurn` / `foretoldThisTurn` fields.
- `src/lib/game-state/game-state.ts` — init + per-turn reset of `foretoldThisTurn`.
- `src/lib/game-state/validation-service.ts` — allow a foretold card to be cast from exile and skip the printed-cost mana check (castSpell charges the foretell cost authoritatively).
- `src/lib/game-state/__tests__/foretell.test.ts` — 24 tests.

## Acceptance criteria

- [x] "Foretell [cost]" parsed from oracle text (`parseForetell` / `parseAlternativeCost` / `extractKeywords`)
- [x] Foretell special action: exile the card face down as foretold (once per turn, your turn, main phase, empty stack, priority, pay `{2}`)
- [x] Cast-for-foretell action: cast a foretold card from exile by paying the foretell cost (alternate cost), revealing it
- [x] Foretell tracking: foretold cards are identifiable (`isForetoldCard`); per-turn limit enforced
- [x] A non-foretell card cannot foretell; a non-foretold card cannot be cast via foretell (illegal-action rejection)
- [x] Tests cover: parse, foretell action (exile face down + pay `{2}`), per-turn limit, later-turn restriction, cast-for-foretell from exile, reveal, resolution, and illegal-action rejection

## Verification

- `npx tsc --noEmit` — clean
- `npm test` — **292 suites / 6147 tests pass**, 0 failures (no regressions)
- `eslint` on changed files — **0 errors, 0 new warnings**
- `npx jest foretell` — 24/24 pass

## Notes / deviations

- `Player.foretoldThisTurn` is **optional** (`?: number`, read with `?? 0`) so legacy `Player` literals across the codebase don't require unrelated edits (keeps the change focused on Foretell).
- `validation-service.ts` was touched because `validateCastSpell` rejected any non-hand card and validated against the printed mana cost; it now permits a foretold card to be cast from exile and defers mana validation to `castSpell` for the foretell path. (This is a related, necessary change for casting correctness.)
- An unrelated formatting artifact (`public/mockServiceWorker.js`, double→single quotes from the install hook) was reverted and is **not** included.

Resolves #1060
