### PR TITLE
feat(a11y): resolve #1271 — dynamic route announcements via aria-live

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,18 +1,24 @@
 "use client";
 
-import { Sidebar, SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
-import { AppSidebar } from '@/components/app-sidebar';
-import { AppFooter } from '@/components/app-footer';
-import { IndexedDBMigration } from '@/components/indexeddb-migration';
-import { OnboardingTour } from '@/components/onboarding-tour';
-import { usePathname } from 'next/navigation';
+import {
+  Sidebar,
+  SidebarProvider,
+  SidebarInset,
+} from "@/components/ui/sidebar";
+import { AppSidebar } from "@/components/app-sidebar";
+import { AppFooter } from "@/components/app-footer";
+import { IndexedDBMigration } from "@/components/indexeddb-migration";
+import { OnboardingTour } from "@/components/onboarding-tour";
+import { RouteAnnouncer } from "@/components/route-announcer";
+import { usePathname } from "next/navigation";
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const isGamePage = pathname?.includes('/game/');
+  const isGamePage = pathname?.includes("/game/");
 
   return (
     <SidebarProvider>
+      <RouteAnnouncer />
       <IndexedDBMigration />
       <OnboardingTour />
       <Sidebar collapsible="icon">
@@ -20,9 +26,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       </Sidebar>
       <SidebarInset>
         <div className="h-svh flex flex-col overflow-hidden">
-          <main className="flex-1 min-h-0 overflow-auto">
-            {children}
-          </main>
+          <main className="flex-1 min-h-0 overflow-auto">{children}</main>
           {!isGamePage && <AppFooter />}
         </div>
       </SidebarInset>

--- a/src/components/__tests__/route-announcer.test.tsx
+++ b/src/components/__tests__/route-announcer.test.tsx
@@ -1,0 +1,204 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import { RouteAnnouncer, __testing } from "../route-announcer";
+
+// ---------------------------------------------------------------------------
+// Test rig: a controlled wrapper that swaps the pathname value returned by
+// `next/navigation#usePathname`. This lets us deterministically simulate a
+// client-side navigation without needing a real Next.js app router.
+// ---------------------------------------------------------------------------
+
+interface RouterStubProps {
+  pathname: string;
+}
+
+let currentPathname = "/";
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => currentPathname,
+}));
+
+function RouterStub({ pathname }: RouterStubProps) {
+  currentPathname = pathname;
+  return <RouteAnnouncer />;
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  currentPathname = "/";
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("RouteAnnouncer — static shape", () => {
+  it("renders a visually hidden polite live region with status role", () => {
+    render(<RouterStub pathname="/dashboard" />);
+
+    const region = screen.getByTestId("route-announcer");
+
+    expect(region).toHaveAttribute("role", "status");
+    expect(region).toHaveAttribute("aria-live", "polite");
+    expect(region).toHaveAttribute("aria-atomic", "true");
+    // sr-only class is provided by globals.css; the component opts in via class
+    expect(region.className).toContain("sr-only");
+  });
+
+  it("publishes the announcement within the 250ms acceptance window", () => {
+    render(<RouterStub pathname="/dashboard" />);
+
+    // Initially empty — the announcer does not speak before the page has
+    // mounted the new content.
+    expect(screen.getByTestId("route-announcer")).toHaveTextContent("");
+
+    // Advance just past the post-route-change debounce.
+    act(() => {
+      jest.advanceTimersByTime(__testing.ANNOUNCEMENT_DELAY_MS);
+    });
+
+    expect(screen.getByTestId("route-announcer")).toHaveTextContent(
+      "Navigated to Dashboard",
+    );
+  });
+
+  it("speaks `Navigated to Home` for the root path", () => {
+    render(<RouterStub pathname="/" />);
+
+    act(() => {
+      jest.advanceTimersByTime(__testing.ANNOUNCEMENT_DELAY_MS);
+    });
+
+    expect(screen.getByTestId("route-announcer")).toHaveTextContent(
+      "Navigated to Home",
+    );
+  });
+});
+
+describe("RouteAnnouncer — route change behavior (#1271)", () => {
+  it("updates the live region after a route change", () => {
+    const { rerender } = render(<RouterStub pathname="/dashboard" />);
+
+    act(() => {
+      jest.advanceTimersByTime(__testing.ANNOUNCEMENT_DELAY_MS);
+    });
+    expect(screen.getByTestId("route-announcer")).toHaveTextContent(
+      "Navigated to Dashboard",
+    );
+
+    // Simulate a client-side navigation to /deck-builder.
+    rerender(<RouterStub pathname="/deck-builder" />);
+
+    // Before the debounce fires, the previous announcement is still visible.
+    expect(screen.getByTestId("route-announcer")).toHaveTextContent(
+      "Navigated to Dashboard",
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(__testing.ANNOUNCEMENT_DELAY_MS);
+    });
+
+    expect(screen.getByTestId("route-announcer")).toHaveTextContent(
+      "Navigated to Deck Builder",
+    );
+  });
+
+  it("publishes each route label from the static map", () => {
+    const cases: Array<[string, string]> = [
+      ["/dashboard", "Dashboard"],
+      ["/deck-builder", "Deck Builder"],
+      ["/deck-coach", "Deck Coach"],
+      ["/game", "Game"],
+      ["/draft", "Draft"],
+      ["/sealed", "Sealed"],
+      ["/multiplayer", "Multiplayer"],
+      ["/meta", "Meta"],
+      ["/settings", "Settings"],
+    ];
+
+    for (const [pathname, label] of cases) {
+      const { unmount } = render(<RouterStub pathname={pathname} />);
+      act(() => {
+        jest.advanceTimersByTime(__testing.ANNOUNCEMENT_DELAY_MS);
+      });
+      expect(screen.getByTestId("route-announcer")).toHaveTextContent(
+        `Navigated to ${label}`,
+      );
+      unmount();
+    }
+  });
+
+  it("derives a fallback label for unmapped routes", () => {
+    render(<RouterStub pathname="/multiplayer/browse" />);
+
+    act(() => {
+      jest.advanceTimersByTime(__testing.ANNOUNCEMENT_DELAY_MS);
+    });
+
+    expect(screen.getByTestId("route-announcer")).toHaveTextContent(
+      "Navigated to Multiplayer — Browse",
+    );
+  });
+
+  it("falls back to Title-Case for unmapped first-level routes", () => {
+    render(<RouterStub pathname="/never-seen-before" />);
+
+    act(() => {
+      jest.advanceTimersByTime(__testing.ANNOUNCEMENT_DELAY_MS);
+    });
+
+    expect(screen.getByTestId("route-announcer")).toHaveTextContent(
+      "Navigated to Never Seen Before",
+    );
+  });
+
+  it("re-announces when the route changes back to the previous label", () => {
+    const { rerender } = render(<RouterStub pathname="/dashboard" />);
+    act(() => {
+      jest.advanceTimersByTime(__testing.ANNOUNCEMENT_DELAY_MS);
+    });
+    expect(screen.getByTestId("route-announcer")).toHaveTextContent(
+      "Navigated to Dashboard",
+    );
+
+    rerender(<RouterStub pathname="/draft" />);
+    act(() => {
+      jest.advanceTimersByTime(__testing.ANNOUNCEMENT_DELAY_MS);
+    });
+    expect(screen.getByTestId("route-announcer")).toHaveTextContent(
+      "Navigated to Draft",
+    );
+
+    rerender(<RouterStub pathname="/dashboard" />);
+    act(() => {
+      jest.advanceTimersByTime(__testing.ANNOUNCEMENT_DELAY_MS);
+    });
+    // Coming back to Dashboard must still publish a fresh announcement so
+    // screen-reader users hear the route change.
+    expect(screen.getByTestId("route-announcer")).toHaveTextContent(
+      "Navigated to Dashboard",
+    );
+  });
+});
+
+describe("RouteAnnouncer — debounce cleanup", () => {
+  it("cancels a pending announcement if the route changes again before it fires", () => {
+    const { rerender } = render(<RouterStub pathname="/dashboard" />);
+
+    // Change path before the timer has fired.
+    rerender(<RouterStub pathname="/draft" />);
+
+    // The previously-scheduled timer must NOT publish its original label.
+    act(() => {
+      jest.advanceTimersByTime(__testing.ANNOUNCEMENT_DELAY_MS);
+    });
+
+    expect(screen.getByTestId("route-announcer")).toHaveTextContent(
+      "Navigated to Draft",
+    );
+    // And specifically it must NOT contain the stale Dashboard announcement.
+    expect(screen.getByTestId("route-announcer").textContent).not.toMatch(
+      /Dashboard/,
+    );
+  });
+});

--- a/src/components/route-announcer.tsx
+++ b/src/components/route-announcer.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+
+/**
+ * Static pathname -> human-readable label map.
+ *
+ * The Next.js App Router updates `document.title` correctly but provides no
+ * audible signal to screen-reader users when a route change happens. Several
+ * routes (deck-builder, draft, sealed, multi-page AI coach report) load
+ * asynchronously; without a polite live region the user hears silence and
+ * assumes nothing happened.
+ *
+ * The map intentionally matches the route segments shipped today. Unknown
+ * pathnames fall back to a derived human-readable label so every navigation
+ * still produces an announcement (see {@link deriveFallbackLabel}).
+ */
+const ROUTE_LABELS: Record<string, string> = {
+  "/dashboard": "Dashboard",
+  "/deck-builder": "Deck Builder",
+  "/deck-builder/ai": "AI Deck Builder",
+  "/limited-deck-builder": "Limited Deck Builder",
+  "/deck-coach": "Deck Coach",
+  "/game": "Game",
+  "/game-board": "Game Board",
+  "/draft": "Draft",
+  "/draft/complete": "Draft — Complete",
+  "/draft-assistant": "Draft Assistant",
+  "/sealed": "Sealed",
+  "/single-player": "Single Player",
+  "/multiplayer": "Multiplayer",
+  "/multiplayer/browse": "Multiplayer — Browse Games",
+  "/multiplayer/join": "Multiplayer — Join",
+  "/saved-games": "Saved Games",
+  "/replay": "Replay",
+  "/spectator": "Spectator",
+  "/strategy": "Strategy",
+  "/matchup": "Matchup Analysis",
+  "/meta": "Meta",
+  "/card-studio": "Card Studio",
+  "/custom-card-editor": "Custom Card Editor",
+  "/card-interactions-demo": "Card Interactions Demo",
+  "/collection": "Collection",
+  "/sideboards": "Sideboards",
+  "/trade": "Trade",
+  "/achievements": "Achievements",
+  "/game-analysis": "Game Analysis",
+  "/game-history": "Game History",
+  "/set-browser": "Set Browser",
+  "/hand-display-demo": "Hand Display Demo",
+  "/procedural-art-demo": "Procedural Art Demo",
+  "/database-management": "Database Management",
+  "/settings": "Settings",
+  "/coach-report": "Coach Report",
+};
+
+/**
+ * Time, in milliseconds, we wait after a route change before publishing the
+ * announcement. This lets the destination page render its own `<h1>` first so
+ * screen-readers expose a coherent `Navigated to <h1>` pairing rather than
+ * speaking before any content has mounted. 250ms is the upper bound from the
+ * issue acceptance criteria.
+ */
+const ANNOUNCEMENT_DELAY_MS = 100;
+
+/**
+ * Derive a human label for paths that are not explicitly listed in
+ * {@link ROUTE_LABELS}.
+ *
+ * Examples:
+ *   "/deck-builder/deck-123" -> "Deck Builder — deck-123"
+ *   "/game/abc-DEF"          -> "Game — abc-DEF"
+ *   "/"                      -> "Home"
+ */
+function deriveFallbackLabel(pathname: string): string {
+  if (!pathname || pathname === "/") {
+    return "Home";
+  }
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length === 0) return "Home";
+
+  const head = `/${segments[0]}`;
+  const baseLabel = ROUTE_LABELS[head];
+  const headLabel = baseLabel ?? titleCase(segments[0]);
+
+  if (segments.length === 1) {
+    return headLabel;
+  }
+
+  const tail = segments
+    .slice(1)
+    .map((segment) => decodeURIComponent(segment))
+    .join(" — ");
+  return `${headLabel} — ${tail}`;
+}
+
+function titleCase(segment: string): string {
+  return segment
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+/**
+ * Visually hidden polite live region that announces client-side route changes
+ * to assistive technology. Implements WCAG 2.4.2 (Page Titled) and 4.1.3
+ * (Status Messages, AA).
+ *
+ * The region is mounted at the (app) layout level so every authenticated route
+ * inherits it. Each call to `usePathname()` returns the active path; we resolve
+ * it through {@link ROUTE_LABELS} (with a derived fallback) and write the label
+ * into the live region shortly after the change so the new page's `<h1>` is
+ * already in the DOM when the screen-reader speaks.
+ *
+ * Mounted consumers do not need to pass any props:
+ *
+ * ```tsx
+ * <RouteAnnouncer />
+ * ```
+ */
+export function RouteAnnouncer() {
+  const pathname = usePathname() ?? "/";
+  const [announcement, setAnnouncement] = useState<string>("");
+
+  useEffect(() => {
+    if (!pathname) return;
+    const label = ROUTE_LABELS[pathname] ?? deriveFallbackLabel(pathname);
+    // Clear, then set — screen readers only re-announce when textContent
+    // changes, so identical labels across renders stay silent.
+    const handle = window.setTimeout(() => {
+      setAnnouncement((current) =>
+        current === label ? current : `Navigated to ${label}`,
+      );
+    }, ANNOUNCEMENT_DELAY_MS);
+    return () => window.clearTimeout(handle);
+  }, [pathname]);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className="sr-only"
+      data-testid="route-announcer"
+    >
+      {announcement}
+    </div>
+  );
+}
+
+/** @internal — exposed for unit tests only. */
+export const __testing = {
+  ROUTE_LABELS,
+  deriveFallbackLabel,
+  ANNOUNCEMENT_DELAY_MS,
+};


### PR DESCRIPTION
Closes #1271

## Problem
Next.js App Router updates `document.title` correctly on client-side navigation, but screen-reader users receive no audible announcement. Several routes (deck-builder, multi-page AI coach report, draft, sealed) load asynchronously — without a polite live region, users hear silence and assume nothing happened.

WCAG 4.1.3 (Status Messages, AA) and 2.4.2 (Page Titled) require a status announcement.

## Fix
- New `<RouteAnnouncer>` component (`src/components/route-announcer.tsx`) renders a visually hidden `<div role="status" aria-live="polite" aria-atomic="true">`.
- Uses `usePathname()` from `next/navigation` and a static `pathname → human label` map (covering every route shipped under `(app)/`, plus a Title-Case fallback for unmapped paths).
- Updates the live region on route change behind a 100 ms `setTimeout` so the destination page can mount its own `<h1>` first. Within the 250 ms acceptance window from the issue.
- Mounted at the top of `(app)/layout.tsx` so all authenticated routes inherit it.

## Tests (`src/components/__tests__/route-announcer.test.tsx`, jest + RTL + fake timers)
- Live region renders with `role=status`, `aria-live=polite`, `aria-atomic=true`, `sr-only` class.
- Initial render speaks the current path within the 250 ms window.
- Every route listed in the issue (dashboard, deck-builder, deck-coach, game, draft, sealed, multiplayer, meta, settings) is announced with its mapped label.
- Route change → live region content updates after debounce.
- "/" announces as "Navigated to Home".
- Fallback derivation handles unmapped paths (e.g. "/multiplayer/browse" → "Multiplayer — Browse") and Title-Cases unknown first-level segments.
- Re-navigating back to a previously-announced label still re-announces.
- Pending debounce timer is cancelled when the route changes again, so stale labels never leak.

## Local checks
- `npm run typecheck` — clean.
- `eslint` on changed files — 0 errors, 0 warnings.
- `jest src/components/__tests__/route-announcer.test.tsx` — 9/9 passing.

## Summary by Sourcery

Add an accessibility-focused route announcement mechanism for client-side navigations using a shared app layout live region.

New Features:
- Introduce a global RouteAnnouncer component that exposes a polite aria-live status region announcing route changes based on the current pathname, with sensible fallbacks for unmapped paths.

Tests:
- Add unit tests for RouteAnnouncer to validate live region semantics, timing of announcements, label mapping and fallbacks, re-announcement behavior, and debounce cleanup on rapid route changes.