### PR TITLE
fix(ai): resolve #991 — derive opponent archetype in DefaultCombatConfigs instead of hardcoding 'unknown'

### DIFF
--- a/src/ai/__tests__/combat-decision-tree.test.ts
+++ b/src/ai/__tests__/combat-decision-tree.test.ts
@@ -915,6 +915,186 @@ describe("CombatDecisionTree", () => {
     });
   });
 
+  describe("live opponent-archetype derivation from board state (#991)", () => {
+    it("derives the opponent archetype from an observed aggro board when none is supplied", () => {
+      // No explicit opponentArchetype argument: the tree must infer from the
+      // opponent's battlefield instead of inheriting the "unknown" baked into
+      // DefaultCombatConfigs.
+      const opponentAggroBoard = [
+        createMockPermanent("o1", "Goblin Guide", "creature", 2, 2, false, 1),
+        createMockPermanent(
+          "o2",
+          "Monastery Swiftspear",
+          "creature",
+          1,
+          2,
+          false,
+          1,
+        ),
+        createMockPermanent("o3", "Ragavan", "creature", 2, 1, false, 1),
+      ];
+      const state = createTestGameState(20, 20, [], opponentAggroBoard);
+
+      const combatAI = new CombatDecisionTree(state, "player1", "hard");
+
+      expect(combatAI.getOpponentArchetype()).toBe("aggro");
+      // The derived archetype reaches the live combat config consumed by block
+      // prediction (DefaultCombatConfigs no longer forces "unknown").
+      expect(combatAI.getConfig().opponentArchetype).toBe("aggro");
+    });
+
+    it("derives control from a planeswalker-heavy opponent board", () => {
+      const opponentControlBoard = [
+        createMockPermanent("o1", "Teferi", "planeswalker", 0, 0, false, 4),
+        createMockPermanent(
+          "o2",
+          "Shark Typhoon",
+          "enchantment",
+          0,
+          0,
+          false,
+          6,
+        ),
+        createMockPermanent(
+          "o3",
+          "Solemn Simulacrum",
+          "creature",
+          1,
+          1,
+          false,
+          4,
+        ),
+      ];
+      const state = createTestGameState(20, 20, [], opponentControlBoard);
+
+      const combatAI = new CombatDecisionTree(state, "player1", "expert");
+
+      expect(combatAI.getOpponentArchetype()).toBe("control");
+      expect(combatAI.getConfig().opponentArchetype).toBe("control");
+    });
+
+    it("keeps 'unknown' when the opponent board is too sparse to classify", () => {
+      // Empty opponent board -> nothing observed -> genuine "unknown" fallback.
+      const empty = createTestGameState();
+      expect(
+        new CombatDecisionTree(
+          empty,
+          "player1",
+          "medium",
+        ).getOpponentArchetype(),
+      ).toBe("unknown");
+      expect(
+        new CombatDecisionTree(empty, "player1", "medium").getConfig()
+          .opponentArchetype,
+      ).toBe("unknown");
+
+      // A single non-land permanent is below the minimum signal threshold.
+      const thin = createTestGameState(
+        20,
+        20,
+        [],
+        [
+          createMockPermanent(
+            "o1",
+            "Birds of Paradise",
+            "creature",
+            0,
+            1,
+            false,
+            1,
+          ),
+        ],
+      );
+      expect(
+        new CombatDecisionTree(
+          thin,
+          "player1",
+          "medium",
+        ).getOpponentArchetype(),
+      ).toBe("unknown");
+    });
+
+    it("prefers an explicitly supplied archetype over board inference", () => {
+      // The caller knows best (e.g. the live turn loop detects from the full
+      // engine state). An explicit value must win even when the board suggests
+      // a different archetype.
+      const opponentAggroBoard = [
+        createMockPermanent("o1", "Goblin Guide", "creature", 2, 2, false, 1),
+        createMockPermanent("o2", "Ragavan", "creature", 2, 1, false, 1),
+        createMockPermanent("o3", "Pashalik Mons", "creature", 2, 1, false, 1),
+      ];
+      const state = createTestGameState(20, 20, [], opponentAggroBoard);
+
+      const combatAI = new CombatDecisionTree(
+        state,
+        "player1",
+        "hard",
+        "unknown",
+        "control",
+      );
+
+      expect(combatAI.getOpponentArchetype()).toBe("control");
+      expect(combatAI.getConfig().opponentArchetype).toBe("control");
+    });
+
+    it("flows the derived archetype into block prediction so combat adapts", () => {
+      // Same attacker/blocker and difficulty; only the opponent's observed
+      // board differs. The derived archetype must change the block-prediction
+      // weights the combat tree plans against, proving the real matchup
+      // context reaches combat decisions rather than a hardcoded "unknown".
+      const attacker = createMockPermanent("a1", "Bear", "creature", 2, 2);
+      const blocker = createMockPermanent("b1", "Bear", "creature", 2, 2);
+      const playerBoard = [attacker];
+
+      const vsAggro = new CombatDecisionTree(
+        createTestGameState(20, 20, playerBoard, [
+          createMockPermanent("o1", "Goblin", "creature", 2, 2, false, 1),
+          createMockPermanent("o2", "Goblin", "creature", 2, 2, false, 1),
+          createMockPermanent("o3", "Goblin", "creature", 2, 2, false, 1),
+        ]),
+        "player1",
+        "hard",
+      );
+      const vsControl = new CombatDecisionTree(
+        createTestGameState(20, 20, playerBoard, [
+          createMockPermanent("o1", "Jace", "planeswalker", 0, 0, false, 4),
+          createMockPermanent(
+            "o2",
+            "Engineered Explosives",
+            "artifact",
+            0,
+            0,
+            false,
+            2,
+          ),
+        ]),
+        "player1",
+        "hard",
+      );
+
+      expect(vsAggro.getOpponentArchetype()).toBe("aggro");
+      expect(vsControl.getOpponentArchetype()).toBe("control");
+
+      // The block-prediction weights differ because the real archetype flows
+      // through (control is far more willing to block than aggro).
+      const aggroPred = predictOpponentBlocks(
+        [attacker],
+        [blocker],
+        20,
+        vsAggro.getConfig().opponentArchetype,
+      );
+      const controlPred = predictOpponentBlocks(
+        [attacker],
+        [blocker],
+        20,
+        vsControl.getConfig().opponentArchetype,
+      );
+      expect(aggroPred.archetypeWeights.willingnessToBlock).toBeLessThan(
+        controlPred.archetypeWeights.willingnessToBlock,
+      );
+    });
+  });
+
   describe("combat blunder frequency by difficulty (#994)", () => {
     const TIERS: DifficultyLevel[] = ["easy", "medium", "hard", "expert"];
 

--- a/src/ai/decision-making/combat-decision-tree.ts
+++ b/src/ai/decision-making/combat-decision-tree.ts
@@ -121,6 +121,106 @@ export function deckArchetypeToOpponentArchetype(
 }
 
 /**
+ * Minimum number of observed non-land permanents the opponent must have on the
+ * battlefield before we are willing to classify their archetype from board
+ * state alone. Below this the signal is too noisy, so we keep "unknown".
+ */
+const MIN_BOARD_SIGNAL = 2;
+
+/**
+ * Infer the opponent's emerging {@link OpponentArchetype} from the cards they
+ * have actually revealed/played (their observed battlefield) inside an
+ * {@link AIGameState}.
+ *
+ * This is the fallback derivation path used by {@link CombatDecisionTree} when
+ * no explicit opponent archetype is supplied (issue #991). Previously the
+ * combat config always inherited the "unknown" baked into
+ * {@link DefaultCombatConfigs}, so every caller that did not wire detection
+ * itself (notably the in-game combat decider) modelled the opponent as unknown
+ * for the entire game and block prediction never adapted.
+ *
+ * The full-fidelity detector ({@link detectArchetype}) needs rich Scryfall card
+ * data that the simplified {@link AIPermanent} does not carry, so this infers
+ * from the shape of the observed board instead — creature count, curve and
+ * non-creature support. It deliberately returns "unknown" when there is too
+ * little to classify, so "unknown" remains the genuine fallback rather than the
+ * hardcoded default. Callers that supply an explicit archetype (e.g. the live
+ * turn loop, which detects from the full engine state) always take precedence.
+ */
+export function inferOpponentArchetype(
+  state: GameState,
+  aiPlayerId: string,
+): OpponentArchetype {
+  const opponent = Object.values(state.players).find(
+    (player) => player.id !== aiPlayerId,
+  );
+  if (!opponent) return "unknown";
+
+  const board = opponent.battlefield ?? [];
+  // Lands reveal very little about archetype, so classification keys off the
+  // non-land permanents the opponent has actually committed to the board.
+  const nonLand = board.filter((permanent) => permanent.type !== "land");
+  if (nonLand.length < MIN_BOARD_SIGNAL) return "unknown";
+
+  const creatures = nonLand.filter(
+    (permanent) => permanent.type === "creature",
+  );
+  const support = nonLand.filter(
+    (permanent) =>
+      permanent.type === "artifact" ||
+      permanent.type === "enchantment" ||
+      permanent.type === "planeswalker",
+  );
+  const planeswalkers = nonLand.filter(
+    (permanent) => permanent.type === "planeswalker",
+  );
+
+  const creatureCmcs = creatures
+    .map((creature) => creature.manaValue ?? 0)
+    .filter((value) => value > 0);
+  const averageCreatureCmc =
+    creatureCmcs.length > 0
+      ? creatureCmcs.reduce((sum, value) => sum + value, 0) /
+        creatureCmcs.length
+      : 0;
+
+  // Aggro: a wide board of cheap creatures with little non-creature support.
+  if (
+    creatures.length >= 3 &&
+    averageCreatureCmc > 0 &&
+    averageCreatureCmc <= 2 &&
+    support.length <= 1
+  ) {
+    return "aggro";
+  }
+
+  // Control: few creatures, leaning on planeswalkers / reactive permanents.
+  if (
+    creatures.length <= 2 &&
+    (planeswalkers.length >= 1 || support.length >= 2)
+  ) {
+    return "control";
+  }
+
+  // Tempo: cheap creatures backed by interactive non-creature permanents.
+  if (
+    creatures.length >= 2 &&
+    averageCreatureCmc > 0 &&
+    averageCreatureCmc <= 2 &&
+    support.length >= 1
+  ) {
+    return "tempo";
+  }
+
+  // Midrange: a healthy creature presence on a mid-to-high curve.
+  if (creatures.length >= 2 && averageCreatureCmc >= 2) {
+    return "midrange";
+  }
+
+  return "unknown";
+}
+
+/**
  * Card data interface for combat tricks
  * Extends the basic HandCard with combat-relevant information
  */
@@ -248,7 +348,14 @@ export interface CombatAIConfig {
   useCombatTricks: boolean;
   /** Whether to use predictive block modeling */
   useBlockPrediction: boolean;
-  /** Estimated opponent archetype for block prediction */
+  /**
+   * Estimated opponent archetype for block prediction. This is the generic
+   * fallback baked into {@link DefaultCombatConfigs}; the live
+   * {@link CombatDecisionTree} overrides it with an explicit value (when the
+   * caller supplies one) or a value derived from the opponent's observed board
+   * (issue #991), so "unknown" only survives when the archetype genuinely
+   * cannot be determined.
+   */
   opponentArchetype: OpponentArchetype;
   /** Whether to use multi-turn lookahead planning */
   useLookahead: boolean;
@@ -343,12 +450,11 @@ export class CombatDecisionTree {
     aiPlayerId: string,
     difficulty: "easy" | "medium" | "hard" | "expert" = "medium",
     archetype: DeckArchetype = "unknown",
-    opponentArchetype: OpponentArchetype = "unknown",
+    opponentArchetype?: OpponentArchetype,
   ) {
     this.gameState = gameState;
     this.aiPlayerId = aiPlayerId;
     this.archetype = archetype;
-    this.opponentArchetype = opponentArchetype;
     this.difficulty = difficulty;
 
     const baseConfig = DefaultCombatConfigs[difficulty];
@@ -374,11 +480,17 @@ export class CombatDecisionTree {
     } else {
       this.config = { ...baseConfig };
     }
-    // Populate the opponent-archetype signal that block prediction consumes.
-    // DefaultCombatConfigs hardcodes this to "unknown", so without an explicit
-    // override the AI could never model how the opponent will block — the
-    // signal was effectively dead code (issue #912).
-    this.config.opponentArchetype = opponentArchetype;
+    // Resolve the opponent-archetype signal that block prediction consumes.
+    // DefaultCombatConfigs only carries a generic "unknown" fallback, so an
+    // explicit archetype always wins; when none is supplied we derive it from
+    // the opponent's observed battlefield so the AI models how they will block.
+    // Previously the config inherited "unknown" verbatim and block prediction
+    // could never adapt for any caller that did not wire detection itself
+    // (issues #912 and #991).
+    const resolvedOpponentArchetype =
+      opponentArchetype ?? inferOpponentArchetype(gameState, aiPlayerId);
+    this.opponentArchetype = resolvedOpponentArchetype;
+    this.config.opponentArchetype = resolvedOpponentArchetype;
     this.heuristicTable = new HeuristicTable();
     this.lookaheadEngine = new LookaheadEngine(
       this.heuristicTable,
@@ -2272,7 +2384,7 @@ export function generateAttackDecisions(
   aiPlayerId: string,
   difficulty: "easy" | "medium" | "hard" | "expert" = "medium",
   archetype: DeckArchetype = "unknown",
-  opponentArchetype: OpponentArchetype = "unknown",
+  opponentArchetype?: OpponentArchetype,
 ): CombatPlan {
   const ai = new CombatDecisionTree(
     gameState,
@@ -2293,7 +2405,7 @@ export function generateBlockingDecisions(
   attackers: Permanent[],
   difficulty: "easy" | "medium" | "hard" | "expert" = "medium",
   archetype: DeckArchetype = "unknown",
-  opponentArchetype: OpponentArchetype = "unknown",
+  opponentArchetype?: OpponentArchetype,
 ): CombatPlan {
   const ai = new CombatDecisionTree(
     gameState,

--- a/src/ai/decision-making/index.ts
+++ b/src/ai/decision-making/index.ts
@@ -11,6 +11,7 @@ export {
   DefaultCombatConfigs,
   ARCHETYPE_COMBAT_MODIFIERS,
   deckArchetypeToOpponentArchetype,
+  inferOpponentArchetype,
   type CombatAIConfig,
   type AttackDecision,
   type BlockDecision,


### PR DESCRIPTION
## Problem

`DefaultCombatConfigs` hardcoded `opponentArchetype: "unknown"` for **all** difficulty levels (easy/medium/hard/expert) in `src/ai/decision-making/combat-decision-tree.ts`. The combat config therefore always treated the opponent as "unknown", so the AI's block-prediction model could never adapt to the real matchup — every caller that did not wire detection itself modelled the opponent as unknown for the entire game.

Notably the **in-game combat decider** (`src/app/(app)/game/[id]/page.tsx` — `shouldAttack`/`getAttackers`/`getBlockers`) constructs `CombatDecisionTree` with only `(state, id, difficulty)` and no opponent archetype, so it always inherited the hardcoded "unknown". Only the live turn loop (`ai-turn-loop.ts`, via #912) passed an explicit derived value.

## Fix

Make the opponent archetype **derived** instead of hardcoded, while keeping "unknown" as the genuine fallback:

- **New exported helper `inferOpponentArchetype(state, aiPlayerId)`** classifies the opponent's *observed* battlefield (creature count, curve, non-creature support) into an `OpponentArchetype`. It returns `"unknown"` when there is too little signal (< 2 non-land permanents), so "unknown" survives only when the archetype genuinely cannot be determined.
- **`CombatDecisionTree` constructor**: the `opponentArchetype` param is now optional. Resolution order: **explicit param wins** → otherwise **infer from board** → otherwise "unknown".
- **`generateAttackDecisions` / `generateBlockingDecisions`** wrappers take an optional `opponentArchetype` too, so the many callers that omit it (combat-examples, validation) now benefit from derivation.
- `DefaultCombatConfigs` retains "unknown" as the documented fallback base; the *live* config no longer hardcodes it.

### Why a board-shape heuristic instead of `detectArchetype`?
The full-fidelity `detectArchetype` needs rich Scryfall card data (`DeckCard`), but the simplified `AIPermanent` in `AIGameState` only carries `type`/`manaValue`/`keywords`. The constructor only has an `AIGameState`, so it infers from board shape. The live turn loop still detects from the full engine state and passes an explicit value, which always takes precedence.

## Where it was hardcoded
`src/ai/decision-making/combat-decision-tree.ts` — `DefaultCombatConfigs` (`opponentArchetype: "unknown"` ×4 difficulties) plus the constructor's default param. The constructor overrode it only when an explicit value was supplied (#912); every other caller fell through to "unknown".

## Fallback
"unknown" is returned when there is no opponent, an empty battlefield, or fewer than 2 observed non-land permanents — preserving existing behavior for sparse/early-game states (the existing #912 backward-compat test still passes).

## Acceptance criteria
- [x] `opponentArchetype` is no longer hardcoded for the live config — derived from the actual opponent
- [x] When determinable, the combat config uses the real archetype; falls back to "unknown" only when genuinely undeterminable
- [x] The real archetype flows into block prediction (derived value reaches `getConfig().opponentArchetype` and shifts block weights)
- [x] No regression — "unknown" fallback preserved; all 53 pre-existing combat tests still pass
- [x] Unit tests cover: derived when determinable (aggro/control), "unknown" fallback (empty + sparse), explicit-override-wins, and config-flows-to-block-prediction

## Verification
- `npx jest src/ai/__tests__/combat-decision-tree.test.ts` → 58 passed (53 existing + 5 new)
- Full matched suite (combat/archetype/block-prediction/combat-trick/combat-ai): 6211 passed
- `npx tsc --noEmit` → No errors found
- `npm run lint` → 0 errors

Resolves #991