### PR TITLE
feat(p2p): resolve #988 — P2P reconnection UI with user-facing messaging

### DIFF
--- a/src/app/(app)/multiplayer/page.tsx
+++ b/src/app/(app)/multiplayer/page.tsx
@@ -20,7 +20,6 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { P2PDiagnosticsPanel } from "@/components/p2p-diagnostics-panel";
-import { P2PReconnectionStatusSection } from "@/components/p2p-reconnection-status-section";
 
 export default function MultiplayerPage() {
   return (
@@ -222,40 +221,6 @@ export default function MultiplayerPage() {
         aria-label="Peer-to-peer connection diagnostics"
       >
         <P2PDiagnosticsPanel />
-      </section>
-
-      <section
-        className="mt-6"
-        aria-label="Peer-to-peer reconnection status"
-        data-testid="p2p-reconnection-status-section"
-      >
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Wifi className="w-5 h-5" />
-              P2P Reconnection Status
-            </CardTitle>
-            <CardDescription>
-              Live feedback when a peer-to-peer connection drops and recovers
-              (issue #988). Mount this section on the active game board to see
-              reconnect attempts, recovery confirmations, and the recovery
-              prompt on terminal failure.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <P2PReconnectionStatusSection
-              playerId="lobby-preview"
-              playerName="Lobby Preview"
-              role="host"
-            />
-            <p className="text-sm text-muted-foreground">
-              The section is wired against a placeholder session and stays
-              hidden while the connection is stable. Once an active game is in
-              progress, replace these props with the live player identity and
-              role.
-            </p>
-          </CardContent>
-        </Card>
       </section>
     </div>
   );

--- a/src/app/(app)/multiplayer/page.tsx
+++ b/src/app/(app)/multiplayer/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { P2PDiagnosticsPanel } from "@/components/p2p-diagnostics-panel";
+import { P2PReconnectionStatusSection } from "@/components/p2p-reconnection-status-section";
 
 export default function MultiplayerPage() {
   return (
@@ -221,6 +222,40 @@ export default function MultiplayerPage() {
         aria-label="Peer-to-peer connection diagnostics"
       >
         <P2PDiagnosticsPanel />
+      </section>
+
+      <section
+        className="mt-6"
+        aria-label="Peer-to-peer reconnection status"
+        data-testid="p2p-reconnection-status-section"
+      >
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Wifi className="w-5 h-5" />
+              P2P Reconnection Status
+            </CardTitle>
+            <CardDescription>
+              Live feedback when a peer-to-peer connection drops and recovers
+              (issue #988). Mount this section on the active game board to see
+              reconnect attempts, recovery confirmations, and the recovery
+              prompt on terminal failure.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <P2PReconnectionStatusSection
+              playerId="lobby-preview"
+              playerName="Lobby Preview"
+              role="host"
+            />
+            <p className="text-sm text-muted-foreground">
+              The section is wired against a placeholder session and stays
+              hidden while the connection is stable. Once an active game is in
+              progress, replace these props with the live player identity and
+              role.
+            </p>
+          </CardContent>
+        </Card>
       </section>
     </div>
   );

--- a/src/components/__tests__/p2p-reconnection-status.test.tsx
+++ b/src/components/__tests__/p2p-reconnection-status.test.tsx
@@ -1,0 +1,314 @@
+/**
+ * P2PReconnectionStatus component tests — issue #988.
+ *
+ * Covers each lifecycle phase with the exact messaging required by the
+ * acceptance criteria:
+ *   - stable       → renders nothing
+ *   - lost         → "Connection lost" with attempt badge
+ *   - reconnecting → "Reconnecting…" with attempt badge + spinner
+ *   - recovered    → transient "Reconnected" banner (auto-dismiss verified)
+ *   - failed       → "Reconnection failed" with [continue/save/abandon] and
+ *                    actionable failure diagnostic surfaced
+ *
+ * Also asserts:
+ *   - Accessible live regions (aria-live) for status transitions.
+ *   - No native alert/confirm is used (#1100/#1150 regression guard).
+ *   - The recovery prompt hands off to the existing degrade flow via
+ *     callbacks — does not invent a parallel state machine.
+ */
+
+import { act, render, screen, fireEvent } from "@testing-library/react";
+
+import { P2PReconnectionStatus } from "../p2p-reconnection-status";
+
+describe("P2PReconnectionStatus (#988)", () => {
+  const noop = () => {};
+
+  it("renders nothing during the stable phase", () => {
+    const { container } = render(
+      <P2PReconnectionStatus
+        reconnectionPhase="stable"
+        connectionState="connected"
+        reconnectAttempts={0}
+        maxReconnectAttempts={3}
+        connectionFailureReason={null}
+        onContinueLocally={noop}
+        onSaveForResume={noop}
+        onAbandon={noop}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the "Connection lost" banner with attempt count on the lost phase', () => {
+    render(
+      <P2PReconnectionStatus
+        reconnectionPhase="lost"
+        connectionState="disconnected"
+        reconnectAttempts={2}
+        maxReconnectAttempts={3}
+        connectionFailureReason={null}
+        onContinueLocally={noop}
+        onSaveForResume={noop}
+        onAbandon={noop}
+      />,
+    );
+    expect(screen.getByTestId("p2p-reconnection-status")).toHaveAttribute(
+      "data-reconnection-phase",
+      "lost",
+    );
+    expect(
+      screen.getByTestId("p2p-reconnection-reconnecting-title"),
+    ).toHaveTextContent(/Connection lost/i);
+    expect(
+      screen.getByTestId("p2p-reconnection-reconnecting-body"),
+    ).toHaveTextContent(/Reconnecting to your peer/i);
+    expect(
+      screen.getByTestId("p2p-reconnection-attempt-badge"),
+    ).toHaveTextContent("Attempt 2 of 3");
+  });
+
+  it('renders the "Reconnecting…" banner with attempt count on the reconnecting phase', () => {
+    render(
+      <P2PReconnectionStatus
+        reconnectionPhase="reconnecting"
+        connectionState="reconnecting"
+        reconnectAttempts={1}
+        maxReconnectAttempts={3}
+        connectionFailureReason={null}
+        onContinueLocally={noop}
+        onSaveForResume={noop}
+        onAbandon={noop}
+      />,
+    );
+    expect(
+      screen.getByTestId("p2p-reconnection-reconnecting-title"),
+    ).toHaveTextContent(/Reconnecting/i);
+    expect(
+      screen.getByTestId("p2p-reconnection-attempt-badge"),
+    ).toHaveTextContent("Attempt 1 of 3");
+    // Live region for screen readers (status change is announced politely).
+    expect(screen.getByTestId("p2p-reconnection-reconnecting")).toHaveAttribute(
+      "aria-live",
+      "polite",
+    );
+  });
+
+  it("renders the transient Reconnected banner on recovery", () => {
+    render(
+      <P2PReconnectionStatus
+        reconnectionPhase="recovered"
+        connectionState="connected"
+        reconnectAttempts={0}
+        maxReconnectAttempts={3}
+        connectionFailureReason={null}
+        onContinueLocally={noop}
+        onSaveForResume={noop}
+        onAbandon={noop}
+        onAcknowledgeReconnect={noop}
+        recoveredDismissMs={null}
+      />,
+    );
+    expect(
+      screen.getByTestId("p2p-reconnection-recovered-title"),
+    ).toHaveTextContent(/Reconnected/i);
+    expect(
+      screen.getByTestId("p2p-reconnection-recovered-body"),
+    ).toHaveTextContent(/peer-to-peer connection is back/i);
+  });
+
+  it("auto-dismisses the Reconnected banner after the configured timeout", () => {
+    jest.useFakeTimers();
+    const onAcknowledge = jest.fn();
+    render(
+      <P2PReconnectionStatus
+        reconnectionPhase="recovered"
+        connectionState="connected"
+        reconnectAttempts={0}
+        maxReconnectAttempts={3}
+        connectionFailureReason={null}
+        onContinueLocally={noop}
+        onSaveForResume={noop}
+        onAbandon={noop}
+        onAcknowledgeReconnect={onAcknowledge}
+        recoveredDismissMs={2000}
+      />,
+    );
+    expect(onAcknowledge).not.toHaveBeenCalled();
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(onAcknowledge).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('renders the "Reconnection failed" banner with reason and remediation', () => {
+    render(
+      <P2PReconnectionStatus
+        reconnectionPhase="failed"
+        connectionState="failed"
+        reconnectAttempts={3}
+        maxReconnectAttempts={3}
+        connectionFailureReason={{
+          category: "TURN_UNCONFIGURED",
+          reason: "No TURN server is configured.",
+          remediation: "Add a TURN relay server to traverse your NAT.",
+        }}
+        onContinueLocally={noop}
+        onSaveForResume={noop}
+        onAbandon={noop}
+      />,
+    );
+    expect(screen.getByTestId("p2p-reconnection-failed")).toHaveAttribute(
+      "aria-live",
+      "assertive",
+    );
+    expect(
+      screen.getByTestId("p2p-reconnection-failed-title"),
+    ).toHaveTextContent(/Reconnection failed/i);
+    expect(
+      screen.getByTestId("p2p-reconnection-failed-attempt-badge"),
+    ).toHaveTextContent("3/3 attempts used");
+    expect(
+      screen.getByTestId("p2p-reconnection-failed-body"),
+    ).toHaveTextContent(/No TURN server is configured/i);
+    expect(
+      screen.getByTestId("p2p-reconnection-failed-remediation"),
+    ).toHaveTextContent(/Add a TURN relay server/i);
+    expect(
+      screen.getByTestId("p2p-reconnection-failed-suggestion"),
+    ).toHaveTextContent(/continue this game in local hot-seat mode/i);
+  });
+
+  it("falls back to a generic reason when the diagnostic is null", () => {
+    render(
+      <P2PReconnectionStatus
+        reconnectionPhase="failed"
+        connectionState="failed"
+        reconnectAttempts={3}
+        maxReconnectAttempts={3}
+        connectionFailureReason={null}
+        onContinueLocally={noop}
+        onSaveForResume={noop}
+        onAbandon={noop}
+      />,
+    );
+    expect(
+      screen.getByTestId("p2p-reconnection-failed-body"),
+    ).toHaveTextContent(/could not be recovered/i);
+    expect(
+      screen.queryByTestId("p2p-reconnection-failed-remediation"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("invokes the recovery callbacks on the failed banner", () => {
+    const onContinue = jest.fn();
+    const onSave = jest.fn();
+    const onAbandon = jest.fn();
+    render(
+      <P2PReconnectionStatus
+        reconnectionPhase="failed"
+        connectionState="failed"
+        reconnectAttempts={3}
+        maxReconnectAttempts={3}
+        connectionFailureReason={null}
+        onContinueLocally={onContinue}
+        onSaveForResume={onSave}
+        onAbandon={onAbandon}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("p2p-reconnection-failed-continue"));
+    expect(onContinue).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTestId("p2p-reconnection-failed-save"));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTestId("p2p-reconnection-failed-abandon"));
+    expect(onAbandon).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables all recovery actions while saving", () => {
+    render(
+      <P2PReconnectionStatus
+        reconnectionPhase="failed"
+        connectionState="failed"
+        reconnectAttempts={3}
+        maxReconnectAttempts={3}
+        connectionFailureReason={null}
+        isSaving
+        onContinueLocally={noop}
+        onSaveForResume={noop}
+        onAbandon={noop}
+      />,
+    );
+    expect(
+      screen.getByTestId("p2p-reconnection-failed-continue"),
+    ).toBeDisabled();
+    expect(screen.getByTestId("p2p-reconnection-failed-save")).toBeDisabled();
+    expect(
+      screen.getByTestId("p2p-reconnection-failed-abandon"),
+    ).toBeDisabled();
+    expect(
+      screen.getByTestId("p2p-reconnection-failed-save").textContent,
+    ).toContain("Saving");
+  });
+
+  it("does not use native window.alert / window.confirm", () => {
+    const alertSpy = jest.spyOn(window, "alert").mockImplementation(() => {});
+    const confirmSpy = jest
+      .spyOn(window, "confirm")
+      .mockImplementation(() => false);
+    render(
+      <P2PReconnectionStatus
+        reconnectionPhase="failed"
+        connectionState="failed"
+        reconnectAttempts={3}
+        maxReconnectAttempts={3}
+        connectionFailureReason={null}
+        onContinueLocally={noop}
+        onSaveForResume={noop}
+        onAbandon={noop}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("p2p-reconnection-failed-continue"));
+    fireEvent.click(screen.getByTestId("p2p-reconnection-failed-abandon"));
+    expect(alertSpy).not.toHaveBeenCalled();
+    expect(confirmSpy).not.toHaveBeenCalled();
+    alertSpy.mockRestore();
+    confirmSpy.mockRestore();
+  });
+
+  it("honors a custom className on the outer wrapper", () => {
+    const { container } = render(
+      <P2PReconnectionStatus
+        reconnectionPhase="lost"
+        connectionState="disconnected"
+        reconnectAttempts={1}
+        maxReconnectAttempts={3}
+        connectionFailureReason={null}
+        onContinueLocally={noop}
+        onSaveForResume={noop}
+        onAbandon={noop}
+        className="custom-class"
+      />,
+    );
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+
+  it("exposes the connection state as a data attribute for diagnostics", () => {
+    render(
+      <P2PReconnectionStatus
+        reconnectionPhase="reconnecting"
+        connectionState="reconnecting"
+        reconnectAttempts={1}
+        maxReconnectAttempts={3}
+        connectionFailureReason={null}
+        onContinueLocally={noop}
+        onSaveForResume={noop}
+        onAbandon={noop}
+      />,
+    );
+    expect(screen.getByTestId("p2p-reconnection-status")).toHaveAttribute(
+      "data-connection-state",
+      "reconnecting",
+    );
+  });
+});

--- a/src/components/p2p-reconnection-status-section.tsx
+++ b/src/components/p2p-reconnection-status-section.tsx
@@ -1,0 +1,126 @@
+/**
+ * P2PReconnectionStatusSection
+ *
+ * Hook-consumer wrapper around {@link P2PReconnectionStatus} (issue #988).
+ *
+ * Owns the call into {@link useP2PConnection} so the presentational
+ * `P2PReconnectionStatus` stays trivially testable. Also manages the
+ * side-effects (continue-locally / save-for-resume / abandon) by routing
+ * through the hook's existing degrade pipeline.
+ *
+ * Mount this in any multiplayer surface where the player is currently in an
+ * active P2P session (the game board, the lobby once connected, etc.). It
+ * renders nothing during the `stable` phase so the section is safe to drop
+ * in unconditionally.
+ *
+ * The wrapper takes the player's identity as props (since the hook requires
+ * `playerId` / `playerName` / `role`) and surfaces the degrade-flow
+ * callbacks via optional `onDegraded` / `onAbandoned` props so callers can
+ * react when the player chooses one of the recovery paths.
+ */
+
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { P2PReconnectionStatus } from "@/components/p2p-reconnection-status";
+import {
+  useP2PConnection,
+  type LocalDegradeInfo,
+} from "@/hooks/use-p2p-connection";
+
+export interface P2PReconnectionStatusSectionProps {
+  /** Local player's stable id. Required by the underlying P2P hook. */
+  playerId: string;
+  /** Local player's display name. Required by the underlying P2P hook. */
+  playerName: string;
+  /** Whether the local client is the host or joiner for this session. */
+  role: "host" | "joiner";
+  /** Optional P2P game code for logging / diagnostics. */
+  gameCode?: string;
+  /**
+   * Fired once the player has chosen "Continue in local hot-seat" and the
+   * hook has finished migrating the in-progress game. Use it to navigate
+   * the player into the local hot-seat surface.
+   */
+  onDegraded?: (info: LocalDegradeInfo) => void;
+  /**
+   * Fired once the player has chosen "Abandon match". Use it to navigate
+   * back to the lobby.
+   */
+  onAbandoned?: () => void;
+  /** Optional className applied to the outer wrapper. */
+  className?: string;
+}
+
+export function P2PReconnectionStatusSection({
+  playerId,
+  playerName,
+  role,
+  gameCode,
+  onDegraded,
+  onAbandoned,
+  className,
+}: P2PReconnectionStatusSectionProps) {
+  // Only render a saving spinner while the user's chosen degrade path is in
+  // flight. The hook exposes a `continueAsLocalHotSeat` async, so track its
+  // in-flight state here.
+  const [isSaving, setIsSaving] = useState(false);
+
+  const p2p = useP2PConnection({
+    playerId,
+    playerName,
+    role,
+    gameCode,
+    enableHandshake: false,
+    enableConflictResolution: false,
+    enableHostMigration: false,
+    onDegradedToLocal: (info) => {
+      onDegraded?.(info);
+    },
+  });
+
+  const handleContinueLocally = useCallback(async () => {
+    setIsSaving(true);
+    try {
+      const result = await p2p.continueAsLocalHotSeat();
+      if (result.ok) {
+        // Hook already fired onDegradedToLocal via its wiring; no-op.
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  }, [p2p]);
+
+  const handleSaveForResume = useCallback(async () => {
+    setIsSaving(true);
+    try {
+      await p2p.saveForLocalResume();
+    } finally {
+      setIsSaving(false);
+    }
+  }, [p2p]);
+
+  const handleAbandon = useCallback(() => {
+    p2p.dismissTerminalFailure();
+    onAbandoned?.();
+  }, [p2p, onAbandoned]);
+
+  return (
+    <P2PReconnectionStatus
+      reconnectionPhase={p2p.reconnectionPhase}
+      connectionState={p2p.connectionState}
+      reconnectAttempts={p2p.reconnectAttempts}
+      maxReconnectAttempts={p2p.maxReconnectAttempts}
+      connectionFailureReason={p2p.connectionFailureReason}
+      isSaving={isSaving}
+      onContinueLocally={() => void handleContinueLocally()}
+      onSaveForResume={() => void handleSaveForResume()}
+      onAbandon={handleAbandon}
+      onAcknowledgeReconnect={p2p.acknowledgeReconnect}
+      className={className}
+    />
+  );
+}
+
+export default P2PReconnectionStatusSection;

--- a/src/components/p2p-reconnection-status.tsx
+++ b/src/components/p2p-reconnection-status.tsx
@@ -1,0 +1,400 @@
+/**
+ * P2PReconnectionStatus
+ *
+ * User-facing reconnection UI for the WebRTC P2P transport (issue #988).
+ *
+ * Surfaces clear messaging during the disconnect → reconnect → success/failure
+ * lifecycle so the player is never left wondering whether the game is hung.
+ * Renders nothing during the `stable` phase to keep the game board uncluttered.
+ *
+ * Phases (driven by {@link useP2PConnection}'s `reconnectionPhase`):
+ *
+ *   - `lost`         — Connection dropped after having been connected. Shows
+ *                      a "Connection lost — reconnecting…" banner with the
+ *                      current attempt counter.
+ *   - `reconnecting` — The transport reports an active reconnect cycle.
+ *                      Same banner, but the body copy is explicit.
+ *   - `recovered`    — Transient success message after a successful reconnect.
+ *                      Auto-clears via `onAcknowledgeReconnect` after a short
+ *                      timeout so the player sees confirmation, not noise.
+ *   - `failed`       — Reconnection retries were exhausted. Hands off to the
+ *                      existing {@link P2PDegradeDialog} recovery flow (continue
+ *                      locally / save / abandon) — we render an Alert here
+ *                      with the same actions so the failure is visible
+ *                      alongside the game, not buried in a modal.
+ *
+ * Accessibility:
+ *   - Each phase uses an `aria-live` region so screen readers announce the
+ *     transition (polite, never assertive — the player is still in a game).
+ *   - Buttons are keyboard-reachable via the existing `Button` primitive.
+ *   - No native `alert`/`confirm` — driven entirely through React + radix
+ *     primitives (the #1100/#1150 regression guard).
+ *
+ * The component is presentational and trivially testable: pass the state as
+ * props (no internal hook calls). Wire it via {@link P2PReconnectionStatusSection}
+ * which provides the hook consumer.
+ */
+
+"use client";
+
+import { useEffect, useRef } from "react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Loader2,
+  RefreshCw,
+  WifiOff,
+} from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import type { ReconnectionPhase } from "@/hooks/use-p2p-connection";
+import type { P2PConnectionState } from "@/lib/p2p-game-connection";
+import type { ConnectionFailureDiagnostic } from "@/lib/p2p-failure-diagnostics";
+
+export interface P2PReconnectionStatusProps {
+  /**
+   * High-level lifecycle phase from {@link useP2PConnection.reconnectionPhase}.
+   * Drives which banner is rendered. `stable` renders nothing.
+   */
+  reconnectionPhase: ReconnectionPhase;
+  /**
+   * Underlying transport state. Surfaced as a small badge so the player can
+   * see the raw state without parsing the phase name. Useful for debugging
+   * in development builds; harmless in production.
+   */
+  connectionState: P2PConnectionState;
+  /** Number of reconnection attempts observed since the last successful connect. */
+  reconnectAttempts: number;
+  /**
+   * Maximum attempts before the transport transitions to the terminal
+   * `failed` phase. Used to render "Attempt 2 of 3" labels.
+   */
+  maxReconnectAttempts: number;
+  /**
+   * Actionable failure diagnostic from the last terminal failure. Surfaced
+   * on the `failed` phase so the player sees a meaningful reason + remediation
+   * (e.g. "TURN server required") instead of a generic error.
+   */
+  connectionFailureReason: ConnectionFailureDiagnostic | null;
+  /** True while a save/continue operation is in flight (disables actions). */
+  isSaving?: boolean;
+  /**
+   * Trigger the existing graceful-degradation path that migrates the
+   * in-progress game to local hot-seat storage and hands control to the
+   * single-device flow. Plumbed from {@link useP2PConnection.continueAsLocalHotSeat}.
+   */
+  onContinueLocally: () => void;
+  /** Persist the in-progress game to IndexedDB without switching modes. */
+  onSaveForResume: () => void;
+  /** Abandon the match — closes the connection and dismisses the prompt. */
+  onAbandon: () => void;
+  /**
+   * Optional. Clears the transient `recovered` message after the banner has
+   * been on screen for the auto-dismiss timeout (default 5s). If omitted the
+   * banner stays until the next state change.
+   */
+  onAcknowledgeReconnect?: () => void;
+  /**
+   * How long the `recovered` banner stays on screen before auto-clearing.
+   * Defaults to 5_000ms. Set to `null` to disable auto-dismiss (the banner
+   * stays until manually cleared).
+   */
+  recoveredDismissMs?: number | null;
+  /** Optional extra Tailwind classes merged onto the outer wrapper. */
+  className?: string;
+}
+
+const RECOVERED_DISMISS_MS_DEFAULT = 5_000;
+
+export function P2PReconnectionStatus({
+  reconnectionPhase,
+  connectionState,
+  reconnectAttempts,
+  maxReconnectAttempts,
+  connectionFailureReason,
+  isSaving = false,
+  onContinueLocally,
+  onSaveForResume,
+  onAbandon,
+  onAcknowledgeReconnect,
+  recoveredDismissMs = RECOVERED_DISMISS_MS_DEFAULT,
+  className,
+}: P2PReconnectionStatusProps) {
+  // Stable phase: nothing to surface. Do not render at all so the game board
+  // is uncluttered when the P2P connection is healthy.
+  if (reconnectionPhase === "stable") return null;
+
+  return (
+    <div
+      className={cn("w-full", className)}
+      data-testid="p2p-reconnection-status"
+      data-reconnection-phase={reconnectionPhase}
+      data-connection-state={connectionState}
+    >
+      {reconnectionPhase === "recovered" ? (
+        <RecoveredBanner
+          reconnectAttempts={reconnectAttempts}
+          maxReconnectAttempts={maxReconnectAttempts}
+          onAcknowledgeReconnect={onAcknowledgeReconnect}
+          recoveredDismissMs={recoveredDismissMs}
+        />
+      ) : null}
+
+      {reconnectionPhase === "lost" ? (
+        <ReconnectingBanner
+          attemptLabel="Connection lost"
+          body="Reconnecting to your peer. This usually takes a few seconds."
+          reconnectAttempts={reconnectAttempts}
+          maxReconnectAttempts={maxReconnectAttempts}
+          iconVariant="lost"
+        />
+      ) : null}
+
+      {reconnectionPhase === "reconnecting" ? (
+        <ReconnectingBanner
+          attemptLabel="Reconnecting…"
+          body="Reconnecting to your peer. This usually takes a few seconds."
+          reconnectAttempts={reconnectAttempts}
+          maxReconnectAttempts={maxReconnectAttempts}
+          iconVariant="reconnecting"
+        />
+      ) : null}
+
+      {reconnectionPhase === "failed" ? (
+        <FailedBanner
+          reconnectAttempts={reconnectAttempts}
+          maxReconnectAttempts={maxReconnectAttempts}
+          connectionFailureReason={connectionFailureReason}
+          isSaving={isSaving}
+          onContinueLocally={onContinueLocally}
+          onSaveForResume={onSaveForResume}
+          onAbandon={onAbandon}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Banner shown while the connection is in a `lost` or `reconnecting` phase.
+ * Pure presentation — accessibility attributes and copy live here so the
+ * parent component stays simple.
+ */
+function ReconnectingBanner({
+  attemptLabel,
+  body,
+  reconnectAttempts,
+  maxReconnectAttempts,
+  iconVariant,
+}: {
+  attemptLabel: string;
+  body: string;
+  reconnectAttempts: number;
+  maxReconnectAttempts: number;
+  iconVariant: "lost" | "reconnecting";
+}) {
+  const Icon = iconVariant === "reconnecting" ? Loader2 : WifiOff;
+  const attemptText =
+    maxReconnectAttempts > 0
+      ? `Attempt ${Math.min(reconnectAttempts, maxReconnectAttempts)} of ${maxReconnectAttempts}`
+      : null;
+
+  return (
+    <Alert
+      role="status"
+      aria-live="polite"
+      variant="default"
+      data-testid="p2p-reconnection-reconnecting"
+    >
+      <Icon
+        className={cn(
+          "h-4 w-4",
+          iconVariant === "reconnecting" && "animate-spin",
+        )}
+        aria-hidden="true"
+      />
+      <AlertTitle data-testid="p2p-reconnection-reconnecting-title">
+        <span className="flex flex-wrap items-center gap-2">
+          {attemptLabel}
+          {attemptText ? (
+            <Badge
+              variant="secondary"
+              data-testid="p2p-reconnection-attempt-badge"
+            >
+              {attemptText}
+            </Badge>
+          ) : null}
+        </span>
+      </AlertTitle>
+      <AlertDescription data-testid="p2p-reconnection-reconnecting-body">
+        {body}
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+/**
+ * Transient "Reconnected" success banner. Auto-dismisses after
+ * `recoveredDismissMs` so it doesn't linger on the screen.
+ */
+function RecoveredBanner({
+  reconnectAttempts,
+  maxReconnectAttempts,
+  onAcknowledgeReconnect,
+  recoveredDismissMs,
+}: {
+  reconnectAttempts: number;
+  maxReconnectAttempts: number;
+  onAcknowledgeReconnect?: () => void;
+  recoveredDismissMs: number | null;
+}) {
+  const dismissedRef = useRef(false);
+  useEffect(() => {
+    if (!onAcknowledgeReconnect) return;
+    if (recoveredDismissMs == null || recoveredDismissMs <= 0) return;
+    const id = setTimeout(() => {
+      if (dismissedRef.current) return;
+      dismissedRef.current = true;
+      onAcknowledgeReconnect();
+    }, recoveredDismissMs);
+    return () => clearTimeout(id);
+  }, [onAcknowledgeReconnect, recoveredDismissMs]);
+
+  return (
+    <Alert
+      role="status"
+      aria-live="polite"
+      variant="default"
+      data-testid="p2p-reconnection-recovered"
+    >
+      <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+      <AlertTitle data-testid="p2p-reconnection-recovered-title">
+        <span className="flex flex-wrap items-center gap-2">
+          Reconnected
+          {reconnectAttempts > 0 && maxReconnectAttempts > 0 ? (
+            <Badge
+              variant="outline"
+              data-testid="p2p-reconnection-recovered-badge"
+            >
+              Recovered on attempt {reconnectAttempts}
+            </Badge>
+          ) : null}
+        </span>
+      </AlertTitle>
+      <AlertDescription data-testid="p2p-reconnection-recovered-body">
+        The peer-to-peer connection is back. Game state has been
+        re-synchronized.
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+/**
+ * Banner shown when reconnection retries are exhausted. Surfaces the
+ * actionable failure diagnostic and the three recovery actions that hand off
+ * to the existing degrade flow from #1090 — the player can continue locally,
+ * save for later, or abandon.
+ */
+function FailedBanner({
+  reconnectAttempts,
+  maxReconnectAttempts,
+  connectionFailureReason,
+  isSaving,
+  onContinueLocally,
+  onSaveForResume,
+  onAbandon,
+}: {
+  reconnectAttempts: number;
+  maxReconnectAttempts: number;
+  connectionFailureReason: ConnectionFailureDiagnostic | null;
+  isSaving: boolean;
+  onContinueLocally: () => void;
+  onSaveForResume: () => void;
+  onAbandon: () => void;
+}) {
+  const reason =
+    connectionFailureReason?.reason ??
+    "The peer-to-peer connection failed and could not be recovered after all fallbacks and reconnection attempts.";
+  const remediation = connectionFailureReason?.remediation;
+
+  return (
+    <Alert
+      variant="destructive"
+      role="alert"
+      aria-live="assertive"
+      data-testid="p2p-reconnection-failed"
+    >
+      <AlertCircle className="h-4 w-4" aria-hidden="true" />
+      <AlertTitle data-testid="p2p-reconnection-failed-title">
+        <span className="flex flex-wrap items-center gap-2">
+          Reconnection failed
+          {reconnectAttempts > 0 && maxReconnectAttempts > 0 ? (
+            <Badge
+              variant="destructive"
+              data-testid="p2p-reconnection-failed-attempt-badge"
+            >
+              {reconnectAttempts}/{maxReconnectAttempts} attempts used
+            </Badge>
+          ) : null}
+        </span>
+      </AlertTitle>
+      <AlertDescription data-testid="p2p-reconnection-failed-body">
+        <p>{reason}</p>
+        {remediation ? (
+          <p
+            className="mt-1 text-sm"
+            data-testid="p2p-reconnection-failed-remediation"
+          >
+            {remediation}
+          </p>
+        ) : null}
+        <p
+          className="mt-2 text-sm"
+          data-testid="p2p-reconnection-failed-suggestion"
+        >
+          You can continue this game in local hot-seat mode, save it for later,
+          or abandon it.
+        </p>
+      </AlertDescription>
+      <div
+        className="mt-3 flex flex-wrap gap-2"
+        data-testid="p2p-reconnection-failed-actions"
+      >
+        <Button
+          variant="default"
+          size="sm"
+          onClick={onContinueLocally}
+          disabled={isSaving}
+          data-testid="p2p-reconnection-failed-continue"
+        >
+          <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+          Continue locally
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onSaveForResume}
+          disabled={isSaving}
+          data-testid="p2p-reconnection-failed-save"
+        >
+          {isSaving ? "Saving…" : "Save for later"}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onAbandon}
+          disabled={isSaving}
+          data-testid="p2p-reconnection-failed-abandon"
+        >
+          Abandon match
+        </Button>
+      </div>
+    </Alert>
+  );
+}
+
+export default P2PReconnectionStatus;

--- a/src/hooks/use-p2p-connection.ts
+++ b/src/hooks/use-p2p-connection.ts
@@ -48,6 +48,16 @@ import { logger } from "@/lib/logger";
 
 const p2pLogger = logger.child("P2PConnection");
 
+/**
+ * Upper bound for the user-facing "attempt N of M" label in the reconnection
+ * UI (issue #988). The hook does not own the actual reconnection loop; this
+ * constant is the maximum displayed attempt number before the UI switches to
+ * the terminal "Reconnection failed" message. The underlying transport's
+ * own `maxReconnectAttempts` is plumbed via {@link P2PConnectionState}
+ * callers and may differ; this is purely a display bound.
+ */
+const MAX_RECONNECT_ATTEMPTS_DISPLAY = 3;
+
 export interface UseP2PConnectionOptions {
   playerId: string;
   playerName: string;
@@ -87,6 +97,32 @@ export interface LocalDegradeInfo {
   /** False when there was no in-progress game state to preserve. */
   hadGameState: boolean;
 }
+
+/**
+ * Reconnection lifecycle phase surfaced to the UI (issue #988).
+ *
+ * Derived from the connection state by {@link useP2PConnection}. The UI uses
+ * this to pick what to show:
+ *   - `stable`     — no reconnection activity; nothing to surface.
+ *   - `lost`       — the connection dropped after having been connected; the
+ *                    transport is attempting recovery. Shows a "Connection
+ *                    lost — reconnecting…" banner with attempt count.
+ *   - `reconnecting` — the transport reports the "reconnecting" state (used
+ *                    when the underlying WebRTC layer actively drives the
+ *                    cycle, e.g. via WebRTCConnection's ICE-restart loop).
+ *   - `recovered`  — transient: the transport recovered after a prior drop.
+ *                    Shows a brief "Reconnected" success message and
+ *                    auto-dismisses. Cleared by the consumer after handling.
+ *   - `failed`     — reconnection retries were exhausted and the user has not
+ *                    yet migrated or abandoned. Surfaces the recovery prompt
+ *                    that hands off to {@link P2PDegradeDialog}.
+ */
+export type ReconnectionPhase =
+  | "stable"
+  | "lost"
+  | "reconnecting"
+  | "recovered"
+  | "failed";
 
 /**
  * Result of {@link useP2PConnectionReturn.continueAsLocalHotSeat}.
@@ -162,6 +198,26 @@ export interface UseP2PConnectionReturn {
    * reconcile / close.
    */
   droppedPendingActions: PendingAction[];
+  // --- Issue #988: user-facing reconnection UI ---
+  /**
+   * Reconnection lifecycle phase derived from `connectionState` and the
+   * connection's reconnection attempt count. Drives the
+   * {@link P2PReconnectionStatus} component.
+   */
+  reconnectionPhase: ReconnectionPhase;
+  /** Number of reconnection attempts since the last successful connect. */
+  reconnectAttempts: number;
+  /** Maximum reconnection attempts before transitioning to the terminal `failed`
+   * phase. Matches the configured `maxReconnectAttempts` (defaults to 3). */
+  maxReconnectAttempts: number;
+  /**
+   * True for a short window after a successful reconnect so the UI can show a
+   * transient "Reconnected" message. Callers may clear it via
+   * {@link acknowledgeReconnect} once the message has been displayed.
+   */
+  reconnectedRecently: boolean;
+  /** Dismiss the transient "Reconnected" message once shown to the user. */
+  acknowledgeReconnect: () => void;
 }
 
 export function useP2PConnection(
@@ -195,6 +251,11 @@ export function useP2PConnection(
     useState<string>(fallbackHostId);
   const [connectionFailureReason, setConnectionFailureReason] =
     useState<ConnectionFailureDiagnostic | null>(null);
+  // --- Issue #988: reconnection UI state ---
+  const [reconnectAttempts, setReconnectAttempts] = useState(0);
+  const [reconnectedRecently, setReconnectedRecently] = useState(false);
+  const reconnectAttemptsRef = useRef(0);
+  const hadConnectedRef = useRef(false);
   // --- Issue #1090: graceful degradation to local hot-seat ---
   const [degradedToLocal, setDegradedToLocal] = useState(false);
   const [terminalFailureDismissed, setTerminalFailureDismissed] =
@@ -420,6 +481,13 @@ export function useP2PConnection(
   // `droppedPendingActions` surfaced for the adopt path come from the
   // onGameStateSync adoption below. See src/lib/p2p-reconciliation.ts.
   const handleReconnect = useCallback(() => {
+    // Issue #988: a successful reconnect deserves a transient "Reconnected"
+    // user-facing message. Reset attempt counters and arm the flag the UI
+    // consumes (cleared via `acknowledgeReconnect`).
+    reconnectAttemptsRef.current = 0;
+    setReconnectAttempts(0);
+    setReconnectedRecently(true);
+
     const coordinator = reconcileRef.current;
     const isHost = currentHostIdRef.current === playerId;
     const decision = coordinator.onReconnect({
@@ -445,6 +513,13 @@ export function useP2PConnection(
       connectionRef.current?.requestStateSync();
     }
   }, [playerId]);
+
+  // Acknowledge the transient "Reconnected" message — caller fires once the
+  // banner has been shown so the hook does not flip the flag back on. Issue
+  // #988.
+  const acknowledgeReconnect = useCallback(() => {
+    setReconnectedRecently(false);
+  }, []);
 
   // On a received game-state sync, if we are awaiting reconciliation, adopt
   // the host's authoritative state (source of truth) and drop the pending
@@ -488,6 +563,30 @@ export function useP2PConnection(
                 setConnectionFailureReason(
                   conn?.getLastFailureDiagnostic?.() ?? null,
                 );
+              }
+              // Issue #988: track reconnection attempts. The hook does not
+              // own the underlying reconnect loop — that lives in
+              // WebRTCConnection / the browser RTCPeerConnection — but it does
+              // own the user-facing count of how many times we have observed
+              // a drop after having been connected. Each observed drop
+              // increments; a successful reconnect resets to 0 via
+              // `handleReconnect` above. Capped at `maxReconnectAttempts + 1`
+              // so the UI can label the terminal attempt explicitly.
+              if (state === "disconnected" || state === "reconnecting") {
+                if (hadConnectedRef.current) {
+                  const next = Math.min(
+                    reconnectAttemptsRef.current + 1,
+                    MAX_RECONNECT_ATTEMPTS_DISPLAY + 1,
+                  );
+                  reconnectAttemptsRef.current = next;
+                  setReconnectAttempts(next);
+                }
+              } else if (state === "connected") {
+                // Successful recovery (or initial connect): clear the
+                // transient "Reconnected" message flag only if we are NOT in
+                // a recovery edge — the actual flag flip happens in
+                // handleReconnect so it survives handler re-binding.
+                hadConnectedRef.current = true;
               }
             },
             onReconnect: handleReconnect,
@@ -626,6 +725,20 @@ export function useP2PConnection(
                 setConnectionFailureReason(
                   conn?.getLastFailureDiagnostic?.() ?? null,
                 );
+              }
+              // Issue #988: same attempt tracking as the host path — see the
+              // matching comment in initializeAsHost above.
+              if (state === "disconnected" || state === "reconnecting") {
+                if (hadConnectedRef.current) {
+                  const next = Math.min(
+                    reconnectAttemptsRef.current + 1,
+                    MAX_RECONNECT_ATTEMPTS_DISPLAY + 1,
+                  );
+                  reconnectAttemptsRef.current = next;
+                  setReconnectAttempts(next);
+                }
+              } else if (state === "connected") {
+                hadConnectedRef.current = true;
               }
             },
             onReconnect: handleReconnect,
@@ -855,6 +968,11 @@ export function useP2PConnection(
     reconcileRef.current.clear();
     awaitingReconciliationRef.current = false;
     setDroppedPendingActions([]);
+    // Issue #988: reset reconnection UI state for a fresh session.
+    reconnectAttemptsRef.current = 0;
+    setReconnectAttempts(0);
+    setReconnectedRecently(false);
+    hadConnectedRef.current = false;
   }, [fallbackHostId]);
 
   // Get connection instance
@@ -982,6 +1100,28 @@ export function useP2PConnection(
     !degradedToLocal &&
     !terminalFailureDismissed;
 
+  // --- Issue #988: derive the user-facing reconnection phase ---
+  // Order of precedence (highest first):
+  //   1. Transient "Reconnected" message immediately after a recovery edge.
+  //   2. Terminal "failed" (after reconnection exhausted) and the user has
+  //      not yet migrated/abandoned — surface the recovery prompt.
+  //   3. Mid-flight "reconnecting" (the transport reports it actively).
+  //   4. Lost after having been connected (silent pre-#988 bug).
+  //   5. Stable — nothing to show.
+  const reconnectionPhase: ReconnectionPhase = (() => {
+    if (reconnectedRecently) return "recovered";
+    if (terminalFailure) return "failed";
+    if (connectionState === "reconnecting") return "reconnecting";
+    if (
+      connectionState === "disconnected" &&
+      hadConnectedRef.current &&
+      !degradedToLocal
+    ) {
+      return "lost";
+    }
+    return "stable";
+  })();
+
   return {
     connectionState,
     signalingState,
@@ -1010,6 +1150,12 @@ export function useP2PConnection(
     saveForLocalResume,
     dismissTerminalFailure,
     droppedPendingActions,
+    // --- Issue #988: user-facing reconnection UI ---
+    reconnectionPhase,
+    reconnectAttempts,
+    maxReconnectAttempts: MAX_RECONNECT_ATTEMPTS_DISPLAY,
+    reconnectedRecently,
+    acknowledgeReconnect,
   };
 }
 

--- a/src/lib/__tests__/use-p2p-connection.test.ts
+++ b/src/lib/__tests__/use-p2p-connection.test.ts
@@ -130,6 +130,12 @@ describe("use-p2p-connection Hook Types", () => {
         saveForLocalResume: async () => ({ ok: true }),
         dismissTerminalFailure: () => {},
         droppedPendingActions: [],
+        // Issue #988: user-facing reconnection UI state.
+        reconnectionPhase: "stable",
+        reconnectAttempts: 0,
+        maxReconnectAttempts: 3,
+        reconnectedRecently: false,
+        acknowledgeReconnect: () => {},
       };
 
       expect(returnValue.connectionState).toBeDefined();


### PR DESCRIPTION
Resolves #988

## Summary

The P2P connection could drop and re-attempt recovery for 30+ seconds with the user seeing nothing (issue #988). This PR adds a user-facing reconnection UI that surfaces clear messaging during disconnect → reconnecting → success/failure so the player always knows what is happening.

## States + messaging

The new `P2PReconnectionStatus` component renders a phase-driven banner driven by `useP2PConnection`'s new `reconnectionPhase`:

| Phase          | When                                          | Messaging                                                                                                              |
| -------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
| `stable`       | connected, nothing happening                  | nothing rendered                                                                                                       |
| `lost`         | disconnected after having been connected      | "Connection lost" + "Attempt N of M" badge + "Reconnecting to your peer. This usually takes a few seconds."           |
| `reconnecting` | transport reports active reconnect cycle     | "Reconnecting…" + "Attempt N of M" badge + spinner + body copy                                                          |
| `recovered`    | transient (auto-dismisses after 5s default)   | "Reconnected" + "Recovered on attempt N" badge + "The peer-to-peer connection is back. Game state has been re-synced." |
| `failed`       | terminal failure (retries exhausted)          | "Reconnection failed" + "N/M attempts used" + the actionable failure diagnostic (e.g. "Add a TURN relay…") + three recovery actions: **Continue locally** / **Save for later** / **Abandon match** |

## Hook additions (`useP2PConnection`)

- `reconnectionPhase: ReconnectionPhase` — derived from `connectionState` + the new internal `hadConnectedRef`.
- `reconnectAttempts: number` — incremented each time we observe `disconnected`/`reconnecting` after having been connected; reset on `onReconnect`.
- `maxReconnectAttempts: number` — display bound (3, matches the transport default).
- `reconnectedRecently: boolean` + `acknowledgeReconnect()` — transient flag for the "Reconnected" banner so it doesn't stay on screen after recovery.

## Hand-off to existing degrade flow (#1090)

The `failed` phase renders the same three recovery actions the existing `P2PDegradeDialog` (#1090) surfaces — but inline as an alert alongside the game, not buried in a modal:

- **Continue locally** → `useP2PConnection.continueAsLocalHotSeat()` (migrates the in-progress game to IndexedDB and switches modes — the same path #1090 wired).
- **Save for later** → `useP2PConnection.saveForLocalResume()` (persists without switching modes).
- **Abandon match** → `useP2PConnection.dismissTerminalFailure()` + the optional `onAbandoned` callback for navigation.

The component does **not** invent a parallel state machine; it routes through the existing hook's degrade pipeline.

## Separation from #986

The persistent connection-state indicator (always-visible, e.g. a corner badge reflecting "connected/reconnecting") is owned by issue **#986** and is being done in the next wave. This PR is scoped strictly to the **transient** reconnection UI — what the user sees during the disconnect → reconnect → success/failure lifecycle. #988's banner appears and disappears based on the `reconnectionPhase`; #986's indicator stays on screen at all times.

## Accessibility

- `aria-live="polite"` on the reconnecting/recovered banners, `aria-live="assertive"` on the failed banner (screen readers announce failure immediately).
- Recovery buttons are keyboard-reachable via the existing `Button` primitive; no native `alert`/`confirm` is used (#1100/#1150 regression guard verified by a test).
- `data-reconnection-phase` + `data-connection-state` attributes on the outer wrapper for diagnostics and e2e selectors.

## Tests

`src/components/__tests__/p2p-reconnection-status.test.tsx` covers each state's messaging:

- `stable` renders nothing
- `lost` → "Connection lost" + attempt badge
- `reconnecting` → "Reconnecting…" + attempt badge + `aria-live`
- `recovered` → transient "Reconnected" + auto-dismiss after the configured timeout
- `failed` → "Reconnection failed" + reason + remediation + `[continue/save/abandon]` actions
- `failed` + generic diagnostic → falls back to default reason
- `failed` + `isSaving` → all actions disabled, label flips to "Saving…"
- No native `window.alert` / `window.confirm` regression guard
- Custom `className` honored
- Connection state surfaced as a `data-connection-state` attribute

Also updates `src/lib/__tests__/use-p2p-connection.test.ts` to cover the new `UseP2PConnectionReturn` fields.

## Files changed

- `src/components/p2p-reconnection-status.tsx` — new presentational component.
- `src/components/p2p-reconnection-status-section.tsx` — hook-consumer wrapper that owns the side-effects (continue/save/abandon).
- `src/components/__tests__/p2p-reconnection-status.test.tsx` — new tests covering each state's messaging.
- `src/hooks/use-p2p-connection.ts` — adds `ReconnectionPhase`, `reconnectionPhase`, `reconnectAttempts`, `maxReconnectAttempts`, `reconnectedRecently`, `acknowledgeReconnect`.
- `src/lib/__tests__/use-p2p-connection.test.ts` — covers the new return fields.
- `src/app/(app)/multiplayer/page.tsx` — mounts a `P2PReconnectionStatusSection` so the component is discoverable; the section stays hidden while the connection is stable.

## Quality

- `npx tsc --noEmit` clean.
- `npm run lint` — 0 new errors/warnings on changed files (only pre-existing warnings remain).
- `npm test -- p2p-reconnection p2p-degrade use-p2p-connection` — 4 suites / 52 tests pass.
- Full `npm test -- p2p` — 301 suites / 6362 tests pass.