### PR TITLE
docs: resolve #1279 — promote canonical contributors guide to repo root

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,12 @@
+# Code of Conduct
+
+The Planar Nexus Code of Conduct is maintained as **§1 of [CONTRIBUTING.md](CONTRIBUTING.md#1-code-of-conduct)**.
+
+Please read and follow that section when participating in this project. It covers:
+
+- Our pledge to a harassment-free community
+- Expected and unacceptable behaviour
+- Enforcement responsibilities and process
+- How to report incidents to the maintainers
+
+By contributing to Planar Nexus — whether through issues, pull requests, discussions, or any other channel — you agree to abide by the Code of Conduct in [CONTRIBUTING.md §1](CONTRIBUTING.md#1-code-of-conduct).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for your interest in contributing to Planar Nexus! This guide will help you get started with contributing code, documentation, or bug reports.
 
+> **Documentation map** — companion guides: [README.md](README.md) (project overview), [TESTING.md](TESTING.md) (testing requirements & workflow), [docs/API.md](docs/API.md) (API reference), [docs/USER_GUIDE.md](docs/USER_GUIDE.md) (end-user docs), [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) (FAQ). The Code of Conduct lives in [§1](#1-code-of-conduct) below.
+
 ---
 
 ## Table of Contents
@@ -624,7 +626,7 @@ Update relevant documentation files when making changes:
 - `README.md` - Project overview and quick start
 - `docs/USER_GUIDE.md` - User-facing documentation
 - `docs/API.md` - API documentation
-- `docs/CONTRIBUTING.md` - This file
+- `CONTRIBUTING.md` - This file (lives at the repo root so GitHub's PR/issue banner can link to it)
 
 ### 10.3 Running Documentation Checks
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ _Create or join games with friends via P2P WebRTC connections_
 | ------------------------------------------------ | --------------------------------------------- |
 | [User Guide](docs/USER_GUIDE.md)                 | Complete guide to using Planar Nexus features |
 | [API Documentation](docs/API.md)                 | AI provider configuration and API reference   |
-| [Contributing Guide](docs/CONTRIBUTING.md)       | How to contribute code and documentation      |
+| [Contributing Guide](CONTRIBUTING.md)            | How to contribute code and documentation      |
 | [Troubleshooting](docs/TROUBLESHOOTING.md)       | Common issues and solutions                   |
 | [Deployment Guide](docs/DEPLOYMENT_GUIDE.md)     | Building and deploying for all platforms      |
 | [Distribution Guide](docs/DISTRIBUTION_GUIDE.md) | Release management and distribution channels  |

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,5 +8,5 @@ contributor testing requirements.
 
 See also:
 
-- [Contributing › Testing](./docs/CONTRIBUTING.md#7-testing)
+- [Contributing › Testing](../CONTRIBUTING.md#7-testing)
 - [Video-Derived Tests Workflow](./docs/VIDEO_DERIVED_TESTS_WORKFLOW.md)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -5,7 +5,7 @@ stack, where tests live, the patterns we expect, the video-derived fixture
 pipeline, and how coverage is measured and enforced.
 
 > If you are writing code, you are writing tests. See
-> [Contributing › Testing requirements](./CONTRIBUTING.md#7-testing) for the
+> [Contributing › Testing requirements](../CONTRIBUTING.md#7-testing) for the
 > rules that gate every pull request.
 
 ---
@@ -422,7 +422,7 @@ npm test -- --testPathPattern=video-derived --coverage
 
 - The **target** is 70% across all metrics (60% for branches). This is the
   documented project goal and is referenced from `README.md`,
-  `docs/CONTRIBUTING.md`, and `jest.config.js`.
+  `CONTRIBUTING.md`, and `jest.config.js`.
 - The **CI-enforced floor** is set _just below currently-measured coverage_ so
   the gate catches real regressions without being flaky. It is raised toward
   the 70% target as coverage improves (tracked via issue #922) — automatically,


### PR DESCRIPTION
## Summary by Sourcery

Promote the main contributing guide to the repository root and update references so GitHub and project docs correctly link to it.

Documentation:
- Add a documentation map blurb to CONTRIBUTING.md to highlight related guides and where the Code of Conduct lives.
- Update all links in README and testing documentation to reference the root-level CONTRIBUTING.md instead of the docs version.
- Introduce a root-level Code of Conduct file that points contributors to the canonical Code of Conduct section in CONTRIBUTING.md.