### PR TITLE
fix(ai): resolve #989 — use the difficulty parameter in StackInteractionAI's constructor

### DIFF
--- a/src/ai/__tests__/stack-interaction-ai.test.ts
+++ b/src/ai/__tests__/stack-interaction-ai.test.ts
@@ -968,6 +968,182 @@ describe("StackInteractionAI", () => {
       expect(threat).toBeLessThanOrEqual(1);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // #989: StackInteractionAI previously ignored its `difficulty` constructor
+  // argument. Every internal evaluateGameState() call was hardcoded to
+  // "medium" and the counterspell threshold was a flat constant, so the stack
+  // lane produced identical decisions regardless of the requested tier. These
+  // tests pin the fix: the constructor difficulty is stored and drives (a) the
+  // now-tier-aware evaluateGameState evaluation, (b) the tiered ResponseWeights
+  // set in the constructor, and (c) the new difficulty-aware counterspell
+  // threshold.
+  // ---------------------------------------------------------------------------
+  describe("Difficulty parameter drives stack-interaction decisions (#989)", () => {
+    const ALL_TIERS: DifficultyLevel[] = ["easy", "medium", "hard", "expert"];
+
+    // High-threat stack that every tier commits to answering, so the response
+    // EV reflects the tiered weights + the (now tier-aware) game-state eval.
+    const buildHighThreat = (): {
+      action: StackAction;
+      context: StackContext;
+      response: AvailableResponse;
+    } => {
+      const action: StackAction = {
+        id: "stack_ht",
+        cardId: "opp_counter",
+        name: "Counterspell",
+        controller: "player2",
+        type: "spell",
+        manaValue: 5,
+        isInstantSpeed: false,
+        timestamp: Date.now(),
+        targets: [{ playerId: "player1" }],
+      };
+      const response: AvailableResponse = {
+        cardId: "cancel",
+        name: "Cancel",
+        type: "instant",
+        manaValue: 2,
+        manaCost: { blue: 2 },
+        canCounter: true,
+        canTarget: ["spell"],
+        effect: {
+          type: "counter",
+          value: 6,
+          targets: [action.id],
+        },
+      };
+      const context: StackContext = {
+        currentAction: action,
+        stackSize: 1,
+        actionsAbove: [],
+        availableMana: { blue: 3, colorless: 0 },
+        availableResponses: [response],
+        opponentsRemaining: [],
+        isMyTurn: false,
+        phase: "precombat_main",
+        step: "main",
+        respondingToOpponent: true,
+      };
+      return { action, context, response };
+    };
+
+    test("evaluateResponse produces a strictly higher-EV decision for expert than easy on an identical stack", () => {
+      const { context } = buildHighThreat();
+      const easy = new StackInteractionAI(gameState, playerId, "easy");
+      const expert = new StackInteractionAI(gameState, playerId, "expert");
+
+      const easyDecision = easy.evaluateResponse(context);
+      const expertDecision = expert.evaluateResponse(context);
+
+      // Both tiers recognise the threat and commit to answering it.
+      expect(easyDecision.shouldRespond).toBe(true);
+      expect(expertDecision.shouldRespond).toBe(true);
+      // Difficulty now flows through evaluateGameState + the tiered weights, so
+      // expert's evaluation is strictly stronger than easy's.
+      expect(expertDecision.expectedValue).toBeGreaterThan(
+        easyDecision.expectedValue,
+      );
+    });
+
+    test("evaluateResponse decisions scale monotonically across all four tiers", () => {
+      const { context } = buildHighThreat();
+      const evs = ALL_TIERS.map(
+        (tier) =>
+          new StackInteractionAI(gameState, playerId, tier).evaluateResponse(
+            context,
+          ).expectedValue,
+      );
+      // easy < medium < hard < expert
+      for (let i = 1; i < evs.length; i++) {
+        expect(evs[i]).toBeGreaterThan(evs[i - 1]);
+      }
+    });
+
+    test("counterspell threshold varies by difficulty (easy fires, expert conserves on a borderline spell)", () => {
+      // A neutral, moderately-costed spell: high enough threat for easy/medium
+      // to counter, below the stricter expert/hard threshold. hasBackup is true
+      // so the score is deterministic regardless of the opponent-counter model.
+      const action: StackAction = {
+        id: "stack_border",
+        cardId: "hill_giant",
+        name: "Hill Giant",
+        controller: "player2",
+        type: "spell",
+        manaValue: 3,
+        isInstantSpeed: false,
+        timestamp: Date.now(),
+      };
+      const counterspell: AvailableResponse = {
+        cardId: "c1",
+        name: "Counterspell",
+        type: "instant",
+        manaValue: 2,
+        manaCost: { blue: 2 },
+        canCounter: true,
+        canTarget: ["spell"],
+        effect: { type: "counter", value: 4, targets: [action.id] },
+      };
+      const backup: AvailableResponse = {
+        cardId: "c2",
+        name: "Backup Counter",
+        type: "instant",
+        manaValue: 2,
+        manaCost: { blue: 2 },
+        canCounter: true,
+        canTarget: ["spell"],
+        effect: { type: "counter", value: 4, targets: [action.id] },
+      };
+      const context: StackContext = {
+        currentAction: action,
+        stackSize: 1,
+        actionsAbove: [],
+        availableMana: { blue: 4, colorless: 0 },
+        availableResponses: [counterspell, backup],
+        opponentsRemaining: [],
+        isMyTurn: false,
+        phase: "precombat_main",
+        step: "main",
+        respondingToOpponent: true,
+      };
+
+      const easy = new StackInteractionAI(gameState, playerId, "easy");
+      const expert = new StackInteractionAI(gameState, playerId, "expert");
+
+      const easyDecision = easy.decideCounterspell(context, counterspell);
+      const expertDecision = expert.decideCounterspell(context, counterspell);
+
+      // Easy's looser threshold (1.5) fires on this borderline spell...
+      expect(easyDecision.shouldRespond).toBe(true);
+      // ...expert's stricter threshold (2.8) conserves interaction. This is the
+      // direct proof that the constructor difficulty is stored and read.
+      expect(expertDecision.shouldRespond).toBe(false);
+    });
+
+    test("decidePriorityPass and manageResources honour the stored difficulty without error across all tiers", () => {
+      const { context } = buildHighThreat();
+      for (const tier of ALL_TIERS) {
+        const ai = new StackInteractionAI(gameState, playerId, tier);
+        const pass = ai.decidePriorityPass(context);
+        const resources = ai.manageResources(context);
+        expect(pass.shouldPass).toBeDefined();
+        expect(resources.holdFor).toBeDefined();
+      }
+    });
+
+    test("instances without an explicit difficulty fall back to the medium default (no regression)", () => {
+      const { context } = buildHighThreat();
+      const implicit = new StackInteractionAI(gameState, playerId);
+      const explicit = new StackInteractionAI(gameState, playerId, "medium");
+
+      // The constructor stores the resolved difficulty, so omitting it must be
+      // indistinguishable from passing "medium".
+      expect(implicit.evaluateResponse(context)).toEqual(
+        explicit.evaluateResponse(context),
+      );
+    });
+  });
 });
 
 /**

--- a/src/ai/game-state-evaluator.ts
+++ b/src/ai/game-state-evaluator.ts
@@ -1483,7 +1483,7 @@ export class GameStateEvaluator {
 export function evaluateGameState(
   gameState: GameState,
   playerId: string,
-  difficulty: "easy" | "medium" | "hard" = "medium",
+  difficulty: DifficultyTier = "medium",
   archetype?: DeckArchetype,
 ): DetailedEvaluation {
   const evaluator = new GameStateEvaluator(

--- a/src/ai/stack-interaction-ai.ts
+++ b/src/ai/stack-interaction-ai.ts
@@ -1060,7 +1060,7 @@ export class StackInteractionAI {
     const currentEvaluation = evaluateGameState(
       this.gameState,
       this.playerId,
-      "medium",
+      this.difficulty,
     );
 
     // Evaluate the threat level of the current action
@@ -1245,7 +1245,7 @@ export class StackInteractionAI {
       const singleEval = this.evaluateResponseOption(
         affordableResponses[0],
         context,
-        evaluateGameState(this.gameState, this.playerId, "medium"),
+        evaluateGameState(this.gameState, this.playerId, this.difficulty),
       );
       return {
         orderedActions: [affordableResponses[0].cardId],
@@ -1283,7 +1283,7 @@ export class StackInteractionAI {
     const currentEvaluation = evaluateGameState(
       this.gameState,
       this.playerId,
-      "medium",
+      this.difficulty,
     );
     const threatLevel = this.assessActionThreat(context, currentEvaluation);
 
@@ -1325,7 +1325,7 @@ export class StackInteractionAI {
     const currentEvaluation = evaluateGameState(
       this.gameState,
       this.playerId,
-      "medium",
+      this.difficulty,
     );
 
     // Calculate total mana available
@@ -1465,7 +1465,7 @@ export class StackInteractionAI {
   async assessActionThreatWithTriggers(context: StackContext): Promise<number> {
     const baseThreat = this.assessActionThreat(
       context,
-      evaluateGameState(this.gameState, this.playerId, "medium"),
+      evaluateGameState(this.gameState, this.playerId, this.difficulty),
     );
     const triggerResult = await this.evaluateTriggerChains(context);
     const cascadeBonus = triggerResult.cascadeThreatBonus;
@@ -1622,7 +1622,7 @@ export class StackInteractionAI {
     const currentEvaluation = evaluateGameState(
       this.gameState,
       this.playerId,
-      "medium",
+      this.difficulty,
     );
 
     return {
@@ -1676,7 +1676,28 @@ export class StackInteractionAI {
       score += 0.3;
     }
 
-    return score > 2.0;
+    return score > this.getCounterspellThreshold();
+  }
+
+  /**
+   * Difficulty-aware counterspell threshold. Easier tiers pull the trigger
+   * more loosely (burning interaction on marginal targets), while expert play
+   * is more selective and conserves interaction for high-value disruption.
+   * Composes with the tiered ResponseWeights (#1070) and the difficulty-aware
+   * evaluateGameState evaluation so the whole stack lane scales with the
+   * constructor's difficulty (#989).
+   */
+  private getCounterspellThreshold(): number {
+    switch (this.difficulty) {
+      case "easy":
+        return 1.5;
+      case "hard":
+        return 2.4;
+      case "expert":
+        return 2.8;
+      default:
+        return 2.0;
+    }
   }
 
   /**
@@ -2620,7 +2641,7 @@ export class StackInteractionAI {
     const currentEvaluation = evaluateGameState(
       this.gameState,
       this.playerId,
-      "medium",
+      this.difficulty,
     );
     const manaAvailable = this.calculateAvailableMana(context);
 
@@ -2674,7 +2695,7 @@ export class StackInteractionAI {
     const currentEvaluation = evaluateGameState(
       this.gameState,
       this.playerId,
-      "medium",
+      this.difficulty,
     );
 
     // Score the choice based on game state
@@ -2767,7 +2788,7 @@ export function shouldBluffHoldMana(
   difficulty: DifficultyLevel = "medium",
 ): BluffHoldDecision {
   const ai = new StackInteractionAI(gameState, playerId, difficulty);
-  const currentEvaluation = evaluateGameState(gameState, playerId, "medium");
+  const currentEvaluation = evaluateGameState(gameState, playerId, difficulty);
   return ai.shouldBluffHoldMana(context, currentEvaluation, opponentHistory);
 }
 


### PR DESCRIPTION
## Problem (#989)

`StackInteractionAI` accepted a `difficulty` parameter in its constructor and stored it (already done as part of #1070), but **every internal `evaluateGameState()` call hardcoded `"medium"`**, and the counterspell threshold was a flat constant. So although the tiered `ResponseWeights` made some decisions differ, the core stack-interaction evaluation was identical across tiers — the stored `this.difficulty` was effectively ignored by the decision methods.

Issue evidence (all on `src/ai/stack-interaction-ai.ts`): `evaluateResponse`, `decidePriorityPass`, `manageResources`, `decideCounterspell`/`evaluateCounterspellFactors`, `optimizeResponseOrder`, `assessActionThreatWithTriggers`, and `evaluateModalChoice` each passed `"medium"` to `evaluateGameState` instead of `this.difficulty`.

## Fix

1. **Thread `this.difficulty`** through all 8 internal `evaluateGameState(...)` call sites (replacing the hardcoded `"medium"`), plus the module-level `shouldBluffHoldMana` convenience helper (which had its own hardcoded `"medium"`). The instance's stack-interaction decisions now reflect the requested tier.
2. **Add a difficulty-aware counterspell threshold** (`getCounterspellThreshold()`): `easy` 1.5 → `medium` 2.0 → `hard` 2.4 → `expert` 2.8. Easier tiers fire counters more loosely (burning interaction on marginal targets); expert is more selective and conserves interaction for high-value disruption. Replaces the flat `score > 2.0`.
3. **Widen `evaluateGameState`'s `difficulty` param** (`src/ai/game-state-evaluator.ts`) from the 3-tier `"easy" | "medium" | "hard"` to the canonical 4-tier `DifficultyTier`. The underlying `GameStateEvaluator` already accepted `expert` (and ships an `expert` weights profile); only the wrapper function's signature was artificially narrow — a leftover from before #1064 unified the taxonomy. This is necessary so `this.difficulty` (which can be `"expert"`) type-checks when threaded, and it completes the #1064 unification so the restored expert tier (#1070) actually reaches the evaluator.

## Composition with related work

- **#1070 (expert tier):** builds on it — the existing expert branch in `assessActionThreatWithTriggers` now also receives an expert-tier game-state evaluation (previously forced to medium).
- **#1064 (unified taxonomy):** the `evaluateGameState` widening finishes unifying the 4-tier taxonomy at the evaluator boundary.
- **#1069 (per-format config) / #1080 (worker offload):** unchanged; the constructor still resolves `ResponseWeights` and the async trigger-chain bridge is untouched.

## Acceptance criteria

- [x] Constructor **stores** the difficulty (`this.difficulty = difficulty`, set in constructor; now also read by every decision method + the new threshold switch)
- [x] Decisions **vary by the passed difficulty** — threaded `evaluateGameState` + tiered weights + tiered counterspell threshold
- [x] **No regression** — instances without explicit difficulty use the `"medium"` default (unchanged behavior; pinned by a test)
- [x] **Unit tests** — difficulty stored+used (expert EV > easy EV; monotonic across all 4 tiers), decisions vary by tier (easy counters / expert conserves on a borderline spell), default preserved

## Files changed

- `src/ai/stack-interaction-ai.ts` — thread `this.difficulty` through 8 `evaluateGameState` calls + `shouldBluffHoldMana`; add `getCounterspellThreshold()`
- `src/ai/game-state-evaluator.ts` — widen `evaluateGameState` param to `DifficultyTier` (1 line; purely additive — existing 3-tier callers still type-check)
- `src/ai/__tests__/stack-interaction-ai.test.ts` — new `#989` describe block (5 tests)

## Verification

- `npx tsc --noEmit` / `npm run lint` / `npm test -- stack-interaction-ai`: **the sandbox this branch was prepared in has an incomplete `node_modules` (partial pnpm store, network-blocked) so these could not be executed locally** — CI on this PR will run the full suite. The counterspell-threshold test was hand-traced (borderline spell → score ≈ 2.1–2.4, robustly above `easy`'s 1.5 and below `expert`'s 2.8 regardless of the opponent-counter model, since `hasBackup` is true).

Resolves #989