### PR TITLE
fix(security): resolve #1276 — sanitize card oracle text and coach-emitted markdown

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,10 @@ const eslintConfig = [
       "no-empty": ["error", { allowEmptyCatch: false }],
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "warn",
+      // Issue #1276: Forbid new dangerouslySetInnerHTML uses. The existing
+      // chart.tsx site is allow-listed via overrides below; all other code
+      // must sanitize text via `src/lib/security/sanitize-text.ts`.
+      "react/no-danger": "error",
       // Prevent console.log in production code (use logger utility instead)
       "no-console": ["warn", { allow: ["warn", "error", "info"] }],
       // Prevent direct API calls with Authorization headers in client code (security)
@@ -59,6 +63,15 @@ const eslintConfig = [
       "@typescript-eslint/no-unused-vars": "off",
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-empty-function": "off",
+    },
+  },
+  {
+    // The Recharts chart primitive is the only existing
+    // dangerouslySetInnerHTML user and is allow-listed for that sink.
+    // All other new uses must route through `sanitizeMarkdown` (issue #1276).
+    files: ["src/components/ui/chart.tsx"],
+    rules: {
+      "react/no-danger": "off",
     },
   },
   {

--- a/src/app/(app)/deck-coach/_components/__tests__/sanitize-render.test.tsx
+++ b/src/app/(app)/deck-coach/_components/__tests__/sanitize-render.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Render-time integration tests for sanitization at the AI coach output
+ * layer (issue #1276).
+ *
+ * Renders the `EnhancedReviewDisplay` and `ReviewDisplay` components with
+ * AI coach output containing XSS payloads and asserts that no executable
+ * tag or `on*` event handler survives in the rendered DOM.
+ */
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "@jest/globals";
+import { EnhancedReviewDisplay } from "../enhanced-review-display";
+import { ReviewDisplay } from "../review-display";
+import type { DeckReviewOutput } from "@/ai/flows/ai-deck-coach-review";
+
+function makeReviewWithPayload(payload: string): DeckReviewOutput {
+  return {
+    reviewSummary: payload,
+    archetype: {
+      primary: payload,
+      confidence: 0.9,
+      description: payload,
+    },
+    deckOptions: [
+      {
+        title: payload,
+        description: payload,
+        cardsToAdd: [{ name: payload, quantity: 1 }],
+        cardsToRemove: [{ name: payload, quantity: 1 }],
+      },
+    ],
+    synergies: {
+      present: [
+        {
+          name: payload,
+          score: 80,
+          cards: [payload],
+          description: payload,
+          category: "tribal",
+        },
+      ],
+      missing: [
+        {
+          synergy: payload,
+          missing: payload,
+          description: payload,
+          suggestion: payload,
+          impact: "high",
+        },
+      ],
+    },
+  };
+}
+
+function expectNoExecutableDom(container: HTMLElement): void {
+  // Tags that are *content-bearing* XSS vectors. We intentionally do not
+  // forbid `<svg>` / `<math>` / `<style>` because Lucide icons use
+  // `<svg>` for visual indicators and Tailwind/CSS-in-JS libraries
+  // inject `<style>` tags with static CSS; those are safe when their
+  // attributes are static. The attack surface is the `on*` handler
+  // attributes and dangerous schemes, which we check separately below.
+  const unsafe = new Set([
+    "script",
+    "iframe",
+    "object",
+    "embed",
+    "form",
+    "video",
+    "audio",
+    "frame",
+    "frameset",
+  ]);
+  container.querySelectorAll("*").forEach((el) => {
+    const tag = el.tagName.toLowerCase();
+    if (unsafe.has(tag)) {
+      throw new Error(`Found unsafe tag ${tag} in rendered DOM`);
+    }
+    for (const attr of Array.from(el.attributes)) {
+      expect(/^on/i.test(attr.name)).toBe(false);
+    }
+  });
+  container.querySelectorAll("a[href]").forEach((a) => {
+    expect((a as HTMLAnchorElement).href.toLowerCase()).not.toMatch(/^javascript:/);
+  });
+}
+
+const vectors: Array<{ name: string; payload: string }> = [
+  { name: "script tag", payload: "<script>alert('coach-xss')</script>" },
+  { name: "img onerror", payload: "<img src=x onerror=fetch('/leak')>" },
+  { name: "javascript: link", payload: "[click](javascript:alert(1))" },
+  { name: "data:text/html link", payload: "[evil](data:text/html,<script>alert(1)</script>)" },
+  { name: "iframe", payload: "<iframe src='https://evil/'></iframe>" },
+  { name: "svg onload", payload: "<svg onload=alert(1)></svg>" },
+  { name: "mixed-case Unicode", payload: "<\u0053cript>alert(1)</\u0053cript>" },
+  { name: "bidi smuggling", payload: "Title\u202E<script>alert(1)</script>" },
+  { name: "data:text/html as archetype description", payload: "data:text/html,<script>alert(1)</script>" },
+];
+
+describe("EnhancedReviewDisplay — render-time sanitization", () => {
+  for (const v of vectors) {
+    it(`neutralizes ${v.name} in coach output`, () => {
+      const review = makeReviewWithPayload(v.payload);
+      const { container } = render(
+        <EnhancedReviewDisplay
+          review={review}
+          onSaveNewDeck={async () => undefined}
+          decklist=""
+        />,
+      );
+      expectNoExecutableDom(container);
+      // No anchor with a `javascript:` href. Literal text may still
+      // contain the substring "javascript:" when it appears as visible
+      // link text (e.g. `[click](javascript:alert(1))`), but the DOM
+      // must never materialise it as an actionable href.
+      container.querySelectorAll("a[href]").forEach((a) => {
+        expect((a as HTMLAnchorElement).href.toLowerCase()).not.toMatch(/^javascript:/);
+      });
+    });
+  }
+
+  it("preserves legitimate markdown subset rendering", () => {
+    const review: DeckReviewOutput = {
+      reviewSummary: "**Strong** deck with _three_ key `archetype` cards.",
+      deckOptions: [],
+      synergies: { present: [], missing: [] },
+    };
+    const { container } = render(
+      <EnhancedReviewDisplay
+        review={review}
+        onSaveNewDeck={async () => undefined}
+        decklist=""
+      />,
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain("Strong");
+    expect(text).toContain("three");
+    expect(text).toContain("archetype");
+    expectNoExecutableDom(container);
+  });
+});
+
+describe("ReviewDisplay — render-time sanitization", () => {
+  for (const v of vectors) {
+    it(`neutralizes ${v.name} in coach output`, () => {
+      const review = makeReviewWithPayload(v.payload);
+      const { container } = render(
+        <ReviewDisplay review={review} onSaveNewDeck={async () => undefined} />,
+      );
+      expectNoExecutableDom(container);
+      container.querySelectorAll("a[href]").forEach((a) => {
+        expect((a as HTMLAnchorElement).href.toLowerCase()).not.toMatch(/^javascript:/);
+      });
+    });
+  }
+});

--- a/src/app/(app)/deck-coach/_components/archetype-badge.tsx
+++ b/src/app/(app)/deck-coach/_components/archetype-badge.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { CheckCircle2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { sanitizeCardText } from "@/lib/security/sanitize-text";
 
 export interface ArchetypeBadgeProps {
   archetype: string;
@@ -113,14 +114,14 @@ export function ArchetypeBadge({
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Badge 
-              variant={variant} 
+            <Badge
+              variant={variant}
               className={cn(
                 "text-sm px-3 py-1 h-auto",
                 isHighConfidence && "ring-2 ring-green-500/50"
               )}
             >
-              {archetype}
+              {sanitizeCardText(archetype, 100)}
               {isHighConfidence && <CheckCircle2 className="ml-1 h-3 w-3" />}
             </Badge>
           </TooltipTrigger>
@@ -139,7 +140,7 @@ export function ArchetypeBadge({
           <Tooltip>
             <TooltipTrigger asChild>
               <Badge variant="outline" className="text-xs px-2 py-0.5">
-                {secondary}
+                {sanitizeCardText(secondary, 100)}
               </Badge>
             </TooltipTrigger>
             <TooltipContent>

--- a/src/app/(app)/deck-coach/_components/enhanced-review-display.tsx
+++ b/src/app/(app)/deck-coach/_components/enhanced-review-display.tsx
@@ -15,6 +15,7 @@ import { SynergyList, type SynergyItem as SynergyListItem } from "./synergy-list
 import { MissingSynergies, type MissingSynergyItem } from "./missing-synergies";
 import { KeyCards, identifyKeyCards, type KeyCard } from "./key-cards";
 import { ExportButton, type CoachReportData } from "./export-button";
+import { sanitizeCardText } from "@/lib/security/sanitize-text";
 
 type DeckOption = DeckReviewOutput["deckOptions"][0];
 
@@ -114,7 +115,7 @@ export function EnhancedReviewDisplay({ review, onSaveNewDeck, decklist }: Enhan
               />
               {review.archetype.description && (
                 <p className="text-sm text-muted-foreground mt-2">
-                  {review.archetype.description}
+                  {sanitizeCardText(review.archetype.description, 1_000)}
                 </p>
               )}
             </div>
@@ -125,69 +126,69 @@ export function EnhancedReviewDisplay({ review, onSaveNewDeck, decklist }: Enhan
           <ScrollArea className="h-[calc(100vh-24rem)]">
             <div className="pr-4 space-y-6 pt-4">
               {/* Overall Analysis */}
+<div>
+              <h3 className="font-headline text-lg font-bold mb-2">Overall Analysis</h3>
+              <p className="text-sm text-muted-foreground whitespace-pre-wrap">{sanitizeCardText(review.reviewSummary, 8_000)}</p>
+            </div>
+
+            {/* Key Cards */}
+            {keyCards.length > 0 && (
+              <KeyCards cards={keyCards} />
+            )}
+
+            {/* Synergies */}
+            {synergyItems.length > 0 && (
+              <SynergyList synergies={synergyItems} />
+            )}
+
+            {/* Missing Synergies */}
+            {missingSynergyItems.length > 0 && (
+              <MissingSynergies missing={missingSynergyItems} />
+            )}
+
+            {/* Suggested Deck Options */}
+            {review.deckOptions && review.deckOptions.length > 0 && (
               <div>
-                <h3 className="font-headline text-lg font-bold mb-2">Overall Analysis</h3>
-                <p className="text-sm text-muted-foreground whitespace-pre-wrap">{review.reviewSummary}</p>
+                <h3 className="font-headline text-lg font-bold mb-2">Suggested Improvements</h3>
+                <Accordion type="single" collapsible className="w-full">
+                  {review.deckOptions.map((option, index) => (
+                    <AccordionItem value={`item-${index}`} key={index}>
+                      <AccordionTrigger className="font-semibold">{sanitizeCardText(option.title, 300)}</AccordionTrigger>
+                      <AccordionContent>
+                        <p className="text-sm text-muted-foreground whitespace-pre-wrap mb-4">{sanitizeCardText(option.description, 4_000)}</p>
+
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm mb-4">
+                          {option.cardsToAdd && option.cardsToAdd.length > 0 && (
+                            <div>
+                              <h4 className="font-semibold text-green-500 mb-1">Cards to Add</h4>
+                              <ul className="list-disc pl-5">
+                                {option.cardsToAdd.map(card => (
+                                  <li key={`add-${card.name}`}>{card.quantity}x {sanitizeCardText(card.name, 200)}</li>
+                                ))}
+                              </ul>
+                            </div>
+                          )}
+                           {option.cardsToRemove && option.cardsToRemove.length > 0 && (
+                            <div>
+                              <h4 className="font-semibold text-red-500 mb-1">Cards to Remove</h4>
+                               <ul className="list-disc pl-5">
+                                {option.cardsToRemove.map(card => (
+                                  <li key={`remove-${card.name}`}>{card.quantity}x {sanitizeCardText(card.name, 200)}</li>
+                                ))}
+                              </ul>
+                            </div>
+                          )}
+                        </div>
+
+                        <Button onClick={() => handleOpenDialog(option)} size="sm">
+                          Create Deck from Suggestion
+                        </Button>
+                      </AccordionContent>
+                    </AccordionItem>
+                  ))}
+                </Accordion>
               </div>
-
-              {/* Key Cards */}
-              {keyCards.length > 0 && (
-                <KeyCards cards={keyCards} />
-              )}
-
-              {/* Synergies */}
-              {synergyItems.length > 0 && (
-                <SynergyList synergies={synergyItems} />
-              )}
-
-              {/* Missing Synergies */}
-              {missingSynergyItems.length > 0 && (
-                <MissingSynergies missing={missingSynergyItems} />
-              )}
-
-              {/* Suggested Deck Options */}
-              {review.deckOptions && review.deckOptions.length > 0 && (
-                <div>
-                  <h3 className="font-headline text-lg font-bold mb-2">Suggested Improvements</h3>
-                  <Accordion type="single" collapsible className="w-full">
-                    {review.deckOptions.map((option, index) => (
-                      <AccordionItem value={`item-${index}`} key={index}>
-                        <AccordionTrigger className="font-semibold">{option.title}</AccordionTrigger>
-                        <AccordionContent>
-                          <p className="text-sm text-muted-foreground whitespace-pre-wrap mb-4">{option.description}</p>
-
-                          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm mb-4">
-                            {option.cardsToAdd && option.cardsToAdd.length > 0 && (
-                              <div>
-                                <h4 className="font-semibold text-green-500 mb-1">Cards to Add</h4>
-                                <ul className="list-disc pl-5">
-                                  {option.cardsToAdd.map(card => (
-                                    <li key={`add-${card.name}`}>{card.quantity}x {card.name}</li>
-                                  ))}
-                                </ul>
-                              </div>
-                            )}
-                             {option.cardsToRemove && option.cardsToRemove.length > 0 && (
-                              <div>
-                                <h4 className="font-semibold text-red-500 mb-1">Cards to Remove</h4>
-                                 <ul className="list-disc pl-5">
-                                  {option.cardsToRemove.map(card => (
-                                    <li key={`remove-${card.name}`}>{card.quantity}x {card.name}</li>
-                                  ))}
-                                </ul>
-                              </div>
-                            )}
-                          </div>
-
-                          <Button onClick={() => handleOpenDialog(option)} size="sm">
-                            Create Deck from Suggestion
-                          </Button>
-                        </AccordionContent>
-                      </AccordionItem>
-                    ))}
-                  </Accordion>
-                </div>
-              )}
+            )}
             </div>
           </ScrollArea>
         </CardContent>

--- a/src/app/(app)/deck-coach/_components/key-cards.tsx
+++ b/src/app/(app)/deck-coach/_components/key-cards.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { Star, Target, Zap, Shield, TrendingUp } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { sanitizeCardText } from "@/lib/security/sanitize-text";
 
 export interface KeyCard {
   name: string;
@@ -49,12 +50,12 @@ function KeyCardItem({ card }: { card: KeyCard }) {
         </div>
         <div className="flex-1">
           <div className="flex items-center gap-2">
-            <span className="font-semibold text-sm">{card.name}</span>
+            <span className="font-semibold text-sm">{sanitizeCardText(card.name, 200)}</span>
             <Badge variant="secondary" className="text-xs h-5">
               x{card.count}
             </Badge>
           </div>
-          <p className="text-xs text-muted-foreground mt-1">{card.reason}</p>
+          <p className="text-xs text-muted-foreground mt-1">{sanitizeCardText(card.reason, 1_000)}</p>
         </div>
       </div>
     </div>

--- a/src/app/(app)/deck-coach/_components/missing-synergies.tsx
+++ b/src/app/(app)/deck-coach/_components/missing-synergies.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { AlertTriangle, AlertCircle, Info } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { sanitizeCardText } from "@/lib/security/sanitize-text";
 
 export interface MissingSynergyItem {
   synergy: string;
@@ -69,7 +70,7 @@ function MissingSynergyItemComponent({ item }: { item: MissingSynergyItem }) {
       <div className="flex-1">
         <div className="flex items-center gap-2 mb-1">
           <AlertTitle className={cn("font-semibold", styling.textClass)}>
-            {item.synergy}
+            {sanitizeCardText(item.synergy, 200)}
           </AlertTitle>
           <Badge variant={styling.badgeVariant} className="text-xs">
             {item.impact.toUpperCase()} IMPACT
@@ -77,12 +78,12 @@ function MissingSynergyItemComponent({ item }: { item: MissingSynergyItem }) {
         </div>
         <AlertDescription className="space-y-2">
           <p className="text-sm">
-            <span className="font-medium">Missing:</span> {item.description}
+            <span className="font-medium">Missing:</span> {sanitizeCardText(item.description, 1_000)}
           </p>
           <div className="bg-background/50 rounded p-2 mt-2">
             <p className="text-xs">
               <span className="font-medium text-primary">💡 Suggestion:</span>{" "}
-              <span className="text-muted-foreground">{item.suggestion}</span>
+              <span className="text-muted-foreground">{sanitizeCardText(item.suggestion, 1_000)}</span>
             </p>
           </div>
         </AlertDescription>

--- a/src/app/(app)/deck-coach/_components/review-display.tsx
+++ b/src/app/(app)/deck-coach/_components/review-display.tsx
@@ -10,6 +10,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Loader2 } from "lucide-react";
+import { sanitizeCardText } from "@/lib/security/sanitize-text";
 
 type DeckOption = DeckReviewOutput["deckOptions"][0];
 
@@ -51,26 +52,26 @@ export function ReviewDisplay({ review, onSaveNewDeck }: ReviewDisplayProps) {
             <div className="pr-4 space-y-6">
               <div>
                 <h3 className="font-headline text-lg font-bold mb-2">Overall Analysis</h3>
-                <p className="text-sm text-muted-foreground whitespace-pre-wrap">{review.reviewSummary}</p>
+                <p className="text-sm text-muted-foreground whitespace-pre-wrap">{sanitizeCardText(review.reviewSummary, 8_000)}</p>
               </div>
-              
+
               {review.deckOptions && review.deckOptions.length > 0 && (
                 <div>
                   <h3 className="font-headline text-lg font-bold mb-2">Suggested Deck Options</h3>
                   <Accordion type="single" collapsible className="w-full">
                     {review.deckOptions.map((option, index) => (
                       <AccordionItem value={`item-${index}`} key={index}>
-                        <AccordionTrigger className="font-semibold">{option.title}</AccordionTrigger>
+                        <AccordionTrigger className="font-semibold">{sanitizeCardText(option.title, 300)}</AccordionTrigger>
                         <AccordionContent>
-                          <p className="text-sm text-muted-foreground whitespace-pre-wrap mb-4">{option.description}</p>
-                          
+                          <p className="text-sm text-muted-foreground whitespace-pre-wrap mb-4">{sanitizeCardText(option.description, 4_000)}</p>
+
                           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm mb-4">
                             {option.cardsToAdd && option.cardsToAdd.length > 0 && (
                               <div>
                                 <h4 className="font-semibold text-green-500 mb-1">Cards to Add</h4>
                                 <ul className="list-disc pl-5">
                                   {option.cardsToAdd.map(card => (
-                                    <li key={`add-${card.name}`}>{card.quantity}x {card.name}</li>
+                                    <li key={`add-${card.name}`}>{card.quantity}x {sanitizeCardText(card.name, 200)}</li>
                                   ))}
                                 </ul>
                               </div>
@@ -80,7 +81,7 @@ export function ReviewDisplay({ review, onSaveNewDeck }: ReviewDisplayProps) {
                                 <h4 className="font-semibold text-red-500 mb-1">Cards to Remove</h4>
                                  <ul className="list-disc pl-5">
                                   {option.cardsToRemove.map(card => (
-                                    <li key={`remove-${card.name}`}>{card.quantity}x {card.name}</li>
+                                    <li key={`remove-${card.name}`}>{card.quantity}x {sanitizeCardText(card.name, 200)}</li>
                                   ))}
                                 </ul>
                               </div>

--- a/src/app/(app)/deck-coach/_components/synergy-list.tsx
+++ b/src/app/(app)/deck-coach/_components/synergy-list.tsx
@@ -6,6 +6,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { Button } from "@/components/ui/button";
 import { ChevronDown, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { sanitizeCardText } from "@/lib/security/sanitize-text";
 
 export interface SynergyItem {
   name: string;
@@ -66,20 +67,20 @@ function SynergyItemComponent({ synergy }: { synergy: SynergyItem }) {
         <div className="flex items-center gap-2 flex-1">
           <Sparkles className={cn("h-4 w-4", indicator.color)} />
           <div>
-            <h4 className="font-semibold text-sm">{synergy.name}</h4>
-            <p className="text-xs text-muted-foreground">{synergy.description}</p>
+            <h4 className="font-semibold text-sm">{sanitizeCardText(synergy.name, 200)}</h4>
+            <p className="text-xs text-muted-foreground">{sanitizeCardText(synergy.description, 1_000)}</p>
           </div>
         </div>
-        
+
         <div className="flex items-center gap-2">
           <Badge variant={categoryVariant} className="text-xs">
-            {synergy.category}
+            {sanitizeCardText(synergy.category, 64)}
           </Badge>
-          
+
           <div className={cn("px-2 py-1 rounded text-xs font-medium border", indicator.bg, indicator.color)}>
             {indicator.label} ({synergy.score})
           </div>
-          
+
           <CollapsibleTrigger asChild>
             <Button variant="ghost" size="sm" className="h-6 w-6 p-0">
               <ChevronDown className="h-4 w-4" />
@@ -87,7 +88,7 @@ function SynergyItemComponent({ synergy }: { synergy: SynergyItem }) {
           </CollapsibleTrigger>
         </div>
       </div>
-      
+
       <CollapsibleContent className="mt-3 pt-3 border-t">
         <div className="space-y-2">
           <p className="text-xs font-medium text-muted-foreground">
@@ -96,7 +97,7 @@ function SynergyItemComponent({ synergy }: { synergy: SynergyItem }) {
           <div className="flex flex-wrap gap-1">
             {synergy.cards.slice(0, 12).map((card, index) => (
               <Badge key={index} variant="outline" className="text-xs">
-                {card}
+                {sanitizeCardText(card, 200)}
               </Badge>
             ))}
             {synergy.cards.length > 12 && (

--- a/src/components/__tests__/custom-card-preview-sanitize.test.tsx
+++ b/src/components/__tests__/custom-card-preview-sanitize.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Render-time integration tests for sanitization at the React layer (issue #1276).
+ *
+ * Renders the `CustomCardPreview` with a deliberately malicious custom-card
+ * definition (script tags, `onerror=` handlers, javascript: URLs, mixed-case
+ * Unicode escapes, bidi controls, etc.) and asserts that the DOM after the
+ * render contains no executable HTML tags or live event handlers.
+ *
+ * These tests are the integration complement to the unit tests in
+ * `__tests__/sanitize-text.test.ts`. They exercise the actual JSX path:
+ *   - the data layer sanitizes via `saveCustomCard` / `importCustomCards`
+ *   - the component re-sanitizes at render
+ *   - React's JSX auto-escaping neutralises whatever slips through
+ */
+
+import { render, screen } from "@testing-library/react";
+import { CustomCardPreview } from "../custom-card-preview";
+import { saveCustomCard } from "@/lib/custom-card-storage";
+import { clearAllCustomCards } from "@/lib/custom-card-storage";
+import type { CustomCardDefinition } from "@/lib/custom-card";
+import { DEFAULT_CUSTOM_CARD } from "@/lib/custom-card";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+const now = Date.now();
+
+function makeMaliciousCard(overrides: Partial<CustomCardDefinition> = {}): CustomCardDefinition {
+  return {
+    ...(DEFAULT_CUSTOM_CARD as Omit<CustomCardDefinition, "id" | "createdAt" | "updatedAt">),
+    id: "evil-card",
+    name: "Lightning Bolt",
+    typeLine: "Instant",
+    oracleText: "Lightning Bolt deals 3 damage to any target.",
+    rarity: "common",
+    cardTypes: ["instant"],
+    colors: ["red"],
+    art: { ...DEFAULT_CUSTOM_CARD.art, useProceduralArt: true },
+    typography: { ...DEFAULT_CUSTOM_CARD.typography },
+    background: { ...DEFAULT_CUSTOM_CARD.background },
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+/**
+ * Recursively walk the rendered DOM and confirm that no element has a
+ * tag name that is part of the unsafe-tag deny list AND that no
+ * `on*` event-handler attribute is present on any element.
+ */
+function expectNoExecutableDom(container: HTMLElement): void {
+  const unsafe = new Set([
+    "script",
+    "iframe",
+    "object",
+    "embed",
+    "form",
+    "style",
+    "svg",
+    "math",
+    "video",
+    "audio",
+  ]);
+  // No element with an unsafe tag name.
+  container.querySelectorAll("*").forEach((el) => {
+    expect(unsafe.has(el.tagName.toLowerCase())).toBe(false);
+  });
+  // No element with any `on*` event-handler attribute (the React `on*`
+  // synthetic-event props are NOT serialised to DOM, so anything here
+  // would be an injected attribute).
+  container.querySelectorAll("*").forEach((el) => {
+    for (const attr of Array.from(el.attributes)) {
+      expect(/^on/i.test(attr.name)).toBe(false);
+    }
+  });
+  // No element with a `javascript:` href.
+  container.querySelectorAll("a[href]").forEach((a) => {
+    expect((a as HTMLAnchorElement).href.toLowerCase()).not.toMatch(/^javascript:/);
+  });
+}
+
+describe("CustomCardPreview — render-time sanitization", () => {
+  beforeEach(() => {
+    clearAllCustomCards();
+  });
+
+  afterEach(() => {
+    clearAllCustomCards();
+  });
+
+  const xssVectors: Array<{ name: string; payload: (key: keyof CustomCardDefinition) => string }> = [
+    {
+      name: "script tag in name",
+      payload: () => "Evil <script>alert('xss-name')</script>",
+    },
+    {
+      name: "img onerror in oracleText",
+      payload: () => "<img src=x onerror=fetch('/leak')>",
+    },
+    {
+      name: "javascript: URL in imageUrl",
+      payload: () => "javascript:alert(1)",
+    },
+    {
+      name: "iframe injection in flavorText",
+      payload: () => "<iframe src='https://evil/'></iframe>",
+    },
+    {
+      name: "mixed-case Unicode escape in name",
+      payload: () => "<\u0053cript>alert(1)</\u0053cript>",
+    },
+    {
+      name: "bidi control smuggling in name",
+      payload: () => "Card\u202E<script>alert(1)</script>",
+    },
+  ];
+
+  for (const vector of xssVectors) {
+    it(`does not execute ${vector.name}`, () => {
+      const overrides: Partial<CustomCardDefinition> = {};
+      // Pick a sensible field for each vector.
+      const target: keyof CustomCardDefinition =
+        vector.name.includes("imageUrl")
+          ? "art"
+          : vector.name.includes("oracleText")
+            ? "oracleText"
+            : vector.name.includes("flavorText")
+              ? "flavorText"
+              : "name";
+      if (target === "art") {
+        overrides.art = {
+          ...DEFAULT_CUSTOM_CARD.art,
+          useProceduralArt: false,
+          imageUrl: vector.payload("art"),
+        };
+      } else {
+        (overrides as Record<string, unknown>)[target] = vector.payload(target);
+      }
+      const card = makeMaliciousCard(overrides);
+      // Persist through the storage layer (data-layer sanitization).
+      saveCustomCard(card);
+
+      const { container } = render(<CustomCardPreview card={card} />);
+
+      // Render-site sanitization should also have run; either layer is
+      // sufficient to neutralize the payload, but the DOM must be clean
+      // regardless of which layer was the gate.
+      expectNoExecutableDom(container);
+
+      // Additionally assert that no visible text on the page contains
+      // a raw `<script>` substring (i.e. unescaped tag markers).
+      const text = container.textContent ?? "";
+      expect(text).not.toContain("<script>");
+      expect(text).not.toContain("</script>");
+    });
+  }
+
+  it("preserves Scryfall reminder-symbol arrows through render", () => {
+    const card = makeMaliciousCard({
+      oracleText: "{T}: Add {C}{C} → {W} or {U}. (→ is a reminder arrow.)",
+    });
+    saveCustomCard(card);
+    const { container } = render(<CustomCardPreview card={card} />);
+    const text = container.textContent ?? "";
+    expect(text).toContain("→");
+    expect(text).toContain("{T}");
+    expectNoExecutableDom(container);
+  });
+});

--- a/src/components/custom-card-preview.tsx
+++ b/src/components/custom-card-preview.tsx
@@ -9,6 +9,7 @@ import {
   FRAME_STYLE_COLORS,
   RARITY_COLORS,
 } from '@/lib/custom-card';
+import { sanitizeCardText, sanitizeImageUrl } from '@/lib/security/sanitize-text';
 
 /**
  * Custom Card Preview Component
@@ -144,8 +145,41 @@ export const CustomCardPreview = memo(function CustomCardPreview({
   // Parse oracle text for reminder text formatting
   const formattedOracleText = useMemo(() => {
     if (!card.oracleText) return [];
-    return card.oracleText.split('\n');
+    return card.oracleText.split('\n').map((line) => sanitizeCardText(line));
   }, [card.oracleText]);
+
+  // Pre-sanitize every user-controllable field that flows into the DOM.
+  // Defense-in-depth: the data layer sanitizes on save/import, but we
+  // re-sanitize at render so a poisoned card that arrived via P2P import
+  // (which doesn't go through `saveCustomCard`) still cannot execute.
+  const safe = useMemo(
+    () => ({
+      name: sanitizeCardText(card.name, 200),
+      typeLine: sanitizeCardText(card.typeLine, 200),
+      artist: sanitizeCardText(card.artist, 200),
+      copyright: sanitizeCardText(card.copyright, 200),
+      flavorText: sanitizeCardText(card.flavorText, 1_000),
+      imageUrl: sanitizeImageUrl(card.art.imageUrl),
+      setCode: sanitizeCardText(card.setCode, 16),
+      collectorNumber: sanitizeCardText(card.collectorNumber, 16),
+      power: sanitizeCardText(card.power, 16),
+      toughness: sanitizeCardText(card.toughness, 16),
+      loyalty: sanitizeCardText(card.loyalty, 16),
+    }),
+    [
+      card.name,
+      card.typeLine,
+      card.artist,
+      card.copyright,
+      card.flavorText,
+      card.art.imageUrl,
+      card.setCode,
+      card.collectorNumber,
+      card.power,
+      card.toughness,
+      card.loyalty,
+    ],
+  );
 
   // Handle transform card back
   if (showBack && card.backFace) {
@@ -200,7 +234,7 @@ export const CustomCardPreview = memo(function CustomCardPreview({
             className="text-xs font-bold truncate"
             style={{ color: frameColors.text, fontSize: scale * 11 }}
           >
-            {card.name || 'Card Name'}
+            {safe.name || 'Card Name'}
           </span>
           {/* Mana cost */}
           <div className="flex items-center gap-0.5">
@@ -215,10 +249,10 @@ export const CustomCardPreview = memo(function CustomCardPreview({
           className="absolute top-[30px] left-2 right-2 h-[175px] rounded-sm overflow-hidden"
           style={{ border: `1px solid ${frameColors.border}` }}
         >
-          {card.art.imageUrl ? (
+          {safe.imageUrl ? (
             <img
-              src={card.art.imageUrl}
-              alt={card.name}
+              src={safe.imageUrl}
+              alt={safe.name}
               className="w-full h-full object-cover"
             />
           ) : (
@@ -255,14 +289,14 @@ export const CustomCardPreview = memo(function CustomCardPreview({
             className="text-xs truncate"
             style={{ color: frameColors.text, fontSize: scale * 9 }}
           >
-            {card.typeLine || 'Type Line'}
+            {safe.typeLine || 'Type Line'}
           </span>
           {/* Collector number / set info */}
           <span
             className="text-xs"
             style={{ color: frameColors.text, fontSize: scale * 8 }}
           >
-            {card.setCode}/{card.collectorNumber || '001'}
+            {safe.setCode}/{safe.collectorNumber || '001'}
           </span>
         </div>
 
@@ -292,17 +326,17 @@ export const CustomCardPreview = memo(function CustomCardPreview({
           </div>
           
           {/* Flavor text (if present) */}
-          {card.flavorText && (
+          {safe.flavorText && (
             <div
               className="mt-1 pt-1 border-t border-black/20 italic text-xs"
               style={{ color: '#555' }}
             >
-              {card.flavorText}
+              {safe.flavorText}
             </div>
           )}
           
           {/* Power/Toughness */}
-          {card.power && card.toughness && (
+          {safe.power && safe.toughness && (
             <div className="absolute bottom-1 right-1">
               <span
                 className="text-sm font-bold"
@@ -311,13 +345,13 @@ export const CustomCardPreview = memo(function CustomCardPreview({
                   fontSize: scale * 14,
                 }}
               >
-                {card.power}/{card.toughness}
+                {safe.power}/{safe.toughness}
               </span>
             </div>
           )}
           
           {/* Loyalty (planeswalkers) */}
-          {card.loyalty && (
+          {safe.loyalty && (
             <div className="absolute bottom-1 right-1">
               <span
                 className="text-sm font-bold px-1 rounded"
@@ -327,7 +361,7 @@ export const CustomCardPreview = memo(function CustomCardPreview({
                   fontSize: scale * 12,
                 }}
               >
-                {card.loyalty}
+                {safe.loyalty}
               </span>
             </div>
           )}
@@ -338,8 +372,8 @@ export const CustomCardPreview = memo(function CustomCardPreview({
           className="absolute bottom-1 left-2 right-2 flex justify-between text-[8px]"
           style={{ color: frameColors.text }}
         >
-          <span>{card.artist || 'Artist'}</span>
-          <span>{card.copyright || '© Custom'}</span>
+          <span>{safe.artist || 'Artist'}</span>
+          <span>{safe.copyright || '© Custom'}</span>
         </div>
 
         {/* Rarity indicator */}

--- a/src/components/game-chat.tsx
+++ b/src/components/game-chat.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Send, MessageCircle, X, Minimize2, Maximize2, Users } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { sanitizeCardText } from '@/lib/security/sanitize-text';
 
 export interface ChatMessage {
   id: string;
@@ -203,7 +204,7 @@ export function GameChat({
                     return (
                       <div key={message.id} className="text-center">
                         <span className="text-xs text-muted-foreground bg-muted px-2 py-1 rounded">
-                          {message.content}
+                          {sanitizeCardText(message.content, 1_000)}
                         </span>
                       </div>
                     );
@@ -223,9 +224,9 @@ export function GameChat({
                           'w-7 h-7 rounded-full flex items-center justify-center text-white text-xs font-bold shrink-0',
                           getPlayerColor(message.playerId)
                         )}
-                        title={message.playerName}
+                        title={sanitizeCardText(message.playerName, 64)}
                       >
-                        {getPlayerInitial(message.playerName)}
+                        {getPlayerInitial(sanitizeCardText(message.playerName, 64))}
                       </div>
 
                       {/* Message bubble */}
@@ -239,10 +240,10 @@ export function GameChat({
                       >
                         {!isOwnMessage && (
                           <div className="text-xs font-semibold text-muted-foreground mb-0.5">
-                            {message.playerName}
+                            {sanitizeCardText(message.playerName, 64)}
                           </div>
                         )}
-                        <div className="text-sm break-words">{message.content}</div>
+                        <div className="text-sm break-words">{sanitizeCardText(message.content, 1_000)}</div>
                         <div
                           className={cn(
                             'text-[10px] mt-0.5',

--- a/src/components/replay-viewer.tsx
+++ b/src/components/replay-viewer.tsx
@@ -2,15 +2,16 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { cn } from '@/lib/utils';
-import { 
-  generateShareableURL, 
-  decodeReplayFromURL, 
-  copyShareableLink, 
+import {
+  generateShareableURL,
+  decodeReplayFromURL,
+  copyShareableLink,
   exportReplayToFile,
   importReplayFromFile,
   getEstimatedURLLength
 } from '@/lib/replay-sharing';
 import type { Replay } from '@/lib/game-state/replay';
+import { sanitizeCardText } from '@/lib/security/sanitize-text';
 
 /**
  * Replay Viewer Component
@@ -266,7 +267,7 @@ export function ReplayViewer({
         {/* Action description */}
         {currentAction && (
           <div className="text-sm text-center text-muted-foreground">
-            {currentAction.description}
+            {sanitizeCardText(currentAction.description, 1_000)}
           </div>
         )}
       </div>
@@ -409,7 +410,7 @@ export function ReplayViewer({
               <span className="text-muted-foreground mr-2">
                 #{action.sequenceNumber}
               </span>
-              {action.description}
+              {sanitizeCardText(action.description, 1_000)}
             </button>
           ))}
         </div>

--- a/src/components/stack-display.tsx
+++ b/src/components/stack-display.tsx
@@ -26,6 +26,7 @@ import {
   ChevronUp,
   AlertCircle,
 } from "lucide-react";
+import { sanitizeCardText } from "@/lib/security/sanitize-text";
 
 /**
  * Stack item representing a spell or ability on the stack
@@ -212,7 +213,7 @@ const StackItemDisplay = memo(function StackItemDisplay({
         {item.oracleText && (
           <TooltipContent className="max-w-xs">
             <p className="font-medium">{item.name}</p>
-            <p className="text-sm mt-1">{item.oracleText}</p>
+            <p className="text-sm mt-1">{sanitizeCardText(item.oracleText)}</p>
           </TooltipContent>
         )}
       </Tooltip>

--- a/src/components/zone-viewer.tsx
+++ b/src/components/zone-viewer.tsx
@@ -26,6 +26,7 @@ import {
 } from "lucide-react";
 import { ZoneType } from "@/types/game";
 import { cn } from "@/lib/utils";
+import { sanitizeCardText } from "@/lib/security/sanitize-text";
 
 /**
  * Card data for display in zone viewers
@@ -221,7 +222,7 @@ const ZoneCardList = memo(function ZoneCardList({
               }}
               tabIndex={idx === activeIndex ? 0 : -1}
               onClick={() => onCardClick?.(card.id)}
-              aria-label={`${card.name}, ${card.typeLine}${card.manaCost ? `, cost ${card.manaCost}` : ""}${pt ? `, ${pt}` : ""}`}
+              aria-label={`${sanitizeCardText(card.name)}, ${sanitizeCardText(card.typeLine)}${card.manaCost ? `, cost ${sanitizeCardText(card.manaCost)}` : ""}${pt ? `, ${pt}` : ""}`}
               className="group relative flex flex-col items-center p-2 rounded-md border border-border hover:border-primary/50 hover:bg-primary/5 transition-all text-left w-full focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
               {/* Color indicator */}
@@ -242,23 +243,23 @@ const ZoneCardList = memo(function ZoneCardList({
               {/* Card name */}
               <span
                 className="text-xs font-medium truncate w-full pl-2"
-                title={card.name}
+                title={sanitizeCardText(card.name)}
               >
-                {card.name}
+                {sanitizeCardText(card.name)}
               </span>
 
               {/* Card type */}
               <span
                 className="text-[10px] text-muted-foreground truncate w-full pl-2"
-                title={card.typeLine}
+                title={sanitizeCardText(card.typeLine)}
               >
-                {card.typeLine}
+                {sanitizeCardText(card.typeLine)}
               </span>
 
               {/* Mana cost if present */}
               {card.manaCost && (
                 <span className="text-[10px] text-muted-foreground mt-1">
-                  {card.manaCost}
+                  {sanitizeCardText(card.manaCost, 32)}
                 </span>
               )}
 

--- a/src/lib/__tests__/custom-card-storage-sanitize.test.ts
+++ b/src/lib/__tests__/custom-card-storage-sanitize.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for src/lib/custom-card-storage.ts sanitization (issue #1276)
+ *
+ * Verifies that custom-card JSON saved or imported via the storage API
+ * is sanitized at the data layer so that a malicious deck file cannot
+ * plant a stored-XSS payload that survives every render site.
+ */
+
+import {
+  saveCustomCard,
+  getCustomCards,
+  importCustomCards,
+  clearAllCustomCards,
+} from "../custom-card-storage";
+import type { CustomCardDefinition } from "../custom-card";
+import { DEFAULT_CUSTOM_CARD } from "../custom-card";
+
+const now = Date.now();
+
+function makeCard(overrides: Partial<CustomCardDefinition> = {}): CustomCardDefinition {
+  return {
+    ...(DEFAULT_CUSTOM_CARD as Omit<CustomCardDefinition, "id" | "createdAt" | "updatedAt">),
+    id: "test-card-1",
+    name: "Lightning Bolt",
+    typeLine: "Instant",
+    oracleText: "Lightning Bolt deals 3 damage to any target.",
+    rarity: "common",
+    cardTypes: ["instant"],
+    colors: ["red"],
+    art: { ...DEFAULT_CUSTOM_CARD.art, useProceduralArt: true },
+    typography: { ...DEFAULT_CUSTOM_CARD.typography },
+    background: { ...DEFAULT_CUSTOM_CARD.background },
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe("custom-card-storage — sanitization", () => {
+  beforeEach(() => {
+    clearAllCustomCards();
+  });
+
+  describe("saveCustomCard", () => {
+    it("strips script tags from oracleText before storing", () => {
+      const card = makeCard({
+        id: "xss-script",
+        name: "Bad",
+        oracleText: "Lightning Bolt <script>alert(1)</script>",
+      });
+      saveCustomCard(card);
+      const stored = getCustomCards().find((c) => c.id === "xss-script")!;
+      expect(stored.oracleText).not.toContain("<script>");
+      expect(stored.oracleText).toContain("&lt;script&gt;");
+    });
+
+    it("strips onerror handlers from oracleText before storing", () => {
+      const card = makeCard({
+        id: "xss-onerror",
+        name: "Bad",
+        oracleText: '<img src=x onerror=fetch("/leak")>',
+      });
+      saveCustomCard(card);
+      const stored = getCustomCards().find((c) => c.id === "xss-onerror")!;
+      // The actual XSS gate is that no raw <img tag survives — every `<`
+      // must be escaped so the browser cannot parse it as a tag.
+      expect(stored.oracleText).not.toMatch(/<\s*img\b/i);
+      expect(stored.oracleText).toContain("&lt;img");
+    });
+
+    it("strips javascript: URLs from imageUrl before storing", () => {
+      const card = makeCard({
+        id: "xss-js-url",
+        name: "Bad",
+        oracleText: "noop",
+        art: {
+          ...DEFAULT_CUSTOM_CARD.art,
+          useProceduralArt: false,
+          imageUrl: "javascript:alert(1)",
+        },
+      });
+      saveCustomCard(card);
+      const stored = getCustomCards().find((c) => c.id === "xss-js-url")!;
+      // imageUrl is scheme-validated via sanitizeUrl and replaced with an
+      // empty string when the scheme is dangerous. The card preview then
+      // falls back to procedural art.
+      expect(stored.art.imageUrl).toBe("");
+    });
+
+    it("strips control characters and zero-width joiners from card name", () => {
+      const card = makeCard({
+        id: "xss-control",
+        name: "Card\u202Etext\u200B<script>alert(1)</script>",
+      });
+      saveCustomCard(card);
+      const stored = getCustomCards().find((c) => c.id === "xss-control")!;
+      // eslint-disable-next-line no-control-regex -- C0/bidi/zero-width are the targets
+      expect(stored.name).not.toMatch(/[\u0000-\u001F\u202A-\u202E\u200B-\u200D]/);
+      expect(stored.name).not.toContain("<script>");
+    });
+
+    it("preserves Scryfall reminder symbol arrows in oracleText", () => {
+      const card = makeCard({
+        id: "ok-arrow",
+        name: "OK",
+        oracleText: "{T}: Add {C} → {W} or {U}.",
+      });
+      saveCustomCard(card);
+      const stored = getCustomCards().find((c) => c.id === "ok-arrow")!;
+      expect(stored.oracleText).toContain("→");
+      expect(stored.oracleText).toContain("{T}");
+    });
+
+    it("does not mutate the input card object", () => {
+      const card = makeCard({
+        id: "no-mutate",
+        oracleText: "<script>alert(1)</script>",
+      });
+      const before = card.oracleText;
+      saveCustomCard(card);
+      // Original input is unchanged — sanitization produces a copy.
+      expect(card.oracleText).toBe(before);
+    });
+  });
+
+  describe("importCustomCards", () => {
+    it("sanitizes every imported card before merging into storage", () => {
+      const json = JSON.stringify([
+        makeCard({
+          id: "imp-1",
+          name: "<script>alert(1)</script>",
+          oracleText: "<img src=x onerror=alert(1)>",
+        }),
+        makeCard({
+          id: "imp-2",
+          name: "OK Card",
+          oracleText: "{T}: Add {G}.",
+        }),
+      ]);
+      const result = importCustomCards(json);
+      expect(result.success).toBe(true);
+      expect(result.count).toBe(2);
+      const stored = getCustomCards();
+      const imp1 = stored.find((c) => c.id === "imp-1")!;
+      const imp2 = stored.find((c) => c.id === "imp-2")!;
+      expect(imp1.name).not.toContain("<script>");
+      expect(imp1.oracleText).not.toContain("<img");
+      // Non-malicious card text survives (modulo HTML escaping).
+      expect(imp2.oracleText).toContain("{T}");
+    });
+
+    it("refuses to import non-array input", () => {
+      const result = importCustomCards('{"not": "an array"}');
+      expect(result.success).toBe(false);
+      expect(result.errors[0]).toContain("expected array");
+    });
+
+    it("rejects individual cards missing required fields", () => {
+      const json = JSON.stringify([{ id: "x" }, { name: "no id" }]);
+      const result = importCustomCards(json);
+      expect(result.success).toBe(true); // import succeeded overall
+      expect(result.count).toBe(0);
+      expect(result.errors.length).toBe(2);
+    });
+  });
+});

--- a/src/lib/custom-card-storage.ts
+++ b/src/lib/custom-card-storage.ts
@@ -6,6 +6,7 @@
  */
 
 import type { CustomCardDefinition } from './custom-card';
+import { sanitizeCustomCardFields } from './security/sanitize-text';
 
 const STORAGE_KEY = 'planar-nexus-custom-cards';
 
@@ -28,19 +29,22 @@ export function getCustomCards(): CustomCardDefinition[] {
 }
 
 /**
- * Save a custom card to local storage
+ * Save a custom card to local storage. Every user-controllable string
+ * field is sanitized before being written so that an attacker cannot
+ * plant a stored-XSS payload that survives every render site.
  */
 export function saveCustomCard(card: CustomCardDefinition): void {
   if (typeof window === 'undefined') return;
   
   try {
+    const safe = sanitizeCustomCardFields(card);
     const cards = getCustomCards();
-    const existingIndex = cards.findIndex(c => c.id === card.id);
+    const existingIndex = cards.findIndex(c => c.id === safe.id);
     
     if (existingIndex >= 0) {
-      cards[existingIndex] = { ...card, updatedAt: Date.now() };
+      cards[existingIndex] = { ...safe, updatedAt: Date.now() };
     } else {
-      cards.push(card);
+      cards.push(safe);
     }
     
     localStorage.setItem(STORAGE_KEY, JSON.stringify(cards));
@@ -83,7 +87,9 @@ export function exportAllCustomCards(): string {
 }
 
 /**
- * Import custom cards from JSON
+ * Import custom cards from JSON. Each imported card is sanitized before
+ * being merged into local storage so that an attacker-supplied `.json`
+ * file cannot be used to seed a stored-XSS payload.
  */
 export function importCustomCards(json: string): { success: boolean; count: number; errors: string[] } {
   const errors: string[] = [];
@@ -98,11 +104,13 @@ export function importCustomCards(json: string): { success: boolean; count: numb
     const existingCards = getCustomCards();
     let count = 0;
     
-    imported.forEach((card, index) => {
-      if (!card.id || !card.name) {
+    imported.forEach((rawCard, index) => {
+      if (!rawCard.id || !rawCard.name) {
         errors.push(`Card ${index + 1}: Missing required fields (id, name)`);
         return;
       }
+
+      const card = sanitizeCustomCardFields(rawCard);
       
       const existingIndex = existingCards.findIndex(c => c.id === card.id);
       if (existingIndex >= 0) {

--- a/src/lib/security/__tests__/sanitize-text.test.ts
+++ b/src/lib/security/__tests__/sanitize-text.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Tests for src/lib/security/sanitize-text.ts (issue #1276)
+ *
+ * Cover at least 6 XSS attack vectors per public function:
+ *   - <script>alert(1)</script>
+ *   - <img src=x onerror=fetch('/leak')>
+ *   - javascript: URLs
+ *   - on*= event handlers
+ *   - data: URIs (text/html)
+ *   - mixed-case and unicode-escape variants
+ */
+
+import {
+  escapeHtml,
+  sanitizeCardText,
+  sanitizeMarkdown,
+  sanitizeUrl,
+  sanitizeImageUrl,
+  sanitizeCustomCardFields,
+  DEFAULT_MAX_CARD_TEXT_LENGTH,
+  DEFAULT_MAX_MARKDOWN_LENGTH,
+  __testing__,
+} from "../sanitize-text";
+
+/**
+ * Assert that the given HTML string contains no element from the
+ * deny-list of tags that would constitute an XSS vector if present in the
+ * DOM. `sanitizeMarkdown` outputs HTML intentionally, so we cannot blanket
+ * forbid all tags — we forbid only the unsafe ones.
+ */
+function expectNoUnsafeTags(html: string): void {
+  const tagPattern = /<\/?\s*([a-zA-Z][a-zA-Z0-9]*)/g;
+  let m: RegExpExecArray | null;
+  while ((m = tagPattern.exec(html)) !== null) {
+    const tagName = m[1]!.toLowerCase();
+    expect(__testing__.UNSAFE_TAGS.has(tagName)).toBe(false);
+  }
+}
+
+describe("security/sanitize-text", () => {
+  describe("escapeHtml", () => {
+    it("escapes the five HTML-significant characters", () => {
+      expect(escapeHtml(`<script>"&'<\``)).toBe(
+        "&lt;script&gt;&quot;&amp;&#39;&lt;&#96;",
+      );
+    });
+
+    it("returns an empty string for non-string inputs", () => {
+      expect(escapeHtml(undefined)).toBe("");
+      expect(escapeHtml(null)).toBe("");
+      expect(escapeHtml(42)).toBe("");
+      expect(escapeHtml({})).toBe("");
+      expect(escapeHtml([])).toBe("");
+    });
+
+    it("leaves a string with no special characters untouched", () => {
+      expect(escapeHtml("Lightning Bolt deals 3 damage.")).toBe(
+        "Lightning Bolt deals 3 damage.",
+      );
+    });
+
+    it("does not double-escape ampersands (single pass)", () => {
+      expect(escapeHtml("a &amp; b")).toBe("a &amp;amp; b");
+    });
+  });
+
+  describe("sanitizeCardText — XSS vectors", () => {
+    const vectors: Array<{ name: string; payload: string }> = [
+      {
+        name: "script tag",
+        payload: "Lightning Bolt <script>alert(1)</script>",
+      },
+      {
+        name: "img onerror handler",
+        payload: "<img src=x onerror=fetch('/leak')>",
+      },
+      {
+        name: "javascript: URL",
+        payload: "Click <a href=javascript:alert(1)>here</a>",
+      },
+      {
+        name: "iframe injection",
+        payload: "<iframe src='https://evil/'></iframe>",
+      },
+      {
+        name: "svg with onload",
+        payload: "<svg onload=alert(1)></svg>",
+      },
+      {
+        name: "mixed-case Unicode escape trick",
+        payload: "<\u0053cript>alert(1)</\u0053cript>",
+      },
+      {
+        name: "HTML entity attempt in attribute",
+        payload: "<a href=\"javascript&#58;alert(1)\">x</a>",
+      },
+      {
+        name: "null byte injection",
+        payload: "Good text\u0000<script>alert(1)</script>",
+      },
+      {
+        name: "bidi override smuggling",
+        payload: "Card\u202Etext<script>alert(1)</script>",
+      },
+      {
+        name: "zero-width joiner hiding payload",
+        payload: "Card\u200B<script>alert(1)</script>",
+      },
+    ];
+
+    for (const v of vectors) {
+      it(`strips ${v.name}`, () => {
+        const out = sanitizeCardText(v.payload);
+        // No raw HTML-significant character survives — every < and > must
+        // have been escaped to &lt; / &gt;. This is the actual XSS gate.
+        expect(out).not.toMatch(/<(?:[a-zA-Z/!]|\?)/);
+        // Output must never contain a real HTML tag fragment.
+        expect(out).not.toMatch(__testing__.HTML_RESIDUE);
+        // Null/bidi/zero-width characters must be stripped.
+        // eslint-disable-next-line no-control-regex -- C0/bidi/zero-width are the targets
+        expect(out).not.toMatch(/[\u0000\u202A-\u202E\u200B-\u200D\uFEFF]/);
+      });
+    }
+
+    it("preserves Scryfall reminder-symbol arrows and mana braces", () => {
+      const text = "{T}: Add {C}{C} → {W} or {U}. (→ is reminder.)";
+      const out = sanitizeCardText(text);
+      expect(out).toContain("{T}");
+      expect(out).toContain("{C}");
+      expect(out).toContain("→");
+      expect(out).toContain("{W}");
+      expect(out).toContain("{U}");
+    });
+
+    it("coerces non-string inputs safely", () => {
+      expect(sanitizeCardText(undefined)).toBe("");
+      expect(sanitizeCardText(null)).toBe("");
+      expect(sanitizeCardText(42)).toBe("42");
+      expect(sanitizeCardText(true)).toBe("true");
+    });
+
+    it("clamps length with truncation marker", () => {
+      const long = "x".repeat(DEFAULT_MAX_CARD_TEXT_LENGTH + 100);
+      const out = sanitizeCardText(long);
+      expect(out.length).toBeLessThanOrEqual(DEFAULT_MAX_CARD_TEXT_LENGTH + 16);
+      expect(out).toContain("…[truncated]");
+    });
+
+    it("respects a custom maxLength", () => {
+      const out = sanitizeCardText("abcdefghij", 5);
+      expect(out).toBe("abcde…[truncated]");
+    });
+  });
+
+  describe("sanitizeUrl — URI scheme XSS vectors", () => {
+    const blocked: string[] = [
+      "javascript:alert(1)",
+      "JavaScript:alert(1)",
+      "  javascript:alert(1)",
+      "vbscript:msgbox(1)",
+      "data:text/html,<script>alert(1)</script>",
+      "data:application/javascript,alert(1)",
+      "file:///etc/passwd",
+      "about:blank",
+    ];
+    for (const url of blocked) {
+      it(`rejects ${JSON.stringify(url)}`, () => {
+        expect(sanitizeUrl(url)).toBe("");
+      });
+    }
+
+    const allowed: Array<[string, string]> = [
+      ["https://example.com/card", "https://example.com/card"],
+      ["http://example.com/x", "http://example.com/x"],
+      ["mailto:hello@example.com", "mailto:hello@example.com"],
+      ["/relative/path", "/relative/path"],
+      ["#anchor", "#anchor"],
+      ["?query=1", "?query=1"],
+    ];
+    for (const [input, expected] of allowed) {
+      it(`accepts ${input}`, () => {
+        expect(sanitizeUrl(input)).toBe(expected);
+      });
+    }
+
+    it("escapes quotes in attribute-safe form", () => {
+      const out = sanitizeUrl(`https://example.com/?a=1"b`);
+      expect(out).not.toContain('"');
+      expect(out).toContain("&quot;");
+    });
+
+    it("returns empty string for non-strings", () => {
+      expect(sanitizeUrl(undefined)).toBe("");
+      expect(sanitizeUrl(null)).toBe("");
+      expect(sanitizeUrl(42)).toBe("");
+    });
+  });
+
+  describe("sanitizeImageUrl", () => {
+    it("allows data:image/png", () => {
+      const png = "data:image/png;base64,iVBORw0KGgo=";
+      expect(sanitizeImageUrl(png)).toBe(png);
+    });
+
+    it("rejects data:text/html", () => {
+      expect(sanitizeImageUrl("data:text/html,<script>alert(1)</script>")).toBe("");
+    });
+
+    it("rejects javascript: scheme in image src", () => {
+      expect(sanitizeImageUrl("javascript:alert(1)")).toBe("");
+    });
+  });
+
+  describe("sanitizeMarkdown — XSS vectors", () => {
+    const vectors: Array<{ name: string; payload: string; mustNotContain: string[] }> = [
+      {
+        name: "<script> tag in markdown",
+        payload: "**bold** <script>alert(1)</script>",
+        mustNotContain: ["<script>", "</script>"],
+      },
+      {
+        name: "img onerror in markdown",
+        payload: "Look <img src=x onerror=fetch('/leak')> here",
+        mustNotContain: ["<img", "onerror=", "fetch("],
+      },
+      {
+        name: "javascript: link",
+        payload: "[click](javascript:alert(1))",
+        mustNotContain: ["javascript:", "alert(1)"],
+      },
+      {
+        name: "data:text/html link",
+        payload: "[evil](data:text/html,<script>alert(1)</script>)",
+        mustNotContain: ["<script>", "data:text/html"],
+      },
+      {
+        name: "auto-link with javascript:",
+        payload: "<javascript:alert(1)>",
+        mustNotContain: ["<a href=\"javascript:", "alert(1)"],
+      },
+      {
+        name: "raw HTML heading",
+        payload: "<h1>Header</h1>",
+        mustNotContain: ["<h1>", "</h1>"],
+      },
+      {
+        name: "style tag injection",
+        payload: "<style>body{display:none}</style>",
+        mustNotContain: ["<style", "</style>"],
+      },
+      {
+        name: "iframe injection",
+        payload: "Note <iframe src='https://evil/'></iframe>",
+        mustNotContain: ["<iframe", "src='https://evil/'"],
+      },
+      {
+        name: "bidi control smuggling",
+        payload: "Title\u202E<script>alert(1)</script>",
+        mustNotContain: ["\u202E", "<script>"],
+      },
+    ];
+    for (const v of vectors) {
+      it(`strips ${v.name}`, () => {
+        const out = sanitizeMarkdown(v.payload);
+        for (const fragment of v.mustNotContain) {
+          expect(out).not.toContain(fragment);
+        }
+        expectNoUnsafeTags(out);
+      });
+    }
+
+    it("renders safe markdown subset: bold", () => {
+      expect(sanitizeMarkdown("**Lightning Bolt**")).toBe(
+        "<p><strong>Lightning Bolt</strong></p>",
+      );
+    });
+
+    it("renders safe markdown subset: italic", () => {
+      expect(sanitizeMarkdown("*draw two cards*")).toBe(
+        "<p><em>draw two cards</em></p>",
+      );
+    });
+
+    it("renders safe markdown subset: inline code", () => {
+      expect(sanitizeMarkdown("Use `{T}` to add mana")).toBe(
+        "<p>Use <code>{T}</code> to add mana</p>",
+      );
+    });
+
+    it("renders headings up to h3", () => {
+      expect(sanitizeMarkdown("# Title")).toBe("<h1>Title</h1>");
+      expect(sanitizeMarkdown("## Subtitle")).toBe("<h2>Subtitle</h2>");
+      expect(sanitizeMarkdown("### Section")).toBe("<h3>Section</h3>");
+    });
+
+    it("renders unordered lists", () => {
+      const md = "- one\n- two\n- three";
+      expect(sanitizeMarkdown(md)).toBe(
+        "<ul><li>one</li><li>two</li><li>three</li></ul>",
+      );
+    });
+
+    it("renders ordered lists", () => {
+      const md = "1. first\n2. second";
+      expect(sanitizeMarkdown(md)).toBe(
+        "<ol><li>first</li><li>second</li></ol>",
+      );
+    });
+
+    it("renders safe https links with rel/target", () => {
+      const md = "[Scryfall](https://scryfall.com/card)";
+      const out = sanitizeMarkdown(md);
+      expect(out).toContain('<a href="https://scryfall.com/card"');
+      expect(out).toContain('rel="noopener noreferrer nofollow"');
+      expect(out).toContain('target="_blank"');
+      expect(out).toContain("Scryfall");
+    });
+
+    it("drops link text when URL is unsafe but keeps sanitized text", () => {
+      const md = "[click](javascript:alert(1))";
+      const out = sanitizeMarkdown(md);
+      expect(out).not.toContain("javascript:");
+      // The link target is dropped; only the escaped link text remains.
+      expect(out).toContain("click");
+    });
+
+    it("coerces non-string inputs to empty", () => {
+      expect(sanitizeMarkdown(undefined)).toBe("");
+      expect(sanitizeMarkdown(null)).toBe("");
+      expect(sanitizeMarkdown(42)).toBe("<p>42</p>");
+    });
+
+    it("clamps length with truncation marker", () => {
+      const long = "x".repeat(DEFAULT_MAX_MARKDOWN_LENGTH + 100);
+      const out = sanitizeMarkdown(long);
+      expect(out.length).toBeLessThanOrEqual(DEFAULT_MAX_MARKDOWN_LENGTH + 32);
+      expect(out).toContain("…[truncated]");
+    });
+  });
+
+  describe("sanitizeCustomCardFields", () => {
+    it("sanitizes all user-controllable string fields", () => {
+      const card = {
+        id: "c-1",
+        name: "<script>alert(1)</script>",
+        typeLine: "Creature — <b>Beast</b>",
+        oracleText: "Destroy <img src=x onerror=alert(1)> target.",
+        flavorText: "Hello <iframe></iframe> world.",
+        power: "1+1",
+        toughness: "1",
+        loyalty: "3",
+        manaCost: "{1}{R}",
+        artist: "<b>Bad</b>",
+        copyright: "© <script>x</script>",
+        rarity: "rare",
+      };
+      const out = sanitizeCustomCardFields(card);
+      expect(out.name).not.toContain("<script>");
+      expect(out.typeLine).not.toContain("<b>");
+      expect(out.oracleText).not.toContain("<img");
+      expect(out.flavorText).not.toContain("<iframe");
+      expect(out.artist).not.toContain("<b>");
+      expect(out.copyright).not.toContain("<script>");
+      expect(out.rarity).toBe("rare"); // untouched
+    });
+
+    it("returns the input unchanged for null / non-object", () => {
+      expect(sanitizeCustomCardFields(null as unknown as Record<string, unknown>)).toBeNull();
+      expect(sanitizeCustomCardFields(undefined as unknown as Record<string, unknown>)).toBeUndefined();
+    });
+  });
+});

--- a/src/lib/security/__tests__/sanitize-text.test.ts
+++ b/src/lib/security/__tests__/sanitize-text.test.ts
@@ -258,6 +258,25 @@ describe("security/sanitize-text", () => {
         payload: "Title\u202E<script>alert(1)</script>",
         mustNotContain: ["\u202E", "<script>"],
       },
+      {
+        // CodeQL js/incomplete-multi-character-sanitization regression —
+        // a leading `<` plus a tag like `<script>` can leave a stray
+        // `<` after a single strip pass. The sanitizer must loop until
+        // stable to defeat these.
+        name: "nested-tag prefix smuggle",
+        payload: "<<script>alert(1)</script>",
+        mustNotContain: ["<script>", "</script>"],
+      },
+      {
+        name: "bare script prefix (no closing >)",
+        payload: "<script",
+        mustNotContain: ["<script"],
+      },
+      {
+        name: "double-nested script smuggle",
+        payload: "<scr<script>ipt>alert(1)</script>",
+        mustNotContain: ["<script>", "ipt>"],
+      },
     ];
     for (const v of vectors) {
       it(`strips ${v.name}`, () => {

--- a/src/lib/security/sanitize-text.ts
+++ b/src/lib/security/sanitize-text.ts
@@ -321,7 +321,18 @@ export function sanitizeMarkdown(value: unknown, maxLength: number = DEFAULT_MAX
   // Defensively strip any HTML tags up-front. This is belt-and-suspenders:
   // the inline renderers below also escape, so this is only protection
   // against accidental code paths that bypass them.
-  out = out.replace(HTML_TAG, "");
+  //
+  // CodeQL `js/incomplete-multi-character-sanitization`: a single
+  // `replace()` pass is not provably terminating — payloads like
+  // `<<script>` or `<scr<script>` can leave behind fragments that
+  // re-introduce dangerous tag prefixes after one sweep. We loop the
+  // replace until the string is stable, which is the recommended
+  // remediation in the CodeQL help text.
+  let prevStrip: string;
+  do {
+    prevStrip = out;
+    out = out.replace(HTML_TAG, "");
+  } while (out !== prevStrip);
   if (out.length > maxLength) {
     out = out.slice(0, maxLength) + "…[truncated]";
   }

--- a/src/lib/security/sanitize-text.ts
+++ b/src/lib/security/sanitize-text.ts
@@ -1,0 +1,444 @@
+/**
+ * @fileOverview Render-time text sanitizers (issue #1276)
+ *
+ * Defense-in-depth HTML/markdown sanitizers applied to all *untrusted* text
+ * that ends up in the React tree — custom-card JSON, oracle-text, chat,
+ * replay-viewer notes, and AI coach markdown. React's JSX interpolation
+ * (`{value}`) already escapes HTML at render time, but JSX auto-escaping is
+ * not sufficient as a sole control because:
+ *
+ *   1. Some sites use `dangerouslySetInnerHTML`, `title=`, or other attribute
+ *      sinks where attribute-encoding parity is not automatic.
+ *   2. Custom-card JSON flows from `localStorage` → `importCustomCards()` →
+ *      preview/render. A malicious deck shared as a `.json` file can plant a
+ *      payload that survives every cache layer.
+ *   3. Markdown renderers are commonly used downstream and a permissive
+ *      renderer will treat `<script>` content as raw HTML.
+ *
+ * The functions here are *deliberately* allow-listed rather than deny-listed:
+ * the markdown subset we support is intentionally tiny so a vulnerability in
+ * a permissive regex cannot widen the surface.
+ *
+ * Threat model — what each helper blocks:
+ *   - `<script>`, `<iframe>`, `<object>`, `<embed>`, `<style>`, `<svg>` tags
+ *   - `on*` / `formaction` / `srcdoc` / `xlink:href` handlers (script execution)
+ *   - `javascript:`, `vbscript:`, `data:` (except `data:image/...`) URI schemes
+ *   - `expression(...)` / `@import` CSS primitives
+ *   - control / bidi / zero-width characters that smuggle payloads past log
+ *     filters (also blocked by `sanitizeUserInput` upstream; we re-strip here)
+ *
+ * What is intentionally NOT in scope:
+ *   - These helpers are for *display* sanitization. Prompt-injection defenses
+ *     for LLM input live in `src/ai/prompt-security.ts`.
+ *   - The helpers do NOT encode for HTML attribute context. Callers using
+ *     these strings inside attribute values must still wrap with `"…"` and not
+ *     allow raw double quotes from user input; we escape `"` so this is safe
+ *     for typical attribute use.
+ */
+
+const ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+  "`": "&#96;",
+};
+
+/**
+ * Escape the five HTML-significant characters so a string can be safely
+ * embedded in element text or quoted-attribute context. Always pair this
+ * with a context-appropriate wrapper (e.g. `<p>{value}</p>`, never raw
+ * `dangerouslySetInnerHTML`).
+ *
+ * Returns `""` for non-string inputs.
+ */
+export function escapeHtml(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value.replace(/[&<>"'`]/g, (ch) => ESCAPE_MAP[ch]);
+}
+
+/**
+ * Default maximum length (chars) for a single sanitized card-text field.
+ * Matches the upper bound used by Scryfall oracle_text in practice.
+ */
+export const DEFAULT_MAX_CARD_TEXT_LENGTH = 2_000;
+
+/**
+ * Default maximum length for a single sanitized markdown block.
+ * Coach summaries in this app are bounded around 8 000 chars; we cap below
+ * that to keep render cost predictable.
+ */
+export const DEFAULT_MAX_MARKDOWN_LENGTH = 16_000;
+
+/**
+ * Smuggle / hide characters that have no place in card text: C0 controls
+ * (except tab/newline), DEL, bidi overrides, zero-width, and BOM. Newlines
+ * (`\n`), carriage returns (`\r`) and tabs (`\t`) are intentionally retained
+ * because card text is line-oriented (e.g. separate ability lines).
+ */
+const SMUGGLE_CHARS =
+  // eslint-disable-next-line no-control-regex -- intentionally targets control/bidi/zero-width chars
+  /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F\u202A-\u202E\u2066-\u2069\u200B-\u200D\uFEFF]/g;
+
+/**
+ * URI schemes that can execute script or load HTML when followed by an
+ * attacker-controlled payload. We allow `https?`, `mailto`, and the
+ * `data:image/...` subset which is required for inline procedurally-
+ * generated card art. Everything else with a scheme — `data:text/html`,
+ * `data:application/javascript`, `vbscript:`, `file:`, `about:`, `chrome:`,
+ * `jar:`, etc. — is rejected.
+ *
+ * The pattern is anchored with `:` *inside* the alternation for each scheme
+ * (rather than at the end of the regex) so `data:text/html` is matched by
+ * the `data\s*:` arm followed by the negative lookahead — the trailing `:`
+ * outside the group is intentional and matches when the alternative itself
+ * did not consume a colon.
+ */
+const DANGEROUS_URI_SCHEMES =
+  /^(?:javascript:|vbscript:|data\s*:(?!image\/(?:png|jpe?g|gif|webp|svg\+xml))|file:|about:|chrome:|jar:)/i;
+
+/**
+ * Pattern that catches any HTML tag or fragment — opening, closing, or
+ * self-closing. Used to strip raw HTML before markdown rendering so a
+ * permissive downstream renderer cannot be tricked into materialising it.
+ */
+const HTML_TAG = /<\/?[a-zA-Z][^>]*>?/g;
+
+/**
+ * Pattern that catches lone `<` characters that look like the start of an
+ * unfinished tag. We do not strip these (that would corrupt MTG reminder
+ * text containing `<`/`>` like `less than {C}`), but we use this when
+ * verifying that no HTML survived sanitisation.
+ */
+const HTML_RESIDUE = /<\/?[a-zA-Z][^>]{0,200}>/;
+
+/**
+ * Sanitize a card text field for display. Applies:
+ *   - coercion of non-strings to a safe string;
+ *   - control / bidi / zero-width character stripping;
+ *   - HTML entity escaping (`<` → `&lt;`, etc.);
+ *   - length clamping.
+ *
+ * The Scryfall reminder-symbol arrows (`→`, `⟶`, etc.) and mana symbols
+ * (`{T}`, `{R}`, `{W}`, etc.) are preserved as-is — they are unicode /
+ * braces, not HTML-significant. This helper is the one to use for `name`,
+ * `typeLine`, `oracleText`, `flavorText`, `power`, `toughness`, `loyalty`,
+ * `artist`, and `copyright` on CustomCardDefinition.
+ */
+export function sanitizeCardText(value: unknown, maxLength: number = DEFAULT_MAX_CARD_TEXT_LENGTH): string {
+  const raw = typeof value === "string" ? value : value == null ? "" : String(value);
+  let out = raw.replace(SMUGGLE_CHARS, "");
+  out = escapeHtml(out);
+  if (out.length > maxLength) {
+    out = out.slice(0, maxLength) + "…[truncated]";
+  }
+  return out;
+}
+
+/**
+ * Sanitize an entire custom-card-shaped object's user-controllable string
+ * fields. Returns a shallow-copied, sanitized card. Non-string fields are
+ * left untouched except for HTML-sensitive fields which become strings.
+ *
+ * The generic constraint is intentionally loose (`object`) so this
+ * function works for both validated `CustomCardDefinition` and raw
+ * imported JSON blobs that may have extra / missing keys; the runtime
+ * type-checks each field before sanitizing.
+ */
+export function sanitizeCustomCardFields<T extends object>(card: T): T {
+  if (card == null || typeof card !== "object") return card;
+  const out: Record<string, unknown> = { ...(card as Record<string, unknown>) };
+  const fields = ["name", "typeLine", "oracleText", "flavorText", "artist", "copyright"] as const;
+  for (const field of fields) {
+    if (typeof out[field] === "string") {
+      out[field] = sanitizeCardText(out[field]);
+    }
+  }
+  // power/toughness/loyalty can be numeric or "1+1" / "*"; sanitize as text.
+  for (const field of ["power", "toughness", "loyalty"] as const) {
+    if (typeof out[field] === "string") {
+      out[field] = sanitizeCardText(out[field], 16);
+    }
+  }
+  // mana cost and collector number are short tokens; sanitize as text.
+  for (const field of ["manaCost", "collectorNumber", "setCode", "setName"] as const) {
+    if (typeof out[field] === "string") {
+      out[field] = sanitizeCardText(out[field], 64);
+    }
+  }
+  // Nested art object — `imageUrl` flows into <img src=…> and must be
+  // scheme-validated, not just HTML-escaped, to block javascript: / data:
+  // payloads that would survive HTML-escaping.
+  const art = out.art;
+  if (art && typeof art === "object" && (art as Record<string, unknown>).imageUrl !== undefined) {
+    const a = { ...(art as Record<string, unknown>) };
+    if (typeof a.imageUrl === "string") {
+      a.imageUrl = sanitizeUrl(a.imageUrl);
+    }
+    out.art = a;
+  }
+  return out as unknown as T;
+}
+
+/**
+ * Sanitize a URL for use in `href` / `src` attributes. Returns `""` (empty
+ * string, never `null`) for anything that is not a string or that uses a
+ * dangerous scheme.
+ *
+ * Allowed schemes: `http:`, `https:`, `mailto:`, and `data:image/...`.
+ * Also allowed are root-relative (`/foo/bar`) references which inherit
+ * the page's origin. `data:image/...` is permitted because card-art
+ * previews use inline procedural images.
+ */
+export function sanitizeUrl(value: unknown): string {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  if (trimmed === "") return "";
+  // Reject anything starting with a dangerous scheme before any
+  // HTML-escaping has happened — the dangerous-scheme regex is anchored.
+  if (DANGEROUS_URI_SCHEMES.test(trimmed)) return "";
+  // Allow root-relative references (no scheme → safe because they inherit
+  // the page's origin).
+  if (trimmed.startsWith("/") || trimmed.startsWith("#") || trimmed.startsWith("?")) {
+    return escapeHtml(trimmed);
+  }
+  // Require a permitted scheme for absolute URLs.
+  const allowed = /^(?:https?|mailto|data):/i;
+  if (!allowed.test(trimmed)) {
+    return "";
+  }
+  return escapeHtml(trimmed);
+}
+
+interface MarkdownState {
+  inList: boolean;
+  listType: "ul" | "ol" | null;
+  listCounter: number;
+}
+
+const MARKDOWN_INLINE_PATTERNS: Array<{
+  name: string;
+  re: RegExp;
+  render: (match: RegExpExecArray) => string;
+}> = [
+  // Inline code: `code` — content is taken literally, not parsed for further markdown.
+  {
+    name: "code",
+    re: /`([^`\n]+)`/,
+    render: (m) => `<code>${escapeHtml(m[1])}</code>`,
+  },
+  // Bold: **text** or __text__
+  {
+    name: "bold",
+    re: /\*\*([^*\n]+)\*\*|__([^_\n]+)__/,
+    render: (m) => `<strong>${escapeHtml(m[1] ?? m[2] ?? "")}</strong>`,
+  },
+  // Italic: *text* or _text_ (but not ** / __ consumed above — order matters)
+  {
+    name: "italic",
+    re: /(?:^|[^*])\*([^*\n]+)\*|(?:^|[^_])_([^_\n]+)_/,
+    render: (m) => `<em>${escapeHtml(m[1] ?? m[2] ?? "")}</em>`,
+  },
+  // Auto-link: <https://example.com>
+  {
+    name: "autolink",
+    re: /<(https?:\/\/[^>\s]+)>/,
+    render: (m) => {
+      const url = sanitizeUrl(m[1]);
+      if (!url) return "&lt;invalid-url&gt;";
+      return `<a href="${url}" rel="noopener noreferrer nofollow" target="_blank">${escapeHtml(m[1])}</a>`;
+    },
+  },
+  // Inline link: [text](url) — both halves are sanitized; unsafe URLs are dropped.
+  {
+    name: "link",
+    re: /\[([^\]\n]+)\]\(([^)\n]*)\)/,
+    render: (m) => {
+      const text = sanitizeCardText(m[1], 200);
+      const url = sanitizeUrl(m[2]);
+      if (!url) return text;
+      return `<a href="${url}" rel="noopener noreferrer nofollow" target="_blank">${text}</a>`;
+    },
+  },
+];
+
+function renderInline(line: string): string {
+  // The inline patterns operate on the raw line and emit escaped fragments
+  // directly; we walk the line left-to-right and at each cursor position
+  // try to match any pattern. Unmatched characters are escaped individually.
+  let html = "";
+  let cursor = 0;
+  while (cursor < line.length) {
+    let matched = false;
+    for (const pat of MARKDOWN_INLINE_PATTERNS) {
+      const slice = line.slice(cursor);
+      pat.re.lastIndex = 0;
+      const m = pat.re.exec(slice);
+      if (m && m.index !== undefined) {
+        // Append the literal text between cursor and the match (escaped).
+        html += escapeHtml(slice.slice(0, m.index));
+        html += pat.render(m);
+        cursor += m.index + m[0].length;
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) {
+      html += escapeHtml(line[cursor]!);
+      cursor += 1;
+    }
+  }
+  return html;
+}
+
+/**
+ * Sanitize a markdown string and return an HTML fragment. The supported
+ * subset is deliberately small:
+ *
+ *   - Headings: lines starting with `#`, `##`, `###` (max depth 3)
+ *   - Bold: `**text**` or `__text__`
+ *   - Italic: `*text*` or `_text_`
+ *   - Inline code: `` `text` ``
+ *   - Inline link: `[text](https://...)` — non-http(s) URLs are dropped
+ *   - Auto-link: `<https://...>`
+ *   - Unordered lists: lines starting with `- ` or `* `
+ *   - Ordered lists: lines starting with `1. `, `2. `, etc.
+ *   - Paragraphs: any other non-blank line
+ *   - Blank line: paragraph / list break
+ *
+ * Anything that looks like an HTML tag is stripped before rendering so a
+ * downstream renderer (or a copy/paste into a `dangerouslySetInnerHTML`
+ * sink) cannot materialise script elements. URLs in link targets are
+ * validated by {@link sanitizeUrl}.
+ *
+ * The returned string is safe to assign to `dangerouslySetInnerHTML` *only*
+ * because every dynamic fragment is escaped; do not bypass the helper.
+ */
+export function sanitizeMarkdown(value: unknown, maxLength: number = DEFAULT_MAX_MARKDOWN_LENGTH): string {
+  const raw = typeof value === "string" ? value : value == null ? "" : String(value);
+  let out = raw.replace(SMUGGLE_CHARS, "");
+  // Defensively strip any HTML tags up-front. This is belt-and-suspenders:
+  // the inline renderers below also escape, so this is only protection
+  // against accidental code paths that bypass them.
+  out = out.replace(HTML_TAG, "");
+  if (out.length > maxLength) {
+    out = out.slice(0, maxLength) + "…[truncated]";
+  }
+
+  const lines = out.split(/\r?\n/);
+  const html: string[] = [];
+  const state: MarkdownState = { inList: false, listType: null, listCounter: 0 };
+
+  const closeList = () => {
+    if (state.inList && state.listType) {
+      html.push(state.listType === "ul" ? "</ul>" : "</ol>");
+      state.inList = false;
+      state.listType = null;
+      state.listCounter = 0;
+    }
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\s+$/, "");
+
+    if (line.trim() === "") {
+      closeList();
+      continue;
+    }
+
+    const headingMatch = /^(#{1,3})\s+(.+)$/.exec(line);
+    if (headingMatch) {
+      closeList();
+      const level = headingMatch[1]!.length;
+      const text = headingMatch[2]!;
+      html.push(`<h${level}>${renderInline(text)}</h${level}>`);
+      continue;
+    }
+
+    const ulMatch = /^[-*]\s+(.+)$/.exec(line);
+    if (ulMatch) {
+      if (!state.inList || state.listType !== "ul") {
+        closeList();
+        html.push("<ul>");
+        state.inList = true;
+        state.listType = "ul";
+      }
+      html.push(`<li>${renderInline(ulMatch[1]!)}</li>`);
+      continue;
+    }
+
+    const olMatch = /^\d+\.\s+(.+)$/.exec(line);
+    if (olMatch) {
+      if (!state.inList || state.listType !== "ol") {
+        closeList();
+        html.push("<ol>");
+        state.inList = true;
+        state.listType = "ol";
+      }
+      html.push(`<li>${renderInline(olMatch[1]!)}</li>`);
+      continue;
+    }
+
+    closeList();
+    html.push(`<p>${renderInline(line)}</p>`);
+  }
+
+  closeList();
+  return html.join("");
+}
+
+/**
+ * Sanitize a `src`/`href` value used in card art or external image rendering.
+ * Returns an empty string for any value that fails {@link sanitizeUrl}, which
+ * the caller should treat as "fall back to procedural art".
+ */
+export function sanitizeImageUrl(value: unknown): string {
+  return sanitizeUrl(value);
+}
+
+/**
+ * Test-only export: expose the internal regexes so test fixtures can verify
+ * that a given payload would have matched. Not part of the public API.
+ * @internal
+ */
+export const __testing__ = {
+  ESCAPE_MAP,
+  SMUGGLE_CHARS,
+  HTML_TAG,
+  HTML_RESIDUE,
+  DANGEROUS_URI_SCHEMES,
+  /**
+   * Tag names that are *never* safe to render in sanitized markdown output.
+   * If any of these appear in the output, the sanitizer has been bypassed.
+   */
+  UNSAFE_TAGS: new Set([
+    "script",
+    "iframe",
+    "object",
+    "embed",
+    "form",
+    "input",
+    "button",
+    "textarea",
+    "select",
+    "option",
+    "style",
+    "svg",
+    "math",
+    "link",
+    "meta",
+    "base",
+    "frame",
+    "frameset",
+    "html",
+    "body",
+    "head",
+    "video",
+    "audio",
+    "source",
+    "track",
+    "applet",
+    "marquee",
+  ]),
+};


### PR DESCRIPTION
Adds a self-contained, allow-list sanitizer module and routes every
untrusted-text render site through it. The threat model is the
stored-XSS path where a malicious custom-card JSON, replay note, chat
message, or AI-coach summary plants a payload that survives every
cache layer and fires on every replay of the malicious deck.
