### PR TITLE
chore: resolve #1280 — add dependabot ecosystems for npm, cargo, github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 # Dependabot dependency-update configuration.
-# Keeps npm packages and GitHub Actions versions current on a weekly cadence
-# so known-vulnerable transitive deps are auto-bumped/reported. Resolves #1108.
+# Keeps npm packages, Rust crates, and GitHub Actions versions current on a
+# weekly cadence so known-vulnerable transitive deps are auto-bumped/reported.
+# Resolves #1108 (npm + actions) and #1280 (cargo + framework-major ignores).
 # Dependabot PRs are skipped by the CodeQL workflow (codeql.yml:
 # `if: github.actor != 'dependabot[bot]'`), so bumps are never blocked by SAST.
 version: 2
@@ -18,8 +19,42 @@ updates:
     labels:
       - "security"
       - "tech-debt"
+    # Major bumps for framework packages (Next.js, React, Tauri CLI) cross
+    # breaking-API lines and require a coordinated migration PR, so we ignore
+    # them here and surface them via the manual roadmap instead.
+    ignore:
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@tauri-apps/cli"
+        update-types: ["version-update:semver-major"]
     # Bundle semver-compatible minor/patch updates into a single PR; major
     # bumps (potential breaking changes) still get individual PRs for review.
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Rust crates consumed by the Tauri host (src-tauri/Cargo.toml + Cargo.lock).
+  # The frontend package.json does not carry Rust deps; all of them live here.
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(rust)"
+      include: "scope"
+    labels:
+      - "security"
+      - "tech-debt"
+    # Bundle semver-compatible minor/patch updates into a single PR so reviewers
+    # only have to read one Cargo.lock diff per week.
     groups:
       minor-and-patch:
         update-types:


### PR DESCRIPTION
## Summary

Adds the missing `cargo` ecosystem to `.github/dependabot.yml` and hardens the existing `npm` block, addressing issue #1280.

The original `dependabot.yml` (added in #1140) covered only `npm` and `github-actions`. The Rust host tree at `/src-tauri` had no automated-update coverage, and framework major-version bumps (Next.js, React, Tauri CLI) were not ignored, so any breaking semver release would generate a flood of review-fatiguing PRs before a coordinated migration PR could be authored.

## Changes

- **New `cargo` ecosystem**: weekly Monday scan of `/src-tauri/Cargo.toml` + `Cargo.lock`, `chore(rust)` commit prefix, 5-PR limit, `security` + `tech-debt` labels, minor/patch grouped into one PR.
- **New `ignore` rules on `npm`**: major-version bumps for `next`, `react`, `react-dom`, `@tauri-apps/cli` are deferred to the manual roadmap (these cross breaking-API lines and need a coordinated migration).
- Updated header comment to reference #1280 alongside #1108.

## Out of scope (per issue #1280)

`SECURITY.md`, `.github/CODEOWNERS`, `docs/CONTRIBUTING.md`, and the weekly-dependabot-summary workflow are tracked under separate follow-ups — this PR intentionally keeps the change surface to the dependabot config only.

## Validation

- YAML parses cleanly (`yaml.safe_load` succeeds on `.github/dependabot.yml`).
- Three ecosystem blocks present: `npm`, `cargo`, `github-actions`.
- Repo has no yamllint/actionlint hook for `.github/` — no CI validator to invoke.

Closes #1280 (dependabot config portion only).

## Summary by Sourcery

Update Dependabot configuration to cover Rust crates and reduce noise from major JavaScript framework upgrades.

New Features:
- Add Dependabot cargo ecosystem monitoring the Tauri host Rust dependencies in src-tauri on a weekly schedule.

Enhancements:
- Extend npm Dependabot configuration to ignore major-version updates for key frontend and Tauri CLI framework packages, deferring them to manual migration work.
- Align Dependabot header comments with current coverage and reference both the original setup issue and the cargo/framework ignore follow-up.