### PR TITLE
feat(rules-engine): resolve #1058 — implement Prowess triggered ability (CR 702.108)

### DIFF
--- a/src/lib/game-state/__tests__/prowess.test.ts
+++ b/src/lib/game-state/__tests__/prowess.test.ts
@@ -1,0 +1,459 @@
+/**
+ * @fileoverview Unit tests for the Prowess evergreen keyword.
+ *
+ * Issue #1058 — [Rules Engine] Implement Prowess triggered ability (CR 702.108).
+ *
+ * Prowess (CR 702.108):
+ * - 702.108a: Prowess is a triggered ability. "Whenever you cast a noncreature
+ *   spell, this creature gets +1/+1 until end of turn."
+ * - 702.108b: Multiple instances of prowess on the same creature trigger
+ *   separately (each instance adds its own +1/+1).
+ *
+ * Coverage: oracle-text parsing, keyword detection + instance counting, the
+ * cast-trigger detection (noncreature fires / creature does not / only the
+ * caster's creatures / multi-instance stacks), the layer-7 +1/+1 application,
+ * end-of-turn cleanup, and end-to-end behaviour through `castSpell`.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { castSpell } from "../spell-casting";
+import { createInitialGameState, startGame } from "../game-state";
+import { createCardInstance } from "../card-instance";
+import { addMana } from "../mana";
+import { parseProwess } from "../oracle-text-parser";
+import { detectProwessTriggers } from "../trigger-system";
+import {
+  hasProwess,
+  getProwessInstanceCount,
+  getProwessBonus,
+  applyProwessBoost,
+  clearProwessBoosts,
+  getEffectivePower,
+  getEffectiveToughness,
+} from "../evergreen-keywords";
+import { Phase } from "../types";
+import type {
+  GameState,
+  PlayerId,
+  CardInstanceId,
+  CardInstance,
+} from "../types";
+import type { ScryfallCard } from "@/app/actions";
+
+// ---------------------------------------------------------------------------
+// Mock card helpers
+// ---------------------------------------------------------------------------
+
+function makeCard(
+  overrides: Partial<ScryfallCard> & { id: string },
+): ScryfallCard {
+  return {
+    name: "Test Card",
+    type_line: "Instant",
+    oracle_text: "",
+    mana_cost: "{1}{R}",
+    cmc: 2,
+    colors: ["R"],
+    color_identity: ["R"],
+    legalities: { standard: "legal", commander: "legal" },
+    layout: "normal",
+    ...overrides,
+  } as ScryfallCard;
+}
+
+/** A 1/2 prowess creature (stands in for Monastery Swiftspear). */
+function prowessCreature(
+  overrides: Partial<ScryfallCard> & { id: string } = { id: "mock-prowess" },
+): ScryfallCard {
+  return makeCard({
+    name: "Prowess Creature",
+    type_line: "Creature — Test",
+    oracle_text: "Prowess",
+    mana_cost: "{R}",
+    cmc: 1,
+    colors: ["R"],
+    power: "1",
+    toughness: "2",
+    keywords: ["prowess"],
+    ...overrides,
+  });
+}
+
+/** A 1/2 creature that has prowess twice (CR 702.108b stacking case). */
+function doubleProwessCreature(): ScryfallCard {
+  return prowessCreature({
+    id: "mock-double-prowess",
+    name: "Double Prowess Creature",
+    keywords: ["prowess", "prowess"],
+  });
+}
+
+/** A cheap noncreature spell used to trigger prowess. */
+function cantrip(): ScryfallCard {
+  return makeCard({
+    id: "mock-opt",
+    name: "Opt",
+    type_line: "Instant",
+    oracle_text: "Draw a card.",
+    mana_cost: "{U}",
+    cmc: 1,
+    colors: ["U"],
+  });
+}
+
+/** A cheap creature spell that must NOT trigger prowess. */
+function creatureSpell(): ScryfallCard {
+  return makeCard({
+    id: "mock-bear",
+    name: "Runeclaw Bear",
+    type_line: "Creature — Bear",
+    oracle_text: "",
+    mana_cost: "{1}{G}",
+    cmc: 2,
+    colors: ["G"],
+    power: "2",
+    toughness: "2",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Shared state scaffolding
+// ---------------------------------------------------------------------------
+
+interface Fixture {
+  state: GameState;
+  aliceId: PlayerId;
+  bobId: PlayerId;
+}
+
+function makeFixture(): Fixture {
+  let state = createInitialGameState(["Alice", "Bob"], 20, false);
+  state = startGame(state);
+
+  const ids = Array.from(state.players.keys());
+  const aliceId = ids[0];
+  const bobId = ids[1];
+
+  state.status = "in_progress";
+  state.priorityPlayerId = aliceId;
+  state.turn.activePlayerId = aliceId;
+  state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+  state.turn.isFirstTurn = false;
+  state.stack = [];
+  state.consecutivePasses = 0;
+  state.players.forEach((p) =>
+    state.players.set(p.id, { ...p, hasPassedPriority: false }),
+  );
+
+  return { state, aliceId, bobId };
+}
+
+/** Place a permanent onto a player's battlefield and the global card map. */
+function putOnBattlefield(
+  state: GameState,
+  playerId: PlayerId,
+  cardData: ScryfallCard,
+  controllerId?: PlayerId,
+): CardInstance {
+  const owner = controllerId ?? playerId;
+  const card = createCardInstance(cardData, owner, owner);
+  // Permanents entering the battlefield are ready (no summoning sickness for
+  // the purposes of these non-combat tests).
+  card.hasSummoningSickness = false;
+  card.currentZoneKey = `${playerId}-battlefield`;
+  state.cards.set(card.id, card);
+  const bf = state.zones.get(`${playerId}-battlefield`)!;
+  state.zones.set(`${playerId}-battlefield`, {
+    ...bf,
+    cardIds: [...bf.cardIds, card.id],
+  });
+  return card;
+}
+
+/** Place a card into a player's hand and the global card map. */
+function putInHand(
+  state: GameState,
+  playerId: PlayerId,
+  cardData: ScryfallCard,
+): CardInstanceId {
+  const card = createCardInstance(cardData, playerId, playerId);
+  card.currentZoneKey = `${playerId}-hand`;
+  state.cards.set(card.id, card);
+  const hand = state.zones.get(`${playerId}-hand`)!;
+  state.zones.set(`${playerId}-hand`, {
+    ...hand,
+    cardIds: [...hand.cardIds, card.id],
+  });
+  return card.id;
+}
+
+// ===========================================================================
+// Tests — parsing (CR 702.108)
+// ===========================================================================
+
+describe("Prowess — parsing (CR 702.108)", () => {
+  it("detects the Prowess keyword in oracle text", () => {
+    expect(parseProwess("Prowess").hasProwess).toBe(true);
+    expect(
+      parseProwess("Prowess\nWhenever you cast a noncreature spell...")
+        .hasProwess,
+    ).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(parseProwess("prowess").hasProwess).toBe(true);
+    expect(parseProwess("PROWESS").hasProwess).toBe(true);
+  });
+
+  it("returns false when the keyword is absent or empty", () => {
+    expect(parseProwess("Draw a card.").hasProwess).toBe(false);
+    expect(parseProwess("").hasProwess).toBe(false);
+    expect(parseProwess("").description).toBe("");
+  });
+
+  it("does not match the keyword inside other words", () => {
+    expect(parseProwess("Spellprowess").hasProwess).toBe(false);
+  });
+
+  it("exposes a description when present", () => {
+    expect(parseProwess("Prowess").description).toBe("Prowess");
+  });
+});
+
+// ===========================================================================
+// Tests — keyword detection + instance counting
+// ===========================================================================
+
+describe("Prowess — detection + instance count (CR 702.108b)", () => {
+  it("detects prowess on a creature", () => {
+    const card = createCardInstance(prowessCreature(), "p1", "p1");
+    expect(hasProwess(card)).toBe(true);
+    expect(getProwessInstanceCount(card)).toBe(1);
+  });
+
+  it("returns false for a noncreature even if the word appears", () => {
+    const card = createCardInstance(
+      makeCard({
+        id: "mock-noncreature",
+        type_line: "Enchantment",
+        oracle_text: "Prowess",
+      }),
+      "p1",
+      "p1",
+    );
+    expect(hasProwess(card)).toBe(false);
+    expect(getProwessInstanceCount(card)).toBe(0);
+  });
+
+  it("counts multiple prowess instances for stacking (CR 702.108b)", () => {
+    const card = createCardInstance(doubleProwessCreature(), "p1", "p1");
+    expect(hasProwess(card)).toBe(true);
+    expect(getProwessInstanceCount(card)).toBe(2);
+  });
+
+  it("returns a 0 bonus when none is active", () => {
+    const card = createCardInstance(prowessCreature(), "p1", "p1");
+    expect(getProwessBonus(card)).toBe(0);
+  });
+});
+
+// ===========================================================================
+// Tests — trigger detection
+// ===========================================================================
+
+describe("Prowess — trigger detection (CR 702.108a)", () => {
+  it("fires one trigger per prowess creature on a noncreature cast", () => {
+    const f = makeFixture();
+    const a = putOnBattlefield(
+      f.state,
+      f.aliceId,
+      prowessCreature({
+        id: "prowess-a",
+      }),
+    );
+    const b = putOnBattlefield(
+      f.state,
+      f.aliceId,
+      prowessCreature({
+        id: "prowess-b",
+      }),
+    );
+    // The spell being cast (noncreature).
+    const spell = putInHand(f.state, f.aliceId, cantrip());
+
+    const triggers = detectProwessTriggers(
+      f.state,
+      spell,
+      f.aliceId,
+      f.aliceId,
+    );
+    expect(triggers).toHaveLength(2);
+    expect(new Set(triggers.map((t) => t.sourceCardId))).toEqual(
+      new Set([a.id, b.id]),
+    );
+  });
+
+  it("does NOT fire when the cast spell is a creature spell", () => {
+    const f = makeFixture();
+    putOnBattlefield(f.state, f.aliceId, prowessCreature());
+    const creature = putInHand(f.state, f.aliceId, creatureSpell());
+
+    const triggers = detectProwessTriggers(
+      f.state,
+      creature,
+      f.aliceId,
+      f.aliceId,
+    );
+    expect(triggers).toHaveLength(0);
+  });
+
+  it("does NOT fire for prowess creatures controlled by an opponent", () => {
+    const f = makeFixture();
+    // Bob controls the prowess creature; Alice casts.
+    putOnBattlefield(f.state, f.bobId, prowessCreature());
+    const spell = putInHand(f.state, f.aliceId, cantrip());
+
+    const triggers = detectProwessTriggers(
+      f.state,
+      spell,
+      f.aliceId,
+      f.aliceId,
+    );
+    expect(triggers).toHaveLength(0);
+  });
+
+  it("fires once per prowess instance when a creature has prowess twice", () => {
+    const f = makeFixture();
+    const dbl = putOnBattlefield(f.state, f.aliceId, doubleProwessCreature());
+    const spell = putInHand(f.state, f.aliceId, cantrip());
+
+    const triggers = detectProwessTriggers(
+      f.state,
+      spell,
+      f.aliceId,
+      f.aliceId,
+    );
+    expect(triggers).toHaveLength(2);
+    expect(triggers.every((t) => t.sourceCardId === dbl.id)).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Tests — layer-7 power/toughness application + EOT cleanup
+// ===========================================================================
+
+describe("Prowess — +1/+1 application + end-of-turn cleanup", () => {
+  it("adds prowessBoost to effective power and toughness", () => {
+    const card = createCardInstance(prowessCreature(), "p1", "p1");
+    expect(getEffectivePower(card)).toBe(1);
+    expect(getEffectiveToughness(card)).toBe(2);
+
+    card.prowessBoost = 1;
+    expect(getEffectivePower(card)).toBe(2);
+    expect(getEffectiveToughness(card)).toBe(3);
+
+    card.prowessBoost = 3;
+    expect(getEffectivePower(card)).toBe(4);
+    expect(getEffectiveToughness(card)).toBe(5);
+  });
+
+  it("applyProwessBoost increments the active bonus", () => {
+    const f = makeFixture();
+    const creature = putOnBattlefield(f.state, f.aliceId, prowessCreature());
+
+    const s1 = applyProwessBoost(f.state, creature.id);
+    expect(getProwessBonus(s1.cards.get(creature.id)!)).toBe(1);
+
+    const s2 = applyProwessBoost(s1, creature.id);
+    expect(getProwessBonus(s2.cards.get(creature.id)!)).toBe(2);
+
+    // Original state is untouched (immutable).
+    expect(getProwessBonus(f.state.cards.get(creature.id)!)).toBe(0);
+  });
+
+  it("clearProwessBoosts removes the bonus at end of turn", () => {
+    const f = makeFixture();
+    const creature = putOnBattlefield(f.state, f.aliceId, prowessCreature());
+    const boosted = applyProwessBoost(
+      applyProwessBoost(f.state, creature.id),
+      creature.id,
+    );
+    expect(getProwessBonus(boosted.cards.get(creature.id)!)).toBe(2);
+
+    const cleared = clearProwessBoosts(boosted);
+    expect(getProwessBonus(cleared.cards.get(creature.id)!)).toBe(0);
+    // Effective P/T return to base after cleanup.
+    expect(getEffectivePower(cleared.cards.get(creature.id)!)).toBe(1);
+    expect(getEffectiveToughness(cleared.cards.get(creature.id)!)).toBe(2);
+  });
+});
+
+// ===========================================================================
+// Tests — end-to-end via castSpell
+// ===========================================================================
+
+describe("Prowess — castSpell integration", () => {
+  it("pumps a prowess creature +1/+1 when its controller casts a noncreature spell", () => {
+    const f = makeFixture();
+    const creature = putOnBattlefield(f.state, f.aliceId, prowessCreature());
+    const spell = putInHand(f.state, f.aliceId, cantrip());
+    f.state = addMana(f.state, f.aliceId, { blue: 2 });
+
+    const result = castSpell(f.state, f.aliceId, spell);
+    expect(result.success).toBe(true);
+
+    const boosted = result.state.cards.get(creature.id)!;
+    expect(boosted.prowessBoost).toBe(1);
+    expect(getEffectivePower(boosted)).toBe(2);
+    expect(getEffectiveToughness(boosted)).toBe(3);
+  });
+
+  it("does NOT trigger when the cast spell is a creature", () => {
+    const f = makeFixture();
+    const creature = putOnBattlefield(f.state, f.aliceId, prowessCreature());
+    const bear = putInHand(f.state, f.aliceId, creatureSpell());
+    f.state = addMana(f.state, f.aliceId, { green: 3 });
+
+    const result = castSpell(f.state, f.aliceId, bear);
+    expect(result.success).toBe(true);
+
+    const unaffected = result.state.cards.get(creature.id)!;
+    expect(unaffected.prowessBoost ?? 0).toBe(0);
+    expect(getEffectivePower(unaffected)).toBe(1);
+  });
+
+  it("stacks across multiple noncreature spells in one turn", () => {
+    const f = makeFixture();
+    const creature = putOnBattlefield(f.state, f.aliceId, prowessCreature());
+    const spell1 = putInHand(f.state, f.aliceId, cantrip());
+    const spell2 = putInHand(f.state, f.aliceId, cantrip());
+    f.state = addMana(f.state, f.aliceId, { blue: 4 });
+
+    const r1 = castSpell(f.state, f.aliceId, spell1);
+    expect(r1.success).toBe(true);
+    expect(r1.state.cards.get(creature.id)!.prowessBoost).toBe(1);
+
+    // castSpell passes priority; hand it back to Alice for the second cast.
+    r1.state.priorityPlayerId = f.aliceId;
+    const r2 = castSpell(r1.state, f.aliceId, spell2);
+    expect(r2.success).toBe(true);
+    expect(r2.state.cards.get(creature.id)!.prowessBoost).toBe(2);
+    expect(getEffectivePower(r2.state.cards.get(creature.id)!)).toBe(3);
+  });
+
+  it("stacks multiple prowess instances on one creature (CR 702.108b)", () => {
+    const f = makeFixture();
+    const dbl = putOnBattlefield(f.state, f.aliceId, doubleProwessCreature());
+    const spell = putInHand(f.state, f.aliceId, cantrip());
+    f.state = addMana(f.state, f.aliceId, { blue: 2 });
+
+    const result = castSpell(f.state, f.aliceId, spell);
+    expect(result.success).toBe(true);
+
+    const boosted = result.state.cards.get(dbl.id)!;
+    // One noncreature spell, two prowess instances → +2/+2.
+    expect(boosted.prowessBoost).toBe(2);
+    expect(getEffectivePower(boosted)).toBe(3);
+    expect(getEffectiveToughness(boosted)).toBe(4);
+  });
+});

--- a/src/lib/game-state/evergreen-keywords.ts
+++ b/src/lib/game-state/evergreen-keywords.ts
@@ -18,6 +18,7 @@ import type {
   GameState,
   PlayerId,
 } from "./types";
+import { ZoneType } from "./types";
 
 /**
  * Check if a card has a specific keyword
@@ -649,6 +650,9 @@ function getToughnessValue(card: CardInstance): number {
 export function getEffectivePower(card: CardInstance): number {
   let power = getPowerValue(card);
   power += card.powerModifier || 0;
+  // CR 702.108 - Prowess: a continuous "+1/+1 until end of turn" effect applied
+  // in layer 7c (power/toughness). `prowessBoost` holds the active bonus count.
+  power += card.prowessBoost || 0;
   return Math.max(0, power);
 }
 
@@ -670,6 +674,9 @@ export function getEffectiveToughness(card: CardInstance): number {
   if (plusCounters) {
     toughness += plusCounters.count;
   }
+
+  // CR 702.108 - Prowess: continuous "+1/+1 until end of turn" effect (layer 7c).
+  toughness += card.prowessBoost || 0;
 
   return Math.max(0, toughness);
 }
@@ -1055,4 +1062,90 @@ export function getToxicLevel(card: CardInstance): number {
   }
 
   return 0;
+}
+
+// ============== PROWESS (CR 702.108) ==============
+
+/**
+ * Check if a card has the Prowess keyword.
+ *
+ * CR 702.108a: Prowess is a triggered ability. "Whenever you cast a noncreature
+ * spell, this creature gets +1/+1 until end of turn." Prowess is a creature
+ * keyword, so it has no effect on non-creatures.
+ */
+export function hasProwess(card: CardInstance): boolean {
+  if (!hasKeyword(card, "prowess")) {
+    return false;
+  }
+  // CR 702.108: prowess only does something on a creature.
+  const typeLine = card.cardData.type_line?.toLowerCase() || "";
+  return typeLine.includes("creature");
+}
+
+/**
+ * Count the number of prowess instances on a creature.
+ *
+ * CR 702.108b: "Multiple instances of prowess on the same creature trigger
+ * separately." A creature that somehow has prowess twice triggers twice (and
+ * thus gets +2/+2) off a single noncreature spell. Counts explicit keyword-list
+ * entries; falls back to 1 when prowess is present only in oracle text.
+ */
+export function getProwessInstanceCount(card: CardInstance): number {
+  const keywords = card.cardData.keywords || [];
+  const count = keywords.filter((k) => k.toLowerCase() === "prowess").length;
+  return count > 0 ? count : hasProwess(card) ? 1 : 0;
+}
+
+/**
+ * Get the prowess +1/+1 bonus currently active on a creature (for the layer
+ * system / effective power-toughness). Returns 0 when no bonus is active.
+ */
+export function getProwessBonus(card: CardInstance): number {
+  return card.prowessBoost || 0;
+}
+
+/**
+ * Add a prowess +1/+1 bonus to a creature (resolves one prowess trigger).
+ *
+ * Returns updated state with the creature's `prowessBoost` incremented by
+ * `amount` (default 1). The bonus is read by the layer-7 power/toughness path
+ * and removed at end of turn by `clearProwessBoosts`.
+ */
+export function applyProwessBoost(
+  state: GameState,
+  cardId: CardInstanceId,
+  amount = 1,
+): GameState {
+  const card = state.cards.get(cardId);
+  if (!card) return state;
+
+  const updatedCards = new Map(state.cards);
+  updatedCards.set(cardId, {
+    ...card,
+    prowessBoost: (card.prowessBoost || 0) + amount,
+  });
+  return { ...state, cards: updatedCards };
+}
+
+/**
+ * Clear all active prowess bonuses (end-of-turn cleanup, CR 702.108a — the
+ * bonus lasts "until end of turn"). Resets `prowessBoost` to 0 for every
+ * creature on every battlefield zone.
+ */
+export function clearProwessBoosts(state: GameState): GameState {
+  let changed = false;
+  const updatedCards = new Map(state.cards);
+
+  for (const [, zone] of state.zones) {
+    if (zone.type !== ZoneType.BATTLEFIELD) continue;
+    for (const cardId of zone.cardIds) {
+      const card = updatedCards.get(cardId);
+      if (card && (card.prowessBoost || 0) !== 0) {
+        updatedCards.set(cardId, { ...card, prowessBoost: 0 });
+        changed = true;
+      }
+    }
+  }
+
+  return changed ? { ...state, cards: updatedCards } : state;
 }

--- a/src/lib/game-state/game-state.ts
+++ b/src/lib/game-state/game-state.ts
@@ -38,7 +38,7 @@ import {
   checkStateBasedActions as checkSBAs,
   type StateBasedActionResult,
 } from "./state-based-actions";
-import { hasLifelink } from "./evergreen-keywords";
+import { hasLifelink, clearProwessBoosts } from "./evergreen-keywords";
 import { detectUntapStepTriggers, putTriggersOnStack } from "./trigger-system";
 import type { TriggeredAbilityInstance } from "./abilities";
 
@@ -559,7 +559,7 @@ function advanceToNextPhase(state: GameState): GameState {
       priorityPlayerId: nextPlayerId,
     });
     const resultState = untapResult.state;
-    const updatedCards = new Map(resultState.cards);
+    let updatedCards = new Map(resultState.cards);
     updatedPlayers = new Map(resultState.players);
 
     // Reset land plays for all players at the start of a new turn
@@ -582,6 +582,14 @@ function advanceToNextPhase(state: GameState): GameState {
         updatedCards.set(cardId, { ...card, attackedLastTurn: false });
       }
     }
+
+    // CR 702.108 - Prowess: the +1/+1 bonus lasts "until end of turn". Clear
+    // every active prowess bonus as the new turn begins (end-of-turn cleanup).
+    const prowessCleared = clearProwessBoosts({
+      ...resultState,
+      cards: updatedCards,
+    });
+    updatedCards = prowessCleared.cards;
 
     return {
       ...resultState,

--- a/src/lib/game-state/oracle-text-parser.ts
+++ b/src/lib/game-state/oracle-text-parser.ts
@@ -1729,6 +1729,41 @@ export function parseStorm(oracleText: string): StormInfo {
 }
 
 /**
+ * Result of detecting Prowess (CR 702.108).
+ */
+export interface ProwessInfo {
+  hasProwess: boolean;
+  description: string;
+}
+
+/**
+ * Parse the Prowess keyword from oracle text.
+ *
+ * CR 702.108a: Prowess is a triggered ability. "Whenever you cast a noncreature
+ * spell, this creature gets +1/+1 until end of turn." Prowess has no parameters,
+ * so a word-boundary anchored, case-insensitive match is sufficient. The
+ * reminder-text variant is tolerated because the leading keyword word is always
+ * present regardless.
+ *
+ * Example oracle text: "Prowess" (e.g. Monastery Mentor, Soul-Scar Mage,
+ * Adeliz, the Cinder Wind).
+ */
+export function parseProwess(oracleText: string): ProwessInfo {
+  if (!oracleText) {
+    return { hasProwess: false, description: "" };
+  }
+
+  // Word-boundary anchored on both sides: "Prowess" matches, but substrings
+  // inside other words do not. Case-insensitive to be tolerant of casing.
+  const hasProwess = /\bprowess\b/i.test(oracleText);
+
+  return {
+    hasProwess,
+    description: hasProwess ? "Prowess" : "",
+  };
+}
+
+/**
  * Result of detecting Attraction mechanic
  */
 export interface AttractionInfo {

--- a/src/lib/game-state/spell-casting.ts
+++ b/src/lib/game-state/spell-casting.ts
@@ -39,7 +39,7 @@ import {
   getSplitCardHalves,
 } from "./oracle-text-parser";
 import { checkTriggeredAbilities } from "./abilities";
-import { detectStormTrigger } from "./trigger-system";
+import { detectStormTrigger, detectProwessTriggers } from "./trigger-system";
 import { completeHandTargeting } from "./hand-targeting";
 import { destroyCard, createTokenCard } from "./keyword-actions";
 import {
@@ -52,7 +52,7 @@ import {
   parseSpellEffects,
 } from "./effect-resolution";
 import type { CardInstance, StackEffect } from "./types";
-import { canTargetKeyword } from "./evergreen-keywords";
+import { canTargetKeyword, applyProwessBoost } from "./evergreen-keywords";
 import { applyWardResolution } from "./ward-system";
 
 /**
@@ -621,6 +621,26 @@ export function castSpell(
       if (copyResult.success && copyResult.state) {
         finalState = copyResult.state;
       }
+    }
+  }
+
+  // CR 702.108 - Prowess: "Whenever you cast a noncreature spell, this creature
+  // gets +1/+1 until end of turn." The trigger fires on cast for each prowess
+  // instance on each creature the caster controls. Detection lives in
+  // trigger-system (detectProwessTriggers); resolution here stamps the +1/+1
+  // onto each triggering creature's `prowessBoost`, which the layer-7
+  // power/toughness path reads and `clearProwessBoosts` removes at end of turn.
+  // Prowess triggers resolve like storm (on cast) rather than queuing on the
+  // stack, matching the engine's established on-cast-trigger convention.
+  const prowessTriggers = detectProwessTriggers(
+    finalState,
+    cardId,
+    playerId,
+    activePlayerId,
+  );
+  if (prowessTriggers.length > 0) {
+    for (const trigger of prowessTriggers) {
+      finalState = applyProwessBoost(finalState, trigger.sourceCardId, 1);
     }
   }
 

--- a/src/lib/game-state/trigger-system.ts
+++ b/src/lib/game-state/trigger-system.ts
@@ -25,6 +25,7 @@ import type {
 import { Phase, ZoneType, isOnBattlefield } from "./types";
 import { isCreature } from "./card-instance";
 import type { TriggeredAbilityInstance } from "./abilities";
+import { hasProwess, getProwessInstanceCount } from "./evergreen-keywords";
 
 /**
  * Trigger condition types for the new trigger system
@@ -633,6 +634,69 @@ export function detectStormTrigger(
   // Subtract 1 for the storm spell itself, which was counted when it was cast.
   const copyCount = Math.max(0, castThisTurn - 1);
   return { shouldFire: copyCount > 0, copyCount };
+}
+
+/**
+ * Detect the Prowess cast trigger (CR 702.108) for a spell being cast.
+ *
+ * Prowess is a triggered ability that reads: "Whenever you cast a noncreature
+ * spell, this creature gets +1/+1 until end of turn." (CR 702.108a). This
+ * function is the detection half: given the spell a player just cast, it
+ * reports one trigger per prowess instance on each creature that player
+ * controls on the battlefield — but ONLY when the cast spell is noncreature.
+ * "Whenever you cast" means the trigger's source must be controlled by the
+ * spell's caster (CR 702.108a). Multiple instances of prowess on the same
+ * creature trigger separately (CR 702.108b), so each instance yields its own
+ * trigger (and thus its own +1/+1).
+ *
+ * The +1/+1 is applied by `castSpell` (incrementing `prowessBoost`), read by
+ * the layer-7 power/toughness path, and removed at end of turn.
+ */
+export function detectProwessTriggers(
+  state: GameState,
+  spellCardId: CardInstanceId,
+  castingPlayerId: PlayerId,
+  activePlayerId: PlayerId,
+): TriggeredAbilityInstance[] {
+  const triggers: TriggeredAbilityInstance[] = [];
+
+  const spellCard = state.cards.get(spellCardId);
+  if (!spellCard) return triggers;
+
+  // CR 702.108a — only NONCREATURE spells trigger prowess.
+  const spellTypeLine = spellCard.cardData.type_line?.toLowerCase() || "";
+  if (spellTypeLine.includes("creature")) {
+    return triggers;
+  }
+
+  for (const [cardId, card] of state.cards) {
+    if (!isOnBattlefield(state, cardId)) continue;
+    // "Whenever YOU cast" — only the caster's own prowess creatures trigger.
+    if (card.controllerId !== castingPlayerId) continue;
+    if (!hasProwess(card)) continue;
+
+    // CR 702.108b — each instance of prowess triggers separately.
+    const instances = getProwessInstanceCount(card);
+    const context: TriggerDetectionContext = {
+      spellCardId,
+      triggerType: TriggerConditionType.SPELL_CAST,
+    };
+
+    for (let i = 0; i < instances; i++) {
+      triggers.push({
+        id: generateTriggeredAbilityId(),
+        sourceCardId: cardId,
+        triggeringPlayerId: card.controllerId,
+        triggerCondition: "spellCast",
+        effect: "Prowess — This creature gets +1/+1 until end of turn.",
+        timestamp: Date.now(),
+        sourceCardTimestamp: card.enteredBattlefieldTimestamp,
+        context: context as any,
+      });
+    }
+  }
+
+  return sortTriggersAPNAP(triggers, state, activePlayerId);
 }
 
 /**

--- a/src/lib/game-state/types.ts
+++ b/src/lib/game-state/types.ts
@@ -151,6 +151,17 @@ export interface CardInstance {
   /** Whether this creature attacked during the previous turn */
   attackedLastTurn: boolean;
 
+  // Prowess keyword (CR 702.108) - +1/+1 bonus active this turn
+  /**
+   * Number of prowess +1/+1 bonuses currently active on this creature (CR
+   * 702.108). Each time the creature's controller casts a noncreature spell,
+   * a prowess trigger adds +1 to this counter (one per prowess instance, CR
+   * 702.108b); the layer-7 power/toughness read path adds `prowessBoost` to
+   * both power and toughness as a continuous "until end of turn" effect. It is
+   * cleared during the end-of-turn cleanup (see `clearProwessBoosts`).
+   */
+  prowessBoost?: number;
+
   // Performance optimization: zone lookup cache (CR 704 - SBA performance)
   /** The zone key where this card currently resides. Updated on zone changes for O(1) lookup */
   currentZoneKey: string | null;


### PR DESCRIPTION
## Prowess triggered ability (CR 702.108)

Resolves #1058.

Implements the Prowess evergreen keyword end-to-end through the rules engine.

### CR 702.108
- **702.108a** — Prowess is a triggered ability: "Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn."
- **702.108b** — Multiple instances of prowess on the same creature trigger separately (each adds its own +1/+1).

### Implementation
| Concern | Location |
| --- | --- |
| Parse `"Prowess"` from oracle text | `oracle-text-parser.ts` — `parseProwess()` (word-boundary, case-insensitive) |
| Keyword detection + instance counting | `evergreen-keywords.ts` — `hasProwess()`, `getProwessInstanceCount()` |
| Trigger detection (noncreature cast, caster-only, multi-instance) | `trigger-system.ts` — `detectProwessTriggers()` |
| Resolve trigger → stamp `prowessBoost` on the creature | `spell-casting.ts` `castSpell()` (mirrors the Storm on-cast hook) |
| Apply the +1/+1 via the layer-7 power/toughness read path | `evergreen-keywords.ts` `getEffectivePower()` / `getEffectiveToughness()` |
| End-of-turn cleanup (the bonus lasts "until end of turn") | `game-state.ts` new-turn transition → `clearProwessBoosts()` |
| Per-turn state | `types.ts` — `CardInstance.prowessBoost?: number` |

**Trigger wiring.** `detectProwessTriggers()` fires only when the cast spell's type line does **not** include "creature", and only for prowess creatures controlled by the spell's caster ("whenever **you** cast"). It emits one trigger per prowess instance, so a creature with prowess twice produces two triggers (CR 702.108b).

**Layer application.** The bonus is a continuous "+1/+1 until end of turn" effect: `prowessBoost` is added to both power and toughness in the layer-7 read path (`getEffectivePower`/`getEffectiveToughness`), alongside counters and modifiers.

**EOT removal.** `clearProwessBoosts()` zeroes `prowessBoost` for every creature on every battlefield; it is called from the new-turn transition in `game-state.ts`, so the bonus does not persist beyond the turn it was created.

**Multi-instance.** `prowessBoost` is a counter, so multiple noncreature spells in one turn stack (+1 each), and multiple prowess instances on one creature stack (+1 per instance per spell).

Like Storm (#1059) and Blitz (#1061), the prowess on-cast trigger is resolved at cast time rather than queued on the stack, matching the engine's established on-cast-trigger convention.

### Acceptance criteria
- [x] `"Prowess"` parsed from oracle text
- [x] Casting a **noncreature** spell pumps each of the caster's prowess creatures +1/+1 EOT
- [x] Casting a **creature** spell does **not** trigger prowess
- [x] Only the **caster's** prowess creatures trigger ("whenever you cast")
- [x] The +1/+1 is applied via the layer system and removed at end of turn
- [x] Multiple prowess instances stack (prowess twice = +2/+2); multiple noncreature spells stack per turn

### Tests
`src/lib/game-state/__tests__/prowess.test.ts` — 20 tests covering parsing, detection + instance counting, trigger detection (noncreature fires / creature does not / opponent's does not / multi-instance), layer-7 +1/+1 application, EOT cleanup, and end-to-end behaviour through `castSpell` (including the multi-spell and multi-instance stacking cases).

### Verification
- `jest prowess` → 20/20 pass
- related suites (`evergreen-keywords trigger layer oracle-text-parser spell-casting storm-spell-copy blitz foretell`) → 298 suites / 6274 tests, 0 failures
- `tsc --noEmit` → no errors
- `npm run lint` → 0 errors (no new warnings introduced)