### PR TITLE
feat(rules-engine): resolve #973 — implement Persist keyword enforcement on creature death

### DIFF
--- a/src/lib/game-state/__tests__/keyword-enforcement.test.ts
+++ b/src/lib/game-state/__tests__/keyword-enforcement.test.ts
@@ -612,7 +612,14 @@ describe("Keyword Enforcement — Combat", () => {
     // fewer than two blockers against a menace attacker.
     it("rejects a single blocker assigned to a menace attacker (attacker stays unblocked)", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures(
-        [{ name: "Dire Wolf Prowler", power: 3, toughness: 3, keywords: ["Menace"] }],
+        [
+          {
+            name: "Dire Wolf Prowler",
+            power: 3,
+            toughness: 3,
+            keywords: ["Menace"],
+          },
+        ],
         [{ name: "Solo Blocker", power: 2, toughness: 2 }],
       );
       const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
@@ -641,7 +648,14 @@ describe("Keyword Enforcement — Combat", () => {
 
     it("accepts two blockers assigned to a menace attacker", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures(
-        [{ name: "Dire Wolf Prowler", power: 3, toughness: 3, keywords: ["Menace"] }],
+        [
+          {
+            name: "Dire Wolf Prowler",
+            power: 3,
+            toughness: 3,
+            keywords: ["Menace"],
+          },
+        ],
         [
           { name: "Blocker A", power: 2, toughness: 2 },
           { name: "Blocker B", power: 2, toughness: 2 },
@@ -697,7 +711,14 @@ describe("Keyword Enforcement — Combat", () => {
 
     it("a menace attacker left unblocked (0 blockers) is legal and not flagged as a menace violation", () => {
       const { state, aliceId, bobId } = setupGameWithCreatures(
-        [{ name: "Dire Wolf Prowler", power: 3, toughness: 3, keywords: ["Menace"] }],
+        [
+          {
+            name: "Dire Wolf Prowler",
+            power: 3,
+            toughness: 3,
+            keywords: ["Menace"],
+          },
+        ],
         [{ name: "Blocker", power: 2, toughness: 2 }],
       );
       const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
@@ -731,8 +752,18 @@ describe("Keyword Enforcement — Combat", () => {
           // A ground creature that cannot block flying
           { name: "Ground Blocker", power: 2, toughness: 2 },
           // Two flyers that can block the flying attacker
-          { name: "Flying Blocker A", power: 2, toughness: 2, keywords: ["Flying"] },
-          { name: "Flying Blocker B", power: 2, toughness: 2, keywords: ["Flying"] },
+          {
+            name: "Flying Blocker A",
+            power: 2,
+            toughness: 2,
+            keywords: ["Flying"],
+          },
+          {
+            name: "Flying Blocker B",
+            power: 2,
+            toughness: 2,
+            keywords: ["Flying"],
+          },
         ],
       );
       const attackerId = state.zones.get(`${aliceId}-battlefield`)!.cardIds[0];
@@ -756,7 +787,8 @@ describe("Keyword Enforcement — Combat", () => {
       );
       expect(oneFlyerResult.state.combat.blockers.has(attackerId)).toBe(false);
       expect(
-        oneFlyerResult.errors && oneFlyerResult.errors.some((e) => /menace/i.test(e)),
+        oneFlyerResult.errors &&
+          oneFlyerResult.errors.some((e) => /menace/i.test(e)),
       ).toBe(true);
 
       // (b) Ground blocker + flyer → ground blocker filtered out by flying
@@ -776,7 +808,9 @@ describe("Keyword Enforcement — Combat", () => {
           [attackerId, flyingBlockerIds],
         ]),
       );
-      expect(twoFlyersResult.state.combat.blockers.get(attackerId)).toHaveLength(2);
+      expect(
+        twoFlyersResult.state.combat.blockers.get(attackerId),
+      ).toHaveLength(2);
       expect(
         twoFlyersResult.errors &&
           twoFlyersResult.errors.some((e) => /menace/i.test(e)),
@@ -834,7 +868,12 @@ describe("Keyword Enforcement — Combat", () => {
     it("getLandwalkTypes detects the five basic landwalk variants", () => {
       const { state } = setupGameWithCreatures(
         [
-          { name: "Swamp Walker", power: 2, toughness: 2, keywords: ["Swampwalk"] },
+          {
+            name: "Swamp Walker",
+            power: 2,
+            toughness: 2,
+            keywords: ["Swampwalk"],
+          },
         ],
         [],
       );
@@ -849,18 +888,24 @@ describe("Keyword Enforcement — Combat", () => {
       const makeOracle = (text: string) =>
         createMockCreatureWithOracle("X", 1, 1, text);
       expect(
-        getLandwalkTypes({ cardData: makeOracle("Islandwalk") } as CardInstance),
+        getLandwalkTypes({
+          cardData: makeOracle("Islandwalk"),
+        } as CardInstance),
       ).toEqual(["island"]);
       expect(
-        getLandwalkTypes({ cardData: makeOracle("Plainswalk") } as CardInstance),
+        getLandwalkTypes({
+          cardData: makeOracle("Plainswalk"),
+        } as CardInstance),
       ).toEqual(["plains"]);
       expect(
-        getLandwalkTypes(
-          { cardData: makeOracle("Mountainwalk") } as CardInstance,
-        ),
+        getLandwalkTypes({
+          cardData: makeOracle("Mountainwalk"),
+        } as CardInstance),
       ).toEqual(["mountain"]);
       expect(
-        getLandwalkTypes({ cardData: makeOracle("Forestwalk") } as CardInstance),
+        getLandwalkTypes({
+          cardData: makeOracle("Forestwalk"),
+        } as CardInstance),
       ).toEqual(["forest"]);
     });
 
@@ -983,7 +1028,8 @@ describe("Keyword Enforcement — Combat", () => {
 
       expect(result.state.combat.blockers.has(attackerId)).toBe(false);
       expect(
-        result.errors && result.errors!.some((e) => /islandwalk|landwalk/i.test(e)),
+        result.errors &&
+          result.errors!.some((e) => /islandwalk|landwalk/i.test(e)),
       ).toBe(true);
     });
 
@@ -1026,7 +1072,14 @@ describe("Keyword Enforcement — Combat", () => {
             keywords: ["Swampwalk", "Flying"],
           },
         ],
-        [{ name: "Flying Blocker", power: 2, toughness: 2, keywords: ["Flying"] }],
+        [
+          {
+            name: "Flying Blocker",
+            power: 2,
+            toughness: 2,
+            keywords: ["Flying"],
+          },
+        ],
       );
       // Defender has both a Swamp (triggers swampwalk) — so even a flyer can't block.
       placeBasicLand(state, bobId, "swamp");
@@ -1049,7 +1102,8 @@ describe("Keyword Enforcement — Combat", () => {
       // Swampwalk takes priority: even a valid flyer cannot block.
       expect(result.state.combat.blockers.has(attackerId)).toBe(false);
       expect(
-        result.errors && result.errors.some((e) => /swampwalk|landwalk/i.test(e)),
+        result.errors &&
+          result.errors.some((e) => /swampwalk|landwalk/i.test(e)),
       ).toBe(true);
     });
 
@@ -1107,10 +1161,7 @@ describe("Keyword Enforcement — Combat", () => {
       const attacker = state.cards.get(
         state.zones.get(`${aliceId}-battlefield`)!.cardIds[0],
       )!;
-      expect(getLandwalkTypes(attacker).sort()).toEqual([
-        "island",
-        "swamp",
-      ]);
+      expect(getLandwalkTypes(attacker).sort()).toEqual(["island", "swamp"]);
 
       // Defender controls only a Mountain → neither landwalk applies → block legal.
       placeBasicLand(state, bobId, "mountain");
@@ -1560,6 +1611,131 @@ describe("Keyword Enforcement — Triggered Abilities", () => {
       expect(hasPersist(state.cards.get(creatureId)!)).toBe(false);
       const result = handlePersist(state, creatureId);
       expect(result.persistedCards).toHaveLength(0);
+    });
+
+    // ---- Integration through the state-based-action death path ----
+    // These exercise the real destroyCard() -> handlePersist() wiring, where
+    // moveCardToZone() clears the card's counters on the way to the graveyard.
+    // The persist intervening-"if" (CR 702.78a / 603.4) must therefore be
+    // evaluated against the counters the creature had at the moment of death.
+
+    function setupPersistCreatureOnBattlefield(
+      keywords: string[] = ["Persist"],
+      options: {
+        counters?: { type: string; count: number }[];
+        damage?: number;
+        typeLine?: string;
+        power?: number;
+        toughness?: number;
+      } = {},
+    ): { state: GameState; aliceId: PlayerId; creatureId: CardInstanceId } {
+      let state = createInitialGameState(["Alice", "Bob"], 20, false);
+      state = startGame(state);
+      const [aliceId] = Array.from(state.players.keys());
+
+      const data = createMockCreature(
+        "Persist Creature",
+        options.power ?? 2,
+        options.toughness ?? 2,
+        keywords,
+      );
+      if (options.typeLine) {
+        (data as { type_line: string }).type_line = options.typeLine;
+      }
+      const inst = createCardInstance(data, aliceId, aliceId);
+      inst.hasSummoningSickness = false;
+      if (options.counters) inst.counters = options.counters;
+      if (options.damage !== undefined) inst.damage = options.damage;
+      inst.currentZoneKey = `${aliceId}-battlefield`;
+      state.cards.set(inst.id, inst);
+      const bf = state.zones.get(`${aliceId}-battlefield`)!;
+      state.zones.set(`${aliceId}-battlefield`, {
+        ...bf,
+        cardIds: [...bf.cardIds, inst.id],
+      });
+      return { state, aliceId, creatureId: inst.id };
+    }
+
+    it("SBA: a persist creature that takes lethal damage with no -1/-1 counter returns to the battlefield with a -1/-1 counter", () => {
+      const { state, aliceId, creatureId } = setupPersistCreatureOnBattlefield(
+        ["Persist"],
+        { damage: 2 },
+      );
+
+      const result = checkStateBasedActions(state);
+      const bf = result.state.zones.get(`${aliceId}-battlefield`)!.cardIds;
+      const gy = result.state.zones.get(`${aliceId}-graveyard`)!.cardIds;
+
+      expect(bf).toContain(creatureId);
+      expect(gy).not.toContain(creatureId);
+      const counters = result.state.cards.get(creatureId)!.counters;
+      expect(counters).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: "-1/-1", count: 1 }),
+        ]),
+      );
+    });
+
+    it("SBA (regression): a persist creature that dies WITH a -1/-1 counter stays in the graveyard", () => {
+      const { state, aliceId, creatureId } = setupPersistCreatureOnBattlefield(
+        ["Persist"],
+        { damage: 2, counters: [{ type: "-1/-1", count: 1 }] },
+      );
+
+      const result = checkStateBasedActions(state);
+      const bf = result.state.zones.get(`${aliceId}-battlefield`)!.cardIds;
+      const gy = result.state.zones.get(`${aliceId}-graveyard`)!.cardIds;
+
+      // Persist's intervening-"if" must NOT trigger: it had a -1/-1 counter.
+      expect(gy).toContain(creatureId);
+      expect(bf).not.toContain(creatureId);
+    });
+
+    it("SBA: a creature returned by persist does not persist again on a second death", () => {
+      // First death: no counter -> persist returns it with a -1/-1 counter.
+      const { state, aliceId, creatureId } = setupPersistCreatureOnBattlefield(
+        ["Persist"],
+        { damage: 2 },
+      );
+      const first = checkStateBasedActions(state);
+      expect(
+        first.state.zones.get(`${aliceId}-battlefield`)!.cardIds,
+      ).toContain(creatureId);
+      expect(first.state.cards.get(creatureId)!.counters).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: "-1/-1", count: 1 }),
+        ]),
+      );
+
+      // Second death: it now has a -1/-1 counter, so persist must not retrigger.
+      const card = first.state.cards.get(creatureId)!;
+      first.state.cards.set(creatureId, { ...card, damage: 2 });
+      const second = checkStateBasedActions(first.state);
+
+      expect(second.state.zones.get(`${aliceId}-graveyard`)!.cardIds).toContain(
+        creatureId,
+      );
+      expect(
+        second.state.zones.get(`${aliceId}-battlefield`)!.cardIds,
+      ).not.toContain(creatureId);
+    });
+
+    it("SBA: a non-creature with persist text is never destroyed or returned by persist", () => {
+      const { state, aliceId, creatureId } = setupPersistCreatureOnBattlefield(
+        ["Persist"],
+        { damage: 5, typeLine: "Enchantment" },
+      );
+
+      expect(hasPersist(state.cards.get(creatureId)!)).toBe(false);
+
+      const result = checkStateBasedActions(state);
+      const bf = result.state.zones.get(`${aliceId}-battlefield`)!.cardIds;
+      const gy = result.state.zones.get(`${aliceId}-graveyard`)!.cardIds;
+
+      // Not a creature -> SBAs do not destroy it on lethal damage, and persist
+      // (creature-only) never applies.
+      expect(bf).toContain(creatureId);
+      expect(gy).not.toContain(creatureId);
     });
   });
 

--- a/src/lib/game-state/evergreen-keywords.ts
+++ b/src/lib/game-state/evergreen-keywords.ts
@@ -15,6 +15,7 @@
 import type {
   CardInstance,
   CardInstanceId,
+  Counter,
   GameState,
   PlayerId,
 } from "./types";
@@ -913,10 +914,21 @@ export function hasPersist(card: CardInstance): boolean {
 
 /**
  * Check if a creature with persist can trigger its ability
- * Returns true if the creature dies WITHOUT a -1/-1 counter on it
+ * Returns true if the creature dies WITHOUT a -1/-1 counter on it.
+ *
+ * Per CR 702.78a / 603.4 this is an intervening-"if": the no-(-1/-1)-counter
+ * condition is checked at the moment the creature dies (and again at
+ * resolution). Because moving a card to the graveyard clears its counters
+ * (see moveCardToZone), callers on the death path MUST pass `countersAtDeath`
+ * — the counters the creature had on the battlefield when it died — otherwise
+ * the check would always pass for a card already in the graveyard.
  */
-export function canPersistTrigger(card: CardInstance): boolean {
-  const minusCounters = card.counters?.find((c) => c.type === "-1/-1");
+export function canPersistTrigger(
+  card: CardInstance,
+  countersAtDeath?: Counter[],
+): boolean {
+  const counters = countersAtDeath ?? card.counters ?? [];
+  const minusCounters = counters.find((c) => c.type === "-1/-1");
   return !minusCounters || minusCounters.count === 0;
 }
 

--- a/src/lib/game-state/keyword-actions.ts
+++ b/src/lib/game-state/keyword-actions.ts
@@ -19,6 +19,7 @@ import type {
   GameState,
   CardInstance,
   CardInstanceId,
+  Counter,
   PlayerId,
   Target,
   Zone,
@@ -1484,10 +1485,19 @@ export function untapCardAction(
  * Handle persist keyword when a creature dies
  * CR 702.78: When a creature with persist dies, if it had no -1/-1 counters on it,
  * return it to the battlefield with a -1/-1 counter on it.
+ *
+ * `countersAtDeath` is the counters the creature had on the battlefield at the
+ * moment it died. It MUST be supplied by death-path callers (e.g. state-based
+ * actions), because destroyCard()/moveCardToZone() clears counters when moving
+ * the card to the graveyard. Without it the intervening-"if" (CR 603.4) could
+ * never fail and persist would wrongly re-trigger on a creature that died with
+ * a -1/-1 counter. Callers that operate on a card whose counters are still
+ * intact (e.g. direct unit tests) may omit it.
  */
 export function handlePersist(
   state: GameState,
   deadCardId: CardInstanceId,
+  countersAtDeath?: Counter[],
 ): {
   state: GameState;
   persistedCards: CardInstanceId[];
@@ -1512,8 +1522,8 @@ export function handlePersist(
     return { state, persistedCards, descriptions };
   }
 
-  // Check if persist can trigger (creature must NOT have -1/-1 counter)
-  if (!canPersistTrigger(card)) {
+  // Check if persist can trigger (creature must NOT have -1/-1 counter at death)
+  if (!canPersistTrigger(card, countersAtDeath)) {
     descriptions.push(
       `${card.cardData.name} had a -1/-1 counter, persist did not trigger`,
     );

--- a/src/lib/game-state/state-based-actions.ts
+++ b/src/lib/game-state/state-based-actions.ts
@@ -323,6 +323,13 @@ export function checkStateBasedActions(
 
   // Destroy all marked cards
   for (const cardId of cardsToDestroy) {
+    // Persist's intervening-"if" (CR 702.78a / 603.4) must be evaluated against
+    // the counters the creature had ON THE BATTLEFIELD when it died. destroyCard()
+    // -> moveCardToZone() clears counters on the zone change to the graveyard, so
+    // snapshot them now (before destruction) and hand them to handlePersist().
+    const dyingCard = updatedState.cards.get(cardId);
+    const countersAtDeath = dyingCard?.counters;
+
     const destroyResult = destroyCard(updatedState, cardId);
     if (destroyResult.success) {
       updatedState = destroyResult.state;
@@ -332,7 +339,11 @@ export function checkStateBasedActions(
       }
       // Handle persist keyword (CR 702.78)
       // Persist triggers when a creature dies without a -1/-1 counter on it
-      const persistResult = handlePersist(updatedState, cardId);
+      const persistResult = handlePersist(
+        updatedState,
+        cardId,
+        countersAtDeath,
+      );
       if (persistResult.persistedCards.length > 0) {
         updatedState = persistResult.state;
         descriptions.push(...persistResult.descriptions);


### PR DESCRIPTION
## Summary

Resolves #973 — implements **Persist** keyword enforcement on creature death (CR 702.78).

## Background

The scaffolding (`hasPersist`, `canPersistTrigger`, `handlePersist`, and the call site in the state-based-action death loop) was already present on `main`, but the integrated death path had a **correctness bug that silently broke persist's intervening-"if"**:

> `destroyCard()` → `moveCardToZone(..., "graveyard")` **clears the card's counters** (`counters: []`) on the way to the graveyard. `handlePersist()` was then called *after* destruction and read the (now empty) graveyard counters via `canPersistTrigger()` — which therefore **always returned `true`**.

Result: a Persist creature that died **with** a `-1/-1` counter wrongly returned to the battlefield, violating CR 702.78a / 603.4. The existing unit tests didn't catch it because they bypass `destroyCard()` (they hand-move the card to the graveyard while leaving its counters intact).

## Fix

Persist's intervening-"if" ("had no `-1/-1` counters on it") must be evaluated against the counters the creature had **on the battlefield at the moment it died**.

- `evergreen-keywords.ts` — `canPersistTrigger(card, countersAtDeath?)` now accepts an optional counter snapshot; falls back to `card.counters` for direct callers.
- `keyword-actions.ts` — `handlePersist(state, deadCardId, countersAtDeath?)` threads the snapshot through to `canPersistTrigger`.
- `state-based-actions.ts` — the SBA death loop snapshots `dyingCard.counters` **before** `destroyCard()` clears them, and passes it to `handlePersist()`.

The change is backward-compatible (the new params are optional), so all existing callers/tests continue to work.

## Behaviour implemented (CR 702.78)

- **Death trigger:** when a creature with persist dies with **no** `-1/-1` counter, it returns to the battlefield under its owner's control with a `-1/-1` counter.
- **Intervening-"if" (CR 603.4):** if it died **with** a `-1/-1` counter, persist does **not** trigger (stays in graveyard).
- **No re-trigger:** a creature returned by persist enters with a `-1/-1` counter, so a second death does not re-trigger persist.
- **Creature-only:** `hasPersist` requires a Creature type line (per #1093/#1158); non-creatures are unaffected by the death path.

## Tests

Added integration tests in `keyword-enforcement.test.ts` that drive the real `checkStateBasedActions()` death path (not just `handlePersist` directly):

- ✅ dies with no counter → returns to battlefield with a `-1/-1` counter
- ✅ **dies with a `-1/-1` counter → stays in graveyard** (regression — verified to **fail** before this fix)
- ✅ second death after a persist return → no re-trigger
- ✅ non-creature with persist text → never destroyed/returned by persist

Plus existing coverage retained for `hasPersist` (keywords array, oracle text, non-creature) and `canPersistTrigger`.

## Verification

- `npx jest keyword-enforcement standard-mechanics state-based-actions evergreen-keywords keyword-actions game-state` → **113 suites / 2658 tests pass**
- `npx tsc --noEmit` → clean
- `npx eslint <changed files>` → clean

## Files changed

- `src/lib/game-state/evergreen-keywords.ts` — `canPersistTrigger` snapshot param + CR citations
- `src/lib/game-state/keyword-actions.ts` — `handlePersist` snapshot param + JSDoc
- `src/lib/game-state/state-based-actions.ts` — snapshot counters before `destroyCard`, pass to `handlePersist`
- `src/lib/game-state/__tests__/keyword-enforcement.test.ts` — SBA integration tests

Resolves #973
