### PR TITLE
ci: resolve #1275 — cargo audit in CI + Rust dependency upgrade runbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,37 +225,120 @@ jobs:
         run: npx commitlint --last --verbose
 
   security:
-    name: Security Audit
+    name: Security Audit (npm)
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Configure git
         run: |
           git config --global --add safe.directory '*'
-      
+
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'npm'
-      
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Run npm audit
         # Fail on high/critical advisories. Previously `critical`, which let
         # every high/moderate advisory pass CI silently (#1108).
         run: npm audit --audit-level=high
-  
+
+  # Mirror of the `security` job for the Rust crate tree consumed by the Tauri
+  # host at `src-tauri/`. Tauri 2 desktop bundles statically link Rust crates,
+  # so CVEs in any of them ship into the installer. Resolves #1275.
+  cargo-audit:
+    name: Security Audit (Rust)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Configure git
+        run: |
+          git config --global --add safe.directory '*'
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo-audit install
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: cargo-audit-v0.22
+
+      - name: Install cargo-audit
+        # `--locked` makes the toolchain installer pick the exact version
+        # referenced in cargo-audit's own Cargo.toml, matching the homebrew
+        # release that the docs runbook recommends.
+        run: cargo install cargo-audit --locked --version ^0.22
+
+      - name: Run cargo audit
+        working-directory: src-tauri
+        # `cargo audit` exits non-zero if RustSec advisories with a recognised
+        # severity are found. Warnings (unmaintained/unsound/notice) are
+        # surfaced but ignored here so the inherited gtk-rs GTK3 binders,
+        # which Tauri pulls in via `wry` on Linux, do not break the build
+        # until the gtk4-rs migration tracked in the roadmap lands.
+        # See docs/RUST_UPGRADE_STRATEGY.md for triage details.
+        run: |
+          set -e
+          cargo audit --json > cargo-audit.json || AUDIT_EXIT=$?
+          set -e
+          python3 - <<'PY'
+          import json, sys
+          with open('cargo-audit.json') as fh:
+              data = json.load(fh)
+          vulns = data.get('vulnerabilities', {}).get('list', []) or []
+          order = {'low': 1, 'moderate': 2, 'medium': 2, 'high': 3, 'critical': 4}
+          threshold = order['high']
+          failing = []
+          for v in vulns:
+              sev = (v.get('advisory') or {}).get('severity') or ''
+              pkg = (v.get('package') or {}).get('name')
+              ver = (v.get('package') or {}).get('version')
+              aid = (v.get('advisory') or {}).get('id')
+              title = (v.get('advisory') or {}).get('title')
+              if order.get(sev, 0) >= threshold:
+                  failing.append(f"  {aid}: {pkg}@{ver} [{sev}] {title}")
+          if failing:
+              print("cargo audit: failing advisories (severity >= high):", file=sys.stderr)
+              for line in failing:
+                  print(line, file=sys.stderr)
+              sys.exit(1)
+          print(f"cargo audit: {len(vulns)} advisories total; none at severity >= high")
+          warnings = data.get('warnings') or {}
+          for kind, items in warnings.items():
+              print(f"  warning [{kind}]: {len(items)} (informational, not gated)")
+          PY
+          # Surface cargo-audit's own exit code if the JSON path succeeded
+          # but the binary itself reported an error.
+          if [ "${AUDIT_EXIT:-0}" -ne 0 ]; then
+              echo "cargo audit exited with status ${AUDIT_EXIT}; see cargo-audit.json"
+              exit "${AUDIT_EXIT}"
+          fi
+
+      - name: Upload cargo-audit report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: cargo-audit-report
+          path: src-tauri/cargo-audit.json
+          retention-days: 14
+
   build:
     name: Build
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
-    needs: [test, lint, typecheck, commitlint, security, e2e, a11y-contrast]
-    
+    needs: [test, lint, typecheck, commitlint, security, cargo-audit, a11y-contrast, e2e]
+
     steps:
       - name: Configure git
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
         # `--locked` makes the toolchain installer pick the exact version
         # referenced in cargo-audit's own Cargo.toml, matching the homebrew
         # release that the docs runbook recommends.
-        run: cargo install cargo-audit --locked --version ^0.22
+        run: cargo install cargo-audit --locked --version ^0.22 --force
 
       - name: Run cargo audit
         working-directory: src-tauri

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing to Planar Nexus! This guide will help you get started with contributing code, documentation, or bug reports.
 
-> **Documentation map** — companion guides: [README.md](README.md) (project overview), [TESTING.md](TESTING.md) (testing requirements & workflow), [docs/API.md](docs/API.md) (API reference), [docs/USER_GUIDE.md](docs/USER_GUIDE.md) (end-user docs), [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) (FAQ), [docs/RELEASE_RUNBOOK.md](docs/RELEASE_RUNBOOK.md) (release-engineering runbook). The Code of Conduct lives in [§1](#1-code-of-conduct) below.
+> **Documentation map** — companion guides: [README.md](README.md) (project overview), [TESTING.md](TESTING.md) (testing requirements & workflow), [docs/API.md](docs/API.md) (API reference), [docs/USER_GUIDE.md](docs/USER_GUIDE.md) (end-user docs), [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) (FAQ), [docs/RELEASE_RUNBOOK.md](docs/RELEASE_RUNBOOK.md) (release-engineering runbook), [docs/RUST_UPGRADE_STRATEGY.md](docs/RUST_UPGRADE_STRATEGY.md) (Tauri/Rust crate upgrade policy — mirrors the npm audit contract from #1108). The Code of Conduct lives in [§1](#1-code-of-conduct) below.
 
 ---
 
@@ -626,6 +626,7 @@ Update relevant documentation files when making changes:
 - `README.md` - Project overview and quick start
 - `docs/USER_GUIDE.md` - User-facing documentation
 - `docs/API.md` - API documentation
+- `docs/RUST_UPGRADE_STRATEGY.md` - Rust/Tauri dependency upgrade policy (#1275)
 - `CONTRIBUTING.md` - This file (lives at the repo root so GitHub's PR/issue banner can link to it)
 
 ### 10.3 Running Documentation Checks

--- a/docs/RUST_UPGRADE_STRATEGY.md
+++ b/docs/RUST_UPGRADE_STRATEGY.md
@@ -1,0 +1,62 @@
+# Rust dependency-upgrade strategy
+
+This runbook governs how the Rust crate tree in `src-tauri/` is audited and
+upgraded. It mirrors the npm workflow landed in #1108 and is the contract
+enforced by the `cargo-audit` job in `.github/workflows/ci.yml`. Resolves #1275.
+
+## Tauri SDK matrix
+
+`src-tauri/Cargo.toml` is pinned to a single Tauri 2 minor branch. The
+frontend `package.json` does **not** carry Rust crates — everything Rust
+lives under `src-tauri/`. Dependabot (`.github/dependabot.yml`) bundles
+semver-compatible minor/patch bumps into one PR; major bumps
+(Tauri 2 → 3) are ignored there and tracked in the manual roadmap.
+
+| Crate                | Pinned line           | Cadence             |
+| -------------------- | --------------------- | ------------------- |
+| `tauri-build`        | `2.5` (build-dep)     | bump with `tauri`   |
+| `tauri`              | `2.10` (runtime)      | weekly Dependabot   |
+| `tauri-plugin-log`   | `2` (runtime plugin)  | weekly Dependabot   |
+
+## Day-to-day upgrades
+
+```bash
+cd src-tauri && cargo update -p serde     # bump a single crate
+cd src-tauri && cargo update              # bulk bump (minor Tauri release)
+./scripts/rust-audit.sh                   # re-verify lock + advisory state
+npm run build:tauri                       # regenerate bundle, catch stale src/
+```
+
+## Triage: cargo audit failure in CI
+
+The `cargo-audit` job emits a JSON report (`cargo-audit-report` artefact)
+and fails on advisories with `Severity: high` or above — matching the
+`npm audit --audit-level=high` contract from #1108. Warnings
+(`unmaintained`, `unsound`, `notice`) are surfaced but **do not block**
+the build while the gtk3-rs → gtk4-rs migration is in flight.
+
+| JSON signal                                | First action                            |
+| ------------------------------------------ | --------------------------------------- |
+| CVE `severity == high`/`critical`          | Patch, bump, or vendor + track          |
+| `unmaintained` on the `gtk*-rs` family     | Open roadmap epic, link from this doc   |
+| `unsound` on `anyhow` / `rand`             | Pin to `>= patched` in `Cargo.toml`     |
+| Notice on a brand-new advisory             | Tracking issue, defer to next sweep     |
+
+Track accepted exceptions in an `## Accepted advisories` table appended
+below, mirroring the npm allowance list from #1108.
+
+## Provenance & supply-chain
+
+Goal: SLSA Build L3 provenance on each `tauri build` (v1.8 roadmap epic).
+Until that lands, every release **must**: (1) pass the `cargo-audit` job
+at severity ≥ high; (2) run `.github/workflows/release.yml` so Windows
+NSIS/MSI and macOS DMG go through `signtool` / `notarytool`; (3) reference
+the lock-file commit SHA in release notes so the bundle is reproducible
+from source.
+
+## See also
+
+- `.github/dependabot.yml` — weekly `cargo` ecosystem config.
+- `.github/workflows/ci.yml` — `cargo-audit` job definition.
+- `scripts/rust-audit.sh` — local equivalent of the CI gate.
+- `CONTRIBUTING.md` §10 — how docs like this one stay in sync.

--- a/scripts/rust-audit.sh
+++ b/scripts/rust-audit.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Local wrapper for `cargo audit` that mirrors the GitHub Actions job.
+# Resolves #1275. Run from the repo root, or invoke via `npm run` once
+# wired in package.json.
+#
+# Behaviour matches `.github/workflows/ci.yml` `cargo-audit`:
+#   - emits JSON next to Cargo.lock for review,
+#   - fails on advisories with severity >= high,
+#   - reports (but does not gate) unmaintained / unsound warnings
+#     that the inherited gtk-rs GTK3 binders raise on Linux.
+
+set -euo pipefail
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "❌ cargo not found on PATH. Install rustup: https://rustup.rs/" >&2
+    exit 127
+fi
+
+if ! command -v cargo-audit >/dev/null 2>&1; then
+    echo "📦 installing cargo-audit (matches CI pinned version)..."
+    cargo install cargo-audit --locked --version '^0.22'
+fi
+
+if [ ! -f src-tauri/Cargo.toml ]; then
+    echo "❌ src-tauri/Cargo.toml not found; run from the repo root." >&2
+    exit 1
+fi
+
+echo "🔍 running cargo audit on src-tauri/..."
+REPORT=src-tauri/cargo-audit.json
+( cd src-tauri && cargo audit --json >cargo-audit.json ) || AUDIT_EXIT=$?
+set -e
+
+REPORT="$REPORT" python3 - <<'PY'
+import json, os
+path = os.environ["REPORT"]
+with open(path) as fh:
+    data = json.load(fh)
+
+vulns = (data.get("vulnerabilities") or {}).get("list") or []
+order = {"low": 1, "moderate": 2, "medium": 2, "high": 3, "critical": 4}
+threshold = order["high"]
+
+failing = []
+for v in vulns:
+    sev = (v.get("advisory") or {}).get("severity") or ""
+    pkg = (v.get("package") or {}).get("name", "?")
+    ver = (v.get("package") or {}).get("version", "?")
+    aid = (v.get("advisory") or {}).get("id", "?")
+    title = (v.get("advisory") or {}).get("title", "")
+    if order.get(sev, 0) >= threshold:
+        failing.append(f"  {aid}: {pkg}@{ver} [{sev}] {title}")
+
+warnings = data.get("warnings") or {}
+for kind, items in warnings.items():
+    print(f"  ⚠  {len(items)} {kind} advisory(s) — informational, review docs/RUST_UPGRADE_STRATEGY.md")
+
+if failing:
+    print(f"\n❌ {len(failing)} advisory(s) at severity >= high:")
+    for line in failing:
+        print(line)
+    sys.exit(1)
+
+print(f"✅ {len(vulns)} advisory(s); none at severity >= high")
+PY
+
+if [ "${AUDIT_EXIT:-0}" -ne 0 ]; then
+    echo "❌ cargo audit exited ${AUDIT_EXIT}; full report at src-tauri/cargo-audit.json" >&2
+    exit "${AUDIT_EXIT}"
+fi
+
+echo "📄 JSON report: src-tauri/cargo-audit.json"


### PR DESCRIPTION
## Summary by Sourcery

Add Rust security auditing to CI and document the Rust/Tauri dependency upgrade policy.

CI:
- Introduce a dedicated `cargo-audit` CI job to run security audits on the Rust crate tree used by the Tauri host.
- Have the main build job depend on the new Rust security audit job in addition to the existing npm security audit.

Documentation:
- Add a Rust/Tauri dependency upgrade runbook describing the cargo-audit contract, Tauri SDK versioning, and triage process for advisories.
- Update contributing guidelines to reference the new Rust upgrade strategy documentation.

Chores:
- Add a local `scripts/rust-audit.sh` helper script that mirrors the CI cargo-audit behaviour for developers running Rust security checks locally.