### PR TITLE
feat(rules-engine): resolve #1057 — enforce intervening-if clauses (CR 603.4, 608.2b)

### DIFF
--- a/src/lib/game-state/__tests__/intervening-if-clauses.test.ts
+++ b/src/lib/game-state/__tests__/intervening-if-clauses.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Tests for CR 603.4 (intervening "if" clauses) and CR 608.2b parsing.
+ *
+ * Issue #1057: Replace the naive regex trigger parser and enforce intervening-if
+ * clauses. These tests pin down:
+ *  - The oracle parser correctly separates trigger condition / intervening-if /
+ *    effect (no longer lumping the if-clause into the effect).
+ *  - An intervening-if is enforced at TRIGGER time (the ability does not go on
+ *    the stack when the clause is false when the trigger event occurs).
+ *  - An intervening-if is re-checked at RESOLUTION and the ability fizzles when
+ *    the clause is no longer true.
+ *  - Triggers without an intervening-if behave exactly as before (no regression).
+ */
+
+import {
+  parseTriggeredAbilities,
+  parseOracleText,
+} from "../oracle-text-parser";
+import {
+  detectTriggeredAbilities,
+  evaluateInterveningIfClause,
+} from "../abilities";
+import { detectTurnStartTriggers } from "../trigger-system";
+import { resolveTopOfStack } from "../spell-casting";
+import { createInitialGameState } from "../game-state";
+import { createCardInstance } from "../card-instance";
+import type {
+  GameState,
+  StackObject,
+  PlayerId,
+  CardInstanceId,
+} from "../types";
+import type { ScryfallCard } from "@/app/actions";
+
+function createMockCard(overrides: Partial<ScryfallCard> = {}): ScryfallCard {
+  return {
+    id: `mock-${Math.random().toString(36).substr(2, 9)}`,
+    name: overrides.name || "Test Card",
+    type_line: overrides.type_line || "Creature — Human",
+    oracle_text: overrides.oracle_text || "",
+    mana_cost: overrides.mana_cost || "{1}{W}",
+    cmc: 2,
+    colors: overrides.colors || ["W"],
+    color_identity: overrides.color_identity || ["W"],
+    legalities: { standard: "legal", commander: "legal" },
+    layout: "normal",
+    ...overrides,
+  } as ScryfallCard;
+}
+
+function makeGame(): GameState {
+  return createInitialGameState(["Alice", "Bob"], 20, false);
+}
+
+function playerIds(state: GameState): [PlayerId, PlayerId] {
+  const ids = Array.from(state.players.keys());
+  return [ids[0], ids[1]];
+}
+
+function placeOnBattlefield(
+  state: GameState,
+  cardData: ScryfallCard,
+  playerId: PlayerId,
+): CardInstanceId {
+  const card = createCardInstance(cardData, playerId, playerId);
+  card.hasSummoningSickness = false;
+  const bf = state.zones.get(`${playerId}-battlefield`)!;
+  state.zones.set(`${playerId}-battlefield`, {
+    ...bf,
+    cardIds: [...bf.cardIds, card.id],
+  });
+  state.cards.set(card.id, card);
+  return card.id;
+}
+
+function setLife(state: GameState, playerId: PlayerId, life: number): void {
+  const player = state.players.get(playerId)!;
+  player.life = life;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Parser: trigger condition / intervening-if / effect separation (CR 603.4)
+// ---------------------------------------------------------------------------
+describe("CR 603.4 — oracle parser separates trigger / intervening-if / effect", () => {
+  it("extracts an intervening-if from a 'When ~ enters, if ..., ...' trigger", () => {
+    const abilities = parseTriggeredAbilities(
+      "When ~ enters the battlefield, if you have 10 or less life, draw a card.",
+    );
+    expect(abilities).toHaveLength(1);
+    const a = abilities[0];
+    expect(a.trigger.event).toBe("entersBattlefield");
+    expect(a.interveningIf).toBe("you have 10 or less life");
+    // The if-clause must be stripped from the effect text.
+    expect(a.effect).toBe("draw a card");
+  });
+
+  it("extracts an intervening-if from an 'At ... upkeep, if ..., ...' trigger", () => {
+    // Real card: Test of Endurance.
+    const abilities = parseTriggeredAbilities(
+      "At the beginning of your upkeep, if you have 50 or more life, you win the game.",
+    );
+    expect(abilities).toHaveLength(1);
+    expect(abilities[0].trigger.event).toBe("upkeep");
+    expect(abilities[0].interveningIf).toBe("you have 50 or more life");
+    expect(abilities[0].effect).toBe("you win the game");
+  });
+
+  it("extracts a 'you control a <Type>' intervening-if", () => {
+    const abilities = parseTriggeredAbilities(
+      "Whenever a creature attacks, if you control a Knight, that creature gains trample until end of turn.",
+    );
+    expect(abilities).toHaveLength(1);
+    expect(abilities[0].trigger.event).toBe("attacked");
+    expect(abilities[0].interveningIf).toBe("you control a Knight");
+    expect(abilities[0].effect).toBe(
+      "that creature gains trample until end of turn",
+    );
+  });
+
+  it("leaves effect intact and interveningIf undefined for triggers without an if-clause", () => {
+    const abilities = parseTriggeredAbilities(
+      "When ~ enters the battlefield, draw a card.",
+    );
+    expect(abilities).toHaveLength(1);
+    expect(abilities[0].trigger.event).toBe("entersBattlefield");
+    expect(abilities[0].interveningIf).toBeUndefined();
+    expect(abilities[0].effect).toBe("draw a card");
+  });
+
+  it("does not treat a later-sentence 'If you do' as an intervening-if", () => {
+    // The 'If you do' lives in a separate sentence (after a period) so it must
+    // NOT be peeled off as an intervening-if.
+    const card = createMockCard({
+      oracle_text:
+        "When ~ enters the battlefield, exile target creature. If you do, draw a card.",
+    });
+    const result = parseOracleText(card);
+    const etb = result.triggeredAbilities.find(
+      (a) => a.trigger.event === "entersBattlefield",
+    );
+    expect(etb).toBeDefined();
+    expect(etb!.interveningIf).toBeUndefined();
+    expect(etb!.effect).toBe("exile target creature");
+  });
+
+  it("parses multiple abilities where only one has an intervening-if", () => {
+    const abilities = parseTriggeredAbilities(
+      "When ~ enters the battlefield, draw a card.\nAt the beginning of your upkeep, if you have 50 or more life, you win the game.",
+    );
+    expect(abilities.length).toBeGreaterThanOrEqual(2);
+    const withIf = abilities.find((a) => a.interveningIf);
+    expect(withIf?.interveningIf).toBe("you have 50 or more life");
+    const withoutIf = abilities.find((a) => !a.interveningIf);
+    expect(withoutIf).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. evaluateInterveningIfClause — recognized conditions + default-false
+// ---------------------------------------------------------------------------
+describe("evaluateInterveningIfClause — recognized conditions", () => {
+  let state: GameState;
+  let alice: PlayerId;
+  beforeEach(() => {
+    state = makeGame();
+    [alice] = playerIds(state);
+  });
+
+  it("'you have N or less life' tracks the controller's life", () => {
+    setLife(state, alice, 5);
+    expect(
+      evaluateInterveningIfClause("you have 10 or less life", state, alice),
+    ).toBe(true);
+    setLife(state, alice, 11);
+    expect(
+      evaluateInterveningIfClause("you have 10 or less life", state, alice),
+    ).toBe(false);
+  });
+
+  it("'you have N or more life'", () => {
+    setLife(state, alice, 60);
+    expect(
+      evaluateInterveningIfClause("you have 50 or more life", state, alice),
+    ).toBe(true);
+    setLife(state, alice, 20);
+    expect(
+      evaluateInterveningIfClause("you have 50 or more life", state, alice),
+    ).toBe(false);
+  });
+
+  it("'you control a Knight'", () => {
+    expect(
+      evaluateInterveningIfClause("you control a Knight", state, alice),
+    ).toBe(false);
+    placeOnBattlefield(
+      state,
+      createMockCard({ name: "Knight", type_line: "Creature — Human Knight" }),
+      alice,
+    );
+    expect(
+      evaluateInterveningIfClause("you control a Knight", state, alice),
+    ).toBe(true);
+  });
+
+  it("'you control N or more Mountains'", () => {
+    expect(
+      evaluateInterveningIfClause(
+        "you control 3 or more Mountains",
+        state,
+        alice,
+      ),
+    ).toBe(false);
+    for (let i = 0; i < 3; i++) {
+      placeOnBattlefield(
+        state,
+        createMockCard({
+          name: `Mountain${i}`,
+          type_line: "Basic Land — Mountain",
+        }),
+        alice,
+      );
+    }
+    expect(
+      evaluateInterveningIfClause(
+        "you control 3 or more Mountains",
+        state,
+        alice,
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for an unrecognized clause (CR 603.4 conservative)", () => {
+    // 'this turn' tracking is out of scope; the ability must NOT fire/resolve.
+    setLife(state, alice, 5);
+    expect(
+      evaluateInterveningIfClause(
+        "an opponent lost 3 or more life this turn",
+        state,
+        alice,
+      ),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Trigger-time gating — abilities path (detectTriggeredAbilities)
+// ---------------------------------------------------------------------------
+describe("CR 603.4 — trigger-time gating (detectTriggeredAbilities)", () => {
+  let state: GameState;
+  let alice: PlayerId;
+  beforeEach(() => {
+    state = makeGame();
+    [alice] = playerIds(state);
+    placeOnBattlefield(
+      state,
+      createMockCard({
+        name: "Lifekeeper",
+        oracle_text:
+          "When ~ enters the battlefield, if you have 10 or less life, draw a card.",
+      }),
+      alice,
+    );
+  });
+
+  it("fires when the intervening-if is true at the trigger event", () => {
+    setLife(state, alice, 5);
+    const triggers = detectTriggeredAbilities(state, "entersBattlefield");
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0].interveningIf).toBe("you have 10 or less life");
+  });
+
+  it("does NOT fire when the intervening-if is false at the trigger event", () => {
+    setLife(state, alice, 20);
+    const triggers = detectTriggeredAbilities(state, "entersBattlefield");
+    expect(triggers).toHaveLength(0);
+  });
+
+  it("does not affect triggers without an intervening-if (no regression)", () => {
+    const plain = makeGame();
+    const [a] = playerIds(plain);
+    placeOnBattlefield(
+      plain,
+      createMockCard({
+        name: "Cantrip Dude",
+        oracle_text: "When ~ enters the battlefield, draw a card.",
+      }),
+      a,
+    );
+    setLife(plain, a, 20); // any life
+    expect(detectTriggeredAbilities(plain, "entersBattlefield")).toHaveLength(
+      1,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Trigger-time gating — trigger-system path (detectTurnStartTriggers)
+//    This also proves getTriggeredAbilitiesFromCard now delegates to the oracle
+//    parser (issue #1057 acceptance criterion).
+// ---------------------------------------------------------------------------
+describe("CR 603.4 — trigger-time gating (detectTurnStartTriggers, parser delegation)", () => {
+  let state: GameState;
+  let alice: PlayerId;
+  beforeEach(() => {
+    state = makeGame();
+    [alice] = playerIds(state);
+    placeOnBattlefield(
+      state,
+      createMockCard({
+        name: "Test of Endurance",
+        type_line: "Enchantment",
+        oracle_text:
+          "At the beginning of your upkeep, if you have 50 or more life, you win the game.",
+      }),
+      alice,
+    );
+  });
+
+  it("fires when the intervening-if is true at the trigger event", () => {
+    setLife(state, alice, 60);
+    expect(detectTurnStartTriggers(state, alice)).toHaveLength(1);
+  });
+
+  it("does NOT fire when the intervening-if is false at the trigger event", () => {
+    setLife(state, alice, 20);
+    expect(detectTurnStartTriggers(state, alice)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Resolution re-check / fizzle (CR 603.4 second check)
+// ---------------------------------------------------------------------------
+function abilityOnStack(
+  state: GameState,
+  controllerId: PlayerId,
+  opts: { interveningIf?: string; effectAmount?: number },
+): GameState {
+  const stackObject: StackObject = {
+    id: `ability-${Math.random().toString(36).substr(2, 9)}`,
+    type: "ability",
+    sourceCardId: null,
+    controllerId,
+    name: "triggered ability",
+    text: "gain life",
+    manaCost: null,
+    targets: [],
+    chosenModes: [],
+    variableValues: new Map(),
+    isCountered: false,
+    timestamp: Date.now(),
+    effects: [
+      {
+        effectType: "life_gain",
+        amount: opts.effectAmount ?? 2,
+        targetId: controllerId,
+      },
+    ],
+    interveningIf: opts.interveningIf,
+  };
+  return { ...state, stack: [...state.stack, stackObject] };
+}
+
+describe("CR 603.4 — resolution re-check (resolveTopOfStack fizzle)", () => {
+  let state: GameState;
+  let alice: PlayerId;
+  beforeEach(() => {
+    state = makeGame();
+    [alice] = playerIds(state);
+  });
+
+  it("applies the effect when the intervening-if is still true at resolution", () => {
+    setLife(state, alice, 5);
+    const withTrigger = abilityOnStack(state, alice, {
+      interveningIf: "you have 10 or less life",
+    });
+    const resolved = resolveTopOfStack(withTrigger);
+    // 5 + 2 (life_gain) = 7
+    expect(state.players.get(alice)!.life).toBe(5);
+    expect(resolved.players.get(alice)!.life).toBe(7);
+    expect(resolved.stack).toHaveLength(0);
+  });
+
+  it("fizzles (no effect) when the intervening-if is false at resolution", () => {
+    setLife(state, alice, 20);
+    const withTrigger = abilityOnStack(state, alice, {
+      interveningIf: "you have 10 or less life",
+    });
+    const resolved = resolveTopOfStack(withTrigger);
+    expect(resolved.players.get(alice)!.life).toBe(20); // unchanged
+    expect(resolved.stack).toHaveLength(0); // removed (fizzled)
+  });
+
+  it("resolves normally when there is no intervening-if (no regression)", () => {
+    setLife(state, alice, 20);
+    const withTrigger = abilityOnStack(state, alice, {
+      interveningIf: undefined,
+    });
+    const resolved = resolveTopOfStack(withTrigger);
+    expect(resolved.players.get(alice)!.life).toBe(22); // 20 + 2
+    expect(resolved.stack).toHaveLength(0);
+  });
+});

--- a/src/lib/game-state/abilities.ts
+++ b/src/lib/game-state/abilities.ts
@@ -115,6 +115,13 @@ export interface TriggeredAbilityInstance {
    * Context information about the trigger event (CR 603.2)
    */
   context?: TriggerContext;
+  /**
+   * An intervening "if" clause (CR 603.4) parsed from the trigger text, e.g.
+   * "When ~ enters the battlefield, if [condition], [effect]". Carried from the
+   * parsed ability onto the stack object so the condition can be re-checked at
+   * resolution time (the ability fizzles if it is no longer true).
+   */
+  interveningIf?: string;
 }
 
 /**
@@ -782,12 +789,13 @@ export function detectTriggeredAbilities(
           break;
       }
 
-      // Apply additional conditions based on trigger type (CR 603.2)
+      // CR 603.4 — intervening "if" clause: the ability only triggers when the
+      // clause is true at the moment the trigger event occurs.
       if (shouldTrigger && ability.interveningIf) {
-        // Handle "when X if Y" clauses - check condition
-        shouldTrigger = evaluateInterveningIf(
+        shouldTrigger = evaluateInterveningIfClause(
           ability.interveningIf,
           state,
+          card.controllerId,
           card,
           context,
         );
@@ -804,6 +812,7 @@ export function detectTriggeredAbilities(
           timestamp: Date.now(),
           sourceCardTimestamp,
           context,
+          interveningIf: ability.interveningIf,
         });
       }
     }
@@ -864,37 +873,133 @@ export function detectTriggeredAbilities(
 }
 
 /**
- * Evaluate an intervening "if" condition for a triggered ability (CR 603.2)
- * Intervening if clauses are conditions that must be true at the time of trigger
- * Example: "When X enters the battlefield, if Y, draw a card."
+ * Evaluate a CR 603.4 intervening "if" clause against the current game state.
+ *
+ * An intervening-if must be true BOTH when the ability would trigger AND when it
+ * would resolve; this single evaluator is therefore called at both points. The
+ * `controllerId` is the controller of the source card (the "you" in the clause).
+ *
+ * Recognised condition families (CR 603.4):
+ *  - Life total: "you have N or less life", "you have N or more life",
+ *    "your life total is N or less/greater".
+ *  - Poison: "you have N or more/fewer poison counters".
+ *  - Hand size: "you have N or more/fewer cards in hand".
+ *  - Permanents controlled: "you control a/an <Type>",
+ *    "you control N or more <Type>(s)", and their negations
+ *    ("you control no <Type>" / "you don't control a/an <Type>").
+ *
+ * For any clause that cannot be evaluated the function returns `false`. Per CR
+ * 603.4 an intervening-if that is not verifiably true must NOT let the ability
+ * fire or resolve, so defaulting to `false` is the rules-correct, conservative
+ * choice (the previous implementation defaulted to `true`, which let triggers
+ * fire illegally). The set of recognised conditions is intentionally limited;
+ * extending it only requires adding a new branch here.
  */
-function evaluateInterveningIf(
+export function evaluateInterveningIfClause(
   condition: string,
   state: GameState,
-  _card: CardInstance,
-  context?: TriggerContext,
+  controllerId: PlayerId,
+  _sourceCard?: CardInstance,
+  _context?: TriggerContext,
 ): boolean {
-  const lowerCondition = condition.toLowerCase();
+  const c = condition.toLowerCase().trim();
 
-  // Check life total conditions
-  // Example: "if you have 10 or less life"
-  const lifeMatch = lowerCondition.match(/you have (\d+) or less life/);
-  if (lifeMatch) {
-    const threshold = parseInt(lifeMatch[1], 10);
-    // The triggering player is the controller of the card with this trigger
-    // We need to find the controller - for now, check the context player
-    const playerId = context?.lifeLostPlayer || state.turn.activePlayerId;
-    const player = state.players.get(playerId);
-    if (player) {
-      return player.life <= threshold;
-    }
-    return false;
+  // Negation handling: detect leading "no" / "don't" forms up front so the
+  // affirmative matchers below can be inverted.
+  const negate = /^(you (?:do not|don't) control|you control no)\b/.test(c);
+
+  // --- Life total ---------------------------------------------------------
+  let m = c.match(/you have (\d+) or less life/);
+  if (m) {
+    const player = state.players.get(controllerId);
+    return player ? player.life <= parseInt(m[1], 10) : false;
+  }
+  m = c.match(/you have (\d+) or more life/);
+  if (m) {
+    const player = state.players.get(controllerId);
+    return player ? player.life >= parseInt(m[1], 10) : false;
+  }
+  m = c.match(/your life total is (\d+) or less/);
+  if (m) {
+    const player = state.players.get(controllerId);
+    return player ? player.life <= parseInt(m[1], 10) : false;
+  }
+  m = c.match(/your life total is (\d+) or (?:greater|more)/);
+  if (m) {
+    const player = state.players.get(controllerId);
+    return player ? player.life >= parseInt(m[1], 10) : false;
   }
 
-  // Check other conditions - for now, default to true
-  // This is a simplified implementation; full implementation would need
-  // to handle all possible intervening if conditions
-  return true;
+  // --- Poison counters ----------------------------------------------------
+  m = c.match(/you have (\d+) or more poison counters/);
+  if (m) {
+    const player = state.players.get(controllerId);
+    return player ? player.poisonCounters >= parseInt(m[1], 10) : false;
+  }
+  m = c.match(/you have (\d+) or (?:fewer|less) poison counters/);
+  if (m) {
+    const player = state.players.get(controllerId);
+    return player ? player.poisonCounters <= parseInt(m[1], 10) : false;
+  }
+
+  // --- Cards in hand ------------------------------------------------------
+  m = c.match(/you have (\d+) or more cards in (?:your )?hand/);
+  if (m) {
+    const zone = state.zones.get(`${controllerId}-hand`);
+    return zone ? zone.cardIds.length >= parseInt(m[1], 10) : false;
+  }
+  m = c.match(/you have (\d+) or (?:fewer|less) cards in (?:your )?hand/);
+  if (m) {
+    const zone = state.zones.get(`${controllerId}-hand`);
+    return zone ? zone.cardIds.length <= parseInt(m[1], 10) : false;
+  }
+
+  // --- Permanents you control --------------------------------------------
+  // "you control N or more <Type>(s)"
+  m = c.match(/you control (\d+) or more (\w+?)(?:s)?(?:\b|$)/);
+  if (m) {
+    const result =
+      countControlledByType(state, controllerId, m[2]) >= parseInt(m[1], 10);
+    return result;
+  }
+  // "you control a/an <Type>" (and its negation handled above)
+  m = c.match(/^you control (?:an?|another)\s+(\w+?)\b/);
+  if (m) {
+    const result = countControlledByType(state, controllerId, m[1]) >= 1;
+    return negate ? !result : result;
+  }
+  // Explicit negation without an affirmative matcher above ("you control no
+  // <Type>" / "you don't control a/an <Type>").
+  m = c.match(
+    /(?:you control no|you do not control a|you don't control an?)\s+(\w+?)\b/,
+  );
+  if (m) {
+    return countControlledByType(state, controllerId, m[1]) === 0;
+  }
+
+  // Unrecognised clause: conservatively do NOT let the ability fire/resolve
+  // (CR 603.4). Add a dedicated branch above to support new condition families.
+  return false;
+}
+
+/**
+ * Count permanents `playerId` controls on the battlefield whose type line
+ * contains `type` (case-insensitive). Used by intervening-if control checks.
+ */
+function countControlledByType(
+  state: GameState,
+  playerId: PlayerId,
+  type: string,
+): number {
+  const needle = type.toLowerCase();
+  let count = 0;
+  for (const [cardId, card] of state.cards) {
+    if (!isOnBattlefield(state, cardId)) continue;
+    if (card.controllerId !== playerId) continue;
+    const typeLine = (card.cardData.type_line || "").toLowerCase();
+    if (typeLine.includes(needle)) count++;
+  }
+  return count;
 }
 
 /**
@@ -933,6 +1038,7 @@ export function checkTriggeredAbilities(
       variableValues: new Map(),
       isCountered: false,
       timestamp: trigger.timestamp,
+      interveningIf: trigger.interveningIf,
     };
 
     const updatedStack = [...currentState.stack, stackObject];

--- a/src/lib/game-state/oracle-text-parser.ts
+++ b/src/lib/game-state/oracle-text-parser.ts
@@ -963,6 +963,30 @@ function parseEffect(
  *
  * Triggered abilities use "when", "whenever", or "at"
  */
+/**
+ * Extract a CR 603.4 intervening "if" clause from the start of an effect text.
+ *
+ * A triggered ability of the form "When/Whenever/At [trigger], if [condition],
+ * [effect]" carries an intervening-if clause. The clause sits immediately after
+ * the trigger condition's comma and is itself followed by a comma. This helper
+ * splits a leading "if <condition>," off the effect text, returning the raw
+ * condition (for evaluation at trigger time AND resolution time, per CR 603.4)
+ * and the remaining effect.
+ *
+ * Returns `interveningIf: undefined` when the text does not begin with an
+ * intervening-if, so ordinary triggers are unaffected.
+ */
+function extractInterveningIfClause(effectText: string): {
+  interveningIf?: string;
+  effect: string;
+} {
+  const match = effectText.match(/^\s*if\s+(.+?),\s*(.+)/i);
+  if (match) {
+    return { interveningIf: match[1].trim(), effect: match[2].trim() };
+  }
+  return { effect: effectText.trim() };
+}
+
 export function parseTriggeredAbilities(
   oracleText: string,
 ): ParsedTriggeredAbility[] {
@@ -980,10 +1004,14 @@ export function parseTriggeredAbilities(
     const atMatch = sentence.match(/\bat\s+(?:the\s+)?(.+?),?\s*,\s*(.+)/i);
 
     if (whenMatch) {
-      const [, , triggerText, effectText] = whenMatch;
+      const [, , triggerText, rawEffect] = whenMatch;
       const trigger = parseTriggerText(triggerText);
 
       if (trigger) {
+        // CR 603.4: peel a leading "if <condition>," off the effect so it can be
+        // gated at trigger time and re-checked at resolution.
+        const { interveningIf, effect: effectText } =
+          extractInterveningIfClause(rawEffect);
         const effect = parseEffect(effectText);
         abilities.push({
           type: AbilityType.TRIGGERED,
@@ -992,13 +1020,16 @@ export function parseTriggeredAbilities(
           effectType: effect?.effectType || "generic",
           targets: effect?.targets || [],
           value: effect?.value,
+          interveningIf,
         });
       }
     } else if (atMatch) {
-      const [, triggerText, effectText] = atMatch;
+      const [, triggerText, rawEffect] = atMatch;
       const trigger = parseTriggerText(triggerText);
 
       if (trigger) {
+        const { interveningIf, effect: effectText } =
+          extractInterveningIfClause(rawEffect);
         const effect = parseEffect(effectText);
         abilities.push({
           type: AbilityType.TRIGGERED,
@@ -1007,6 +1038,7 @@ export function parseTriggeredAbilities(
           effectType: effect?.effectType || "generic",
           targets: effect?.targets || [],
           value: effect?.value,
+          interveningIf,
         });
       }
     }
@@ -1080,6 +1112,11 @@ function parseTriggerText(triggerText: string): TriggerCondition | null {
   // End of turn
   if (text.includes("end of turn")) {
     return { event: "turnEnds" };
+  }
+
+  // Untap step — "At the beginning of your untap step" (CR 502.3)
+  if (text.includes("untap step") || text.includes("beginning of your untap")) {
+    return { event: "untapStep" };
   }
 
   // Upkeep

--- a/src/lib/game-state/spell-casting.ts
+++ b/src/lib/game-state/spell-casting.ts
@@ -38,7 +38,10 @@ import {
   isSplitCard,
   getSplitCardHalves,
 } from "./oracle-text-parser";
-import { checkTriggeredAbilities } from "./abilities";
+import {
+  checkTriggeredAbilities,
+  evaluateInterveningIfClause,
+} from "./abilities";
 import { detectStormTrigger, detectProwessTriggers } from "./trigger-system";
 import { completeHandTargeting } from "./hand-targeting";
 import { destroyCard, createTokenCard } from "./keyword-actions";
@@ -760,6 +763,28 @@ export function resolveTopOfStack(state: GameState): GameState {
   const wardResult = applyWardResolution(state, stackObject);
   if (wardResult.countered) {
     return removeFromStack(state, stackObject.id);
+  }
+
+  // CR 603.4 — intervening "if" clause re-check at resolution. A triggered
+  // ability ("When/Whenever/At X, if Y, Z") only triggers when Y is true at the
+  // trigger event, AND when it would resolve Y is checked again: if it is no
+  // longer true the ability is removed from the stack and does nothing. The
+  // clause was carried onto the StackObject when the trigger was put on the
+  // stack; re-evaluate it against the current (resolution-time) game state.
+  if (stackObject.type === "ability" && stackObject.interveningIf) {
+    const sourceCard = stackObject.sourceCardId
+      ? state.cards.get(stackObject.sourceCardId)
+      : undefined;
+    if (
+      !evaluateInterveningIfClause(
+        stackObject.interveningIf,
+        state,
+        stackObject.controllerId,
+        sourceCard,
+      )
+    ) {
+      return removeFromStack(state, stackObject.id);
+    }
   }
 
   let currentState = state;

--- a/src/lib/game-state/trigger-system.ts
+++ b/src/lib/game-state/trigger-system.ts
@@ -25,7 +25,9 @@ import type {
 import { Phase, ZoneType, isOnBattlefield } from "./types";
 import { isCreature } from "./card-instance";
 import type { TriggeredAbilityInstance } from "./abilities";
+import { evaluateInterveningIfClause } from "./abilities";
 import { hasProwess, getProwessInstanceCount } from "./evergreen-keywords";
+import { parseTriggeredAbilities } from "./oracle-text-parser";
 
 /**
  * Trigger condition types for the new trigger system
@@ -127,6 +129,7 @@ export function detectTurnStartTriggers(
           effect: ability.effect,
           timestamp: Date.now(),
           sourceCardTimestamp: card.enteredBattlefieldTimestamp,
+          interveningIf: ability.interveningIf,
           context: context as any, // Cast to existing TriggerContext type
         });
       }
@@ -185,6 +188,7 @@ export function detectUntapStepTriggers(
           effect: ability.effect,
           timestamp: Date.now(),
           sourceCardTimestamp: card.enteredBattlefieldTimestamp,
+          interveningIf: ability.interveningIf,
           context: context as any,
         });
       }
@@ -240,6 +244,7 @@ export function detectTurnEndTriggers(
           effect: ability.effect,
           timestamp: Date.now(),
           sourceCardTimestamp: card.enteredBattlefieldTimestamp,
+          interveningIf: ability.interveningIf,
           context: context as any,
         });
       }
@@ -383,6 +388,7 @@ export function detectDamageTriggers(
           effect: ability.effect,
           timestamp: Date.now(),
           sourceCardTimestamp: card.enteredBattlefieldTimestamp,
+          interveningIf: ability.interveningIf,
           context: context as any,
         });
       }
@@ -439,6 +445,7 @@ export function detectCreatureDeathTriggers(
           effect: ability.effect,
           timestamp: Date.now(),
           sourceCardTimestamp: card.enteredBattlefieldTimestamp,
+          interveningIf: ability.interveningIf,
           context: context as any,
         });
       }
@@ -522,6 +529,7 @@ export function detectLifeLossTriggers(
           effect: ability.effect,
           timestamp: Date.now(),
           sourceCardTimestamp: card.enteredBattlefieldTimestamp,
+          interveningIf: ability.interveningIf,
           context: context as any,
         });
       }
@@ -591,6 +599,7 @@ export function detectSpellCastTriggers(
           effect: ability.effect,
           timestamp: Date.now(),
           sourceCardTimestamp: card.enteredBattlefieldTimestamp,
+          interveningIf: ability.interveningIf,
           context: context as any,
         });
       }
@@ -740,6 +749,7 @@ export function detectStateTriggers(
           effect: ability.effect,
           timestamp: Date.now(),
           sourceCardTimestamp: card.enteredBattlefieldTimestamp,
+          interveningIf: ability.interveningIf,
           context: context as any,
         });
       }
@@ -777,6 +787,7 @@ export function putTriggersOnStack(
       variableValues: new Map(),
       isCountered: false,
       timestamp: trigger.timestamp,
+      interveningIf: trigger.interveningIf,
     };
 
     currentState = {
@@ -851,67 +862,19 @@ function sortTriggersAPNAP(
 }
 
 /**
- * Evaluate a state condition for intervening "if" clauses
- * Example: "if you have 10 or less life"
+ * Evaluate an intervening "if" clause for the trigger-system detect functions.
+ *
+ * Delegates to the shared {@link evaluateInterveningIfClause} in `abilities.ts`
+ * so the trigger-time gate (CR 603.4) uses exactly the same logic as the
+ * resolution-time re-check, and so that an unrecognised clause evaluates to
+ * `false` rather than the previous (illegal) `true`.
  */
 function evaluateStateCondition(
   condition: string,
   state: GameState,
   playerId: PlayerId,
 ): boolean {
-  const lowerCondition = condition.toLowerCase();
-
-  // Life total conditions
-  const lifeMatch = lowerCondition.match(/you have (\d+) or less life/);
-  if (lifeMatch) {
-    const threshold = parseInt(lifeMatch[1], 10);
-    const player = state.players.get(playerId);
-    if (player) {
-      return player.life <= threshold;
-    }
-    return false;
-  }
-
-  // Life total conditions (alternative phrasing)
-  const lifeMatch2 = lowerCondition.match(/your life total is (\d+) or less/);
-  if (lifeMatch2) {
-    const threshold = parseInt(lifeMatch2[1], 10);
-    const player = state.players.get(playerId);
-    if (player) {
-      return player.life <= threshold;
-    }
-    return false;
-  }
-
-  // Poison counter conditions
-  const poisonMatch = lowerCondition.match(
-    /you have (\d+) or more poison counters/,
-  );
-  if (poisonMatch) {
-    const threshold = parseInt(poisonMatch[1], 10);
-    const player = state.players.get(playerId);
-    if (player) {
-      return player.poisonCounters >= threshold;
-    }
-    return false;
-  }
-
-  // Cards in hand conditions
-  const handMatch = lowerCondition.match(
-    /you have (\d+) or more cards in hand/,
-  );
-  if (handMatch) {
-    const threshold = parseInt(handMatch[1], 10);
-    const handZone = state.zones.get(`${playerId}-hand`);
-    if (handZone) {
-      return handZone.cardIds.length >= threshold;
-    }
-    return false;
-  }
-
-  // Default to true if condition not recognized
-  // Full implementation would handle all possible conditions
-  return true;
+  return evaluateInterveningIfClause(condition, state, playerId);
 }
 
 /**
@@ -960,110 +923,28 @@ interface ParsedAbility {
 }
 
 /**
- * Get triggered abilities from card data
- * This is a simplified version - in production would use proper oracle text parsing
+ * Get triggered abilities from card data.
+ *
+ * Detection is delegated to {@link parseTriggeredAbilities} in
+ * `oracle-text-parser.ts` (resolves issue #1057): the previous implementation
+ * used a single inline regex that could not separate the trigger condition,
+ * the CR 603.4 intervening "if" clause, and the effect. The shared parser now
+ * produces typed `{ trigger, effect, interveningIf }` objects, including the
+ * intervening-if clause which the detect functions gate on at trigger time and
+ * which is re-checked at resolution (CR 603.4).
  */
 function getTriggeredAbilitiesFromCard(
   cardData: CardInstance["cardData"],
 ): ParsedAbility[] {
-  const abilities: ParsedAbility[] = [];
-  const oracleText = cardData.oracle_text || "";
-
-  // Simple pattern matching for triggered abilities
-  // This would be replaced with proper oracle text parsing in production
-
-  // Match "When X..." / "Whenever X..." / "At X..."
-  // Require a comma separator between the trigger clause and its effect (standard
-  // MTG oracle wording). The clause is group 2, the effect is group 3.
-  const triggerRegex = /(when|whenever|at)\s+(.+?),\s*(.+?)(?:\.|$)/gi;
-  let match;
-
-  while ((match = triggerRegex.exec(oracleText)) !== null) {
-    const [, , triggerClause, effect] = match;
-
-    // Parse trigger clause
-    if (
-      triggerClause.includes("enters the battlefield") ||
-      triggerClause.includes("enters battlefield")
-    ) {
-      abilities.push({
-        trigger: { event: "entersBattlefield" },
-        effect: effect.trim(),
-      });
-    } else if (
-      triggerClause.includes("leaves the battlefield") ||
-      triggerClause.includes("leaves battlefield")
-    ) {
-      abilities.push({
-        trigger: { event: "leavesBattlefield" },
-        effect: effect.trim(),
-      });
-    } else if (
-      triggerClause.includes("dies") ||
-      triggerClause.includes("creature dies")
-    ) {
-      abilities.push({
-        trigger: { event: "dies" },
-        effect: effect.trim(),
-      });
-    } else if (
-      triggerClause.includes("deals damage") ||
-      triggerClause.includes("deal damage")
-    ) {
-      abilities.push({
-        trigger: { event: "damageDealt" },
-        effect: effect.trim(),
-      });
-    } else if (
-      triggerClause.includes("beginning of your untap") ||
-      triggerClause.includes("beginning of your untap step")
-    ) {
-      abilities.push({
-        trigger: { event: "untapStep" },
-        effect: effect.trim(),
-      });
-    } else if (
-      triggerClause.includes("beginning of your upkeep") ||
-      triggerClause.includes("at the beginning")
-    ) {
-      abilities.push({
-        trigger: { event: "upkeep" },
-        effect: effect.trim(),
-      });
-    } else if (
-      triggerClause.includes("end of turn") ||
-      triggerClause.includes("at end of turn")
-    ) {
-      abilities.push({
-        trigger: { event: "endOfTurn" },
-        effect: effect.trim(),
-      });
-    } else if (
-      triggerClause.includes("you lose life") ||
-      triggerClause.includes("loses life")
-    ) {
-      abilities.push({
-        trigger: { event: "lifeLost" },
-        effect: effect.trim(),
-      });
-    } else if (
-      triggerClause.includes("you gain life") ||
-      triggerClause.includes("gains life")
-    ) {
-      abilities.push({
-        trigger: { event: "lifeGain" },
-        effect: effect.trim(),
-      });
-    } else if (
-      triggerClause.includes("you cast") ||
-      triggerClause.includes("cast a")
-    ) {
-      abilities.push({
-        trigger: { event: "spellCast" },
-        effect: effect.trim(),
-      });
-    }
-  }
-
-  return abilities;
+  return parseTriggeredAbilities(cardData.oracle_text || "").map((parsed) => ({
+    trigger: {
+      event: parsed.trigger.event,
+      source: parsed.trigger.source,
+      // The oracle parser does not emit a spellType; leaving it undefined makes
+      // the spellCast detect branch fall back to "matches any spell".
+      spellType: undefined,
+    },
+    effect: parsed.effect,
+    interveningIf: parsed.interveningIf,
+  }));
 }

--- a/src/lib/game-state/types.ts
+++ b/src/lib/game-state/types.ts
@@ -514,6 +514,17 @@ export interface StackObject {
    * copy simply ceases to exist (see `resolveCopyCompletion`).
    */
   isCopy?: boolean;
+  /**
+   * Intervening "if" clause (CR 603.4).
+   *
+   * Set on a triggered ability's StackObject when its Oracle text is of the form
+   * "When/Whenever/At [trigger], if [condition], [effect]". The condition must be
+   * true when the ability is put on the stack AND is re-checked when it would
+   * resolve; if it is no longer true the ability is removed from the stack and
+   * does nothing (it "fizzles"). See `resolveTopOfStack` in spell-casting.ts and
+   * `evaluateInterveningIfClause` in abilities.ts.
+   */
+  interveningIf?: string;
   /** Structured effects to resolve (CR 608) */
   effects?: StackEffect[];
 }


### PR DESCRIPTION
## Summary

Replaces the naive inline regex trigger parser and enforces CR 603.4 intervening \"if\" clauses at **both** trigger time and resolution time. Previously the parser lumped the if-clause into the effect text and the intervening-if evaluator defaulted to `true`, so any `\"When ~ enters, if [cond], [effect]\"` ability fired even when the condition was false.

Resolves #1057.

## Parser (oracle-text-parser.ts)

- New `extractInterveningIfClause()` peels a leading `\"if <condition>,\"` off the effect of a `When/Whenever/At` trigger, producing typed `{ trigger, effect, interveningIf }` objects. The if-clause is no longer part of the effect string.
- A later-sentence `\"If you do, ...\"` (after a period) is **not** treated as an intervening-if.
- Added the missing **untap-step** detection to `parseTriggerText` (`\"At the beginning of your untap step\"` -> `untapStep`); this event was handled by the old inline regex but absent from the shared parser, so the delegation below would otherwise have been a regression.

## Trigger system (trigger-system.ts)

- `getTriggeredAbilitiesFromCard` no longer uses a hand-rolled regex; it **delegates to `parseTriggeredAbilities`** (oracle-text-parser) and maps results onto the local `ParsedAbility` shape (issue acceptance criterion).
- `evaluateStateCondition` now delegates to the single shared `evaluateInterveningIfClause` (abilities.ts), so the trigger-time gate uses exactly the same logic as the resolution re-check and no longer defaults to `true`.
- The intervening-if is carried from the parsed ability -> `TriggeredAbilityInstance` (all 8 generic detect functions) -> the `StackObject` created by `putTriggersOnStack`.

## Gating (abilities.ts)

- New exported `evaluateInterveningIfClause(condition, state, controllerId, sourceCard?, context?)` evaluates the clause against game state. **Recognized conditions:**
  - Life: `\"you have N or less/more life\"`, `\"your life total is N or less/greater\"`
  - Poison: `\"you have N or more/fewer poison counters\"`
  - Hand: `\"you have N or more/fewer cards in hand\"`
  - Permanents controlled: `\"you control a/an <Type>\"`, `\"you control N or more <Type>(s)\"`, and negations (`\"you control no <Type>\"`)
- `TriggeredAbilityInstance` and the stack object in `checkTriggeredAbilities` now carry `interveningIf`.
- For an **unrecognized** clause the evaluator returns `false` (CR 603.4 conservative) instead of the previous illegal `true` — an unverifiable condition must not let an ability fire/resolve.

## Resolution re-check (spell-casting.ts + types.ts)

- `StackObject` gains an optional `interveningIf` field.
- `resolveTopOfStack` re-checks the clause for `type: \"ability\"` objects before applying effects; if it is no longer true the ability is removed from the stack with no effect (it **fizzles**, CR 603.4 second check).

## Conditions in scope / out of scope

- **In scope (evaluated):** life-total thresholds, poison counters, hand-size counts, and `\"you control a/N <permanent type>\"` checks.
- **Out of scope (evaluate to `false` until added):** `\"... this turn\"` tracking (e.g. life lost / cards drawn this turn), devotion, power/toughness thresholds, `\"this creature has ...\"`. These parse correctly (the if-clause is separated) and are correctly *gated* — they simply won't fire until a dedicated branch is added to `evaluateInterveningIfClause`. The framework is the deliverable.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — pass (0 errors)
- `npx jest game-state` — **113 suites, 2663 passed, 4 skipped, 0 failed**
- New suite `intervening-if-clauses.test.ts` — 19 tests covering: parse separation, trigger-time gating (false-at-trigger does not fire / true fires), resolution re-check (true resolves / false fizzles / no-if unaffected), no-regression for triggers without an if-clause, and the parser-delegation path (`detectTurnStartTriggers`).

### Acceptance criteria
- [x] Trigger parsing separates trigger-condition / intervening-if / effect
- [x] Intervening-if enforced at **trigger time** (false-at-ETB does not go on the stack)
- [x] Intervening-if re-checked at **resolution** (fizzles if no longer true)
- [x] Triggers **without** an intervening-if behave as before (no regression; full game-state suite green)
- [x] `getTriggeredAbilitiesFromCard` delegates detection to `oracle-text-parser.ts`
- [x] Tests: false-at-trigger, false-at-resolution (fizzle), true-both, no-if, representative real oracle text

### Note on scope
Removing the deprecated `checkTriggeredAbilities` (the #763 migration) is **not** included: it is still wired into `spell-casting.ts` and a large number of tests, so removing it is a separate, higher-risk change. `checkTriggeredAbilities` now honors the intervening-if correctly (it routes through the same gating) and is consistent with the rest of the system.