### PR TITLE
feat(p2p): resolve #987 — logging levels and production-build stripping for P2P infrastructure

### DIFF
--- a/src/lib/__tests__/p2p-logger.test.ts
+++ b/src/lib/__tests__/p2p-logger.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for the P2P leveled logger (Issue #987)
+ *
+ * Covers the acceptance criteria:
+ *   - Leveled logger (debug/info/warn/error) used by the P2P infrastructure.
+ *   - In PRODUCTION builds, debug/info are gated off (the body is wrapped in
+ *     a `process.env.NODE_ENV !== 'production'` guard that the bundler can
+ *     dead-code-eliminate).
+ *   - warn/error ALWAYS emit, in development AND production.
+ *   - A configurable level (NEXT_PUBLIC_P2P_LOG_LEVEL) controls dev verbosity.
+ *   - The message is forwarded as the first argument to console.* so the #982
+ *     redaction layer and existing test spies keep working.
+ */
+
+import {
+  P2PLogger,
+  createP2PLogger,
+  p2pLogger,
+  resolveP2PLevel,
+} from "../p2p-logger";
+
+// Capture the original NODE_ENV so every test can restore it. Several tests
+// mutate process.env.NODE_ENV to emulate production builds.
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+interface ConsoleSpies {
+  debug: jest.SpyInstance;
+  info: jest.SpyInstance;
+  warn: jest.SpyInstance;
+  error: jest.SpyInstance;
+}
+
+let spies: ConsoleSpies;
+
+beforeEach(() => {
+  spies = {
+    debug: jest.spyOn(console, "debug").mockImplementation(() => {}),
+    info: jest.spyOn(console, "info").mockImplementation(() => {}),
+    warn: jest.spyOn(console, "warn").mockImplementation(() => {}),
+    error: jest.spyOn(console, "error").mockImplementation(() => {}),
+  };
+});
+
+afterEach(() => {
+  // Restore console spies so they never leak into other test files sharing
+  // the same Jest worker (the global `console` object is process-wide).
+  jest.restoreAllMocks();
+  setEnv(ORIGINAL_NODE_ENV);
+});
+
+function setEnv(env: string | undefined): void {
+  // `process.env.NODE_ENV` is typed read-only by @types/node; cast to a
+  // mutable record so tests can emulate development / production builds.
+  const envRecord = process.env as Record<string, string | undefined>;
+  if (env === undefined) {
+    delete envRecord.NODE_ENV;
+  } else {
+    envRecord.NODE_ENV = env;
+  }
+}
+
+describe("resolveP2PLevel", () => {
+  it("accepts each valid level (case-insensitive)", () => {
+    expect(resolveP2PLevel("debug", "warn")).toBe("debug");
+    expect(resolveP2PLevel("INFO", "warn")).toBe("info");
+    expect(resolveP2PLevel("Warn", "debug")).toBe("warn");
+    expect(resolveP2PLevel("ERROR", "debug")).toBe("error");
+  });
+
+  it("normalizes to lowercase", () => {
+    expect(resolveP2PLevel("DEBUG", "info")).toBe("debug");
+    expect(resolveP2PLevel("Error", "info")).toBe("error");
+  });
+
+  it("falls back for unknown / missing values", () => {
+    expect(resolveP2PLevel("trace", "info")).toBe("info");
+    expect(resolveP2PLevel("", "warn")).toBe("warn");
+    expect(resolveP2PLevel(undefined, "error")).toBe("error");
+    expect(resolveP2PLevel("verbose", "debug")).toBe("debug");
+  });
+});
+
+describe("P2PLogger", () => {
+  describe("message forwarding (redaction compatibility)", () => {
+    it("forwards the message as the first console argument", () => {
+      const log = new P2PLogger();
+      log.error("[WebRTC] init failed:", "detail");
+      expect(spies.error).toHaveBeenCalledTimes(1);
+      expect(spies.error.mock.calls[0][0]).toBe("[WebRTC] init failed:");
+      expect(spies.error.mock.calls[0][1]).toBe("detail");
+    });
+  });
+
+  describe("warn / error always emit (dev + production)", () => {
+    it("warn emits in development and forwards args verbatim", () => {
+      setEnv("development");
+      const log = new P2PLogger();
+      log.warn("[WebRTC] Rate limit exceeded", { count: 3 });
+      expect(spies.warn).toHaveBeenCalledTimes(1);
+      expect(spies.warn.mock.calls[0][0]).toBe("[WebRTC] Rate limit exceeded");
+    });
+
+    it("error emits in development", () => {
+      setEnv("development");
+      const log = new P2PLogger();
+      log.error("[Signaling] Failed:", new Error("boom"));
+      expect(spies.error).toHaveBeenCalledTimes(1);
+    });
+
+    it("warn emits in a PRODUCTION environment (not stripped)", () => {
+      setEnv("production");
+      const log = new P2PLogger();
+      log.warn("[ICE] No TURN servers configured");
+      expect(spies.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it("error emits in a PRODUCTION environment (not stripped)", () => {
+      setEnv("production");
+      const log = new P2PLogger();
+      log.error("[WebRTC] Failed to initialize:", "redacted");
+      expect(spies.error).toHaveBeenCalledTimes(1);
+      expect(spies.error.mock.calls[0][0]).toBe(
+        "[WebRTC] Failed to initialize:",
+      );
+    });
+  });
+
+  describe("debug / info are gated off in production (stripping)", () => {
+    it("debug does NOT emit in a PRODUCTION environment", () => {
+      setEnv("production");
+      const log = new P2PLogger();
+      log.debug("[WebRTC] negotiating", { sdp: "secret" });
+      expect(spies.debug).not.toHaveBeenCalled();
+    });
+
+    it("info does NOT emit in a PRODUCTION environment", () => {
+      setEnv("production");
+      const log = new P2PLogger();
+      log.info("[ICE] Connection state:", "connected");
+      expect(spies.info).not.toHaveBeenCalled();
+    });
+
+    it("production gating holds even when minLevel is explicitly 'debug'", () => {
+      // The build-time NODE_ENV guard must win over any runtime level config.
+      setEnv("production");
+      const log = new P2PLogger({ minLevel: "debug" });
+      log.debug("should be stripped");
+      log.info("also stripped");
+      expect(spies.debug).not.toHaveBeenCalled();
+      expect(spies.info).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("debug / info emit in development, gated by minLevel", () => {
+    it("debug and info emit when minLevel is 'debug' (default)", () => {
+      setEnv("development");
+      const log = new P2PLogger();
+      log.debug("d");
+      log.info("i");
+      expect(spies.debug).toHaveBeenCalledTimes(1);
+      expect(spies.info).toHaveBeenCalledTimes(1);
+    });
+
+    it("minLevel 'info' suppresses debug but allows info", () => {
+      setEnv("development");
+      const log = new P2PLogger({ minLevel: "info" });
+      log.debug("d");
+      log.info("i");
+      expect(spies.debug).not.toHaveBeenCalled();
+      expect(spies.info).toHaveBeenCalledTimes(1);
+    });
+
+    it("minLevel 'warn' suppresses debug and info (warn/error still emit)", () => {
+      setEnv("development");
+      const log = new P2PLogger({ minLevel: "warn" });
+      log.debug("d");
+      log.info("i");
+      log.warn("w");
+      log.error("e");
+      expect(spies.debug).not.toHaveBeenCalled();
+      expect(spies.info).not.toHaveBeenCalled();
+      expect(spies.warn).toHaveBeenCalledTimes(1);
+      expect(spies.error).toHaveBeenCalledTimes(1);
+    });
+
+    it("minLevel 'error' keeps warn/error emitting (they are never level-gated)", () => {
+      setEnv("development");
+      const log = new P2PLogger({ minLevel: "error" });
+      log.debug("d");
+      log.info("i");
+      log.warn("w");
+      log.error("e");
+      expect(spies.debug).not.toHaveBeenCalled();
+      expect(spies.info).not.toHaveBeenCalled();
+      // warn/error always surface, regardless of minLevel (acceptance criterion).
+      expect(spies.warn).toHaveBeenCalledTimes(1);
+      expect(spies.error).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("createP2PLogger factory + child loggers", () => {
+    it("creates a logger and forwards errors", () => {
+      const log = createP2PLogger("WebRTC");
+      log.error("[WebRTC] boom");
+      expect(spies.error).toHaveBeenCalledTimes(1);
+    });
+
+    it("child shares the parent's level config", () => {
+      setEnv("development");
+      const parent = new P2PLogger({ minLevel: "warn" });
+      const child = parent.child("DataChannel");
+      child.debug("d");
+      child.info("i");
+      child.warn("w");
+      expect(spies.debug).not.toHaveBeenCalled();
+      expect(spies.info).not.toHaveBeenCalled();
+      expect(spies.warn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("shared instance", () => {
+    it("p2pLogger exposes the four leveled methods", () => {
+      expect(typeof p2pLogger.debug).toBe("function");
+      expect(typeof p2pLogger.info).toBe("function");
+      expect(typeof p2pLogger.warn).toBe("function");
+      expect(typeof p2pLogger.error).toBe("function");
+    });
+  });
+});

--- a/src/lib/ice-config.ts
+++ b/src/lib/ice-config.ts
@@ -6,6 +6,8 @@
  * enabling P2P connectivity across various network configurations.
  */
 
+import { p2pLogger } from "./p2p-logger";
+
 /**
  * ICE Server configuration
  */
@@ -186,7 +188,7 @@ export function warnIfNoEnvTurnConfigured(
   if (!result.usedFallback) return;
   if (turnConfigWarningEmitted && !force) return;
   turnConfigWarningEmitted = true;
-  console.warn(
+  p2pLogger.warn(
     '[ICE] No TURN servers configured via NEXT_PUBLIC_TURN_URL / ' +
       'NEXT_PUBLIC_TURN_USER / NEXT_PUBLIC_TURN_PASS. Falling back to public ' +
       'OpenRelay TURN servers, which are rate-limited and not suitable for ' +
@@ -416,7 +418,7 @@ export class ICEConnectionMonitor {
     if (!this.connection) return;
 
     const state = this.connection.iceConnectionState;
-    console.info('[ICE] Connection state:', state);
+    p2pLogger.info('[ICE] Connection state:', state);
     
     this.onStateChange?.(state);
 
@@ -449,7 +451,7 @@ export class ICEConnectionMonitor {
   private startFailureTimeout(): void {
     this.clearFailureTimeout();
     this.failureTimeout = setTimeout(() => {
-      console.info('[ICE] Connection timeout - considering failed');
+      p2pLogger.info('[ICE] Connection timeout - considering failed');
       this.onFailed?.();
     }, this.failureTimeoutMs);
   }

--- a/src/lib/p2p-logger.ts
+++ b/src/lib/p2p-logger.ts
@@ -1,0 +1,172 @@
+/**
+ * @fileOverview P2P logging utility (Issue #987)
+ *
+ * Level-aware logger for the P2P infrastructure (WebRTC, signaling, ICE).
+ * Provides `debug` / `info` / `warn` / `error` levels with two guarantees:
+ *
+ *  1. PRODUCTION STRIPPING — `debug()` and `info()` bodies are wrapped in a
+ *     build-time `process.env.NODE_ENV !== 'production'` guard. Next.js
+ *     (and therefore the Tauri build) inlines `NODE_ENV` as a string literal
+ *     and the minimizer dead-code-eliminates the entire body, so verbose P2P
+ *     diagnostics never ship to end users. This reduces DevTools noise and
+ *     avoids minor information leakage for a local-first app.
+ *
+ *  2. RUNTIME LEVEL CONTROL — in development, verbosity is configurable via
+ *     the `NEXT_PUBLIC_P2P_LOG_LEVEL` env var (`debug` | `info` | `warn` |
+ *     `error`), defaulting to `debug`. `warn` and `error` ALWAYS emit, in
+ *     every environment, so real issues keep surfacing in production.
+ *
+ * The logger is intentionally lightweight: it does NOT reformat messages or
+ * inject timestamps/prefixes. Existing log lines already carry their own
+ * `[WebRTC]` / `[Signaling]` / `[ICE]` component tags, and keeping the
+ * message as the first forwarded argument means the #982 redaction layer
+ * (`redactSensitive`) and existing test spies on `console.*` keep working
+ * unchanged.
+ *
+ * @example
+ * ```ts
+ * import { p2pLogger } from "@/lib/p2p-logger";
+ *
+ * p2pLogger.debug("[WebRTC] negotiating", detail); // stripped in prod
+ * p2pLogger.info("[ICE] Connection state:", state); // stripped in prod
+ * p2pLogger.warn("[WebRTC] Rate limit exceeded");    // always emits
+ * p2pLogger.error("[WebRTC] init failed:", err);      // always emits
+ * ```
+ */
+
+export type P2PLogLevel = "debug" | "info" | "warn" | "error";
+
+const LEVEL_WEIGHT: Record<P2PLogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+const VALID_LEVELS: readonly P2PLogLevel[] = [
+  "debug",
+  "info",
+  "warn",
+  "error",
+];
+
+/**
+ * Resolve a level string from an env var, falling back to a default when the
+ * value is missing or unrecognized. Pure + exported for unit testing.
+ */
+export function resolveP2PLevel(
+  envValue: string | undefined,
+  fallback: P2PLogLevel,
+): P2PLogLevel {
+  const v = (envValue ?? "").toLowerCase();
+  return (VALID_LEVELS as readonly string[]).includes(v)
+    ? (v as P2PLogLevel)
+    : fallback;
+}
+
+/**
+ * Minimum level for `debug`/`info` in development. Configurable via
+ * `NEXT_PUBLIC_P2P_LOG_LEVEL`. Has NO effect on `warn`/`error`, which always
+ * emit (and which are dead-code-eliminated independently of this value).
+ */
+const DEV_MIN_LEVEL: P2PLogLevel = resolveP2PLevel(
+  process.env.NEXT_PUBLIC_P2P_LOG_LEVEL,
+  "debug",
+);
+
+export interface P2PLoggerOptions {
+  /**
+   * Minimum level to emit in development (applies to `debug`/`info` only).
+   * Defaults to the `NEXT_PUBLIC_P2P_LOG_LEVEL` env var, or `debug`.
+   */
+  minLevel?: P2PLogLevel;
+  /** Optional component tag for scoping a child logger. */
+  component?: string;
+}
+
+export class P2PLogger {
+  private readonly minLevel: P2PLogLevel;
+  private readonly component: string | undefined;
+
+  constructor(options: P2PLoggerOptions = {}) {
+    this.minLevel = options.minLevel ?? DEV_MIN_LEVEL;
+    this.component = options.component;
+  }
+
+  /** @internal Whether `level` meets the configured dev minimum. */
+  private levelEnabled(level: P2PLogLevel): boolean {
+    return LEVEL_WEIGHT[level] >= LEVEL_WEIGHT[this.minLevel];
+  }
+
+  /**
+   * Debug logging — detailed diagnostics. Stripped from production builds:
+   * the body is dead-code-eliminated when `NODE_ENV === 'production'`. In
+   * development it is gated by the configured minimum level.
+   */
+  debug(message: string, ...args: unknown[]): void {
+    if (process.env.NODE_ENV !== "production") {
+      if (this.levelEnabled("debug")) {
+        console.debug(message, ...args);
+      }
+    }
+  }
+
+  /**
+   * Info logging — lifecycle / state transitions. Stripped from production
+   * builds (dead-code-eliminated when `NODE_ENV === 'production'`). In
+   * development it is gated by the configured minimum level.
+   */
+  info(message: string, ...args: unknown[]): void {
+    if (process.env.NODE_ENV !== "production") {
+      if (this.levelEnabled("info")) {
+        console.info(message, ...args);
+      }
+    }
+  }
+
+  /**
+   * Warning logging — recoverable issues. ALWAYS emitted, in both development
+   * and production. Never stripped, never gated by the configured level.
+   */
+  warn(message: string, ...args: unknown[]): void {
+    console.warn(message, ...args);
+  }
+
+  /**
+   * Error logging — failures and exceptions. ALWAYS emitted, in both
+   * development and production. Arguments are forwarded verbatim so the #982
+   * `redactSensitive` layer continues to mask session IDs / SDP / credentials.
+   */
+  error(message: string, ...args: unknown[]): void {
+    console.error(message, ...args);
+  }
+
+  /**
+   * Create a child logger scoped to a component. Shares the level config of
+   * the parent. The component tag is currently informational (messages keep
+   * their own inline tags) but is retained for future structured logging.
+   */
+  child(component: string): P2PLogger {
+    return new P2PLogger({
+      minLevel: this.minLevel,
+      component: this.component ? `${this.component}:${component}` : component,
+    });
+  }
+}
+
+/** Shared P2P logger instance used across the P2P infrastructure. */
+export const p2pLogger = new P2PLogger();
+
+/**
+ * Factory for component-scoped P2P loggers.
+ *
+ * @example
+ *   const log = createP2PLogger("WebRTC");
+ *   log.error("[WebRTC] init failed:", err);
+ */
+export function createP2PLogger(
+  component: string,
+  options?: Omit<P2PLoggerOptions, "component">,
+): P2PLogger {
+  return new P2PLogger({ ...options, component });
+}

--- a/src/lib/p2p-signaling-client.ts
+++ b/src/lib/p2p-signaling-client.ts
@@ -24,6 +24,7 @@ import type {
 import { WebRTCConnection, createP2PConnection } from "./webrtc-p2p";
 import { safeParseJson } from "./p2p-json-validation";
 import { redactSensitive } from "./p2p-log-redact";
+import { p2pLogger } from "./p2p-logger";
 
 /**
  * Connection information for P2P handshake
@@ -195,7 +196,7 @@ export class P2PSignalingClient {
       await this.connection.initialize();
     } catch (error) {
       // #982: redact — init errors may embed ICE config / TURN credentials.
-      console.error("[Signaling] Failed to initialize:", redactSensitive(error));
+      p2pLogger.error("[Signaling] Failed to initialize:", redactSensitive(error));
       this.events.onError(
         error instanceof Error ? error : new Error("Failed to initialize"),
       );
@@ -230,7 +231,7 @@ export class P2PSignalingClient {
     } catch (error) {
       // #982: redact — QRCode errors may include the serialized connectionInfo
       // (which carries gameCode / hostName).
-      console.error(
+      p2pLogger.error(
         "[Signaling] Failed to generate QR code:",
         redactSensitive(error),
       );
@@ -268,7 +269,7 @@ export class P2PSignalingClient {
       return offer;
     } catch (error) {
       // #982: redact — offer creation errors may embed the local SDP offer.
-      console.error(
+      p2pLogger.error(
         "[Signaling] Failed to create offer:",
         redactSensitive(error),
       );
@@ -303,7 +304,7 @@ export class P2PSignalingClient {
       return answer;
     } catch (error) {
       // #982: redact — handle-offer errors may embed the remote SDP offer.
-      console.error(
+      p2pLogger.error(
         "[Signaling] Failed to handle offer:",
         redactSensitive(error),
       );
@@ -331,7 +332,7 @@ export class P2PSignalingClient {
       await this.connection.handleAnswer(answer);
     } catch (error) {
       // #982: redact — handle-answer errors may embed the remote SDP answer.
-      console.error(
+      p2pLogger.error(
         "[Signaling] Failed to handle answer:",
         redactSensitive(error),
       );
@@ -355,7 +356,7 @@ export class P2PSignalingClient {
       await this.connection.addIceCandidate(candidate);
     } catch (error) {
       // #982: redact — candidate errors may embed the ICE candidate blob.
-      console.error(
+      p2pLogger.error(
         "[Signaling] Failed to add ICE candidate:",
         redactSensitive(error),
       );
@@ -403,7 +404,7 @@ export class P2PSignalingClient {
    */
   sendMessage(message: P2PMessage): void {
     if (!this.connection || !this.connection.isConnected()) {
-      console.warn("[Signaling] Cannot send message: not connected");
+      p2pLogger.warn("[Signaling] Cannot send message: not connected");
       return;
     }
 
@@ -479,7 +480,7 @@ export function createClientSignalingClient(
 export function parseConnectionInfo(data: string): ConnectionInfo | null {
   const parsed = safeParseJson<ConnectionInfo>(data, isConnectionInfo);
   if (!parsed) {
-    console.error(
+    p2pLogger.error(
       "[Signaling] Failed to parse connection info: rejected malformed input",
     );
     return null;
@@ -500,7 +501,7 @@ export function serializeSignalingData(data: SignalingData): string {
 export function deserializeSignalingData(data: string): SignalingData | null {
   const parsed = safeParseJson<SignalingData>(data, isSignalingData);
   if (!parsed) {
-    console.error(
+    p2pLogger.error(
       "[Signaling] Failed to deserialize signaling data: rejected malformed input",
     );
     return null;

--- a/src/lib/webrtc-p2p.ts
+++ b/src/lib/webrtc-p2p.ts
@@ -35,6 +35,7 @@ import {
   type ICEDiagnosticsSnapshot,
 } from "./ice-diagnostics";
 import { redactSensitive } from "./p2p-log-redact";
+import { p2pLogger } from "./p2p-logger";
 import {
   MAX_MESSAGE_SIZE_BYTES,
   withinStructuralLimits,
@@ -452,7 +453,7 @@ export class WebRTCConnection {
       }
     } catch (error) {
       // #982: redact — RTCPeerConnection errors may embed SDP / ICE config.
-      console.error("[WebRTC] Failed to initialize:", redactSensitive(error));
+      p2pLogger.error("[WebRTC] Failed to initialize:", redactSensitive(error));
       this.updateConnectionState("failed");
       throw error;
     }
@@ -519,7 +520,7 @@ export class WebRTCConnection {
       this.updateConnectionState("reconnecting");
     } catch (error) {
       // #982: redact — relay fallback errors may reference TURN credentials.
-      console.error("[WebRTC] Relay fallback failed:", redactSensitive(error));
+      p2pLogger.error("[WebRTC] Relay fallback failed:", redactSensitive(error));
       this.handleConnectionFailure();
     }
   }
@@ -539,7 +540,7 @@ export class WebRTCConnection {
       return offer;
     } catch (error) {
       // #982: redact — offer creation errors may embed the SDP offer.
-      console.error("[WebRTC] Failed to create offer:", redactSensitive(error));
+      p2pLogger.error("[WebRTC] Failed to create offer:", redactSensitive(error));
       this.events.onError(
         error instanceof Error ? error : new Error("Failed to create offer"),
         "",
@@ -568,7 +569,7 @@ export class WebRTCConnection {
       return answer;
     } catch (error) {
       // #982: redact — handleOffer errors may embed the remote SDP offer.
-      console.error("[WebRTC] Failed to handle offer:", redactSensitive(error));
+      p2pLogger.error("[WebRTC] Failed to handle offer:", redactSensitive(error));
       this.events.onError(
         error instanceof Error ? error : new Error("Failed to handle offer"),
         "",
@@ -603,7 +604,7 @@ export class WebRTCConnection {
       await this.peerConnection.addIceCandidate(new RTCIceCandidate(candidate));
     } catch (error) {
       // #982: redact — candidate errors may embed the ICE candidate blob.
-      console.error(
+      p2pLogger.error(
         "[WebRTC] Failed to add ICE candidate:",
         redactSensitive(error),
       );
@@ -653,7 +654,7 @@ export class WebRTCConnection {
       this.setupDataChannelEvents();
     } catch (error) {
       // #982: redact — data-channel setup errors may embed peer config.
-      console.error(
+      p2pLogger.error(
         "[WebRTC] Failed to connect to peer:",
         redactSensitive(error),
       );
@@ -684,7 +685,7 @@ export class WebRTCConnection {
 
     this.dataChannel.onerror = (event) => {
       // #982: redact — error events may include diagnostic data channel info.
-      console.error("[WebRTC] Data channel error:", redactSensitive(event));
+      p2pLogger.error("[WebRTC] Data channel error:", redactSensitive(event));
 
       let errorToReport: Error;
 
@@ -709,7 +710,7 @@ export class WebRTCConnection {
 
     this.dataChannel.onmessage = (event) => {
       if (typeof event.data !== "string") {
-        console.warn("[WebRTC] Received non-string message, ignoring");
+        p2pLogger.warn("[WebRTC] Received non-string message, ignoring");
         return;
       }
       this.handleMessage(event.data);
@@ -736,13 +737,13 @@ export class WebRTCConnection {
     try {
       // 1. Rate-limit first: never do parse work for a flooding peer.
       if (!this.rateLimiter.tryAcquire()) {
-        console.warn("[WebRTC] Rate limit exceeded; dropping peer message");
+        p2pLogger.warn("[WebRTC] Rate limit exceeded; dropping peer message");
         return;
       }
 
       // 2. Hard size cap before JSON.parse to bound parser memory allocation.
       if (data.length > MAX_MESSAGE_SIZE_BYTES) {
-        console.warn(
+        p2pLogger.warn(
           "[WebRTC] Rejected oversize peer message",
           data.length,
           ">",
@@ -756,7 +757,7 @@ export class WebRTCConnection {
       // 3. Structural caps: reject pathologically deep / wide payloads before
       // the recursive message handlers run.
       if (!withinStructuralLimits(message)) {
-        console.warn(
+        p2pLogger.warn(
           "[WebRTC] Rejected peer message exceeding structural limits",
         );
         return;
@@ -796,7 +797,7 @@ export class WebRTCConnection {
     } catch (error) {
       // #982: redact — JSON.parse errors include the raw (potentially
       // attacker-controlled, potentially sensitive) payload in their message.
-      console.error(
+      p2pLogger.error(
         "[WebRTC] Failed to parse message:",
         redactSensitive(error),
       );
@@ -1263,7 +1264,7 @@ export class WebRTCConnection {
    */
   send(message: P2PMessage): void {
     if (!this.dataChannel || this.dataChannel.readyState !== "open") {
-      console.warn("[WebRTC] Data channel not ready");
+      p2pLogger.warn("[WebRTC] Data channel not ready");
       return;
     }
 
@@ -1504,7 +1505,7 @@ export class WebRTCConnection {
       return await this.peerConnection.getStats();
     } catch (error) {
       // #982: redact — getStats errors may reference ICE candidates.
-      console.error("[WebRTC] Failed to get stats:", redactSensitive(error));
+      p2pLogger.error("[WebRTC] Failed to get stats:", redactSensitive(error));
       return null;
     }
   }


### PR DESCRIPTION
## Summary

Resolves #987.

Adds a level-aware logger for the P2P infrastructure (WebRTC, signaling, ICE) and routes the three highest-traffic P2P modules through it, so verbose diagnostics are **stripped from production builds** while `warn`/`error` always surface.

## What changed

- **New: `src/lib/p2p-logger.ts`** — a tiny leveled logger (`debug` / `info` / `warn` / `error`) with two guarantees:
  - **Production stripping (build-time DCE).** The `debug()` and `info()` bodies are wrapped in `if (process.env.NODE_ENV !== "production") { ... }`. Next.js (and therefore the Tauri build) inlines `NODE_ENV` as a string literal, so the minimizer dead-code-eliminates the entire body — verbose P2P logs never ship to end users (noise + minor info-leak reduction for a local-first app).
  - **Runtime level control (dev only).** Verbosity is configurable via `NEXT_PUBLIC_P2P_LOG_LEVEL` (`debug`|`info`|`warn`|`error`, default `debug`). This only affects `debug`/`info`.
  - **`warn`/`error` always emit** — in dev *and* production, never level-gated, never stripped, so real issues keep surfacing.
  - Messages are forwarded **verbatim as the first `console.*` argument** (no prefix/timestamp injection), so the existing inline `[WebRTC]`/`[Signaling]`/`[ICE]` tags, the #982 `redactSensitive` layer, and existing test spies on `console.*` all keep working unchanged.
- **Routed through the logger** (message intent preserved, `redactSensitive(error)` args untouched):
  - `src/lib/webrtc-p2p.ts` — 14 calls (9 `error`, 5 `warn`)
  - `src/lib/p2p-signaling-client.ts` — 9 calls (8 `error`, 1 `warn`)
  - `src/lib/ice-config.ts` — 3 calls (1 `warn`, 2 `info`)
- **New tests: `src/lib/__tests__/p2p-logger.test.ts`** — covers level filtering, dev gating, and production gating.

## Design rationale

- A dedicated `p2p-logger.ts` (rather than reusing `src/lib/logger.ts`) keeps the change scoped to P2P. The shared `logger.ts` defaults to `info` in production (info still ships) and has no build-time DCE guarantee; changing its behavior would affect AI/game/network/UI logging, which is out of scope for this issue and would violate the "no unrelated changes" constraint. `p2p-log-redact.ts` is explicitly *not* a logger (its header says #987 tracks the structured logger) and is left untouched.
- `warn`/`error` are intentionally **not** gated by the configurable level — the issue requires real issues to surface in production, so they are unconditionally emitted.

## Acceptance criteria

- [x] A leveled logger (`debug`/`info`/`warn`/`error`) is used by the P2P infrastructure
- [x] In **production builds**, `debug`/`info` are stripped (build-time `NODE_ENV` guard → DCE)
- [x] `warn`/`error` remain in production (unconditional emit)
- [x] A configurable level (`NEXT_PUBLIC_P2P_LOG_LEVEL`) controls dev verbosity
- [x] Unit tests cover level filtering + production gating (debug/info gated in prod, warn/error always)

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm run lint` — 0 errors (only pre-existing warnings; none in new/edited files)
- Tests — all green, no regressions:
  - `jest p2p-logger p2p-signaling-client ice-config webrtc-p2p` → 128 passed
  - Full P2P surface `jest p2p webrtc ice signaling use-p2p` → **298 suites / 6272 tests passed**
- **Production stripping confirmed empirically** by bundling `p2p-logger.ts` with esbuild using `--define:process.env.NODE_ENV='"production"'` (the same inlining Next.js applies) + `--minify`:
  - Production bundle (664 B): `console.debug` = **0**, `console.info` = **0** (stripped); `console.warn` = 1, `console.error` = 1 (preserved)
  - Development bundle: all four present

## Out of scope / follow-ups

- Other P2P modules that still log directly (`p2p-game-connection.ts`, `p2p-direct-connection.ts`, `signaling-client.ts`, `local-signaling-client.ts`) were left untouched to keep this change low-risk and focused on the files cited in the issue evidence. They can adopt `p2pLogger` in a follow-up; the logger is ready as-is.

Resolves #987