### PR TITLE
feat(rules-engine): resolve #1059 — implement spell-copy effects and storm count (CR 702.41, 707)

### DIFF
--- a/src/lib/game-state/__tests__/storm-spell-copy.test.ts
+++ b/src/lib/game-state/__tests__/storm-spell-copy.test.ts
@@ -1,0 +1,585 @@
+/**
+ * @fileoverview Unit tests for spell-copy effects and the Storm keyword.
+ *
+ * Issue #1059 — [Rules Engine] Implement spell-copy effects and storm count
+ * (CR 702.41, CR 707).
+ *
+ * Storm (CR 702.41):
+ * - 702.41a: "When you cast this spell, copy it for each spell cast before it
+ *   this turn. If the spell has any targets, you may choose new targets for any
+ *   of the copies."
+ * - 702.41c: multiple instances are redundant.
+ *
+ * Copying spells (CR 707.10):
+ * - 707.10: a copy of a spell is itself a spell on the stack, with the same
+ *   characteristics (name, cost, text, modes, targets, controller) and no cost
+ *   paid. It is not "cast", so it does not add to the storm count.
+ * - 707.10c: the copy retains the original's targets.
+ * - 707.10d: the controller may choose new targets; a permanent copy enters as
+ *   a token.
+ *
+ * Coverage: parsing, storm-count tracking (+ per-turn reset), storm copies
+ * count, the copySpellOnStack primitive (characteristics/targets), and copy
+ * resolution (instant vs permanent).
+ */
+
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import {
+  castSpell,
+  copySpellOnStack,
+  resolveTopOfStack,
+} from "../spell-casting";
+import { createInitialGameState, startGame, passPriority } from "../game-state";
+import { createCardInstance } from "../card-instance";
+import { addMana } from "../mana";
+import { parseStorm } from "../oracle-text-parser";
+import { detectStormTrigger } from "../trigger-system";
+import { Phase } from "../types";
+import type {
+  GameState,
+  PlayerId,
+  CardInstanceId,
+  CardInstance,
+  StackObject,
+  Target,
+} from "../types";
+import type { ScryfallCard } from "@/app/actions";
+
+// ---------------------------------------------------------------------------
+// Mock card helpers
+// ---------------------------------------------------------------------------
+
+function makeCard(
+  overrides: Partial<ScryfallCard> & { id: string },
+): ScryfallCard {
+  return {
+    name: "Test Card",
+    type_line: "Instant",
+    oracle_text: "",
+    mana_cost: "{1}{R}",
+    cmc: 2,
+    colors: ["R"],
+    color_identity: ["R"],
+    legalities: { standard: "legal", commander: "legal" },
+    layout: "normal",
+    ...overrides,
+  } as ScryfallCard;
+}
+
+/**
+ * A storm cantrip (stands in for Grapeshot / Empty the Warrens). Untargeted so
+ * the test can focus on copy COUNT without exercising target validation.
+ */
+function stormCantrip(): ScryfallCard {
+  return makeCard({
+    id: "mock-grapeshot",
+    name: "Grapeshot",
+    type_line: "Instant",
+    oracle_text: "Storm\nYou draw a card.",
+    mana_cost: "{1}{R}",
+    cmc: 2,
+  });
+}
+
+/** A cheap non-storm instant used to increment the storm count by casting. */
+function cheapCantrip(): ScryfallCard {
+  return makeCard({
+    id: "mock-opt",
+    name: "Opt",
+    type_line: "Instant",
+    oracle_text: "Draw a card.",
+    mana_cost: "{U}",
+    cmc: 1,
+    colors: ["U"],
+  });
+}
+
+/** A targeted damage instant (Lightning Bolt–like) for copy-target tests. */
+function damageSpell(): ScryfallCard {
+  return makeCard({
+    id: "mock-bolt",
+    name: "Lightning Bolt",
+    type_line: "Instant",
+    oracle_text: "Lightning Bolt deals 3 damage to any target.",
+    mana_cost: "{R}",
+    cmc: 1,
+    colors: ["R"],
+  });
+}
+
+/** A vanilla creature spell for the permanent-copy-to-token test. */
+function vanillaCreature(): ScryfallCard {
+  return makeCard({
+    id: "mock-bear",
+    name: "Runeclaw Bear",
+    type_line: "Creature — Bear",
+    oracle_text: "",
+    mana_cost: "{1}{G}",
+    cmc: 2,
+    colors: ["G"],
+    power: "2",
+    toughness: "2",
+  });
+}
+
+function playerTarget(playerId: PlayerId): Target {
+  return { type: "player", targetId: playerId, isValid: true };
+}
+
+// ---------------------------------------------------------------------------
+// Shared state scaffolding
+// ---------------------------------------------------------------------------
+
+interface Fixture {
+  state: GameState;
+  aliceId: PlayerId;
+  bobId: PlayerId;
+}
+
+function makeFixture(): Fixture {
+  let state = createInitialGameState(["Alice", "Bob"], 20, false);
+  state = startGame(state);
+
+  const ids = Array.from(state.players.keys());
+  const aliceId = ids[0];
+  const bobId = ids[1];
+
+  state.status = "in_progress";
+  state.priorityPlayerId = aliceId;
+  state.turn.activePlayerId = aliceId;
+  state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+  state.turn.isFirstTurn = false;
+  state.stack = [];
+  state.consecutivePasses = 0;
+  state.players.forEach((p) =>
+    state.players.set(p.id, { ...p, hasPassedPriority: false }),
+  );
+
+  return { state, aliceId, bobId };
+}
+
+/** Place a card into a player's hand and the global card map. */
+function putInHand(
+  state: GameState,
+  playerId: PlayerId,
+  cardData: ScryfallCard,
+): CardInstanceId {
+  const card = createCardInstance(cardData, playerId, playerId);
+  state.cards.set(card.id, card);
+  const hand = state.zones.get(`${playerId}-hand`)!;
+  state.zones.set(`${playerId}-hand`, {
+    ...hand,
+    cardIds: [...hand.cardIds, card.id],
+  });
+  return card.id;
+}
+
+/** Register a card in the card map (without placing it in a zone). */
+function registerCard(
+  state: GameState,
+  playerId: PlayerId,
+  cardData: ScryfallCard,
+): CardInstance {
+  const card = createCardInstance(cardData, playerId, playerId);
+  state.cards.set(card.id, card);
+  return card;
+}
+
+/** Push a spell StackObject onto the stack (simulating it having been cast). */
+function pushSpell(
+  state: GameState,
+  controllerId: PlayerId,
+  card: CardInstance,
+  overrides: Partial<StackObject> = {},
+): StackObject {
+  const obj: StackObject = {
+    id: `spell-${state.stack.length + 1}-${Math.random().toString(36).slice(2, 8)}`,
+    type: "spell",
+    sourceCardId: card.id,
+    controllerId,
+    name: card.cardData.name,
+    text: card.cardData.oracle_text ?? "",
+    manaCost: card.cardData.mana_cost ?? null,
+    targets: [],
+    chosenModes: [],
+    variableValues: new Map(),
+    isCountered: false,
+    timestamp: Date.now(),
+    ...overrides,
+  };
+  state.stack = [...state.stack, obj];
+  return obj;
+}
+
+// ===========================================================================
+// Tests — parsing
+// ===========================================================================
+
+describe("Storm — parsing (CR 702.41)", () => {
+  it("detects the Storm keyword in oracle text", () => {
+    expect(parseStorm("Storm\nYou draw a card.").hasStorm).toBe(true);
+    expect(parseStorm("Storm").hasStorm).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(parseStorm("storm").hasStorm).toBe(true);
+    expect(parseStorm("STORM").hasStorm).toBe(true);
+  });
+
+  it("returns false when the keyword is absent or empty", () => {
+    expect(parseStorm("Draw a card.").hasStorm).toBe(false);
+    expect(parseStorm("").hasStorm).toBe(false);
+  });
+
+  it("does not match substrings inside other words", () => {
+    // word-boundary anchored on both sides
+    expect(parseStorm("Brainstorm").hasStorm).toBe(false); // no boundary before 's'
+    expect(parseStorm("stormbound").hasStorm).toBe(false); // no boundary after 'm'
+  });
+
+  it("exposes a description when present", () => {
+    expect(parseStorm("Storm").description).toBe("Storm");
+    expect(parseStorm("Draw a card.").description).toBe("");
+  });
+});
+
+// ===========================================================================
+// Tests — storm count tracking
+// ===========================================================================
+
+describe("Storm count tracking (Player.spellsCastThisTurn)", () => {
+  let f: Fixture;
+
+  beforeEach(() => {
+    f = makeFixture();
+  });
+
+  it("initializes to 0 for a freshly created player", () => {
+    expect(f.state.players.get(f.aliceId)!.spellsCastThisTurn ?? 0).toBe(0);
+    expect(f.state.players.get(f.bobId)!.spellsCastThisTurn ?? 0).toBe(0);
+  });
+
+  it("increments by 1 each time a player casts a spell", () => {
+    const card1 = putInHand(f.state, f.aliceId, cheapCantrip());
+    const card2 = putInHand(f.state, f.aliceId, cheapCantrip());
+    f.state = addMana(f.state, f.aliceId, { blue: 4, generic: 0 });
+
+    const r1 = castSpell(f.state, f.aliceId, card1);
+    expect(r1.success).toBe(true);
+    expect(r1.state.players.get(f.aliceId)!.spellsCastThisTurn).toBe(1);
+
+    // castSpell passes priority; hand it back to Alice for the second cast.
+    r1.state.priorityPlayerId = f.aliceId;
+    const r2 = castSpell(r1.state, f.aliceId, card2);
+    expect(r2.success).toBe(true);
+    expect(r2.state.players.get(f.aliceId)!.spellsCastThisTurn).toBe(2);
+  });
+
+  it("spell COPIES do not increment the storm count (CR 707.10)", () => {
+    const card = registerCard(f.state, f.aliceId, damageSpell());
+    const spell = pushSpell(f.state, f.aliceId, card, {
+      targets: [playerTarget(f.bobId)],
+    });
+    expect(f.state.players.get(f.aliceId)!.spellsCastThisTurn ?? 0).toBe(0);
+
+    const copy = copySpellOnStack(f.state, spell.id);
+    expect(copy.success).toBe(true);
+    // Copying did not change the cast counter.
+    expect(copy.state.players.get(f.aliceId)!.spellsCastThisTurn ?? 0).toBe(0);
+  });
+
+  it("resets to 0 at the start of the next turn (CR 702.41a)", () => {
+    // Simulate Alice having cast several spells this turn.
+    const alice = f.state.players.get(f.aliceId)!;
+    f.state.players.set(f.aliceId, { ...alice, spellsCastThisTurn: 5 });
+
+    // Park the turn at CLEANUP (the final step). When all players pass with an
+    // empty stack from CLEANUP, advancePhase wraps and the engine starts a new
+    // turn, resetting every player's per-turn counters.
+    f.state.turn.currentPhase = Phase.CLEANUP;
+    f.state.stack = [];
+    f.state.consecutivePasses = 0;
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.players.forEach((p) =>
+      f.state.players.set(p.id, { ...p, hasPassedPriority: false }),
+    );
+
+    const turnBefore = f.state.turn.turnNumber;
+    let s = passPriority(f.state, f.aliceId);
+    s = passPriority(s, f.bobId);
+
+    expect(s.turn.turnNumber).toBe(turnBefore + 1);
+    expect(s.players.get(f.aliceId)!.spellsCastThisTurn ?? 0).toBe(0);
+    expect(s.players.get(f.bobId)!.spellsCastThisTurn ?? 0).toBe(0);
+  });
+});
+
+// ===========================================================================
+// Tests — storm trigger copy count
+// ===========================================================================
+
+describe("Storm trigger — copy count (CR 702.41a)", () => {
+  let f: Fixture;
+
+  beforeEach(() => {
+    f = makeFixture();
+  });
+
+  it("detectStormTrigger reports copyCount = spells cast before this one", () => {
+    const card = registerCard(f.state, f.aliceId, stormCantrip());
+    const spell = pushSpell(f.state, f.aliceId, card, { storm: true });
+
+    // 4 spells cast this turn (including the storm spell itself) → 3 copies.
+    const alice = f.state.players.get(f.aliceId)!;
+    f.state.players.set(f.aliceId, { ...alice, spellsCastThisTurn: 4 });
+
+    const storm = detectStormTrigger(f.state, spell.id);
+    expect(storm.shouldFire).toBe(true);
+    expect(storm.copyCount).toBe(3);
+  });
+
+  it("returns copyCount 0 for a non-storm spell", () => {
+    const card = registerCard(f.state, f.aliceId, cheapCantrip());
+    const spell = pushSpell(f.state, f.aliceId, card);
+    const alice = f.state.players.get(f.aliceId)!;
+    f.state.players.set(f.aliceId, { ...alice, spellsCastThisTurn: 4 });
+    expect(detectStormTrigger(f.state, spell.id)).toEqual({
+      shouldFire: false,
+      copyCount: 0,
+    });
+  });
+
+  it("casting a storm spell with 3 prior spells creates exactly 3 copies", () => {
+    // Simulate 3 spells already cast this turn (the "storm count").
+    const alice = f.state.players.get(f.aliceId)!;
+    f.state.players.set(f.aliceId, { ...alice, spellsCastThisTurn: 3 });
+
+    const stormCard = putInHand(f.state, f.aliceId, stormCantrip());
+    f.state = addMana(f.state, f.aliceId, { red: 2, generic: 5 });
+
+    const result = castSpell(f.state, f.aliceId, stormCard);
+    expect(result.success).toBe(true);
+
+    const stack = result.state.stack;
+    // 1 original + 3 copies.
+    const stormObjects = stack.filter((o) => o.storm === true);
+    expect(stormObjects.length).toBe(4);
+    expect(stack.filter((o) => o.isCopy === true).length).toBe(3);
+
+    // The original (pushed first) is not a copy; the rest are.
+    expect(stack[0].isCopy !== true).toBe(true);
+    expect(stack.slice(1).every((o) => o.isCopy === true)).toBe(true);
+
+    // All copies share the original's characteristics.
+    expect(stack.every((o) => o.name === "Grapeshot")).toBe(true);
+    expect(stack.every((o) => o.controllerId === f.aliceId)).toBe(true);
+
+    // The storm spell itself was counted when cast → 4.
+    expect(result.state.players.get(f.aliceId)!.spellsCastThisTurn).toBe(4);
+  });
+
+  it("a storm spell cast as the first spell this turn creates no copies", () => {
+    const stormCard = putInHand(f.state, f.aliceId, stormCantrip());
+    f.state = addMana(f.state, f.aliceId, { red: 2, generic: 5 });
+
+    const result = castSpell(f.state, f.aliceId, stormCard);
+    expect(result.success).toBe(true);
+    expect(result.state.stack.length).toBe(1);
+    expect(result.state.stack[0].isCopy !== true).toBe(true);
+    expect(result.state.players.get(f.aliceId)!.spellsCastThisTurn).toBe(1);
+  });
+});
+
+// ===========================================================================
+// Tests — copySpellOnStack primitive (CR 707.10)
+// ===========================================================================
+
+describe("copySpellOnStack — characteristics & targets (CR 707.10)", () => {
+  let f: Fixture;
+
+  beforeEach(() => {
+    f = makeFixture();
+  });
+
+  it("creates a new spell on the stack with the same characteristics", () => {
+    const card = registerCard(f.state, f.aliceId, stormCantrip());
+    const original = pushSpell(f.state, f.aliceId, card, {
+      manaCost: "{1}{R}",
+      chosenModes: ["modeA"],
+      storm: true,
+    });
+    original.variableValues.set("X", 3);
+
+    const result = copySpellOnStack(f.state, original.id);
+    expect(result.success).toBe(true);
+    expect(result.copiedStackObjectId).toBeTruthy();
+
+    const copy = result.state.stack[result.state.stack.length - 1];
+    expect(copy.id).not.toBe(original.id);
+    expect(copy.isCopy).toBe(true);
+    expect(copy.name).toBe(original.name);
+    expect(copy.text).toBe(original.text);
+    expect(copy.manaCost).toBe(original.manaCost);
+    expect(copy.controllerId).toBe(original.controllerId);
+    expect(copy.sourceCardId).toBe(original.sourceCardId);
+    expect(copy.chosenModes).toEqual(original.chosenModes);
+    expect(copy.variableValues.get("X")).toBe(3);
+    expect(copy.storm).toBe(true);
+    expect(copy.isCountered).toBe(false);
+  });
+
+  it("retains the original's targets by default (CR 707.10c)", () => {
+    const card = registerCard(f.state, f.aliceId, damageSpell());
+    const original = pushSpell(f.state, f.aliceId, card, {
+      targets: [playerTarget(f.bobId)],
+    });
+
+    const result = copySpellOnStack(f.state, original.id);
+    const copy = result.state.stack[result.state.stack.length - 1];
+    expect(copy.targets).toEqual(original.targets);
+    expect(copy.targets[0].targetId).toBe(f.bobId);
+  });
+
+  it("allows the controller to choose new targets (CR 707.10d)", () => {
+    const card = registerCard(f.state, f.aliceId, damageSpell());
+    const original = pushSpell(f.state, f.aliceId, card, {
+      targets: [playerTarget(f.aliceId)],
+    });
+
+    const result = copySpellOnStack(f.state, original.id, [
+      playerTarget(f.bobId),
+    ]);
+    const copy = result.state.stack[result.state.stack.length - 1];
+    // Copy is retargeted at Bob; the original still targets Alice.
+    expect(copy.targets[0].targetId).toBe(f.bobId);
+    expect(original.targets[0].targetId).toBe(f.aliceId);
+  });
+
+  it("can copy a copy (CR 707.10)", () => {
+    const card = registerCard(f.state, f.aliceId, damageSpell());
+    const original = pushSpell(f.state, f.aliceId, card, {
+      targets: [playerTarget(f.bobId)],
+    });
+
+    const first = copySpellOnStack(f.state, original.id);
+    expect(first.success).toBe(true);
+    const firstCopy = first.state.stack[first.state.stack.length - 1];
+    expect(firstCopy.isCopy).toBe(true);
+
+    const second = copySpellOnStack(first.state, firstCopy.id);
+    expect(second.success).toBe(true);
+    const secondCopy = second.state.stack[second.state.stack.length - 1];
+    expect(secondCopy.isCopy).toBe(true);
+    expect(secondCopy.name).toBe(original.name);
+    expect(secondCopy.targets[0].targetId).toBe(f.bobId);
+  });
+
+  it("rejects copying a non-spell stack object", () => {
+    const card = registerCard(f.state, f.aliceId, damageSpell());
+    const ability: StackObject = {
+      id: "ability-1",
+      type: "ability",
+      sourceCardId: card.id,
+      controllerId: f.aliceId,
+      name: "Tap: Draw",
+      text: "{T}: Draw a card.",
+      manaCost: null,
+      targets: [],
+      chosenModes: [],
+      variableValues: new Map(),
+      isCountered: false,
+      timestamp: Date.now(),
+    };
+    f.state.stack = [...f.state.stack, ability];
+
+    const result = copySpellOnStack(f.state, ability.id);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/spell/i);
+  });
+
+  it("rejects an unknown source stack object id", () => {
+    const result = copySpellOnStack(f.state, "does-not-exist");
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+  });
+});
+
+// ===========================================================================
+// Tests — copy resolution (CR 707.10d)
+// ===========================================================================
+
+describe("Copy resolution (CR 707.10d)", () => {
+  let f: Fixture;
+
+  beforeEach(() => {
+    f = makeFixture();
+  });
+
+  it("an instant copy resolves against its (possibly new) target then leaves the stack", () => {
+    // Original Lightning Bolt targets Alice; the copy is retargeted at Bob.
+    const card = registerCard(f.state, f.aliceId, damageSpell());
+    const original = pushSpell(f.state, f.aliceId, card, {
+      targets: [playerTarget(f.aliceId)],
+    });
+
+    const copy = copySpellOnStack(f.state, original.id, [
+      playerTarget(f.bobId),
+    ]);
+    expect(copy.success).toBe(true);
+
+    const bobLifeBefore = copy.state.players.get(f.bobId)!.life;
+    const aliceLifeBefore = copy.state.players.get(f.aliceId)!.life;
+    const graveBefore = copy.state.zones.get(`${f.aliceId}-graveyard`)!.cardIds
+      .length;
+
+    // resolveTopOfStack resolves the TOP object (the copy, which was pushed last).
+    const resolved = resolveTopOfStack(copy.state);
+
+    // The copy dealt 3 to its target (Bob), not to Alice.
+    expect(resolved.players.get(f.bobId)!.life).toBe(bobLifeBefore - 3);
+    expect(resolved.players.get(f.aliceId)!.life).toBe(aliceLifeBefore);
+
+    // The copy is gone from the stack...
+    expect(resolved.stack.some((o) => o.id === copy.copiedStackObjectId)).toBe(
+      false,
+    );
+    // ...and no card was moved to graveyard (a copy has no card backing it).
+    expect(resolved.zones.get(`${f.aliceId}-graveyard`)!.cardIds.length).toBe(
+      graveBefore,
+    );
+  });
+
+  it("a permanent copy enters the battlefield as a token", () => {
+    const card = registerCard(f.state, f.aliceId, vanillaCreature());
+    // The copy is itself a spell on the stack (isCopy), backed by the creature
+    // card's characteristics via sourceCardId.
+    const copyObj: StackObject = {
+      id: "creature-copy",
+      type: "spell",
+      sourceCardId: card.id,
+      controllerId: f.aliceId,
+      name: card.cardData.name,
+      text: card.cardData.oracle_text ?? "",
+      manaCost: card.cardData.mana_cost ?? null,
+      targets: [],
+      chosenModes: [],
+      variableValues: new Map(),
+      isCountered: false,
+      timestamp: Date.now(),
+      isCopy: true,
+    };
+    f.state.stack = [...f.state.stack, copyObj];
+
+    const bfBefore = f.state.zones.get(`${f.aliceId}-battlefield`)!.cardIds
+      .length;
+
+    const resolved = resolveTopOfStack(f.state);
+
+    // Copy removed from the stack...
+    expect(resolved.stack.some((o) => o.id === "creature-copy")).toBe(false);
+    // ...and a token (copy of the permanent) entered Alice's battlefield.
+    expect(resolved.zones.get(`${f.aliceId}-battlefield`)!.cardIds.length).toBe(
+      bfBefore + 1,
+    );
+  });
+});

--- a/src/lib/game-state/event-sourcing.ts
+++ b/src/lib/game-state/event-sourcing.ts
@@ -640,6 +640,17 @@ export class EventSourcingGameState {
   /**
    * Apply an action event to a given state (for replay)
    * This is a pure function that applies the action without emitting events
+   *
+   * Determinism note (CR 702.41 Storm / CR 707.10 Copying Spells): spell-copy
+   * and storm are NOT separate event types in this log. They are deterministic
+   * state transitions produced entirely inside `castSpell` when a `cast_spell`
+   * action is applied — the storm count (`Player.spellsCastThisTurn`) is
+   * incremented and the required stack copies are created as a pure function of
+   * the cast_spell action and the pre-existing state. Because the registered
+   * mutation applier replays the same `castSpell` for the same `cast_spell`
+   * action, the copies and the storm count are reconstructed identically on
+   * every replay, so the resulting `state-hash` stays deterministic without a
+   * dedicated SPELL_COPIED event.
    */
   private applyActionToState(
     state: GameState,

--- a/src/lib/game-state/game-state.ts
+++ b/src/lib/game-state/game-state.ts
@@ -81,6 +81,7 @@ function createPlayer(
     landsPlayedThisTurn: 0,
     maxLandsPerTurn: 1,
     foretoldThisTurn: 0,
+    spellsCastThisTurn: 0,
     manaPool: {
       colorless: 0,
       white: 0,
@@ -568,6 +569,7 @@ function advanceToNextPhase(state: GameState): GameState {
         ...player,
         landsPlayedThisTurn: 0,
         foretoldThisTurn: 0,
+        spellsCastThisTurn: 0,
       });
     }
 

--- a/src/lib/game-state/oracle-text-parser.ts
+++ b/src/lib/game-state/oracle-text-parser.ts
@@ -1692,6 +1692,43 @@ export function parseSplitSecond(oracleText: string): SplitSecondInfo {
 }
 
 /**
+ * Result of detecting Storm (CR 702.41).
+ */
+export interface StormInfo {
+  hasStorm: boolean;
+  description: string;
+}
+
+/**
+ * Parse the Storm keyword from oracle text.
+ *
+ * CR 702.41: "Storm" is a triggered ability that functions only while the
+ * spell is on the stack. It reads, "When you cast this spell, copy it for each
+ * spell cast before it this turn. If the spell has any targets, you may choose
+ * new targets for any of the copies." Storm has no parameters and no cost, so
+ * a simple, word-boundary anchored, case-insensitive match is sufficient. The
+ * reminder-text variant is tolerated because the leading keyword word is
+ * always present regardless.
+ *
+ * Example oracle text: "Storm" (Grapeshot, Tendrils of Agony, Empty the Warrens).
+ */
+export function parseStorm(oracleText: string): StormInfo {
+  if (!oracleText) {
+    return { hasStorm: false, description: "" };
+  }
+
+  // Word-boundary anchored on both sides: "Storm" matches, but "Brainstorm"
+  // (no boundary before the 's') and a hypothetical "stormbound" (no boundary
+  // after the 'm') do not. Case-insensitive to be tolerant of casing.
+  const hasStorm = /\bstorm\b/i.test(oracleText);
+
+  return {
+    hasStorm,
+    description: hasStorm ? "Storm" : "",
+  };
+}
+
+/**
  * Result of detecting Attraction mechanic
  */
 export interface AttractionInfo {

--- a/src/lib/game-state/spell-casting.ts
+++ b/src/lib/game-state/spell-casting.ts
@@ -31,6 +31,7 @@ import {
   parseBlitz,
   parseForetell,
   parseSplitSecond,
+  parseStorm,
   isModalSpell,
   getModesForModalSpell,
   hasFuse,
@@ -38,8 +39,9 @@ import {
   getSplitCardHalves,
 } from "./oracle-text-parser";
 import { checkTriggeredAbilities } from "./abilities";
+import { detectStormTrigger } from "./trigger-system";
 import { completeHandTargeting } from "./hand-targeting";
-import { destroyCard } from "./keyword-actions";
+import { destroyCard, createTokenCard } from "./keyword-actions";
 import {
   getPrototypeInfo,
   initializePrototype,
@@ -521,6 +523,10 @@ export function castSpell(
     // the stack (see hasSplitSecondOnStack / ValidationService).
     splitSecond: parseSplitSecond(card.cardData.oracle_text || "")
       .hasSplitSecond,
+    // CR 702.41 - Storm: parsed from Oracle text and stamped onto the spell's
+    // StackObject so the on-cast trigger can fire (see detectStormTrigger /
+    // copySpellOnStack below).
+    storm: parseStorm(card.cardData.oracle_text || "").hasStorm,
   };
 
   // Move card from hand (or graveyard for flashback) to stack
@@ -560,10 +566,16 @@ export function castSpell(
   // Reset the player's priority pass flag since they just cast something
   const updatedPlayer = currentState.players.get(playerId);
   const updatedPlayers = new Map(currentState.players);
+  // CR 702.41 - Storm count basis: a spell was cast this turn. Increment the
+  // per-player counter that storm reads from. (A spell COPY is not "cast" —
+  // CR 707.10 — so copySpellOnStack does NOT increment this, which is what
+  // stops storm copies from recursively re-triggering storm.)
+  const spellsCastBefore = updatedPlayer?.spellsCastThisTurn ?? 0;
   if (updatedPlayer) {
     updatedPlayers.set(playerId, {
       ...updatedPlayer,
       hasPassedPriority: false,
+      spellsCastThisTurn: spellsCastBefore + 1,
     });
   }
 
@@ -584,16 +596,122 @@ export function castSpell(
     nextIndex = (nextIndex + 1) % playerIds.length;
   }
 
+  let finalState: GameState = {
+    ...currentState,
+    zones: updatedZones,
+    cards: updatedCards,
+    stack: updatedStack,
+    players: updatedPlayers,
+    priorityPlayerId: playerIds[nextIndex],
+    consecutivePasses: 0,
+    lastModifiedAt: Date.now(),
+  };
+
+  // CR 702.41 - Storm: "When you cast this spell, copy it for each spell cast
+  // before it this turn." The storm trigger fires on cast; resolve it here by
+  // creating `spellsCastBefore` copies on top of the stack. Detection/count
+  // lives in trigger-system (detectStormTrigger); creation uses the shared
+  // copySpellOnStack primitive (CR 707.10). Each copy retains the original's
+  // targets by default — the controller MAY reselect, exposed via
+  // copySpellOnStack's `newTargets` argument (CR 702.41a / 707.10d).
+  if (stackObject.storm) {
+    const storm = detectStormTrigger(finalState, stackObject.id);
+    for (let i = 0; i < storm.copyCount; i++) {
+      const copyResult = copySpellOnStack(finalState, stackObject.id);
+      if (copyResult.success && copyResult.state) {
+        finalState = copyResult.state;
+      }
+    }
+  }
+
+  return { success: true, state: finalState };
+}
+
+/**
+ * Copy a spell on the stack (CR 707.10).
+ *
+ * Foundational primitive used by Storm (CR 702.41) and by general "copy target
+ * spell" effects (e.g. Twincast, Reverberate, Lithoform Engine). Creates a NEW
+ * spell on the stack, on top of the original, sharing the original's
+ * characteristics — name, oracle text, mana cost, chosen modes, X values,
+ * controller, split second/storm markers, and structured effects — with no cost
+ * paid (CR 707.10). The copy RETAINS the original's targets by default (CR
+ * 707.10c); pass `newTargets` to reselect them (CR 707.10d).
+ *
+ * A copy is not "cast" (CR 707.10), so it does NOT increment the storm count
+ * and does NOT trigger "when you cast" abilities — only `castSpell` does. On
+ * resolution a permanent copy becomes a token and an instant/sorcery copy
+ * ceases to exist (see `resolveCopyCompletion`).
+ *
+ * @returns the new copy's stack object id on success.
+ */
+export function copySpellOnStack(
+  state: GameState,
+  sourceStackObjectId: string,
+  newTargets?: Target[],
+): {
+  success: boolean;
+  state: GameState;
+  copiedStackObjectId?: string;
+  error?: string;
+} {
+  const sourceIndex = state.stack.findIndex(
+    (o) => o.id === sourceStackObjectId,
+  );
+  if (sourceIndex === -1) {
+    return {
+      success: false,
+      state,
+      error: "Source spell not found on the stack.",
+    };
+  }
+  const source = state.stack[sourceIndex];
+  if (source.type !== "spell") {
+    return {
+      success: false,
+      state,
+      error: "Only spells (not abilities) can be copied (CR 707.10).",
+    };
+  }
+
+  // CR 707.10 — copy the spell's characteristics. Targets default to the
+  // original's (707.10c) and may be overridden (707.10d). `isCopy` marks the
+  // object so resolution knows not to move a card and to create a token for
+  // permanents instead. `manaCost` is a characteristic and is copied (the "no
+  // cost paid" rule means only that the copy is never paid for, not that the
+  // value differs). `sourceCardId` is retained so the copy's oracle text / type
+  // line can still be looked up during effect resolution.
+  const copy: StackObject = {
+    id: generateStackObjectId(),
+    type: "spell",
+    sourceCardId: source.sourceCardId,
+    controllerId: source.controllerId,
+    name: source.name,
+    text: source.text,
+    manaCost: source.manaCost,
+    targets: newTargets
+      ? newTargets.map((t) => ({ ...t }))
+      : source.targets.map((t) => ({ ...t })),
+    chosenModes: [...source.chosenModes],
+    variableValues: new Map(source.variableValues),
+    isCountered: false,
+    timestamp: Date.now(),
+    alternativeCostsUsed: source.alternativeCostsUsed
+      ? [...source.alternativeCostsUsed]
+      : undefined,
+    wasKicked: source.wasKicked,
+    splitSecond: source.splitSecond,
+    storm: source.storm,
+    isCopy: true,
+    effects: source.effects,
+  };
+
   return {
     success: true,
+    copiedStackObjectId: copy.id,
     state: {
-      ...currentState,
-      zones: updatedZones,
-      cards: updatedCards,
-      stack: updatedStack,
-      players: updatedPlayers,
-      priorityPlayerId: playerIds[nextIndex],
-      consecutivePasses: 0,
+      ...state,
+      stack: [...state.stack, copy],
       lastModifiedAt: Date.now(),
     },
   };
@@ -700,6 +818,16 @@ function resolveSpellCompletion(
   state: GameState,
   stackObject: StackObject,
 ): GameState {
+  // CR 707.10 — a copy of a spell is not backed by a card. Its effects were
+  // already applied in resolveTopOfStack (which looks the source card up via
+  // `sourceCardId` to parse oracle-text effects). On completion a permanent
+  // copy becomes a token on the battlefield under its controller (CR 707.10d /
+  // CR 111) and an instant/sorcery copy simply ceases to exist. No card is
+  // moved because there is no card to move.
+  if (stackObject.isCopy) {
+    return resolveCopyCompletion(state, stackObject);
+  }
+
   // Get the card
   if (stackObject.sourceCardId) {
     const card = state.cards.get(stackObject.sourceCardId);
@@ -928,6 +1056,47 @@ function resolveSpellCompletion(
 
   // Fallback: just remove from stack
   return removeFromStack(state, stackObject.id);
+}
+
+/**
+ * Complete the resolution of a SPELL COPY (CR 707.10).
+ *
+ * Copies have no card backing them, so the normal "move card to graveyard /
+ * battlefield" path does not apply. A copy of a permanent spell enters the
+ * battlefield as a token under its controller (CR 707.10d → CR 111); a copy of
+ * an instant/sorcery spell simply ceases to exist once its effects have
+ * resolved. The copy is then removed from the stack.
+ */
+function resolveCopyCompletion(
+  state: GameState,
+  stackObject: StackObject,
+): GameState {
+  const sourceCard = stackObject.sourceCardId
+    ? state.cards.get(stackObject.sourceCardId)
+    : undefined;
+  const typeLine = sourceCard?.cardData.type_line?.toLowerCase() ?? "";
+  const isPermanent =
+    typeLine.length > 0 &&
+    !typeLine.includes("instant") &&
+    !typeLine.includes("sorcery");
+
+  let currentState = state;
+  if (isPermanent && sourceCard) {
+    // CR 707.10d — a copy of a permanent spell enters the battlefield as a
+    // token owned and controlled by the copy's controller.
+    const tokenResult = createTokenCard(
+      currentState,
+      sourceCard.cardData,
+      stackObject.controllerId,
+      stackObject.controllerId,
+      1,
+    );
+    if (tokenResult.success) {
+      currentState = tokenResult.state;
+    }
+  }
+
+  return removeFromStack(currentState, stackObject.id);
 }
 
 /**

--- a/src/lib/game-state/trigger-system.ts
+++ b/src/lib/game-state/trigger-system.ts
@@ -600,6 +600,42 @@ export function detectSpellCastTriggers(
 }
 
 /**
+ * Detect the Storm on-cast trigger (CR 702.41) for a spell on the stack.
+ *
+ * Storm is a triggered ability that reads: "When you cast this spell, copy it
+ * for each spell cast before it this turn. If the spell has any targets, you
+ * may choose new targets for any of the copies." This function is the detection
+ * half of the mechanic: given a spell already on the stack, it reports whether
+ * its storm trigger should fire and how many copies to create. The copy count
+ * equals the number of spells the spell's controller CAST before this spell
+ * this turn (the "storm count"), derived from `Player.spellsCastThisTurn`.
+ *
+ * `castSpell` increments `spellsCastThisTurn` AFTER pushing the spell onto the
+ * stack, so the count includes the storm spell itself — hence the `- 1` (the
+ * storm spell is never a copy of itself; CR 702.41a "spells cast BEFORE it").
+ * The copies themselves are created by `copySpellOnStack` (CR 707.10) in
+ * spell-casting.ts, which is also what enforces that copies do not re-trigger
+ * storm (copies are not "cast").
+ *
+ * @returns `{ shouldFire, copyCount }` — `copyCount` is 0 when no copies are
+ * created (e.g. the storm spell is the first spell cast this turn).
+ */
+export function detectStormTrigger(
+  state: GameState,
+  stackObjectId: string,
+): { shouldFire: boolean; copyCount: number } {
+  const obj = state.stack.find((o) => o.id === stackObjectId);
+  if (!obj || !obj.storm) {
+    return { shouldFire: false, copyCount: 0 };
+  }
+  const controller = state.players.get(obj.controllerId);
+  const castThisTurn = controller?.spellsCastThisTurn ?? 0;
+  // Subtract 1 for the storm spell itself, which was counted when it was cast.
+  const copyCount = Math.max(0, castThisTurn - 1);
+  return { shouldFire: copyCount > 0, copyCount };
+}
+
+/**
  * Detect state-based triggers
  * Example: "When you have 10 or less life"
  * These check continuously at SBA points

--- a/src/lib/game-state/types.ts
+++ b/src/lib/game-state/types.ts
@@ -307,6 +307,20 @@ export interface Player {
    */
   foretoldThisTurn?: number;
 
+  // Storm tracking (CR 702.41)
+  /**
+   * Number of spells this player has CAST this turn. CR 702.41a bases the storm
+   * count on "spells cast before it this turn", so this counter is the source
+   * of the storm count. Reset to 0 at the start of each turn (mirrors
+   * `landsPlayedThisTurn` / `foretoldThisTurn`). Optional so legacy Player
+   * literals default to "no spells cast yet" (read with `?? 0`).
+   *
+   * Note: a spell COPY is not "cast" (CR 707.10) and so does NOT increment this
+   * counter — only `castSpell` does. This is what stops storm copies from
+   * recursively re-triggering storm.
+   */
+  spellsCastThisTurn?: number;
+
   // Mana pool (internally tracked, displayed as "energy" to users)
   /** Available mana in each color */
   manaPool: ManaPool;
@@ -468,6 +482,27 @@ export interface StackObject {
    * instances are redundant (CR 702.60c).
    */
   splitSecond?: boolean;
+  /**
+   * Storm (CR 702.41).
+   *
+   * Set on a spell's StackObject when its Oracle text contains "Storm". Storm
+   * is a triggered ability that fires "when you cast this spell": on cast, the
+   * engine creates one copy of the spell for each spell cast before it this
+   * turn (see `detectStormTrigger` in trigger-system.ts and `copySpellOnStack`
+   * in spell-casting.ts). Targets may be reselected for each copy (CR 702.41a /
+   * CR 707.10d). Multiple instances are redundant (CR 702.41c).
+   */
+  storm?: boolean;
+  /**
+   * Whether this stack object is a COPY of a spell rather than a spell that was
+   * cast (CR 707.10). Copies share the original's characteristics — name,
+   * oracle text, mana cost, targets, chosen modes, X values, controller — with
+   * no cost paid, but are not themselves "cast": they do not increment the
+   * storm count and do not trigger "when you cast" abilities. On resolution a
+   * permanent copy becomes a token (CR 707.10d / CR 111) and an instant/sorcery
+   * copy simply ceases to exist (see `resolveCopyCompletion`).
+   */
+  isCopy?: boolean;
   /** Structured effects to resolve (CR 608) */
   effects?: StackEffect[];
 }


### PR DESCRIPTION
Implements spell-copy effects and the Storm keyword per CR 702.41 (Storm) and CR 707 (Copying Objects).

## What

- **Storm-count tracking** — adds `Player.spellsCastThisTurn` (per-player, reset each turn alongside `landsPlayedThisTurn`/`foretoldThisTurn`). It is the source of the storm count. A spell **copy** is not "cast" (CR 707.10), so copying never increments it — which is what stops storm copies from recursively re-triggering storm.
- **`copySpellOnStack(state, sourceStackObjectId, newTargets?)`** — the foundational spell-copy primitive (CR 707.10). Creates a new spell on the stack sharing the original's characteristics (name, text, mana cost, modes, X values, controller, split-second/storm markers, effects), with no cost paid. The copy retains the original's targets by default (707.10c) and accepts `newTargets` for target reselection (707.10d). Marked `isCopy: true`.
- **Storm trigger** — `detectStormTrigger` (trigger-system.ts) reports whether a stack spell's storm ability fires and how many copies to create (`spellsCastThisTurn − 1`, i.e. spells cast *before* it). `castSpell` stamps a `storm` marker on cast and, when storm fires, creates the copies via `copySpellOnStack`.
- **Copy resolution** — copies resolve through the normal stack path; on completion an instant/sorcery copy simply ceases to exist (no card is moved — copies have no card backing them) and a permanent copy enters the battlefield as a token (CR 707.10d / CR 111).
- **Determinism** — storm count and the created copies are pure functions of the `cast_spell` action applied by `castSpell`, so they are reconstructed identically on event replay and the state-hash stays deterministic (documented on `applyActionToState`).

## Files
- `src/lib/game-state/types.ts` — `Player.spellsCastThisTurn`; `StackObject.storm` / `isCopy`.
- `src/lib/game-state/spell-casting.ts` — storm stamp + count increment on cast; storm copy wiring; `copySpellOnStack`; `resolveCopyCompletion` + `isCopy` branch.
- `src/lib/game-state/trigger-system.ts` — `detectStormTrigger`.
- `src/lib/game-state/oracle-text-parser.ts` — `parseStorm` (+ `StormInfo`).
- `src/lib/game-state/game-state.ts` — init + per-turn reset of `spellsCastThisTurn`.
- `src/lib/game-state/event-sourcing.ts` — determinism note for storm/copy replay.
- `src/lib/game-state/__tests__/storm-spell-copy.test.ts` — 21 new tests.

## Acceptance criteria
- [x] Spells cast this turn are tracked (storm count), reset each turn.
- [x] A storm spell, when cast, creates N copies where N = spells cast before it this turn.
- [x] Copies are spells on the stack with the same characteristics; targets retained (reselectable).
- [x] A general spell-copy effect exists (`copySpellOnStack`).
- [x] Copies resolve like spells; copied permanents become tokens.
- [x] Tests cover storm count + reset, storm copies count, copy characteristics/targets (incl. retargeting + copy-of-copy), and copy resolution.

## Verification
- `npx tsc --noEmit` — clean.
- `npm run lint` — 0 errors (no new warnings in touched files).
- `jest` — full affected suite green (296 suites / 6227 tests, incl. 21 new); no regressions across spell-casting, effect-resolution, event-sourcing, trigger-system, oracle parser, split-second/blitz/foretell.

Resolves #1059