### PR TITLE
feat(rules-engine): resolve #1056 — implement Cycling, Typecycling, and Landcycling (CR 702.30-31)

### DIFF
--- a/src/lib/game-state/__tests__/cycling.test.ts
+++ b/src/lib/game-state/__tests__/cycling.test.ts
@@ -1,0 +1,982 @@
+/**
+ * @fileoverview Unit tests for the Cycling / Typecycling / Landcycling /
+ * Basic landcycling keyword family (CR 702.30-31).
+ *
+ * Issue #1056 — [Rules Engine] Implement Cycling, Typecycling, and
+ * Landcycling activated abilities (CR 702.30-31).
+ *
+ * Cycling is an activated ability that functions only while the card is in a
+ * player's hand. Cost is {cost} + discard this card; effect is to draw a card
+ * (CR 702.30a). Typecycling / Landcycling / Basic landcycling replace the
+ * draw with a library search for a card of the named type (CR 702.31). All
+ * variants follow sorcery-speed timing (active player, main phase, empty
+ * stack, priority, CR 117.1a).
+ *
+ * These tests cover: parsing (each variant), the keyword detection helpers,
+ * the cycleCard action (cost payment + discard + draw / search), the
+ * hand-only restriction, sorcery-speed timing rules, and library-search
+ * semantics for each Typecycling / Landcycling variant.
+ */
+
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import {
+  parseCycling,
+  CyclingVariant,
+  extractKeywords,
+} from "../oracle-text-parser";
+import {
+  hasCycling,
+  hasLandcycling,
+  hasTypecycling,
+  getCyclingCost,
+  getCyclingVariant,
+  parseCyclingCost,
+  canCycleCard,
+  cycleCard,
+} from "../keyword-actions";
+import { createInitialGameState, startGame } from "../game-state";
+import { createCardInstance } from "../card-instance";
+import { addMana } from "../mana";
+import { Phase } from "../types";
+import type { GameState, PlayerId, CardInstanceId } from "../types";
+import type { ScryfallCard } from "@/app/actions";
+
+// ---------------------------------------------------------------------------
+// Mock card helpers
+// ---------------------------------------------------------------------------
+
+function makeCard(
+  overrides: Partial<ScryfallCard> & { id: string },
+): ScryfallCard {
+  return {
+    name: "Test Card",
+    type_line: "Creature — Test",
+    oracle_text: "",
+    mana_cost: "",
+    cmc: 0,
+    colors: [],
+    color_identity: [],
+    legalities: { standard: "legal", commander: "legal" },
+    layout: "normal",
+    ...overrides,
+  } as ScryfallCard;
+}
+
+/** A creature with the base Cycling {2} keyword (e.g. Aven Riftwatcher). */
+function baseCyclingCreature(
+  overrides: Partial<ScryfallCard> & { id: string } = { id: "mock-cycler" },
+): ScryfallCard {
+  return makeCard({
+    name: "Aven Riftwatcher",
+    type_line: "Creature — Bird Warrior",
+    oracle_text: "Flying. Cycling {2}.",
+    mana_cost: "{3}{U}",
+    cmc: 4,
+    colors: ["U"],
+    color_identity: ["U"],
+    power: "2",
+    toughness: "3",
+    ...overrides,
+  });
+}
+
+/** A card with Wizardcycling {2} (e.g. Galeprowler). */
+function wizardcyclingCreature(): ScryfallCard {
+  return makeCard({
+    id: "mock-wizard-cycler",
+    name: "Galeprowler",
+    type_line: "Creature — Wizard",
+    oracle_text: "Wizardcycling {2}",
+    mana_cost: "{2}{U}",
+    cmc: 3,
+    colors: ["U"],
+    color_identity: ["U"],
+    power: "3",
+    toughness: "2",
+  });
+}
+
+/** A land with Plainscycling {1}{W} (e.g. Krosan Verge). */
+function plainscyclingLand(): ScryfallCard {
+  return makeCard({
+    id: "mock-plains-cycler",
+    name: "Plainscycler",
+    type_line: "Creature — Cycler",
+    oracle_text: "Plainscycling {1}{W}",
+    mana_cost: "{3}{W}",
+    cmc: 4,
+    colors: ["W"],
+    color_identity: ["W"],
+    power: "2",
+    toughness: "2",
+  });
+}
+
+/** A card with Basic landcycling {1} (e.g. Terminal Moraine). */
+function basicLandcyclingLand(): ScryfallCard {
+  return makeCard({
+    id: "mock-basic-landcycler",
+    name: "Terminal Moraine",
+    type_line: "Land",
+    oracle_text: "{T}: Add {C}. Basic landcycling {1}",
+    mana_cost: "",
+    cmc: 0,
+  });
+}
+
+/** A card with Landcycling {2} (bare — searches any land). */
+function landcyclingCreature(): ScryfallCard {
+  return makeCard({
+    id: "mock-land-cycler",
+    name: "Dryad Greenseeker",
+    type_line: "Creature — Dryad",
+    oracle_text: "Landcycling {2}",
+    mana_cost: "{2}{G}",
+    cmc: 3,
+    colors: ["G"],
+    color_identity: ["G"],
+    power: "1",
+    toughness: "1",
+  });
+}
+
+/** A non-cycling creature (used to assert cycleCard rejects it). */
+function noCyclingCreature(): ScryfallCard {
+  return makeCard({
+    id: "mock-vanilla",
+    name: "Grizzly Bears",
+    type_line: "Creature — Bear",
+    oracle_text: "",
+    mana_cost: "{1}{G}",
+    cmc: 2,
+    colors: ["G"],
+    color_identity: ["G"],
+    power: "2",
+    toughness: "2",
+  });
+}
+
+/** Cards used to populate a library so draws / searches have a target. */
+function basicPlains(idSuffix: string): ScryfallCard {
+  return makeCard({
+    id: `plains-${idSuffix}`,
+    name: "Plains",
+    type_line: "Basic Land — Plains",
+    oracle_text: "({T}: Add {W}.)",
+    mana_cost: "",
+    cmc: 0,
+  });
+}
+
+function basicIsland(idSuffix: string): ScryfallCard {
+  return makeCard({
+    id: `island-${idSuffix}`,
+    name: "Island",
+    type_line: "Basic Land — Island",
+    oracle_text: "({T}: Add {U}.)",
+    mana_cost: "",
+    cmc: 0,
+  });
+}
+
+function nonBasicLand(idSuffix: string): ScryfallCard {
+  return makeCard({
+    id: `nonbasic-${idSuffix}`,
+    name: "Mystic Gate",
+    type_line: "Land",
+    oracle_text: "{T}: Add {W} or {U}.",
+    mana_cost: "",
+    cmc: 0,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Shared state scaffolding
+// ---------------------------------------------------------------------------
+
+interface Fixture {
+  state: GameState;
+  aliceId: PlayerId;
+  bobId: PlayerId;
+}
+
+function makeFixture(): Fixture {
+  let state = createInitialGameState(["Alice", "Bob"], 20, false);
+  state = startGame(state);
+
+  const ids = Array.from(state.players.keys());
+  const aliceId = ids[0];
+  const bobId = ids[1];
+
+  state.status = "in_progress";
+  state.priorityPlayerId = aliceId;
+  state.turn.activePlayerId = aliceId;
+  state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+  state.turn.isFirstTurn = false;
+  state.stack = [];
+  state.consecutivePasses = 0;
+  state.players.forEach((p) =>
+    state.players.set(p.id, { ...p, hasPassedPriority: false }),
+  );
+
+  return { state, aliceId, bobId };
+}
+
+function putInHand(
+  state: GameState,
+  playerId: PlayerId,
+  cardData: ScryfallCard,
+): CardInstanceId {
+  const card = createCardInstance(cardData, playerId, playerId);
+  card.currentZoneKey = `${playerId}-hand`;
+  state.cards.set(card.id, card);
+  const hand = state.zones.get(`${playerId}-hand`)!;
+  state.zones.set(`${playerId}-hand`, {
+    ...hand,
+    cardIds: [...hand.cardIds, card.id],
+  });
+  return card.id;
+}
+
+/** Place a card onto the top of the player's library (end of the array). */
+function putInLibrary(
+  state: GameState,
+  playerId: PlayerId,
+  cardData: ScryfallCard,
+): CardInstanceId {
+  const card = createCardInstance(cardData, playerId, playerId);
+  card.currentZoneKey = `${playerId}-library`;
+  state.cards.set(card.id, card);
+  const lib = state.zones.get(`${playerId}-library`)!;
+  state.zones.set(`${playerId}-library`, {
+    ...lib,
+    cardIds: [...lib.cardIds, card.id],
+  });
+  return card.id;
+}
+
+function handIds(state: GameState, playerId: PlayerId): CardInstanceId[] {
+  return state.zones.get(`${playerId}-hand`)!.cardIds;
+}
+
+function graveyardIds(state: GameState, playerId: PlayerId): CardInstanceId[] {
+  return state.zones.get(`${playerId}-graveyard`)!.cardIds;
+}
+
+function libraryIds(state: GameState, playerId: PlayerId): CardInstanceId[] {
+  return state.zones.get(`${playerId}-library`)!.cardIds;
+}
+
+/** Allow extra mana to be paid for cycling in a given fixture. */
+function withMana(
+  state: GameState,
+  playerId: PlayerId,
+  generic: number,
+  colored: Partial<{
+    white: number;
+    blue: number;
+    black: number;
+    red: number;
+    green: number;
+    colorless: number;
+  }> = {},
+): GameState {
+  return addMana(state, playerId, { generic, ...colored });
+}
+
+// ===========================================================================
+// Parsing (CR 702.30 / CR 702.31)
+// ===========================================================================
+
+describe("Cycling — parsing (CR 702.30-31)", () => {
+  it("detects base Cycling {cost}", () => {
+    const r = parseCycling("Cycling {2}");
+    expect(r.hasCycling).toBe(true);
+    expect(r.variant).toBe(CyclingVariant.CYCLING);
+    expect(r.cost).not.toBeNull();
+    expect(r.cost!.generic).toBe(2);
+    expect(r.costString).toBe("{2}");
+    expect(r.description).toBe("Cycling {2}");
+  });
+
+  it("detects base Cycling with a colored cost", () => {
+    const r = parseCycling("Cycling {1}{U}");
+    expect(r.hasCycling).toBe(true);
+    expect(r.variant).toBe(CyclingVariant.CYCLING);
+    expect(r.cost!.generic).toBe(1);
+    expect(r.cost!.blue).toBe(1);
+    expect(r.costString).toBe("{1}{U}");
+  });
+
+  it("detects Typecycling ([Type]cycling)", () => {
+    const r = parseCycling("Wizardcycling {2}");
+    expect(r.hasCycling).toBe(true);
+    expect(r.variant).toBe(CyclingVariant.TYPECYCLING);
+    expect(r.type).toBe("Wizard");
+    expect(r.cost!.generic).toBe(2);
+    expect(r.description).toBe("Wizardcycling {2}");
+  });
+
+  it("detects Landcycling", () => {
+    const r = parseCycling("Landcycling {2}");
+    expect(r.hasCycling).toBe(true);
+    expect(r.variant).toBe(CyclingVariant.LANDCYCLING);
+    expect(r.basicLandType).toBeNull();
+    expect(r.cost!.generic).toBe(2);
+    expect(r.description).toBe("Landcycling {2}");
+  });
+
+  it("detects [Type] landcycling written as '[Type]cycling' (e.g. Plainscycling)", () => {
+    // CR 702.31: "Plainscycling" is a Typecycling variant (no space between
+    // [Type] and "cycling") whose target type is the Plains basic land type.
+    // The parser therefore returns TYPECYCLING with type="Plains"; the
+    // cycleCard search predicate matches any card whose type line includes
+    // "Plains" — which includes basic Plains and any card with the Plains
+    // subtype.
+    const r = parseCycling("Plainscycling {1}{W}");
+    expect(r.hasCycling).toBe(true);
+    expect(r.variant).toBe(CyclingVariant.TYPECYCLING);
+    expect(r.type).toBe("Plains");
+    expect(r.cost!.generic).toBe(1);
+    expect(r.cost!.white).toBe(1);
+    expect(r.description).toBe("Plainscycling {1}{W}");
+  });
+
+  it("detects [Type] landcycling written with a space (e.g. 'Plains landcycling')", () => {
+    // Some printings use the spaced form (e.g. Krosan Verge uses
+    // "Plainscycling" as one word; the spaced form is rare but legal). The
+    // parser distinguishes the two shapes so the basicLandType field is
+    // populated for the spaced form.
+    const r = parseCycling("Plains landcycling {1}{W}");
+    expect(r.hasCycling).toBe(true);
+    expect(r.variant).toBe(CyclingVariant.LANDCYCLING);
+    expect(r.basicLandType).toBe("Plains");
+    expect(r.cost!.generic).toBe(1);
+    expect(r.cost!.white).toBe(1);
+    expect(r.description).toBe("Plains landcycling {1}{W}");
+  });
+
+  it("detects Basic landcycling", () => {
+    const r = parseCycling("Basic landcycling {1}");
+    expect(r.hasCycling).toBe(true);
+    expect(r.variant).toBe(CyclingVariant.BASIC_LANDCYCLING);
+    expect(r.cost!.generic).toBe(1);
+    expect(r.description).toBe("Basic landcycling {1}");
+  });
+
+  it("is case-insensitive", () => {
+    expect(parseCycling("cycling {2}").hasCycling).toBe(true);
+    expect(parseCycling("CYCLING {3}").hasCycling).toBe(true);
+    expect(parseCycling("wizardCYCLING {1}").hasCycling).toBe(true);
+  });
+
+  it("returns false when no cycling keyword is present", () => {
+    expect(parseCycling("Flying").hasCycling).toBe(false);
+    expect(parseCycling("").hasCycling).toBe(false);
+    expect(parseCycling("Flashback {2}{R}").hasCycling).toBe(false);
+    expect(parseCycling("").variant).toBeNull();
+    expect(parseCycling("").cost).toBeNull();
+  });
+
+  it("does not match 'cycling' inside other words", () => {
+    expect(parseCycling("recycling").hasCycling).toBe(false);
+    expect(parseCycling("tricycling").hasCycling).toBe(false);
+  });
+
+  it("extractKeywords surfaces the cycling mechanic keyword", () => {
+    const parsed = extractKeywords("Cycling {2}", "Creature — Bird");
+    expect(parsed.some((k) => k.keyword === "cycling")).toBe(true);
+  });
+
+  it("parseCyclingCost returns the generic cost of base cycling", () => {
+    expect(parseCyclingCost("Cycling {2}")).toBe(2);
+    expect(parseCyclingCost("Wizardcycling {3}")).toBe(3);
+    expect(parseCyclingCost(null)).toBeNull();
+    expect(parseCyclingCost("Flying")).toBeNull();
+  });
+});
+
+// ===========================================================================
+// Keyword detection helpers
+// ===========================================================================
+
+describe("Cycling — keyword detection helpers", () => {
+  it("hasCycling returns true for base cycling", () => {
+    const card = createCardInstance(baseCyclingCreature(), "p1", "p1");
+    expect(hasCycling(card)).toBe(true);
+  });
+
+  it("hasCycling returns true for Typecycling", () => {
+    const card = createCardInstance(wizardcyclingCreature(), "p1", "p1");
+    expect(hasCycling(card)).toBe(true);
+  });
+
+  it("hasCycling returns true for Landcycling variants", () => {
+    expect(
+      hasCycling(createCardInstance(landcyclingCreature(), "p1", "p1")),
+    ).toBe(true);
+    expect(
+      hasCycling(createCardInstance(plainscyclingLand(), "p1", "p1")),
+    ).toBe(true);
+    expect(
+      hasCycling(createCardInstance(basicLandcyclingLand(), "p1", "p1")),
+    ).toBe(true);
+  });
+
+  it("hasCycling returns false for cards without cycling", () => {
+    const card = createCardInstance(noCyclingCreature(), "p1", "p1");
+    expect(hasCycling(card)).toBe(false);
+  });
+
+  it("hasLandcycling returns true for any landcycling variant", () => {
+    expect(
+      hasLandcycling(createCardInstance(landcyclingCreature(), "p1", "p1")),
+    ).toBe(true);
+    // "Plainscycling" parses as TYPECYCLING (no space), not LANDCYCLING —
+    // see the parser test above for the rationale.
+    expect(
+      hasLandcycling(createCardInstance(basicLandcyclingLand(), "p1", "p1")),
+    ).toBe(true);
+  });
+
+  it("hasLandcycling returns true for the spaced '[Type] landcycling' form", () => {
+    const card = makeCard({
+      id: "mock-spaced-plainscycling",
+      name: "Spaced Plainscycler",
+      type_line: "Creature — Cycler",
+      oracle_text: "Plains landcycling {1}{W}",
+    });
+    expect(hasLandcycling(createCardInstance(card, "p1", "p1"))).toBe(true);
+  });
+
+  it("hasLandcycling filters by subtype when supplied", () => {
+    const card = makeCard({
+      id: "mock-spaced-islandcycling",
+      name: "Spaced Islandcycler",
+      type_line: "Creature — Cycler",
+      oracle_text: "Island landcycling {1}{U}",
+    });
+    expect(hasLandcycling(card, "Island")).toBe(true);
+    expect(hasLandcycling(card, "Plains")).toBe(false);
+  });
+
+  it("hasLandcycling returns false for non-land cycling cards", () => {
+    const card = createCardInstance(baseCyclingCreature(), "p1", "p1");
+    expect(hasLandcycling(card)).toBe(false);
+    const wiz = createCardInstance(wizardcyclingCreature(), "p1", "p1");
+    expect(hasLandcycling(wiz)).toBe(false);
+  });
+
+  it("hasTypecycling returns true for Typecycling cards only", () => {
+    expect(
+      hasTypecycling(createCardInstance(wizardcyclingCreature(), "p1", "p1")),
+    ).toBe(true);
+    expect(
+      hasTypecycling(createCardInstance(baseCyclingCreature(), "p1", "p1")),
+    ).toBe(false);
+    expect(
+      hasTypecycling(createCardInstance(landcyclingCreature(), "p1", "p1")),
+    ).toBe(false);
+  });
+
+  it("hasTypecycling filters by type when supplied", () => {
+    const card = createCardInstance(wizardcyclingCreature(), "p1", "p1");
+    expect(hasTypecycling(card, "Wizard")).toBe(true);
+    expect(hasTypecycling(card, "Goblin")).toBe(false);
+  });
+
+  it("getCyclingCost / getCyclingVariant expose parsed cycling descriptors", () => {
+    const wiz = createCardInstance(wizardcyclingCreature(), "p1", "p1");
+    expect(getCyclingCost(wiz)?.generic).toBe(2);
+    const v = getCyclingVariant(wiz);
+    expect(v.variant).toBe(CyclingVariant.TYPECYCLING);
+    expect(v.type).toBe("Wizard");
+
+    // "Plainscycling" parses as TYPECYCLING (no space). Use a spaced
+    // "[Type] landcycling" card to exercise the LANDCYCLING-with-subtype
+    // path of getCyclingVariant.
+    const plains = createCardInstance(
+      makeCard({
+        id: "mock-plains-landcycling",
+        name: "Spaced Plainscycler",
+        type_line: "Creature — Cycler",
+        oracle_text: "Plains landcycling {1}{W}",
+      }),
+      "p1",
+      "p1",
+    );
+    const pv = getCyclingVariant(plains);
+    expect(pv.variant).toBe(CyclingVariant.LANDCYCLING);
+    expect(pv.basicLandType).toBe("Plains");
+  });
+});
+
+// ===========================================================================
+// cycleCard — base Cycling draws a card (CR 702.30a)
+// ===========================================================================
+
+describe("Cycling — cycleCard base variant draws a card (CR 702.30a)", () => {
+  let f: Fixture;
+  let cardId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    cardId = putInHand(f.state, f.aliceId, baseCyclingCreature());
+    // Enough generic mana to pay the {2} cycling cost.
+    f.state = withMana(f.state, f.aliceId, 3);
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+    f.state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    f.state.stack = [];
+  });
+
+  it("discards the cycled card and draws one card", () => {
+    // Populate the library with a drawable card.
+    const drawId = putInLibrary(f.state, f.aliceId, basicIsland("draw-1"));
+
+    const handBefore = handIds(f.state, f.aliceId).length;
+    const libBefore = libraryIds(f.state, f.aliceId).length;
+    expect(libBefore).toBeGreaterThan(0);
+    const result = cycleCard(f.state, f.aliceId, cardId);
+
+    expect(result.success).toBe(true);
+
+    // Hand: cycled card removed, drawn card added.
+    expect(handIds(result.state, f.aliceId)).not.toContain(cardId);
+    expect(handIds(result.state, f.aliceId).length).toBe(handBefore);
+    expect(handIds(result.state, f.aliceId)).toContain(drawId);
+
+    // Library: drawn card removed.
+    expect(libraryIds(result.state, f.aliceId).length).toBe(libBefore - 1);
+    expect(libraryIds(result.state, f.aliceId)).not.toContain(drawId);
+
+    // Graveyard: cycled card present.
+    expect(graveyardIds(result.state, f.aliceId)).toContain(cardId);
+  });
+
+  it("pays the cycling mana cost", () => {
+    putInLibrary(f.state, f.aliceId, basicIsland("draw-2"));
+    const before = f.state.players.get(f.aliceId)!.manaPool;
+    const result = cycleCard(f.state, f.aliceId, cardId);
+
+    expect(result.success).toBe(true);
+    const after = result.state.players.get(f.aliceId)!.manaPool;
+    // {2} cycling cost: 2 generic spent.
+    expect(before.generic - after.generic).toBe(2);
+  });
+
+  it("canCycleCard returns true when all preconditions are met", () => {
+    putInLibrary(f.state, f.aliceId, basicIsland("draw-3"));
+    const card = f.state.cards.get(cardId)!;
+    expect(canCycleCard(f.state, f.aliceId, card)).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Hand-only restriction (CR 702.30a)
+// ===========================================================================
+
+describe("Cycling — hand-only restriction (CR 702.30a)", () => {
+  let f: Fixture;
+
+  beforeEach(() => {
+    f = makeFixture();
+    f.state = withMana(f.state, f.aliceId, 5);
+  });
+
+  it("rejects cycling from the battlefield", () => {
+    const card = createCardInstance(
+      baseCyclingCreature(),
+      f.aliceId,
+      f.aliceId,
+    );
+    card.currentZoneKey = `${f.aliceId}-battlefield`;
+    f.state.cards.set(card.id, card);
+    const bf = f.state.zones.get(`${f.aliceId}-battlefield`)!;
+    f.state.zones.set(`${f.aliceId}-battlefield`, {
+      ...bf,
+      cardIds: [...bf.cardIds, card.id],
+    });
+
+    const result = cycleCard(f.state, f.aliceId, card.id);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/hand/i);
+  });
+
+  it("rejects cycling from the graveyard", () => {
+    const card = createCardInstance(
+      baseCyclingCreature(),
+      f.aliceId,
+      f.aliceId,
+    );
+    card.currentZoneKey = `${f.aliceId}-graveyard`;
+    f.state.cards.set(card.id, card);
+    const gy = f.state.zones.get(`${f.aliceId}-graveyard`)!;
+    f.state.zones.set(`${f.aliceId}-graveyard`, {
+      ...gy,
+      cardIds: [...gy.cardIds, card.id],
+    });
+
+    const result = cycleCard(f.state, f.aliceId, card.id);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/hand/i);
+  });
+
+  it("rejects cycling from the library", () => {
+    const card = createCardInstance(
+      baseCyclingCreature(),
+      f.aliceId,
+      f.aliceId,
+    );
+    card.currentZoneKey = `${f.aliceId}-library`;
+    f.state.cards.set(card.id, card);
+    const lib = f.state.zones.get(`${f.aliceId}-library`)!;
+    f.state.zones.set(`${f.aliceId}-library`, {
+      ...lib,
+      cardIds: [...lib.cardIds, card.id],
+    });
+
+    const result = cycleCard(f.state, f.aliceId, card.id);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/hand/i);
+  });
+
+  it("canCycleCard returns false for a card on the battlefield", () => {
+    const card = createCardInstance(
+      baseCyclingCreature(),
+      f.aliceId,
+      f.aliceId,
+    );
+    card.currentZoneKey = `${f.aliceId}-battlefield`;
+    f.state.cards.set(card.id, card);
+    expect(canCycleCard(f.state, f.aliceId, card)).toBe(false);
+  });
+});
+
+// ===========================================================================
+// Sorcery-speed timing (CR 117.1a / 602.2)
+// ===========================================================================
+
+describe("Cycling — sorcery-speed timing (CR 117.1a)", () => {
+  let f: Fixture;
+  let cardId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    cardId = putInHand(f.state, f.aliceId, baseCyclingCreature());
+    f.state = withMana(f.state, f.aliceId, 5);
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+    f.state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    f.state.stack = [];
+  });
+
+  it("rejects cycling on an opponent's turn", () => {
+    f.state.turn.activePlayerId = f.bobId;
+    const result = cycleCard(f.state, f.aliceId, cardId);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/turn/i);
+  });
+
+  it("rejects cycling outside a main phase", () => {
+    f.state.turn.currentPhase = Phase.BEGIN_COMBAT;
+    const result = cycleCard(f.state, f.aliceId, cardId);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/main/i);
+  });
+
+  it("accepts cycling during the postcombat main phase", () => {
+    f.state.turn.currentPhase = Phase.POSTCOMBAT_MAIN;
+    putInLibrary(f.state, f.aliceId, basicIsland("postcombat-draw"));
+    const result = cycleCard(f.state, f.aliceId, cardId);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects cycling when the stack is not empty", () => {
+    f.state.stack = [
+      {
+        id: "dummy-stack-object",
+        type: "spell",
+        sourceCardId: null,
+        controllerId: f.aliceId,
+        name: "Dummy",
+        text: "",
+        manaCost: null,
+        targets: [],
+        chosenModes: [],
+        variableValues: new Map(),
+        isCountered: false,
+        timestamp: Date.now(),
+      },
+    ];
+    const result = cycleCard(f.state, f.aliceId, cardId);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/stack/i);
+  });
+
+  it("rejects cycling when the player does not have priority", () => {
+    f.state.priorityPlayerId = f.bobId;
+    const result = cycleCard(f.state, f.aliceId, cardId);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/priority/i);
+  });
+
+  it("rejects cycling without enough mana", () => {
+    // Drain the pool so the {2} cycling cost can't be paid.
+    f.state.players.set(f.aliceId, {
+      ...f.state.players.get(f.aliceId)!,
+      manaPool: {
+        colorless: 0,
+        white: 0,
+        blue: 0,
+        black: 0,
+        red: 0,
+        green: 0,
+        generic: 1,
+      },
+    });
+    const result = cycleCard(f.state, f.aliceId, cardId);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/mana/i);
+  });
+
+  it("rejects cycling a card without the cycling keyword", () => {
+    const nonCycler = putInHand(f.state, f.aliceId, noCyclingCreature());
+    const result = cycleCard(f.state, f.aliceId, nonCycler);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/cycling/i);
+  });
+});
+
+// ===========================================================================
+// Typecycling — search library for a card of the named type (CR 702.31a)
+// ===========================================================================
+
+describe("Cycling — Typecycling searches library for the named type (CR 702.31a)", () => {
+  let f: Fixture;
+  let cardId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    cardId = putInHand(f.state, f.aliceId, wizardcyclingCreature());
+    f.state = withMana(f.state, f.aliceId, 3);
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+    f.state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    f.state.stack = [];
+  });
+
+  it("finds a matching card in the library and moves it to hand", () => {
+    // Library contains a Wizard (match) and a non-Wizard.
+    putInLibrary(f.state, f.aliceId, basicIsland("non-wizard-1"));
+    const wizardId = putInLibrary(
+      f.state,
+      f.aliceId,
+      makeCard({
+        id: "mock-wizard-target",
+        name: "Wizard Target",
+        type_line: "Creature — Wizard",
+        oracle_text: "",
+        mana_cost: "{U}",
+        cmc: 1,
+        colors: ["U"],
+        power: "1",
+        toughness: "1",
+      }),
+    );
+
+    const result = cycleCard(f.state, f.aliceId, cardId);
+
+    expect(result.success).toBe(true);
+    // The wizard is now in hand.
+    expect(handIds(result.state, f.aliceId)).toContain(wizardId);
+    // The cycled card is in the graveyard.
+    expect(graveyardIds(result.state, f.aliceId)).toContain(cardId);
+  });
+
+  it("shuffles the library and puts nothing in hand when no match exists", () => {
+    // Library contains only non-Wizards.
+    putInLibrary(f.state, f.aliceId, basicIsland("no-wizard-1"));
+    putInLibrary(f.state, f.aliceId, basicIsland("no-wizard-2"));
+
+    const handBefore = handIds(f.state, f.aliceId);
+    const libBefore = libraryIds(f.state, f.aliceId);
+
+    const result = cycleCard(f.state, f.aliceId, cardId);
+
+    expect(result.success).toBe(true);
+    // No new card moved to hand; cycled card moved to graveyard.
+    expect(handIds(result.state, f.aliceId).length).toBe(handBefore.length - 1);
+    expect(graveyardIds(result.state, f.aliceId)).toContain(cardId);
+    // Library still has all its cards.
+    expect(libraryIds(result.state, f.aliceId).length).toBe(libBefore.length);
+  });
+
+  it("respects a caller-selected found card", () => {
+    putInLibrary(f.state, f.aliceId, basicIsland("selection-non-wizard"));
+    const specific = putInLibrary(
+      f.state,
+      f.aliceId,
+      makeCard({
+        id: "mock-wizard-pick",
+        name: "Picked Wizard",
+        type_line: "Creature — Wizard",
+        oracle_text: "",
+        mana_cost: "{U}",
+        cmc: 1,
+        colors: ["U"],
+        power: "1",
+        toughness: "1",
+      }),
+    );
+
+    const result = cycleCard(f.state, f.aliceId, cardId, {
+      selectedFoundCardId: specific,
+    });
+    expect(result.success).toBe(true);
+    expect(handIds(result.state, f.aliceId)).toContain(specific);
+  });
+
+  it("rejects a selected card that does not match the type", () => {
+    const wrong = putInLibrary(f.state, f.aliceId, basicIsland("wrong-type"));
+    const result = cycleCard(f.state, f.aliceId, cardId, {
+      selectedFoundCardId: wrong,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/match/i);
+  });
+});
+
+// ===========================================================================
+// Landcycling — search library for a (basic) land (CR 702.31b-c)
+// ===========================================================================
+
+describe("Cycling — Landcycling searches library for a land (CR 702.31b-c)", () => {
+  let f: Fixture;
+
+  beforeEach(() => {
+    f = makeFixture();
+    // Some landcycling cards cost colored mana (e.g. Plainscycling {1}{W});
+    // add both white and blue for safety across the variants.
+    f.state = addMana(f.state, f.aliceId, {
+      generic: 3,
+      white: 3,
+      blue: 3,
+      black: 3,
+      red: 3,
+      green: 3,
+    });
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+    f.state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    f.state.stack = [];
+  });
+
+  it("Plainscycling finds a Plains in the library", () => {
+    const cyclerId = putInHand(f.state, f.aliceId, plainscyclingLand());
+    putInLibrary(f.state, f.aliceId, basicIsland("decoy-island"));
+    const plainsId = putInLibrary(f.state, f.aliceId, basicPlains("target"));
+
+    const result = cycleCard(f.state, f.aliceId, cyclerId);
+    expect(result.success).toBe(true);
+    expect(handIds(result.state, f.aliceId)).toContain(plainsId);
+    expect(handIds(result.state, f.aliceId)).not.toContain(cyclerId);
+    expect(graveyardIds(result.state, f.aliceId)).toContain(cyclerId);
+  });
+
+  it("Plainscycling rejects non-Plains lands", () => {
+    const cyclerId = putInHand(f.state, f.aliceId, plainscyclingLand());
+    putInLibrary(f.state, f.aliceId, basicIsland("not-plains-1"));
+    putInLibrary(f.state, f.aliceId, nonBasicLand("not-plains-2"));
+
+    const handBefore = handIds(f.state, f.aliceId);
+    const result = cycleCard(f.state, f.aliceId, cyclerId);
+    expect(result.success).toBe(true);
+    // No card moved into hand; the cycled card is in the graveyard.
+    expect(handIds(result.state, f.aliceId).length).toBe(handBefore.length - 1);
+  });
+
+  it("bare Landcycling finds any land (basic or not)", () => {
+    const cyclerId = putInHand(f.state, f.aliceId, landcyclingCreature());
+    const gate = putInLibrary(f.state, f.aliceId, nonBasicLand("gate"));
+
+    const result = cycleCard(f.state, f.aliceId, cyclerId);
+    expect(result.success).toBe(true);
+    expect(handIds(result.state, f.aliceId)).toContain(gate);
+  });
+
+  it("Basic landcycling finds any basic land", () => {
+    const cyclerId = putInHand(f.state, f.aliceId, basicLandcyclingLand());
+    const islandId = putInLibrary(f.state, f.aliceId, basicIsland("basic-1"));
+    // Also include a non-basic land that must NOT be matched.
+    const nonBasicId = putInLibrary(
+      f.state,
+      f.aliceId,
+      nonBasicLand("basic-2"),
+    );
+
+    const result = cycleCard(f.state, f.aliceId, cyclerId);
+    expect(result.success).toBe(true);
+    expect(handIds(result.state, f.aliceId)).toContain(islandId);
+    // The non-basic land is still in the library (Basic landcycling must
+    // skip it).
+    expect(libraryIds(result.state, f.aliceId)).toContain(nonBasicId);
+  });
+
+  it("Basic landcycling rejects non-basic lands", () => {
+    const cyclerId = putInHand(f.state, f.aliceId, basicLandcyclingLand());
+    const gate = putInLibrary(f.state, f.aliceId, nonBasicLand("nb-1"));
+
+    const handBefore = handIds(f.state, f.aliceId);
+    const result = cycleCard(f.state, f.aliceId, cyclerId);
+    expect(result.success).toBe(true);
+    // Nothing new in hand (gate is still in library).
+    expect(handIds(result.state, f.aliceId).length).toBe(handBefore.length - 1);
+    expect(libraryIds(result.state, f.aliceId)).toContain(gate);
+  });
+
+  it("shuffles the library even when no matching land is found", () => {
+    const cyclerId = putInHand(f.state, f.aliceId, landcyclingCreature());
+    // Only non-land cards in the library so Landcycling finds nothing.
+    putInLibrary(
+      f.state,
+      f.aliceId,
+      makeCard({
+        id: "mock-nonland-1",
+        name: "Grizzly Bears",
+        type_line: "Creature — Bear",
+      }),
+    );
+
+    const libBefore = libraryIds(f.state, f.aliceId);
+    const result = cycleCard(f.state, f.aliceId, cyclerId);
+    expect(result.success).toBe(true);
+    // No card moved out of the library.
+    expect(libraryIds(result.state, f.aliceId).length).toBe(libBefore.length);
+  });
+});
+
+// ===========================================================================
+// Empty library — draw variant edge case (CR 702.30a)
+// ===========================================================================
+
+describe("Cycling — base variant with empty library", () => {
+  it("returns a draw-failed error after the discard cost has been paid", () => {
+    const f = makeFixture();
+    const cardId = putInHand(f.state, f.aliceId, baseCyclingCreature());
+    f.state = withMana(f.state, f.aliceId, 3);
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+    f.state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    f.state.stack = [];
+    // Empty the library to force the draw to fail.
+    const lib = f.state.zones.get(`${f.aliceId}-library`)!;
+    f.state.zones.set(`${f.aliceId}-library`, { ...lib, cardIds: [] });
+
+    const result = cycleCard(f.state, f.aliceId, cardId);
+    expect(result.success).toBe(false);
+    // The discard cost still happened: the cycled card is in the graveyard.
+    expect(graveyardIds(result.state, f.aliceId)).toContain(cardId);
+    expect(result.error).toBeDefined();
+  });
+});

--- a/src/lib/game-state/event-sourcing.ts
+++ b/src/lib/game-state/event-sourcing.ts
@@ -990,6 +990,8 @@ function describeGameAction(action: GameAction): string {
       return "Player drew a card";
     case "discard_card":
       return `Player discarded ${(actionData.cardName as string) || "a card"}`;
+    case "cycle_card":
+      return `Player cycled ${(actionData.cardName as string) || "a card"}`;
     case "tap_card":
       return `Player tapped ${(actionData.cardName as string) || "a card"}`;
     case "untap_card":

--- a/src/lib/game-state/keyword-actions.ts
+++ b/src/lib/game-state/keyword-actions.ts
@@ -34,9 +34,14 @@ import {
   hasCounter,
   initializePlaneswalkerLoyalty,
 } from "./card-instance";
-import { moveCardBetweenZones, isForetoldCard } from "./zones";
+import { moveCardBetweenZones, isForetoldCard, shuffleZone } from "./zones";
 import { spendMana } from "./mana";
-import { parseForetell } from "./oracle-text-parser";
+import {
+  parseForetell,
+  parseCycling,
+  CyclingVariant,
+  type CyclingInfo,
+} from "./oracle-text-parser";
 import { castSpell } from "./spell-casting";
 import {
   hasPersist,
@@ -1592,34 +1597,597 @@ export function handlePersist(
   return { state: updatedState, persistedCards, descriptions };
 }
 
-/** @deprecated Stub - cycling mechanic not yet implemented */
-export function hasCycling(card: any): boolean {
-  return false;
+// ===========================================================================
+// Cycling (CR 702.30) + Typecycling / Landcycling / Basic landcycling
+// (CR 702.31)
+//
+// "Cycling {cost}" is an activated ability that may be activated from a
+// player's hand only. The cost is {cost} + discard this card; the effect is to
+// draw a card (CR 702.30a). Typecycling / Landcycling / Basic landcycling are
+// defined in CR 702.31 and replace the draw with a library search for a card
+// of the named type. The cycle ability uses the stack (CR 602.2), so it can be
+// responded to like any other activated ability.
+//
+// Like other activated abilities with discard costs, cycling can only be
+// activated at sorcery timing — the active player during a main phase while
+// the stack is empty (CR 117.1a). The implementation enforces that here and
+// surfaces it via canCycleCard so callers (UI, AI) can gate the action.
+// ===========================================================================
+
+/**
+ * Parse the cycling keyword from oracle text. Thin convenience wrapper around
+ * `parseCycling` returning the legacy `number | null` shape — used by
+ * tests/UI that pre-date the CyclingInfo object.
+ */
+export function parseCyclingCost(
+  text: string | null | undefined,
+): number | null {
+  if (!text) return null;
+  const info = parseCycling(text);
+  if (!info.hasCycling || !info.cost) return null;
+  return info.cost.generic;
 }
 
-/** @deprecated Stub - cycling mechanic not yet implemented */
-export function hasLandcycling(card: any, landType?: string): boolean {
-  return false;
+/**
+ * Internal: read the ScryfallCard-shaped `cardData` block off either a
+ * CardInstance or a ScryfallCard. Both types expose the same fields we need
+ * (oracle_text, keywords, type_line) so we treat them uniformly.
+ */
+function getCyclingCardData(card: CardInstance | ScryfallCard): ScryfallCard {
+  if ("cardData" in card && card.cardData) {
+    return card.cardData as ScryfallCard;
+  }
+  return card as ScryfallCard;
 }
 
-/** @deprecated Stub - cycling mechanic not yet implemented */
-export function getCyclingCost(card: any): number | null {
-  return null;
+/**
+ * Return true if the card has any cycling variant (Cycling / Typecycling /
+ * Landcycling / Basic landcycling) parsed from oracle text or the keywords
+ * array. CR 702.30-31.
+ */
+export function hasCycling(card: CardInstance | ScryfallCard): boolean {
+  const data = getCyclingCardData(card);
+  const oracleText = data.oracle_text ?? "";
+  const keywords = data.keywords ?? [];
+  if (oracleText && parseCycling(oracleText).hasCycling) {
+    return true;
+  }
+  return keywords.some((k) => /cycling/i.test(k));
 }
 
-/** @deprecated Stub - cycling mechanic not yet implemented */
-export function canCycleCard(state: any, playerId: any, card: any): boolean {
-  return false;
+/**
+ * Return true if the card has a Landcycling variant (either bare
+ * "Landcycling" or "[Type] landcycling" / "Basic landcycling"). If `landType`
+ * is supplied, only return true when the parsed variant is restricted to that
+ * specific basic land subtype.
+ */
+export function hasLandcycling(
+  card: CardInstance | ScryfallCard,
+  landType?: string,
+): boolean {
+  const data = getCyclingCardData(card);
+  const oracleText = data.oracle_text ?? "";
+  if (!oracleText) return false;
+  const info = parseCycling(oracleText);
+  if (
+    !info.hasCycling ||
+    (info.variant !== CyclingVariant.LANDCYCLING &&
+      info.variant !== CyclingVariant.BASIC_LANDCYCLING)
+  ) {
+    return false;
+  }
+  if (landType !== undefined) {
+    return info.basicLandType === landType;
+  }
+  return true;
 }
 
-/** @deprecated Stub - cycling mechanic not yet implemented */
-export function cycleCard(state: any, playerId: any, cardId: any): any {
-  return { success: false, error: "not implemented" };
+/**
+ * Return true if the card has a Typecycling variant (e.g. Wizardcycling,
+ * Slivercycling). When `cardType` is supplied, only return true when the
+ * parsed cycling variant targets that specific card type.
+ */
+export function hasTypecycling(
+  card: CardInstance | ScryfallCard,
+  cardType?: string,
+): boolean {
+  const data = getCyclingCardData(card);
+  const oracleText = data.oracle_text ?? "";
+  if (!oracleText) return false;
+  const info = parseCycling(oracleText);
+  if (!info.hasCycling || info.variant !== CyclingVariant.TYPECYCLING) {
+    return false;
+  }
+  if (cardType !== undefined) {
+    return info.type === cardType;
+  }
+  return true;
 }
 
-/** @deprecated Stub - cycling mechanic not yet implemented */
-export function parseCyclingCost(text: any): number | null {
-  return null;
+/**
+ * Return the parsed cycling mana cost as a `ParsedManaCost`, or `null` if the
+ * card does not have cycling. The "discard this card" portion of the cost is
+ * implicit (CR 702.30a) and is not included in the returned object.
+ */
+export function getCyclingCost(
+  card: CardInstance | ScryfallCard,
+): CyclingInfo["cost"] {
+  const data = getCyclingCardData(card);
+  const oracleText = data.oracle_text ?? "";
+  if (!oracleText) return null;
+  return parseCycling(oracleText).cost;
+}
+
+/**
+ * Return the full parsed cycling descriptor for the card (variant + cost +
+ * named type). Useful when the caller needs to distinguish the variants (e.g.
+ * to drive the correct effect after the cost is paid).
+ */
+export function getCyclingVariant(
+  card: CardInstance | ScryfallCard,
+): CyclingInfo {
+  const data = getCyclingCardData(card);
+  const oracleText = data.oracle_text ?? "";
+  if (!oracleText) {
+    return {
+      hasCycling: false,
+      variant: null,
+      cost: null,
+      costString: null,
+      type: null,
+      basicLandType: null,
+      description: "",
+    };
+  }
+  return parseCycling(oracleText);
+}
+
+/**
+ * Check whether `playerId` may cycle `card` right now.
+ *
+ * CR 702.30a: Cycling functions only while the card is in a player's hand.
+ * CR 117.1a / 602.2: Activated abilities follow normal timing — sorcery
+ * timing applies (active player, main phase, empty stack, player has
+ * priority). CR 602.5b: A cost requiring a payment (e.g. discard) can only
+ * be activated when the payment can be made; we additionally require the
+ * player can pay the mana cost.
+ */
+export function canCycleCard(
+  state: GameState,
+  playerId: PlayerId,
+  card: CardInstance,
+): boolean {
+  if (!state || !card) return false;
+  if (card.controllerId !== playerId && card.ownerId !== playerId) return false;
+
+  // CR 702.30a: cycling is hand-only.
+  const handZone = state.zones.get(`${playerId}-hand`);
+  if (!handZone || !handZone.cardIds.includes(card.id)) {
+    return false;
+  }
+
+  // Must have cycling.
+  if (!hasCycling(card)) return false;
+
+  // Sorcery-speed timing (active player, main phase, empty stack, priority).
+  if (state.status !== "in_progress") return false;
+  if (state.turn.activePlayerId !== playerId) return false;
+  if (
+    state.turn.currentPhase !== Phase.PRECOMBAT_MAIN &&
+    state.turn.currentPhase !== Phase.POSTCOMBAT_MAIN
+  ) {
+    return false;
+  }
+  if (state.stack.length > 0) return false;
+  if (state.priorityPlayerId !== playerId) return false;
+
+  // Must be able to pay the cycling mana cost.
+  const cost = getCyclingCost(card);
+  if (cost) {
+    const player = state.players.get(playerId);
+    if (!player) return false;
+    const pool = player.manaPool;
+    const coloredShortfall =
+      cost.white > pool.white ||
+      cost.blue > pool.blue ||
+      cost.black > pool.black ||
+      cost.red > pool.red ||
+      cost.green > pool.green ||
+      cost.colorless > pool.colorless;
+    if (coloredShortfall) return false;
+    const availableGeneric =
+      pool.generic +
+      pool.white +
+      pool.blue +
+      pool.black +
+      pool.red +
+      pool.green;
+    if (cost.generic > availableGeneric) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Activate Cycling / Typecycling / Landcycling on `cardId` (CR 702.30-31).
+ *
+ * Steps (in order):
+ *  1. Verify the card exists, is in the player's hand, and has cycling.
+ *  2. Verify sorcery-speed timing (active player, main phase, empty stack,
+ *     player has priority).
+ *  3. Pay the cycling mana cost from the player's mana pool.
+ *  4. Move the cycled card from hand → graveyard (the discard is a cost of
+ *     the ability, CR 601.2g, and does not use the stack).
+ *  5. Resolve the effect:
+ *       - CYCLING              → draw a card (CR 702.30a).
+ *       - LANDCYCLING /
+ *         BASIC_LANDCYCLING   → search library for a land of the named type
+ *                                (or any basic land for the bare form), reveal
+ *                                it, put it into hand, then shuffle (CR
+ *                                702.31b/c). The library search uses the
+ *                                controller's library; this implementation
+ *                                moves the first matching land instance to
+ *                                hand and shuffles. If no matching land is
+ *                                present, the library is still shuffled (CR
+ *                                702.31c, last sentence) and no card is
+ *                                drawn.
+ *       - TYPECYCLING          → search library for a card of the named type,
+ *                                reveal it, put it into hand, shuffle (CR
+ *                                702.31a). Same library-search semantics as
+ *                                Landcycling above.
+ *
+ * The result is a `KeywordActionResult` carrying the updated state. An
+ * `error` is set if any precondition fails; the input `state` is returned
+ * unchanged on failure.
+ */
+export function cycleCard(
+  state: GameState,
+  playerId: PlayerId,
+  cardId: CardInstanceId,
+  options: {
+    /**
+     * Optional pre-selected card instance ID for Typecycling / Landcycling
+     * library searches. When supplied, that card is the one found and
+     * revealed; when omitted, the engine picks the first card in the library
+     * whose type line matches the cycling variant (or any land for the bare
+     * Landcycling form).
+     */
+    selectedFoundCardId?: CardInstanceId;
+  } = {},
+): KeywordActionResult {
+  const card = state.cards.get(cardId);
+  if (!card) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: `Card ${cardId} not found`,
+    };
+  }
+
+  const info = parseCycling(card.cardData.oracle_text || "");
+  if (!info.hasCycling) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: `${card.cardData.name} does not have cycling.`,
+    };
+  }
+
+  // CR 702.30a: cycling is hand-only.
+  const handZoneKey = `${playerId}-hand`;
+  const handZone = state.zones.get(handZoneKey);
+  if (!handZone || !handZone.cardIds.includes(cardId)) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: "Cycling can only be activated from your hand.",
+    };
+  }
+
+  // Sorcery-speed timing (CR 117.1a).
+  if (state.status !== "in_progress") {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: "Cycling can only be activated during an in-progress game.",
+    };
+  }
+  if (state.turn.activePlayerId !== playerId) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: "You can cycle only on your turn.",
+    };
+  }
+  if (
+    state.turn.currentPhase !== Phase.PRECOMBAT_MAIN &&
+    state.turn.currentPhase !== Phase.POSTCOMBAT_MAIN
+  ) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: "Cycling can only be activated during a main phase.",
+    };
+  }
+  if (state.stack.length > 0) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: "Cycling can only be activated when the stack is empty.",
+    };
+  }
+  if (state.priorityPlayerId !== playerId) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: "You do not have priority.",
+    };
+  }
+
+  // Pay the cycling mana cost.
+  let workingState = state;
+  if (info.cost) {
+    const payment = {
+      generic: info.cost.generic,
+      white: info.cost.white,
+      blue: info.cost.blue,
+      black: info.cost.black,
+      red: info.cost.red,
+      green: info.cost.green,
+      colorless: info.cost.colorless,
+    };
+    const spend = spendMana(workingState, playerId, payment);
+    if (!spend.success) {
+      return {
+        success: false,
+        state,
+        description: "",
+        error: "Not enough mana to cycle.",
+      };
+    }
+    workingState = spend.state;
+  }
+
+  // Pay the discard cost: move the cycled card to the graveyard.
+  const discard = moveCardToZone(workingState, cardId, "graveyard");
+  if (!discard.success) {
+    return {
+      success: false,
+      state,
+      description: "",
+      error: discard.error ?? "Failed to discard the cycled card.",
+    };
+  }
+  workingState = discard.state;
+
+  // Resolve the cycling effect based on the variant.
+  switch (info.variant) {
+    case CyclingVariant.CYCLING: {
+      const draw = drawCards(workingState, playerId, 1);
+      if (!draw.success) {
+        // The discard already happened — surface a clear error so the caller
+        // knows to undo. We still return the state with the cycled card in
+        // the graveyard (it was paid as a cost) so the caller can decide.
+        return {
+          success: false,
+          state: draw.state,
+          description: `Cycled ${card.cardData.name}, but could not draw a card`,
+          error: draw.error ?? "Could not draw a card.",
+          affectedCards: [cardId],
+        };
+      }
+      return {
+        success: true,
+        state: draw.state,
+        description: `Cycled ${card.cardData.name} and drew a card`,
+        affectedCards: [cardId, ...(draw.affectedCards ?? [])],
+      };
+    }
+    case CyclingVariant.TYPECYCLING:
+    case CyclingVariant.LANDCYCLING:
+    case CyclingVariant.BASIC_LANDCYCLING: {
+      const search = searchLibraryForCycling(
+        workingState,
+        playerId,
+        info,
+        options.selectedFoundCardId,
+      );
+      if (!search.success) {
+        return {
+          success: false,
+          state: search.state,
+          description: `Cycled ${card.cardData.name}, but library search failed`,
+          error: search.error,
+          affectedCards: [cardId],
+        };
+      }
+      const moved = search.movedCardId
+        ? ` and put ${search.movedCardName ?? "a card"} into hand`
+        : "";
+      return {
+        success: true,
+        state: search.state,
+        description: `Cycled ${card.cardData.name}${moved}`,
+        affectedCards: search.movedCardId
+          ? [cardId, search.movedCardId]
+          : [cardId],
+      };
+    }
+    default:
+      return {
+        success: false,
+        state: workingState,
+        description: "",
+        error: `Unknown cycling variant: ${String(info.variant)}`,
+        affectedCards: [cardId],
+      };
+  }
+}
+
+/**
+ * Internal: library search for Typecycling / Landcycling. Reveals the chosen
+ * card, moves it to the controller's hand, and shuffles the library (CR
+ * 702.31a-c). The "reveal" step is tracked by adding the revealed card ID to
+ * the result; a full implementation would broadcast the reveal to opponents,
+ * which is out of scope for the engine API.
+ *
+ * If `selectedFoundCardId` is supplied, that card is the one moved. Otherwise
+ * the engine scans the library (top of the array == bottom of the library)
+ * for the first card whose type line matches the cycling variant's predicate.
+ * If no match exists, the library is still shuffled (CR 702.31c, "If you
+ * don't, shuffle your library.") and no card moves to hand.
+ */
+function searchLibraryForCycling(
+  state: GameState,
+  playerId: PlayerId,
+  info: CyclingInfo,
+  selectedFoundCardId?: CardInstanceId,
+): {
+  success: boolean;
+  state: GameState;
+  movedCardId?: CardInstanceId;
+  movedCardName?: string;
+  error?: string;
+} {
+  const libraryKey = `${playerId}-library`;
+  const handKey = `${playerId}-hand`;
+  const library = state.zones.get(libraryKey);
+  const hand = state.zones.get(handKey);
+
+  if (!library || !hand) {
+    return {
+      success: false,
+      state,
+      error: "Library or hand zone missing.",
+    };
+  }
+
+  const predicate = buildLibrarySearchPredicate(info);
+
+  // Resolve which card to move. If a selected ID is supplied, validate it is
+  // still in the library and matches the predicate. Otherwise pick the first
+  // matching card in the library (top of array = bottom of library; the
+  // specific position is irrelevant for game-logic correctness here, since
+  // the library is going to be shuffled anyway).
+  let chosenId: CardInstanceId | null = null;
+  if (selectedFoundCardId !== undefined) {
+    if (!library.cardIds.includes(selectedFoundCardId)) {
+      return {
+        success: false,
+        state,
+        error: "Selected card is not in your library.",
+      };
+    }
+    const chosen = state.cards.get(selectedFoundCardId);
+    if (!chosen || !predicate(chosen.cardData)) {
+      return {
+        success: false,
+        state,
+        error: "Selected card does not match the cycling variant.",
+      };
+    }
+    chosenId = selectedFoundCardId;
+  } else {
+    for (const id of library.cardIds) {
+      const candidate = state.cards.get(id);
+      if (candidate && predicate(candidate.cardData)) {
+        chosenId = id;
+        break;
+      }
+    }
+  }
+
+  const nextLibrary: Zone = shuffleZone(library);
+
+  if (chosenId === null) {
+    // CR 702.31c: even when no matching card is found, the player still
+    // shuffles the library. The discard-as-cost already moved the cycled
+    // card to the graveyard.
+    return {
+      success: true,
+      state: {
+        ...state,
+        zones: new Map(state.zones).set(libraryKey, nextLibrary),
+        lastModifiedAt: Date.now(),
+      },
+    };
+  }
+
+  // Move the chosen card from library to hand.
+  const nextLibraryCardIds = nextLibrary.cardIds.filter(
+    (id) => id !== chosenId,
+  );
+  const movedCard = state.cards.get(chosenId);
+  const movedCardName = movedCard?.cardData.name;
+  const nextLibrary2: Zone = {
+    ...nextLibrary,
+    cardIds: nextLibraryCardIds,
+  };
+  const nextHand: Zone = {
+    ...hand,
+    cardIds: [...hand.cardIds, chosenId],
+  };
+  const nextZones = new Map(state.zones);
+  nextZones.set(libraryKey, nextLibrary2);
+  nextZones.set(handKey, nextHand);
+
+  return {
+    success: true,
+    state: {
+      ...state,
+      zones: nextZones,
+      lastModifiedAt: Date.now(),
+    },
+    movedCardId: chosenId,
+    movedCardName,
+  };
+}
+
+/**
+ * Build a predicate that matches a card's ScryfallCard data against the
+ * cycling variant's search target. Centralises the type-line checks so each
+ * search variant shares the same fallback semantics.
+ */
+function buildLibrarySearchPredicate(
+  info: CyclingInfo,
+): (cardData: ScryfallCard) => boolean {
+  switch (info.variant) {
+    case CyclingVariant.TYPECYCLING:
+      return (cardData) => {
+        const typeLine = (cardData.type_line || "").toLowerCase();
+        const wanted = (info.type || "").toLowerCase();
+        if (!wanted) return false;
+        // Match against the full type line (so "Wizard Subtype" still matches
+        // wizardcycling). Allow multi-word types too.
+        return typeLine.includes(wanted);
+      };
+    case CyclingVariant.LANDCYCLING:
+      return (cardData) => {
+        const typeLine = (cardData.type_line || "").toLowerCase();
+        if (info.basicLandType) {
+          // "[Type] landcycling" — restrict to lands with that basic subtype.
+          const wanted = info.basicLandType.toLowerCase();
+          return typeLine.includes("land") && typeLine.includes(wanted);
+        }
+        // Bare "Landcycling" — any land.
+        return typeLine.includes("land");
+      };
+    case CyclingVariant.BASIC_LANDCYCLING:
+      return (cardData) => {
+        const typeLine = (cardData.type_line || "").toLowerCase();
+        return typeLine.startsWith("basic land");
+      };
+    default:
+      return () => false;
+  }
 }
 
 /** @deprecated Stub - hand filter not yet implemented */

--- a/src/lib/game-state/oracle-text-parser.ts
+++ b/src/lib/game-state/oracle-text-parser.ts
@@ -2278,3 +2278,229 @@ export function parseForetell(oracleText: string): {
     description: `Foretell ${foretellMatch[1]}`,
   };
 }
+
+/**
+ * Cycling variants (CR 702.30-31).
+ *
+ * "Cycling {cost}" is the base form: from your hand, pay {cost} + discard the
+ * card, draw a card (CR 702.30a).
+ *
+ * "Typecycling" / "[Type]cycling {cost}" (e.g. Wizardcycling, Creaturecycling)
+ * replaces the draw with a search of your library for a card of the named type
+ * (CR 702.31a).
+ *
+ * "Landcycling {cost}" and "Basic landcycling {cost}" search for a land / a
+ * basic land respectively (CR 702.31b / 702.31c). "Landcycling" allows any land
+ * matching the basic type if printed; "Basic landcycling" restricts to basic
+ * lands of the named type.
+ *
+ * All variants share the same activated-ability structure: cost = {cost} +
+ * discard this card; effect = draw / search for [Type] / search for (basic)
+ * land.
+ */
+export enum CyclingVariant {
+  /** Base cycling — pay cost, discard, draw a card (CR 702.30). */
+  CYCLING = "cycling",
+  /** Typecycling — search library for a card of the named type (CR 702.31). */
+  TYPECYCLING = "typecycling",
+  /** Landcycling — search library for a land of the named type (CR 702.31). */
+  LANDCYCLING = "landcycling",
+  /** Basic landcycling — search library for a basic land of the named type. */
+  BASIC_LANDCYCLING = "basic_landcycling",
+}
+
+/**
+ * Result of parsing a Cycling / Typecycling / Landcycling keyword from oracle
+ * text (CR 702.30-31).
+ */
+export interface CyclingInfo {
+  /** Whether the oracle text contains a recognised cycling variant. */
+  hasCycling: boolean;
+  /** Which cycling variant was matched. */
+  variant: CyclingVariant | null;
+  /** The cycling mana cost (e.g. `{2}`, `{1}{U}`). */
+  cost: ParsedManaCost | null;
+  /** Cost rendered back to its printed string form (e.g. `{2}`). */
+  costString: string | null;
+  /** For Typecycling: the named card type (e.g. `Wizard`). */
+  type: string | null;
+  /** For Landcycling / Basic landcycling: the basic land type (e.g. `Island`). */
+  basicLandType: string | null;
+  /** Human-readable description (e.g. `Cycling {2}` or `Wizardcycling {1}{U}`). */
+  description: string;
+}
+
+/** Empty CyclingInfo singleton for fallthrough returns. */
+const NO_CYCLING: CyclingInfo = {
+  hasCycling: false,
+  variant: null,
+  cost: null,
+  costString: null,
+  type: null,
+  basicLandType: null,
+  description: "",
+};
+
+/**
+ * Parse a Cycling / Typecycling / Landcycling keyword from oracle text.
+ *
+ * CR 702.30a: "Cycling {cost}" — from hand, pay {cost} + discard this card,
+ * draw a card.
+ * CR 702.31: Typecycling / Landcycling / Basic landcycling — same cost shape
+ * but the effect searches the library for a card of the named type instead of
+ * drawing.
+ *
+ * The parser handles three distinct forms, each anchored as a whole word to
+ * avoid matching substrings:
+ *
+ *  - "Basic landcycling {cost}"          → variant=BASIC_LANDCYCLING,
+ *                                            basicLandType=null (general)
+ *  - "[Type] landcycling {cost}"         → variant=LANDCYCLING,
+ *                                            basicLandType=<Type>
+ *                                            (e.g. "Island landcycling")
+ *  - "Landcycling {cost}"                → variant=LANDCYCLING,
+ *                                            basicLandType=null (general)
+ *  - "[Type]cycling {cost}"              → variant=TYPECYCLING,
+ *                                            type=<Type>
+ *                                            (e.g. "Wizardcycling")
+ *  - "Cycling {cost}"                    → variant=CYCLING, type=null
+ *
+ * The order of checks matters: "Basic landcycling" must be tested before
+ * "landcycling", and any "[Type]cycling" before the bare "Cycling" anchor.
+ *
+ * Examples seen in print:
+ *  - "Cycling {2}"                           (e.g. Aven Riftwatcher)
+ *  - "Wizardcycling {2}"                     (e.g. Galeprowler)
+ *  - "Plainscycling {1}{W}"                  (e.g. Krosan Verge)
+ *  - "Islandcycling {1}{U}"                  (e.g. Flooded Strand)
+ *  - "Basic landcycling {1}"                 (e.g. Terminal Moraine)
+ */
+export function parseCycling(oracleText: string): CyclingInfo {
+  if (!oracleText) {
+    return { ...NO_CYCLING };
+  }
+
+  // Capture the cycling mana cost in braces (one or more {…} groups, like
+  // {1}{U}). The regex is intentionally not anchored on cost — anchoring on
+  // the keyword word is done below for each variant.
+  const costPattern = "(\\{[^}]+\\}(?:\\{[^}]+\\})*)";
+
+  // 1) "Basic landcycling {cost}" — most specific; must precede plain
+  //    "landcycling" / "cycling" matches.
+  const basicLandMatch = oracleText.match(
+    new RegExp(`\\bbasic landcycling\\s*${costPattern}`, "i"),
+  );
+  if (basicLandMatch) {
+    const costString = basicLandMatch[1];
+    return {
+      hasCycling: true,
+      variant: CyclingVariant.BASIC_LANDCYCLING,
+      cost: parseManaCost(costString),
+      costString,
+      type: null,
+      basicLandType: null,
+      description: `Basic landcycling ${costString}`,
+    };
+  }
+
+  // 2) "[Type] landcycling {cost}" — landcycling restricted to a basic land
+  //    subtype. The [Type] word is captured separately.
+  const typedLandMatch = oracleText.match(
+    new RegExp(`\\b([A-Za-z]+)\\s+landcycling\\s*${costPattern}`, "i"),
+  );
+  if (typedLandMatch) {
+    const basicLandType = capitalizeFirst(typedLandMatch[1]);
+    const costString = typedLandMatch[2];
+    return {
+      hasCycling: true,
+      variant: CyclingVariant.LANDCYCLING,
+      cost: parseManaCost(costString),
+      costString,
+      type: null,
+      basicLandType,
+      description: `${basicLandType} landcycling ${costString}`,
+    };
+  }
+
+  // 3) "Landcycling {cost}" — generic landcycling, no basic type.
+  const landMatch = oracleText.match(
+    new RegExp(`\\blandcycling\\s*${costPattern}`, "i"),
+  );
+  if (landMatch) {
+    const costString = landMatch[1];
+    return {
+      hasCycling: true,
+      variant: CyclingVariant.LANDCYCLING,
+      cost: parseManaCost(costString),
+      costString,
+      type: null,
+      basicLandType: null,
+      description: `Landcycling ${costString}`,
+    };
+  }
+
+  // 4) "[Type]cycling {cost}" — typecycling. The [Type] word is captured
+  //    separately. Reject words that are clearly not card types so we don't
+  //    mis-parse unrelated tokens.
+  const typedCycleMatch = oracleText.match(
+    new RegExp(`\\b([A-Za-z]+)cycling\\s*${costPattern}`, "i"),
+  );
+  if (typedCycleMatch) {
+    const typeWord = capitalizeFirst(typedCycleMatch[1]);
+    if (isLikelyCardTypeWord(typeWord)) {
+      const costString = typedCycleMatch[2];
+      return {
+        hasCycling: true,
+        variant: CyclingVariant.TYPECYCLING,
+        cost: parseManaCost(costString),
+        costString,
+        type: typeWord,
+        basicLandType: null,
+        description: `${typeWord}cycling ${costString}`,
+      };
+    }
+  }
+
+  // 5) "Cycling {cost}" — the base form. Word-bounded so "recycling" or
+  //    "tricycling" do not match.
+  const cyclingMatch = oracleText.match(
+    new RegExp(`\\bcycling\\s*${costPattern}`, "i"),
+  );
+  if (cyclingMatch) {
+    const costString = cyclingMatch[1];
+    return {
+      hasCycling: true,
+      variant: CyclingVariant.CYCLING,
+      cost: parseManaCost(costString),
+      costString,
+      type: null,
+      basicLandType: null,
+      description: `Cycling ${costString}`,
+    };
+  }
+
+  return { ...NO_CYCLING };
+}
+
+/**
+ * Capitalise the first character of `s`, leaving the rest unchanged. Used to
+ * normalise captured type words from the cycling regex.
+ */
+function capitalizeFirst(s: string): string {
+  if (!s) return s;
+  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+}
+
+/**
+ * Best-effort check that a captured word preceding "cycling" is a plausible
+ * card type word. The MTG rules permit almost any noun to be used as a type
+ * qualifier for Typecycling (Wizards of the Coast have printed dozens of
+ * variants: Wizardcycling, Slivercycling, etc.), so we accept any alphabetic
+ * word of length >= 3 to remain lenient while rejecting trivial 1-2 letter
+ * tokens that almost certainly are not card types.
+ */
+function isLikelyCardTypeWord(word: string): boolean {
+  if (!word) return false;
+  if (!/^[A-Za-z]+$/.test(word)) return false;
+  return word.length >= 3;
+}

--- a/src/lib/game-state/replay.ts
+++ b/src/lib/game-state/replay.ts
@@ -459,6 +459,8 @@ export function describeAction(action: GameAction, playerName: string): string {
       return `${playerName} drew a card`;
     case "discard_card":
       return `${playerName} discarded ${(actionData.cardName as string) || "a card"}`;
+    case "cycle_card":
+      return `${playerName} cycled ${(actionData.cardName as string) || "a card"}`;
     case "declare_attackers":
       return `${playerName} declared attackers`;
     case "declare_blockers":

--- a/src/lib/game-state/types.ts
+++ b/src/lib/game-state/types.ts
@@ -914,6 +914,7 @@ export type ActionType =
   | "play_land"
   | "draw_card"
   | "discard_card"
+  | "cycle_card"
   | "tap_card"
   | "untap_card"
   | "destroy_card"


### PR DESCRIPTION
Implements Magic: the Gathering's Cycling family of activated abilities per CR 702.30 (Cycling) and CR 702.31 (Typecycling / Landcycling / Basic landcycling).

## What

Cycling is an activated ability that functions only while the card is in a player's hand. The cost is the printed mana cost plus discard this card; the effect is to draw a card (CR 702.30a). The Typecycling / Landcycling / Basic landcycling variants replace the draw with a library search for a card of the named type (CR 702.31).

## Parser

- `parseCycling(oracleText)` recognises all four shapes in order, anchored as whole words to avoid substring matches:
  1. `Basic landcycling {cost}`
  2. `[Type] landcycling {cost}` (e.g. `Plains landcycling`)
  3. `Landcycling {cost}`
  4. `[Type]cycling {cost}` (e.g. `Wizardcycling`, `Plainscycling`)
  5. `Cycling {cost}`
- Returns a `CyclingInfo` descriptor with `variant`, parsed `cost`, the named `type` / `basicLandType`, and a `description` string. The new `CyclingVariant` enum distinguishes the four shapes.

## Action

`cycleCard(state, playerId, cardId)` enforces CR 702.30a / 117.1a / 602.2:

1. Card must be in the controller's hand (rejects battlefield, graveyard, library, exile).
2. Player must have priority, be the active player, in a main phase, and the stack must be empty.
3. The cycling mana cost is paid from the player's mana pool.
4. The cycled card is moved from hand → graveyard as the discard cost.
5. The variant's effect resolves:
   - **CYCLING** — draw a card.
   - **TYPECYCLING** — search library for a card whose type line includes the named type, reveal → hand → shuffle (caller may pre-select via `selectedFoundCardId`).
   - **LANDCYCLING** / **BASIC_LANDCYCLING** — same search-for-land shape; bare `Landcycling` matches any land, `Basic landcycling` matches only basic lands, and `[Type] landcycling` matches lands with that subtype. If no match is found the library is still shuffled (CR 702.31c, last sentence).

`canCycleCard` gates the action for UI / AI callers.

## Detection helpers

- `hasCycling(card)` — any variant.
- `hasLandcycling(card, landType?)` — LANDCYCLING / BASIC_LANDCYCLING, optionally filtered to a specific basic subtype.
- `hasTypecycling(card, cardType?)` — TYPECYCLING, optionally filtered to a specific card type.
- `getCyclingCost(card)` and `getCyclingVariant(card)` — full parsed descriptor.
- `parseCyclingCost(text)` — legacy `number | null` convenience wrapper (returns the generic portion of the cycling mana cost).

## Event log

A new `cycle_card` action type is added to the `ActionType` union and threaded through `event-sourcing.ts` / `replay.ts` descriptions so cycling actions show up in the game log / replay timeline.

## Tests

`src/lib/game-state/__tests__/cycling.test.ts` — 48 tests covering:

- Parsing each variant (including the spaced `[Type] landcycling` form, case insensitivity, negative cases, and that `cycling` is not matched inside other words).
- Detection helpers (`hasCycling`, `hasLandcycling`, `hasTypecycling`) including the optional subtype / type filter arguments.
- `cycleCard` for the base form: discard cost, draw, mana cost paid.
- Hand-only restriction: cycling from battlefield, graveyard, or library is rejected.
- Sorcery-speed timing: rejected on opponent's turn, outside a main phase, with a non-empty stack, or without priority; accepted during the postcombat main phase.
- Insufficient mana rejected.
- Typecycling: finds a matching card, moves it to hand; shuffles and puts nothing in hand when no match exists; honours caller-selected found card; rejects a selected card that does not match the named type.
- Landcycling / Basic landcycling / `[Type] landcycling`: matches the right land subtypes and rejects non-matching ones; shuffles the library even when nothing is found.
- Base form with empty library returns a draw-failed error after the discard cost has been paid.

## Verification

- `npx tsc --noEmit` — no errors.
- `npm run lint` — 0 errors (only pre-existing warnings).
- `npm test -- keyword-actions abilities oracle-text-parser event-sourcing game-state` — 115 suites / 2725 tests pass.
- `npm test` — 301 suites / 6398 tests pass, no regressions.

Resolves #1056