### PR TITLE
fix(ai): resolve #990 — tie mana-sequencing recommendations to difficulty level

### DIFF
--- a/src/ai/__tests__/mana-sequencing.test.ts
+++ b/src/ai/__tests__/mana-sequencing.test.ts
@@ -10,7 +10,11 @@ import {
   evaluateLandDropTiming,
   getSequencingRecommendation,
   computeCurveConformance,
+  DIFFICULTY_MANA_SEQUENCING_SCALING,
+  getDifficultyManaSequencingScaling,
+  resolveManaSequencingScaling,
 } from "../mana-sequencing";
+import type { DifficultyLevel, DifficultyFormat } from "../ai-difficulty";
 import type { HandCard } from "../game-state-evaluator";
 
 function makeCard(
@@ -258,4 +262,473 @@ describe("computeCurveConformance", () => {
 
     expect(score).toBe(0);
   });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #990 — difficulty-scaled mana-sequencing recommendations.
+//
+// Mirrors the structure of combat-trick-probability.test.ts (#1067): a per-tier
+// scaling table, a format-composing resolver, and difficulty-keyed degradation
+// in computeOptimalSequence / scoreSequencing / evaluateLandDropTiming /
+// getSequencingRecommendation. All rolls are driven by an injected `rng` so
+// every assertion is deterministic (no flakiness).
+// ---------------------------------------------------------------------------
+
+const DIFFICULTY_LEVELS: DifficultyLevel[] = [
+  "easy",
+  "medium",
+  "hard",
+  "expert",
+];
+
+/** RNG that always returns a value above every mistake threshold (no blunder). */
+const NO_BLUNDER_RNG = () => 0.99;
+/** RNG that always returns a value below every mistake threshold (always blunder). */
+const ALWAYS_BLUNDER_RNG = () => 0.0;
+/**
+ * A roll that lands above expert's wasteChance (0.02) but below easy's (0.4),
+ * medium's (0.15) and hard's (0.05) → distinguishes expert from the lower
+ * tiers without forcing every tier to blunder.
+ */
+const EASY_ONLY_BLUNDER_ROLL = 0.1;
+
+describe("DIFFICULTY_MANA_SEQUENCING_SCALING table (#990)", () => {
+  it("exposes a monotonic wasteChance (decreasing in skill)", () => {
+    const vals = DIFFICULTY_LEVELS.map(
+      (d) => DIFFICULTY_MANA_SEQUENCING_SCALING[d].wasteChance,
+    );
+    for (let i = 1; i < vals.length; i++) {
+      expect(vals[i]).toBeLessThan(vals[i - 1]);
+    }
+    // Easy frequently wastes; expert almost never.
+    expect(DIFFICULTY_MANA_SEQUENCING_SCALING.easy.wasteChance).toBeGreaterThan(
+      0.3,
+    );
+    expect(
+      DIFFICULTY_MANA_SEQUENCING_SCALING.expert.wasteChance,
+    ).toBeLessThanOrEqual(0.05);
+  });
+
+  it("exposes a monotonic efficiencyMultiplier (increasing in skill)", () => {
+    const vals = DIFFICULTY_LEVELS.map(
+      (d) => DIFFICULTY_MANA_SEQUENCING_SCALING[d].efficiencyMultiplier,
+    );
+    for (let i = 1; i < vals.length; i++) {
+      expect(vals[i]).toBeGreaterThan(vals[i - 1]);
+    }
+    expect(DIFFICULTY_MANA_SEQUENCING_SCALING.expert.efficiencyMultiplier).toBe(
+      1,
+    );
+  });
+
+  it("exposes a monotonic misorderChance (decreasing in skill)", () => {
+    const vals = DIFFICULTY_LEVELS.map(
+      (d) => DIFFICULTY_MANA_SEQUENCING_SCALING[d].misorderChance,
+    );
+    for (let i = 1; i < vals.length; i++) {
+      expect(vals[i]).toBeLessThan(vals[i - 1]);
+    }
+    expect(DIFFICULTY_MANA_SEQUENCING_SCALING.expert.misorderChance).toBe(0);
+  });
+
+  it("getDifficultyManaSequencingScaling returns the table entry by reference", () => {
+    for (const level of DIFFICULTY_LEVELS) {
+      expect(getDifficultyManaSequencingScaling(level)).toBe(
+        DIFFICULTY_MANA_SEQUENCING_SCALING[level],
+      );
+    }
+  });
+});
+
+describe("resolveManaSequencingScaling — per-format composition (#990/#1069)", () => {
+  it("returns the base scaling by reference when no format is supplied", () => {
+    for (const level of DIFFICULTY_LEVELS) {
+      expect(resolveManaSequencingScaling(level, undefined)).toBe(
+        DIFFICULTY_MANA_SEQUENCING_SCALING[level],
+      );
+    }
+  });
+
+  it("keeps every resolved mistake chance within [0, 1] across all formats", () => {
+    for (const level of DIFFICULTY_LEVELS) {
+      for (const format of [
+        "commander",
+        "constructed",
+        "limited",
+      ] as DifficultyFormat[]) {
+        const s = resolveManaSequencingScaling(level, format);
+        expect(s.wasteChance).toBeGreaterThanOrEqual(0);
+        expect(s.wasteChance).toBeLessThanOrEqual(1);
+        expect(s.misorderChance).toBeGreaterThanOrEqual(0);
+        expect(s.misorderChance).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  it("folds the per-format blunderChance delta into wasteChance (bounded)", () => {
+    // Every format family declares overrides for every tier in #1069, so this
+    // asserts the composition path executes and stays within the base bounds.
+    for (const level of DIFFICULTY_LEVELS) {
+      const base = resolveManaSequencingScaling(level, undefined);
+      for (const format of [
+        "commander",
+        "constructed",
+        "limited",
+      ] as DifficultyFormat[]) {
+        const resolved = resolveManaSequencingScaling(level, format);
+        // Resolved waste can only move proportionally with blunderChance; it
+        // never exceeds the geometric ceiling of (base * ratio) clamped to 1.
+        expect(resolved.wasteChance).toBeGreaterThanOrEqual(0);
+        // efficiencyMultiplier is never touched by the format composition.
+        expect(resolved.efficiencyMultiplier).toBe(base.efficiencyMultiplier);
+      }
+    }
+  });
+});
+
+describe("computeOptimalSequence — difficulty waste blunder (#990)", () => {
+  // A hand with an on-curve 1-drop + 2-drop so 3 mana yields [1, 2] optimally.
+  const hand: HandCard[] = [
+    makeCard("Savannah Lions", 1),
+    makeCard("Grizzly Bears", 2),
+    makeLand("Plains"),
+  ];
+  const comp = getHandComposition(hand);
+
+  it("omitting difficulty preserves the legacy (optimal) sequence", () => {
+    const seq = computeOptimalSequence(comp, 3, 2);
+    expect(seq).toEqual([1, 2]);
+  });
+
+  it("expert produces the optimal sequence (no waste) on a no-blunder roll", () => {
+    const seq = computeOptimalSequence(
+      comp,
+      3,
+      2,
+      false,
+      "expert",
+      NO_BLUNDER_RNG,
+    );
+    expect(seq).toEqual([1, 2]);
+  });
+
+  it("easy wastes the highest-cmc spell when the waste roll hits", () => {
+    // roll 0.0 < easy.wasteChance(0.4) → drop the 2-drop, leaving [1].
+    const seq = computeOptimalSequence(
+      comp,
+      3,
+      2,
+      false,
+      "easy",
+      ALWAYS_BLUNDER_RNG,
+    );
+    expect(seq).toEqual([1]);
+    // Confirm 1 mana is now unspent (3 available, only 1 used).
+    expect(seq.reduce((a, b) => a + b, 0)).toBe(1);
+  });
+
+  it("expert produces the full sequence on a roll above its waste threshold", () => {
+    // EASY_ONLY_BLUNDER_ROLL (0.1) ≥ expert.wasteChance(0.02) → no waste.
+    const seq = computeOptimalSequence(
+      comp,
+      3,
+      2,
+      false,
+      "expert",
+      () => EASY_ONLY_BLUNDER_ROLL,
+    );
+    expect(seq).toEqual([1, 2]);
+  });
+
+  it("is monotonic in mana utilized across tiers (aggregated over a roll ladder)", () => {
+    // Across a ladder of rolls, higher tiers waste less often → use at least
+    // as much mana cumulatively as the tier below. Mirrors the combat-trick
+    // aggregated-hold-rate test (issue #1067).
+    const rolls: number[] = [];
+    for (let i = 1; i <= 20; i++) rolls.push(i / 25); // 0.04 .. 0.80
+    const used = DIFFICULTY_LEVELS.map((d) => {
+      let total = 0;
+      for (const r of rolls) {
+        total += computeOptimalSequence(comp, 3, 2, false, d, () => r).reduce(
+          (a, b) => a + b,
+          0,
+        );
+      }
+      return total;
+    });
+    for (let i = 1; i < used.length; i++) {
+      expect(used[i]).toBeGreaterThanOrEqual(used[i - 1]);
+    }
+    // Easy wastes strictly more often than expert over the ladder.
+    expect(used[0]).toBeLessThan(used[used.length - 1]);
+  });
+});
+
+describe("scoreSequencing — difficulty efficiency multiplier (#990)", () => {
+  const sequence = [1, 2]; // perfect 3-mana utilization
+
+  it("omitting difficulty preserves the legacy score", () => {
+    const legacy = scoreSequencing(sequence, 3, 3);
+    const explicit = scoreSequencing(sequence, 3, 3, undefined);
+    expect(explicit).toBe(legacy);
+  });
+
+  it("expert scores at least as high as easy on the identical sequence", () => {
+    const easy = scoreSequencing(sequence, 3, 3, "easy");
+    const expert = scoreSequencing(sequence, 3, 3, "expert");
+    expect(expert).toBeGreaterThanOrEqual(easy);
+  });
+
+  it("is monotonic in skill across every tier", () => {
+    const scores = DIFFICULTY_LEVELS.map((d) =>
+      scoreSequencing(sequence, 3, 3, d),
+    );
+    for (let i = 1; i < scores.length; i++) {
+      expect(scores[i]).toBeGreaterThanOrEqual(scores[i - 1]);
+    }
+  });
+
+  it("expert matches the legacy (unscaled) score", () => {
+    // efficiencyMultiplier = 1 at expert → identical to the difficulty-agnostic score.
+    expect(scoreSequencing(sequence, 3, 3, "expert")).toBe(
+      scoreSequencing(sequence, 3, 3),
+    );
+  });
+});
+
+describe("evaluateLandDropTiming — difficulty misorder blunder (#990)", () => {
+  it("omitting difficulty preserves the legacy score", () => {
+    const legacy = evaluateLandDropTiming(2, 1, 3);
+    expect(evaluateLandDropTiming(2, 1, 3, false, 0, undefined)).toBe(legacy);
+  });
+
+  it("easy penalizes land timing when the misorder roll hits", () => {
+    const clean = evaluateLandDropTiming(
+      2,
+      1,
+      3,
+      false,
+      0,
+      "easy",
+      NO_BLUNDER_RNG,
+    );
+    const misordered = evaluateLandDropTiming(
+      2,
+      1,
+      3,
+      false,
+      0,
+      "easy",
+      ALWAYS_BLUNDER_RNG,
+    );
+    expect(misordered).toBeLessThan(clean);
+  });
+
+  it("expert never misorders (misorderChance = 0)", () => {
+    const clean = evaluateLandDropTiming(
+      2,
+      1,
+      3,
+      false,
+      0,
+      "expert",
+      NO_BLUNDER_RNG,
+    );
+    const rolled = evaluateLandDropTiming(
+      2,
+      1,
+      3,
+      false,
+      0,
+      "expert",
+      ALWAYS_BLUNDER_RNG,
+    );
+    expect(rolled).toBe(clean);
+  });
+
+  it("is monotonic in skill on an always-blunder roll (lower tiers ≤ higher)", () => {
+    const scores = DIFFICULTY_LEVELS.map((d) =>
+      evaluateLandDropTiming(2, 1, 3, false, 0, d, ALWAYS_BLUNDER_RNG),
+    );
+    for (let i = 1; i < scores.length; i++) {
+      expect(scores[i]).toBeGreaterThanOrEqual(scores[i - 1]);
+    }
+  });
+});
+
+describe("getSequencingRecommendation — difficulty scaling (#990)", () => {
+  // Hand chosen so the optimal sequence achieves PERFECT 4-mana utilization:
+  // 1-drop + 3-drop → [1, 3] = 4 mana used. This lets the reasoning test
+  // assert "Optimal" for expert (no waste) vs "Suboptimal" for easy (waste).
+  const hand: HandCard[] = [
+    makeCard("One Drop", 1),
+    makeCard("Three Drop", 3),
+    makeLand("Plains"),
+    makeLand("Plains2"),
+    makeLand("Plains3"),
+  ];
+  const MANA = 4;
+  const TURN = 4;
+
+  it("omitting difficulty preserves the legacy recommendation cast order", () => {
+    const legacy = getSequencingRecommendation(hand, MANA, MANA, TURN);
+    const explicit = getSequencingRecommendation(
+      hand,
+      MANA,
+      MANA,
+      TURN,
+      false,
+      0,
+      {},
+    );
+    expect(explicit.castOrder).toEqual(legacy.castOrder);
+    // Sanity: the optimal sequence uses all 4 mana.
+    expect(explicit.castOrder).toEqual([1, 3]);
+  });
+
+  it("expert recommendation uses at least as much mana as easy on identical rolls", () => {
+    // Same seeded RNG stream for both tiers (deterministic, comparable). A
+    // roll of 0.1 fires easy's waste (0.1 < 0.4) but not expert's (0.1 ≥ 0.02).
+    const easy = getSequencingRecommendation(hand, MANA, MANA, TURN, false, 0, {
+      difficulty: "easy",
+      rng: () => EASY_ONLY_BLUNDER_ROLL,
+    });
+    const expert = getSequencingRecommendation(
+      hand,
+      MANA,
+      MANA,
+      TURN,
+      false,
+      0,
+      {
+        difficulty: "expert",
+        rng: () => EASY_ONLY_BLUNDER_ROLL,
+      },
+    );
+    const easyUsed = easy.castOrder.reduce((a, b) => a + b, 0);
+    const expertUsed = expert.castOrder.reduce((a, b) => a + b, 0);
+    expect(expertUsed).toBeGreaterThanOrEqual(easyUsed);
+  });
+
+  it("easy wastes mana on a distinguishing roll; expert does not", () => {
+    // EASY_ONLY_BLUNDER_ROLL (0.1): easy wastes (drops the 3-drop → [1]),
+    // expert keeps the full sequence ([1, 3]).
+    const easy = getSequencingRecommendation(hand, MANA, MANA, TURN, false, 0, {
+      difficulty: "easy",
+      rng: () => EASY_ONLY_BLUNDER_ROLL,
+    });
+    const expert = getSequencingRecommendation(
+      hand,
+      MANA,
+      MANA,
+      TURN,
+      false,
+      0,
+      {
+        difficulty: "expert",
+        rng: () => EASY_ONLY_BLUNDER_ROLL,
+      },
+    );
+    const easyUsed = easy.castOrder.reduce((a, b) => a + b, 0);
+    const expertUsed = expert.castOrder.reduce((a, b) => a + b, 0);
+    expect(easyUsed).toBeLessThan(expertUsed);
+    // Easy leaves ≥1 mana unspent (only the 1-drop is cast).
+    expect(MANA - easyUsed).toBeGreaterThanOrEqual(1);
+    // Expert achieves perfect utilization.
+    expect(expertUsed).toBe(MANA);
+  });
+
+  it("produces a monotonic recommendation score across tiers on identical no-blunder rolls", () => {
+    // No-blunder roll → identical cast order across tiers; the score delta
+    // comes purely from efficiencyMultiplier (monotonic in skill).
+    const scores = DIFFICULTY_LEVELS.map(
+      (d) =>
+        getSequencingRecommendation(hand, MANA, MANA, TURN, false, 0, {
+          difficulty: d,
+          rng: NO_BLUNDER_RNG,
+        }).score,
+    );
+    for (let i = 1; i < scores.length; i++) {
+      expect(scores[i]).toBeGreaterThanOrEqual(scores[i - 1]);
+    }
+    expect(scores[0]).toBeLessThanOrEqual(scores[scores.length - 1]);
+  });
+
+  it("produces monotonic mana utilization across tiers (aggregated over a roll ladder)", () => {
+    const rolls: number[] = [];
+    for (let i = 1; i <= 20; i++) rolls.push(i / 25); // 0.04 .. 0.80
+    const used = DIFFICULTY_LEVELS.map((d) => {
+      let total = 0;
+      for (const r of rolls) {
+        total += getSequencingRecommendation(hand, MANA, MANA, TURN, false, 0, {
+          difficulty: d,
+          rng: () => r,
+        }).castOrder.reduce((a, b) => a + b, 0);
+      }
+      return total;
+    });
+    for (let i = 1; i < used.length; i++) {
+      expect(used[i]).toBeGreaterThanOrEqual(used[i - 1]);
+    }
+    expect(used[0]).toBeLessThan(used[used.length - 1]);
+  });
+
+  it("surfaces difficulty-appropriate expectations in the reasoning", () => {
+    // Easy on a distinguishing roll wastes mana → "Suboptimal sequencing".
+    const easy = getSequencingRecommendation(hand, MANA, MANA, TURN, false, 0, {
+      difficulty: "easy",
+      rng: () => EASY_ONLY_BLUNDER_ROLL,
+    });
+    expect(
+      easy.reasoning.some((r) => r.toLowerCase().includes("suboptimal")),
+    ).toBe(true);
+    expect(easy.reasoning.some((r) => r.includes("easy"))).toBe(true);
+
+    // Expert on a no-blunder roll achieves perfect utilization → "Optimal".
+    const expert = getSequencingRecommendation(
+      hand,
+      MANA,
+      MANA,
+      TURN,
+      false,
+      0,
+      {
+        difficulty: "expert",
+        rng: NO_BLUNDER_RNG,
+      },
+    );
+    expect(
+      expert.reasoning.some((r) => r.toLowerCase().includes("optimal")),
+    ).toBe(true);
+    expect(expert.reasoning.some((r) => r.includes("expert"))).toBe(true);
+  });
+
+  it.each(DIFFICULTY_LEVELS)(
+    "composes with every per-format config without error (%s)",
+    (level) => {
+      for (const format of [
+        "commander",
+        "constructed",
+        "limited",
+      ] as DifficultyFormat[]) {
+        const rec = getSequencingRecommendation(
+          hand,
+          MANA,
+          MANA,
+          TURN,
+          false,
+          0,
+          {
+            difficulty: level,
+            format,
+            rng: NO_BLUNDER_RNG,
+          },
+        );
+        expect(rec.score).toBeGreaterThanOrEqual(-1);
+        expect(rec.score).toBeLessThanOrEqual(1);
+        expect(Array.isArray(rec.castOrder)).toBe(true);
+        expect(rec.reasoning.some((r) => r.includes(level))).toBe(true);
+      }
+    },
+  );
 });

--- a/src/ai/mana-sequencing.ts
+++ b/src/ai/mana-sequencing.ts
@@ -7,6 +7,12 @@
  */
 
 import type { HandCard } from "./game-state-evaluator";
+import {
+  DIFFICULTY_CONFIGS,
+  resolveDifficultyConfig,
+  type DifficultyFormat,
+  type DifficultyLevel,
+} from "./ai-difficulty";
 
 export interface SequencingSlot {
   turn: number;
@@ -27,6 +33,24 @@ export interface HandComposition {
   spellCount: number;
 }
 
+/**
+ * Optional difficulty context threaded through the sequencing
+ * recommendation pipeline (issue #990). All fields are optional so every
+ * existing call site keeps working unchanged — omitting the whole object
+ * reproduces the pre-#990 difficulty-agnostic behavior.
+ */
+export interface SequencingRecommendationOptions {
+  /** Skill tier of the AI producing/receiving the recommendation. */
+  difficulty?: DifficultyLevel;
+  /** Active format family, used to fold per-format blunder tuning (#1069). */
+  format?: DifficultyFormat;
+  /**
+   * Deterministic randomness source for tests. Defaults to `Math.random`.
+   * Each recommendation consumes up to two rolls (waste, then misorder).
+   */
+  rng?: () => number;
+}
+
 const FIRST_FOUR_TURNS: SequencingSlot[] = [
   { turn: 1, availableMana: 1, recommendedDrops: [1], landType: "untapped" },
   { turn: 2, availableMana: 2, recommendedDrops: [2], landType: "untapped" },
@@ -35,6 +59,129 @@ const FIRST_FOUR_TURNS: SequencingSlot[] = [
 ];
 
 const IDEAL_CURVE = [0, 1, 2, 2, 3, 3, 4, 4, 5, 6];
+
+/**
+ * Per-difficulty scaling for mana-sequencing recommendation quality
+ * (issue #990).
+ *
+ * Before #990 every tier produced the identical "optimal" cast ordering, so
+ * Easy and Expert represented mana sequencing indistinguishably. These knobs
+ * reintroduce a skill axis. Every knob is **monotonic in skill** so a higher
+ * tier always sequences mana at least as well as the tier below it:
+ *
+ * - `wasteChance` — probability the AI leaves mana unspent by dropping a
+ *   playable spell (the issue's "Easy AI should frequently leave 1-2 mana
+ *   unspent in early turns"). Easy frequently wastes; Expert almost never.
+ *   Decreasing in skill.
+ * - `efficiencyMultiplier` — multiplier applied to the achieved mana
+ *   efficiency term in {@link scoreSequencing}. Lower tiers extract less
+ *   value from the same mana (suboptimal color sequencing, poor curve
+ *   conformance); Expert achieves ~100%. Increasing in skill (1.0 at expert).
+ * - `misorderChance` — probability the AI mis-orders its land drops (tapped
+ *   lands first, wrong color sequencing) modelled as a land-timing penalty
+ *   in {@link evaluateLandDropTiming}. Easy frequently misorders; Expert
+ *   never. Decreasing in skill.
+ *
+ * Composition with the unified difficulty taxonomy (#1064/#1192) + per-format
+ * config (#1069): {@link resolveManaSequencingScaling} folds the resolved
+ * per-format `blunderChance` into `wasteChance` and `misorderChance`, so a
+ * format delta that raises/lowers blunders proportionally scales sequencing
+ * mistakes — exactly the same mechanism the combat-trick module uses for
+ * `miscastChance` (issue #1067).
+ */
+export interface ManaSequencingDifficultyScaling {
+  wasteChance: number;
+  efficiencyMultiplier: number;
+  misorderChance: number;
+}
+
+export const DIFFICULTY_MANA_SEQUENCING_SCALING: Record<
+  DifficultyLevel,
+  ManaSequencingDifficultyScaling
+> = {
+  easy: {
+    wasteChance: 0.4,
+    efficiencyMultiplier: 0.6,
+    misorderChance: 0.3,
+  },
+  medium: {
+    wasteChance: 0.15,
+    efficiencyMultiplier: 0.85,
+    misorderChance: 0.1,
+  },
+  hard: {
+    wasteChance: 0.05,
+    efficiencyMultiplier: 0.95,
+    misorderChance: 0.03,
+  },
+  expert: {
+    wasteChance: 0.02,
+    efficiencyMultiplier: 1.0,
+    misorderChance: 0.0,
+  },
+};
+
+/**
+ * Baseline scaling (no degradation) used when no difficulty is supplied,
+ * preserving the pre-#990 behavior of every sequencing function. With
+ * `efficiencyMultiplier = 1` the score is unscaled and both mistake chances
+ * are zero, so the output is identical to the legacy difficulty-agnostic
+ * path.
+ */
+const NO_DIFFICULTY_SCALING: ManaSequencingDifficultyScaling = {
+  wasteChance: 0,
+  efficiencyMultiplier: 1,
+  misorderChance: 0,
+};
+
+/**
+ * Get the base tier-keyed mana-sequencing scaling.
+ */
+export function getDifficultyManaSequencingScaling(
+  difficulty: DifficultyLevel,
+): ManaSequencingDifficultyScaling {
+  return DIFFICULTY_MANA_SEQUENCING_SCALING[difficulty];
+}
+
+/**
+ * Resolve the effective mana-sequencing scaling for a (tier, format) pair,
+ * composing the per-tier base with the per-format difficulty config (#1069).
+ *
+ * The base multipliers come from {@link DIFFICULTY_MANA_SEQUENCING_SCALING}.
+ * The two mistake knobs (`wasteChance`, `misorderChance`) are then re-weighted
+ * by the ratio of the resolved per-format `blunderChance` to the base tier
+ * `blunderChance`, so a format override that raises blunders proportionally
+ * raises sequencing mistakes and vice-versa. Both are clamped to [0, 1]. When
+ * no format is supplied (or the format has no override for the tier) the base
+ * scaling is returned unchanged — fully backward compatible. This mirrors
+ * {@link resolveTrickScaling} in the combat-trick module (issue #1067) so the
+ * two mistake-driven subsystems compose identically with the format layer.
+ */
+export function resolveManaSequencingScaling(
+  difficulty: DifficultyLevel,
+  format?: DifficultyFormat,
+): ManaSequencingDifficultyScaling {
+  const base = DIFFICULTY_MANA_SEQUENCING_SCALING[difficulty];
+  if (!format) return base;
+  const resolved = resolveDifficultyConfig(difficulty, format);
+  const baseConfig = DIFFICULTY_CONFIGS[difficulty];
+  if (baseConfig.blunderChance <= 0) return base;
+  const ratio = resolved.blunderChance / baseConfig.blunderChance;
+  const wasteChance = clamp01(base.wasteChance * ratio);
+  const misorderChance = clamp01(base.misorderChance * ratio);
+  if (
+    wasteChance === base.wasteChance &&
+    misorderChance === base.misorderChance
+  ) {
+    return base;
+  }
+  return { ...base, wasteChance, misorderChance };
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
 
 export function getHandComposition(hand: HandCard[]): HandComposition {
   const spells = hand.filter((c) => !c.type.toLowerCase().includes("land"));
@@ -58,6 +205,8 @@ export function computeOptimalSequence(
   availableMana: number,
   untappedLands: number,
   hasChecklands: boolean = false,
+  difficulty?: DifficultyLevel,
+  rng: () => number = Math.random,
 ): number[] {
   const sequence: number[] = [];
   let mana = availableMana;
@@ -70,6 +219,14 @@ export function computeOptimalSequence(
       remaining[cmc]--;
     }
   }
+
+  // Issue #990: the leaf uses the base tier table (tier-only). Format
+  // composition (#1069) is applied at the orchestrator level in
+  // {@link getSequencingRecommendation} via {@link resolveManaSequencingScaling}.
+  const scaling =
+    difficulty === undefined
+      ? NO_DIFFICULTY_SCALING
+      : DIFFICULTY_MANA_SEQUENCING_SCALING[difficulty];
 
   if (hasChecklands && untappedLands >= 2) {
     const effectiveMana = untappedLands - 1;
@@ -86,25 +243,87 @@ export function computeOptimalSequence(
     }
 
     if (checklandSequence.length < sequence.length) {
-      return checklandSequence;
+      return applySequencingWaste(checklandSequence, scaling, rng);
     }
   }
 
-  return sequence;
+  return applySequencingWaste(sequence, scaling, rng);
+}
+
+/**
+ * Apply the per-difficulty mana-waste blunder to a computed cast sequence
+ * (issue #990).
+ *
+ * When a roll lands under `scaling.wasteChance`, the highest-cmc spell in the
+ * sequence is dropped — modelling the low-skill AI choosing to leave mana
+ * unspent ("Easy AI should frequently leave 1-2 mana unspent in early turns").
+ * Dropping the highest-cmc entry wastes the most mana, matching the issue's
+ * intent. The {@link NO_DIFFICULTY_SCALING} sentinel (wasteChance = 0) makes
+ * this a no-op for the legacy difficulty-agnostic path. The roll is driven by
+ * the supplied `rng` so tests are fully deterministic.
+ */
+function applySequencingWaste(
+  sequence: number[],
+  scaling: ManaSequencingDifficultyScaling,
+  rng: () => number,
+): number[] {
+  if (scaling.wasteChance <= 0 || sequence.length === 0) {
+    return sequence;
+  }
+  if (rng() >= scaling.wasteChance) {
+    return sequence;
+  }
+  // Drop the highest-cmc spell: greedy sequences are low→high, so the last
+  // entry is the most expensive. A fresh copy is returned so the caller's
+  // reference is never mutated.
+  return sequence.slice(0, -1);
+}
+
+/**
+ * Apply the per-difficulty land-drop misordering blunder to a land-timing
+ * score (issue #990).
+ *
+ * When a roll lands under `scaling.misorderChance`, a fixed tempo penalty is
+ * subtracted — modelling the low-skill AI mis-ordering its land drops (tapped
+ * lands first, wrong color sequencing). The result is clamped to [-1, 1]. The
+ * {@link NO_DIFFICULTY_SCALING} sentinel (misorderChance = 0) makes this a
+ * no-op for the legacy path. Driven by the supplied `rng` for determinism.
+ */
+function applyMisorderPenalty(
+  score: number,
+  scaling: ManaSequencingDifficultyScaling,
+  rng: () => number,
+): number {
+  if (scaling.misorderChance <= 0 || rng() >= scaling.misorderChance) {
+    return score;
+  }
+  return Math.max(-1, Math.min(1, score - 0.2));
 }
 
 export function scoreSequencing(
   optimalSequence: number[],
   availableMana: number,
   turnNumber: number,
+  difficulty?: DifficultyLevel,
 ): number {
   if (optimalSequence.length === 0) return 0;
+
+  // Issue #990: scale the achieved mana-efficiency term by the tier's
+  // `efficiencyMultiplier`. Lower tiers extract less value from the same mana
+  // (suboptimal color sequencing, poor curve conformance), so the reported
+  // sequencing quality is dampened — "penalize imperfect mana usage based on
+  // difficulty". When `difficulty` is omitted the multiplier is 1 (unscaled),
+  // preserving the legacy score for existing callers.
+  const efficiencyMultiplier =
+    difficulty === undefined
+      ? NO_DIFFICULTY_SCALING.efficiencyMultiplier
+      : DIFFICULTY_MANA_SEQUENCING_SCALING[difficulty].efficiencyMultiplier;
 
   let score = 0;
   const totalManaUsed = optimalSequence.reduce((a, b) => a + b, 0);
   const manaEfficiency = totalManaUsed / availableMana;
 
-  score += manaEfficiency * 0.4;
+  score += manaEfficiency * 0.4 * efficiencyMultiplier;
 
   const curveFit = Math.abs(totalManaUsed - availableMana);
   if (curveFit === 0) score += 0.3;
@@ -123,6 +342,8 @@ export function evaluateLandDropTiming(
   currentTurn: number,
   hasChecklands: boolean = false,
   tappedLandCount: number = 0,
+  difficulty?: DifficultyLevel,
+  rng: () => number = Math.random,
 ): number {
   if (landsInHand === 0) return -0.5;
   if (landsOnBattlefield >= 4 && currentTurn <= 4) return 0.8;
@@ -142,7 +363,15 @@ export function evaluateLandDropTiming(
     score -= 0.1;
   }
 
-  return Math.max(-1, Math.min(1, score));
+  // Issue #990: per-difficulty land-drop misordering blunder. The leaf uses
+  // the base tier table (tier-only); format composition (#1069) is applied at
+  // the orchestrator level. When `difficulty` is omitted the sentinel scaling
+  // (misorderChance = 0) makes this a no-op, preserving legacy behavior.
+  const scaling =
+    difficulty === undefined
+      ? NO_DIFFICULTY_SCALING
+      : DIFFICULTY_MANA_SEQUENCING_SCALING[difficulty];
+  return applyMisorderPenalty(score, scaling, rng);
 }
 
 export function getSequencingRecommendation(
@@ -152,34 +381,60 @@ export function getSequencingRecommendation(
   turnNumber: number,
   hasChecklands: boolean = false,
   tappedLandCount: number = 0,
+  options?: SequencingRecommendationOptions,
 ): SequencingRecommendation {
+  const difficulty = options?.difficulty;
+  const format = options?.format;
+  const rng = options?.rng ?? Math.random;
+
+  // Resolve the format-composed scaling so the per-format blunder tuning
+  // (#1069) actually affects the mistake rolls — exactly like the combat-trick
+  // orchestrator {@link decideCombatTrickHold} (issue #1067). The leaf
+  // functions below are called WITHOUT difficulty so they produce their raw
+  // (unscaled) outputs; the resolved waste/misorder blunders are applied here.
+  const scaling =
+    difficulty === undefined
+      ? NO_DIFFICULTY_SCALING
+      : resolveManaSequencingScaling(difficulty, format);
+
   const composition = getHandComposition(hand);
-  const optimalSequence = computeOptimalSequence(
+
+  // Raw optimal sequence — no internal waste roll (difficulty omitted).
+  const rawSequence = computeOptimalSequence(
     composition,
     availableMana,
     untappedLands,
     hasChecklands,
   );
+  // Apply the format-resolved mana-waste blunder (first roll consumed).
+  const optimalSequence = applySequencingWaste(rawSequence, scaling, rng);
+
   const sequenceScore = scoreSequencing(
     optimalSequence,
     availableMana,
     turnNumber,
+    difficulty,
   );
-  const landTimingScore = evaluateLandDropTiming(
+
+  // Raw land timing — no internal misorder roll (difficulty omitted). Then
+  // apply the format-resolved misorder blunder (second roll consumed).
+  const rawLandTiming = evaluateLandDropTiming(
     composition.landCount,
     untappedLands,
     turnNumber,
     hasChecklands,
     tappedLandCount,
   );
+  const landTimingScore = applyMisorderPenalty(rawLandTiming, scaling, rng);
 
   const reasoning: string[] = [];
 
   const totalManaUsed = optimalSequence.reduce((a, b) => a + b, 0);
+  const wastedMana = availableMana - totalManaUsed;
   if (totalManaUsed === availableMana && optimalSequence.length > 0) {
     reasoning.push("Perfect mana utilization");
-  } else if (totalManaUsed < availableMana - 1 && optimalSequence.length > 0) {
-    reasoning.push("Unused mana detected in sequence");
+  } else if (wastedMana > 1 && optimalSequence.length > 0) {
+    reasoning.push(`Unused mana detected in sequence (${wastedMana} unspent)`);
   }
 
   if (optimalSequence.length >= 2 && turnNumber <= 4) {
@@ -192,6 +447,28 @@ export function getSequencingRecommendation(
 
   if (composition.landCount === 0 && turnNumber <= 3) {
     reasoning.push("No land drops available");
+  }
+
+  // Issue #990: surface difficulty-appropriate expectations in the reasoning.
+  // Easy routinely wastes mana / mis-orders lands; Expert is expected to be
+  // near-optimal — the comment should reflect that, not claim perfection.
+  if (difficulty !== undefined) {
+    const efficiencyPct = Math.round(
+      (totalManaUsed / Math.max(1, availableMana)) * 100,
+    );
+    if (difficulty === "easy" && wastedMana >= 1) {
+      reasoning.push(
+        `Suboptimal sequencing — ${wastedMana} mana wasted (difficulty: easy)`,
+      );
+    } else if (difficulty === "expert" && wastedMana === 0) {
+      reasoning.push(
+        `Optimal sequencing — ${efficiencyPct}% mana efficiency (difficulty: expert)`,
+      );
+    } else {
+      reasoning.push(
+        `Sequencing quality: ${efficiencyPct}% mana efficiency (difficulty: ${difficulty})`,
+      );
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

Resolves #990 — mana-sequencing recommendations (`getSequencingRecommendation`, `computeOptimalSequence`, `scoreSequencing`, `evaluateLandDropTiming`) now scale by AI difficulty level.

Previously every tier produced the identical "optimal" cast ordering, so Easy and Expert sequenced mana indistinguishably. This PR reintroduces a skill axis, mirroring the established per-tier blunder pattern already used by combat blunders (#994/#1195), combat-trick scaling (#1067/#1188), mulligan (#1063/#1196), and deck power (#992/#1202).

## Where it lives

- **`src/ai/mana-sequencing.ts`** — the recommendation module.
- **Per-tier scaling table** `DIFFICULTY_MANA_SEQUENCING_SCALING` + resolver `resolveManaSequencingScaling`.

## Per-tier scaling (monotonic in skill)

| Knob | easy | medium | hard | expert | Direction |
| --- | --- | --- | --- | --- | --- |
| `wasteChance` | 0.40 | 0.15 | 0.05 | 0.02 | ↓ decreasing |
| `efficiencyMultiplier` | 0.60 | 0.85 | 0.95 | 1.00 | ↑ increasing |
| `misorderChance` | 0.30 | 0.10 | 0.03 | 0.00 | ↓ decreasing |

- **`wasteChance`** — probability the AI leaves mana unspent by dropping a playable spell ("Easy AI should frequently leave 1-2 mana unspent in early turns"). On a waste roll, `computeOptimalSequence` drops the highest-cmc entry.
- **`efficiencyMultiplier`** — scales the achieved mana-efficiency term in `scoreSequencing` ("penalize imperfect mana usage based on difficulty").
- **`misorderChance`** — probability of mis-ordered land drops (tapped lands first, wrong color sequencing), modelled as a land-timing penalty in `evaluateLandDropTiming`.

Expert achieves ~100% mana efficiency; Easy frequently wastes 1+ mana.

## Composition with the canonical taxonomy

- `resolveManaSequencingScaling(difficulty, format?)` folds the resolved per-format `blunderChance` (#1069) into `wasteChance` and `misorderChance` via the same `resolved/base blunderChance` ratio mechanism the combat-trick module uses for `miscastChance` (#1067). So a format delta that raises/lowers blunders proportionally scales sequencing mistakes.
- The unified difficulty taxonomy (#1064/#1192) is reused as-is — `DifficultyLevel` / `DifficultyFormat` are imported from `ai-difficulty.ts`.

## API (backward compatible)

All four functions gained an **optional** trailing difficulty/rng parameter; omitting it reproduces the pre-#990 difficulty-agnostic behavior exactly. `getSequencingRecommendation` takes an options object `{ difficulty?, format?, rng? }`:

```ts
computeOptimalSequence(composition, mana, untapped, hasChecklands?, difficulty?, rng?)
scoreSequencing(sequence, mana, turn, difficulty?)
evaluateLandDropTiming(landsInHand, landsOnBattlefield, turn, hasChecklands?, tapped?, difficulty?, rng?)
getSequencingRecommendation(hand, mana, untapped, turn, hasChecklands?, tapped?, options?: { difficulty?, format?, rng? })
```

Deterministic + testable: every roll is driven by an injectable `rng` (defaults to `Math.random`).

## Acceptance criteria

- [x] Mana-sequencing recommendation/quality scales by difficulty: expert optimal; beginner worse (suboptimal sequencing / wasted mana)
- [x] Bounded/smooth and monotonic in skill (every knob monotonic; results clamped to valid ranges)
- [x] Composes with the unified difficulty taxonomy (#1064/#1192) + per-format config (#1069)
- [x] Unit tests cover: per-difficulty sequencing quality (expert better than beginner), monotonicity

## Tests added (`src/ai/__tests__/mana-sequencing.test.ts`)

- Scaling table: monotonic `wasteChance` (↓), `efficiencyMultiplier` (↑), `misorderChance` (↓); `getDifficultyManaSequencingScaling` returns the table entry.
- `resolveManaSequencingScaling`: base-by-reference fallback, bounded `[0,1]` across all formats, folds per-format `blunderChance` delta.
- `computeOptimalSequence`: legacy preserved, expert optimal on no-blunder, easy wastes highest-cmc on blunder, **monotonic mana utilization aggregated over a roll ladder**.
- `scoreSequencing`: legacy preserved, expert ≥ easy, **monotonic across tiers**, expert matches legacy.
- `evaluateLandDropTiming`: legacy preserved, easy penalized on misorder, expert never misorders, **monotonic on always-blunder roll**.
- `getSequencingRecommendation`: legacy preserved, expert ≥ easy mana used, easy wastes / expert doesn't on a distinguishing roll, **monotonic score across tiers**, **monotonic mana utilization aggregated**, difficulty-appropriate reasoning ("Suboptimal"/"Optimal"), composes with every per-format config.

## Verification

- `npm test -- mana-sequencing mana ai-difficulty` → 297 suites / 6284 tests pass (0 regressions)
- `npx tsc --noEmit` → clean
- `eslint` on changed files → 0 errors (2 pre-existing unused-const warnings, unrelated)

Resolves #990