### PR TITLE
feat(a11y): resolve #1267 — aria-live game-state announcer for turn/phase/priority

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -131,3 +131,70 @@ indicators, mana pip rows, etc.), add it to the next entry of the table
 above with the `data-state` value(s) and the CSS classes you need the global
 HCM block to override. A single PR per new chrome entry keeps the rule
 maintainable.
+
+## Live regions for dynamic game state
+
+Any game-state transition that screen-reader users must perceive (turn swap,
+phase change, priority passing, life totals) is published through a polite
+`aria-live` region next to the board. The component is
+`<GameAnnouncer>` (`src/components/game-announcer.tsx`, issue #1267) and the
+existing visual live region in `game-board.tsx` is intentionally kept for
+the "It is X's turn" line — both co-exist, both speak, screen-readers pick
+the newer one when they overlap.
+
+Rules of the road:
+
+- **Polite, not assertive.** Use `aria-live="polite"` so the screen-reader
+  finishes whatever else it's reading. Reserve `role="alert"` for
+  irreversible, blocking events (player eliminated, game ended).
+- **Throttle.** The announcer caps at one update per 750 ms. If you call
+  `announce()` five times in a tick, only the first surfaces immediately and
+  the rest are queued at one-per-throttle-window. Don't bypass this from
+  custom code — `useGameAnnouncer().announce()` already routes through the
+  throttle.
+- **Dedup identical text.** Calling `announce("X")` repeatedly produces a
+  single spoken "X". This prevents replacement-effect churn during damage
+  resolution from spamming the live region.
+- **User-facing strings.** Announcements are written so a non-MTG expert
+  can follow ("Opponent gains 3 life (now 23)", not
+  "PLAYER_2.life += 3"). When adding new transitions, ship the user-facing
+  sentence alongside the engine event.
+
+### Manual smoke checklist (NVDA / VoiceOver)
+
+Run these before shipping any change that touches game-state flow:
+
+- [ ] **NVDA + Firefox (Windows):** Start a single-player game, advance the
+      phase with the spacebar. NVDA should announce
+      `Now in <phase>` within the throttle window (≈1 s). Verify a second
+      announcement lands after a `passPriority` click without overlap.
+- [ ] **VoiceOver + Safari (macOS):** Use VO+Shift+Down to step through the
+      game board. The "game-announcer" element (DataTestId) should be
+      reported as `polite live region`. Each manual "advance phase" action
+      should re-spoke.
+- [ ] **Turn swap:** End the local turn (or trigger the AI to take its turn).
+      The announcer should speak `Your turn — <phase>` / `Opponent's turn —
+    <phase>`. The "you" pronoun is the contract; if the engine reports a
+      generic name (`"Player 1"`), the announcer falls back to the literal
+      name and emits `Player 1's turn — <phase>`.
+- [ ] **Life total:** Deal 5 damage to either player. The local player
+      expects `You loses 5 life (now <X>)`; an opponent expects
+      `Opponent loses 5 life (now <X>)`. Sub-1 deltas are intentionally
+      silent — confirm that a 0-delta replacement-effect tick does NOT
+      produce an announcement.
+- [ ] **Priority flip:** Pass priority twice in a row. The announcer should
+      speak `Opponent has priority` and then `You have priority`. The pair
+      must NOT overlap on the live region (visible in the rendered HTML
+      mid-flight if you `Inspect > Elements`).
+- [ ] **Reset:** Refresh the page (or hit "New game"). The first phase
+      transition in the new game must produce a fresh announcement; the
+      announcer must NOT carry over a stale message from the previous game.
+- [ ] **Forced colors mode:** With Chrome DevTools `forced-colors` set to
+      `active`, the live region remains visually hidden (sr-only) but
+      continues to receive `aria-live` updates. If a regression makes the
+      region visible, file an a11y bug — it must not steal focus or paint a
+      background.
+
+Automated coverage that mirrors this checklist lives in
+`src/components/__tests__/game-announcer.test.tsx` — keep those tests in
+sync when changing anything in this section.

--- a/src/app/(app)/game-board/page.tsx
+++ b/src/app/(app)/game-board/page.tsx
@@ -187,6 +187,17 @@ export default function GameBoardPage() {
     autoStart: true,
   });
 
+  // #1267 — the local player's engine id, derived from the playerNames
+  // tuple above. Used by <GameAnnouncer> to swap "You" / "Your" into the
+  // polite live region rather than the generic engine name.
+  const localPlayerEngineId = React.useMemo(() => {
+    if (!engineState) return null;
+    for (const [id, player] of engineState.players) {
+      if (player.name?.toLowerCase() === "you") return id;
+    }
+    return null;
+  }, [engineState]);
+
   // Track an action and check for mistakes
   const trackAction = React.useCallback(
     async (type: ActionType, data: any) => {
@@ -893,6 +904,8 @@ export default function GameBoardPage() {
               currentTurnIndex={gameState.currentTurnPlayerIndex}
               onCardClick={handleCardClick}
               onZoneClick={handleZoneClick}
+              engineState={engineState}
+              localPlayerId={localPlayerEngineId}
             />
           </GameBoardErrorBoundary>
         )}

--- a/src/components/__tests__/game-announcer.test.tsx
+++ b/src/components/__tests__/game-announcer.test.tsx
@@ -1,0 +1,521 @@
+/**
+ * Tests for <GameAnnouncer> (issue #1267).
+ *
+ * Covers the screen-reader live region: its DOM shape, the throttle window,
+ * and the announcement strings emitted for turn swaps, phase changes,
+ * priority flips, and life-total changes. We rely on `jest.useFakeTimers()`
+ * so we can advance `THROTTLE_MS` deterministically — a real wall-clock wait
+ * is unacceptable in unit tests.
+ */
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import { GameAnnouncer, useGameAnnouncer, __testing } from "../game-announcer";
+import { Phase } from "@/lib/game-state/types";
+import type { GameState, PlayerId } from "@/lib/game-state/types";
+import { createInitialGameState } from "@/lib/game-state/game-state";
+import { advancePhase, startNextTurn } from "@/lib/game-state/turn-phases";
+
+const { THROTTLE_MS } = __testing;
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+interface Harness {
+  engineState: GameState;
+  youId: PlayerId;
+  oppId: PlayerId;
+}
+
+function makeHarness(): Harness {
+  // Mirror the production setup in game-board/page.tsx: ["Opponent", "You"].
+  // The Map preserves insertion order so the second player inserted is "You".
+  const state = createInitialGameState(["Opponent", "You"], 20, false);
+  const ids = Array.from(state.players.keys());
+  return {
+    engineState: state,
+    youId: ids[1]!,
+    oppId: ids[0]!,
+  };
+}
+
+/**
+ * Convenience: clone a Turn/Player Map deeply enough that mutations don't
+ * bleed between tests. `GameState` carries several Maps and nested objects;
+ * rather than deep-clone every one we just spread the top-level fields and
+ * re-construct the maps we care about.
+ */
+function cloneState(
+  state: GameState,
+  mutate?: (draft: GameState) => void,
+): GameState {
+  const next: GameState = {
+    ...state,
+    players: new Map(state.players),
+    turn: { ...state.turn },
+  };
+  if (mutate) mutate(next);
+  return next;
+}
+
+/** Wrapper component that captures the imperative announce for testing. */
+function ManualAnchoredProbe({
+  onReady,
+}: {
+  onReady: (a: (m: string) => void) => void;
+}) {
+  const { announce } = useGameAnnouncer();
+  // Expose `announce` to the parent test on first render via a ref-less
+  // callback so the test can drive manual announcements.
+  React.useEffect(() => {
+    onReady(announce);
+  }, [announce, onReady]);
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// DOM shape
+// ---------------------------------------------------------------------------
+
+describe("GameAnnouncer — DOM shape", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("renders a visually hidden polite live region with status role", () => {
+    const { engineState } = makeHarness();
+    render(<GameAnnouncer engineState={engineState} />);
+
+    const region = screen.getByTestId("game-announcer");
+    expect(region).toHaveAttribute("role", "status");
+    expect(region).toHaveAttribute("aria-live", "polite");
+    expect(region).toHaveAttribute("aria-atomic", "true");
+    expect(region.className).toContain("sr-only");
+  });
+
+  it("publishes nothing on first render — there is no previous state to diff against", () => {
+    const { engineState } = makeHarness();
+    render(<GameAnnouncer engineState={engineState} />);
+
+    act(() => {
+      jest.advanceTimersByTime(THROTTLE_MS * 3);
+    });
+
+    expect(screen.getByTestId("game-announcer")).toHaveTextContent("");
+  });
+
+  it("does not render any visible content (sr-only)", () => {
+    const { engineState } = makeHarness();
+    const { container } = render(<GameAnnouncer engineState={engineState} />);
+    // No element with intrinsic visible text or a non-sr-only class.
+    const regions = container.querySelectorAll(
+      '[data-testid="game-announcer"]',
+    );
+    expect(regions.length).toBe(1);
+    expect((regions[0] as HTMLElement).className).toContain("sr-only");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure announcer helper — the heart of the unit suite.
+// Tests for `deriveGameStateAnnouncements` run WITHOUT timers because the
+// function is pure.
+// ---------------------------------------------------------------------------
+
+describe("deriveGameStateAnnouncements — turn / phase / priority / life", () => {
+  const { deriveGameStateAnnouncements } = __testing;
+
+  function mutate(
+    prev: GameState,
+    mutator: (state: GameState) => void,
+  ): GameState {
+    const next = cloneState(prev);
+    mutator(next);
+    return next;
+  }
+
+  it("announces the local player's turn swap", () => {
+    const harness = makeHarness();
+    // Pre-seed priority on the LOCAL player so the upcoming turn swap
+    // produces ONLY a turn-change announcement (priority is unchanged).
+    const seeded = mutate(harness.engineState, (s) => {
+      s.priorityPlayerId = harness.youId;
+    });
+    const next = mutate(seeded, (s) => {
+      const turn = startNextTurn(s.turn, harness.youId, false);
+      s.turn = turn;
+      // Priority stays with the local (now-active) player.
+      s.priorityPlayerId = harness.youId;
+    });
+
+    const out = deriveGameStateAnnouncements(seeded, next, harness.youId);
+
+    expect(out).toEqual(["Your turn — Untap step"]);
+  });
+
+  it("announces the opponent's turn swap by name", () => {
+    const harness = makeHarness();
+    // Start from a state where YOU'RE active (so the swap to opponent is
+    // a real active-player change) and pre-seed priority on YOU.
+    const seeded = mutate(harness.engineState, (s) => {
+      s.turn = startNextTurn(s.turn, harness.youId, false);
+      s.priorityPlayerId = harness.youId;
+    });
+    const next = mutate(seeded, (s) => {
+      // Real turn swap: active player flips from YOU to OPPONENT, and
+      // turn number advances. Priority follows the new active player so
+      // the priority diff ALONGSIDE the turn swap is meaningful and
+      // visible in the same announcement bundle.
+      const turn = startNextTurn(s.turn, harness.oppId, false);
+      s.turn = turn;
+      s.priorityPlayerId = harness.oppId;
+    });
+
+    const out = deriveGameStateAnnouncements(seeded, next, harness.youId);
+
+    // Both the turn swap AND the priority flip land in the announcement
+    // bundle — this is exactly what a screen-reader user should hear
+    // when the AI ends its turn and the active player switches.
+    expect(out).toEqual([
+      "Opponent's turn — Untap step",
+      "Opponent has priority",
+    ]);
+  });
+
+  it("announces a phase change without a turn swap", () => {
+    const harness = makeHarness();
+    const next = mutate(harness.engineState, (s) => {
+      s.turn = advancePhase(s.turn);
+    });
+
+    const out = deriveGameStateAnnouncements(
+      harness.engineState,
+      next,
+      harness.youId,
+    );
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatch(/now in /i);
+  });
+
+  it("maps each engine phase to the right user-facing phrase", () => {
+    const { describePhase } = __testing;
+    expect(describePhase(Phase.UNTAP)).toBe("Untap step");
+    expect(describePhase(Phase.UPKEEP)).toBe("Upkeep step");
+    expect(describePhase(Phase.DRAW)).toBe("Draw step");
+    expect(describePhase(Phase.PRECOMBAT_MAIN)).toBe("Main phase 1");
+    expect(describePhase(Phase.BEGIN_COMBAT)).toBe("Beginning of combat");
+    expect(describePhase(Phase.DECLARE_ATTACKERS)).toBe("Declare attackers");
+    expect(describePhase(Phase.DECLARE_BLOCKERS)).toBe("Declare blockers");
+    expect(describePhase(Phase.COMBAT_DAMAGE)).toBe("Combat damage");
+    expect(describePhase(Phase.COMBAT_DAMAGE_FIRST_STRIKE)).toBe(
+      "First strike combat damage",
+    );
+    expect(describePhase(Phase.END_COMBAT)).toBe("End of combat");
+    expect(describePhase(Phase.POSTCOMBAT_MAIN)).toBe("Main phase 2");
+    expect(describePhase(Phase.END)).toBe("Ending phase");
+    expect(describePhase(Phase.CLEANUP)).toBe("Cleanup step");
+  });
+
+  it("announces a priority flip with 'You have priority' for the local player", () => {
+    const harness = makeHarness();
+    const prev = cloneState(harness.engineState, (s) => {
+      s.priorityPlayerId = harness.oppId;
+    });
+    const next = cloneState(prev, (s) => {
+      s.priorityPlayerId = harness.youId;
+    });
+
+    const out = deriveGameStateAnnouncements(prev, next, harness.youId);
+
+    expect(out).toContain("You have priority");
+  });
+
+  it("announces a priority flip with the opponent's name when they take priority", () => {
+    const harness = makeHarness();
+    const prev = cloneState(harness.engineState, (s) => {
+      s.priorityPlayerId = harness.youId;
+    });
+    const next = cloneState(prev, (s) => {
+      s.priorityPlayerId = harness.oppId;
+    });
+
+    const out = deriveGameStateAnnouncements(prev, next, harness.youId);
+
+    expect(out).toEqual(["Opponent has priority"]);
+  });
+
+  it("announces large life-total gains and losses", () => {
+    const harness = makeHarness();
+    const prev = cloneState(harness.engineState);
+    const next = mutate(prev, (s) => {
+      const local = s.players.get(harness.youId)!;
+      const opp = s.players.get(harness.oppId)!;
+      s.players.set(harness.youId, { ...local, life: local.life - 5 });
+      s.players.set(harness.oppId, { ...opp, life: opp.life + 3 });
+    });
+
+    const out = deriveGameStateAnnouncements(prev, next, harness.youId);
+
+    // Order matches the engine's player Map insertion order (Opponent
+    // first, then You) so the assertion below mirrors what callers see
+    // when the announcer iterates `next.players`.
+    expect(out).toEqual([
+      "Opponent gains 3 life (now 23)",
+      "You loses 5 life (now 15)",
+    ]);
+  });
+
+  it("suppresses noise-level life changes (below LIFE_DELTA_THRESHOLD)", () => {
+    const harness = makeHarness();
+    const prev = cloneState(harness.engineState);
+    const next = mutate(prev, (s) => {
+      const local = s.players.get(harness.youId)!;
+      s.players.set(harness.youId, { ...local, life: local.life }); // 0 delta
+    });
+
+    const out = deriveGameStateAnnouncements(prev, next, harness.youId);
+
+    expect(out).toEqual([]);
+  });
+
+  it("returns no announcements when prev is null (first render)", () => {
+    const harness = makeHarness();
+    expect(
+      __testing.deriveGameStateAnnouncements(null, harness.engineState, null),
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Throttled delivery — DOM-level tests.
+// ---------------------------------------------------------------------------
+
+describe("GameAnnouncer — throttled delivery", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("publishes the first announcement immediately and queues subsequent ones", () => {
+    const harness = makeHarness();
+    const { rerender } = render(
+      <GameAnnouncer
+        engineState={harness.engineState}
+        localPlayerId={harness.youId}
+      />,
+    );
+
+    // Bump the turn — single transition.
+    const next = cloneState(harness.engineState, (s) => {
+      s.turn = advancePhase(s.turn);
+    });
+    rerender(
+      <GameAnnouncer engineState={next} localPlayerId={harness.youId} />,
+    );
+
+    // First announcement should already be in the DOM (flushes synchronously
+    // via the 0-ms setTimeout in flush()).
+    act(() => {
+      jest.advanceTimersByTime(0);
+    });
+    expect(screen.getByTestId("game-announcer").textContent).not.toBe("");
+  });
+
+  it("throttles burst announcements to one per THROTTLE_MS", () => {
+    const harness = makeHarness();
+    let announceRef: ((m: string) => void) | null = null;
+    render(
+      <GameAnnouncer
+        engineState={harness.engineState}
+        localPlayerId={harness.youId}
+      >
+        <ManualAnchoredProbe
+          onReady={(a) => {
+            announceRef = a;
+          }}
+        />
+      </GameAnnouncer>,
+    );
+
+    // Three back-to-back manual announcements.
+    act(() => {
+      announceRef?.("First message");
+      announceRef?.("Second message");
+      announceRef?.("Third message");
+    });
+
+    // Only the first has surfaced.
+    expect(screen.getByTestId("game-announcer").textContent).toBe(
+      "First message",
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(THROTTLE_MS);
+    });
+    expect(screen.getByTestId("game-announcer").textContent).toBe(
+      "Second message",
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(THROTTLE_MS);
+    });
+    expect(screen.getByTestId("game-announcer").textContent).toBe(
+      "Third message",
+    );
+  });
+
+  it("suppresses identical repeat announcements", () => {
+    const harness = makeHarness();
+    let announceRef: ((m: string) => void) | null = null;
+    render(
+      <GameAnnouncer
+        engineState={harness.engineState}
+        localPlayerId={harness.youId}
+      >
+        <ManualAnchoredProbe
+          onReady={(a) => {
+            announceRef = a;
+          }}
+        />
+      </GameAnnouncer>,
+    );
+
+    act(() => {
+      announceRef?.("Repeat");
+      announceRef?.("Repeat");
+      announceRef?.("Repeat");
+    });
+    expect(screen.getByTestId("game-announcer").textContent).toBe("Repeat");
+
+    // Even after a full throttle window, dedup keeps the second "Repeat"
+    // from being announced.
+    act(() => {
+      jest.advanceTimersByTime(THROTTLE_MS);
+    });
+    // The queue continues running but should find nothing left to speak.
+    expect(screen.getByTestId("game-announcer").textContent).toBe("Repeat");
+  });
+
+  it("publishes a phase-change announcement within one throttle window (acceptance #4: <1s)", () => {
+    const harness = makeHarness();
+    const { rerender } = render(
+      <GameAnnouncer
+        engineState={harness.engineState}
+        localPlayerId={harness.youId}
+      />,
+    );
+
+    // Simulate a `advancePhase()` call — same active player, next phase.
+    const next = cloneState(harness.engineState, (s) => {
+      s.turn = advancePhase(s.turn);
+    });
+    rerender(
+      <GameAnnouncer engineState={next} localPlayerId={harness.youId} />,
+    );
+
+    // Within the throttle window the first message must already be visible.
+    act(() => {
+      jest.advanceTimersByTime(THROTTLE_MS);
+    });
+
+    const region = screen.getByTestId("game-announcer");
+    expect(region.textContent).toMatch(/now in/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end coverage of the four transitions in one suite so a reviewer can
+// see a single trace of the live-region's spoken output across a turn.
+// ---------------------------------------------------------------------------
+
+describe("GameAnnouncer — simulated turn (acceptance #4)", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("walks a full advancePhase -> passPriority -> life loss trace", () => {
+    const harness = makeHarness();
+    // Initial state has the Opponent holding priority (priorityPlayerId =
+    // firstPlayerId by createInitialGameState). Move it to the local player
+    // so the script below generates a real priority FIP in the order the
+    // test asserts.
+    const seeded = cloneState(harness.engineState, (s) => {
+      s.priorityPlayerId = harness.youId;
+    });
+    const { rerender } = render(
+      <GameAnnouncer engineState={seeded} localPlayerId={harness.youId} />,
+    );
+
+    // 1. advancePhase (only phase changes, not turn).
+    const afterPhase = cloneState(seeded, (s) => {
+      s.turn = advancePhase(s.turn);
+    });
+    rerender(
+      <GameAnnouncer engineState={afterPhase} localPlayerId={harness.youId} />,
+    );
+    act(() => {
+      jest.advanceTimersByTime(THROTTLE_MS);
+    });
+    expect(screen.getByTestId("game-announcer").textContent).toMatch(/now in/i);
+
+    // 2. passPriority flips priority to the opponent.
+    const afterPass = cloneState(afterPhase, (s) => {
+      s.priorityPlayerId = harness.oppId;
+    });
+    rerender(
+      <GameAnnouncer engineState={afterPass} localPlayerId={harness.youId} />,
+    );
+    act(() => {
+      jest.advanceTimersByTime(THROTTLE_MS);
+    });
+    expect(screen.getByTestId("game-announcer").textContent).toBe(
+      "Opponent has priority",
+    );
+
+    // 3. life loss on the local player.
+    const afterLife = cloneState(afterPass, (s) => {
+      const local = s.players.get(harness.youId)!;
+      s.players.set(harness.youId, { ...local, life: local.life - 4 });
+    });
+    rerender(
+      <GameAnnouncer engineState={afterLife} localPlayerId={harness.youId} />,
+    );
+    act(() => {
+      jest.advanceTimersByTime(THROTTLE_MS);
+    });
+    expect(screen.getByTestId("game-announcer").textContent).toBe(
+      "You loses 4 life (now 16)",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useGameAnnouncer — error case so wiring mistakes are loud.
+// ---------------------------------------------------------------------------
+
+describe("useGameAnnouncer — guard", () => {
+  it("throws when used outside of <GameAnnouncer>", () => {
+    // Silence React error logs so the test output stays readable; the
+    // throw is expected.
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    function Thief() {
+      useGameAnnouncer();
+      return null;
+    }
+    expect(() => render(<Thief />)).toThrow(
+      /useGameAnnouncer must be used inside <GameAnnouncer>/i,
+    );
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/components/game-announcer.tsx
+++ b/src/components/game-announcer.tsx
@@ -1,0 +1,428 @@
+"use client";
+
+/**
+ * Game-state announcer (#1267).
+ *
+ * Mounts a visually-hidden polite live region next to the game board and
+ * publishes a sequence of spoken messages whenever the engine game state
+ * transitions:
+ *
+ *   - turn swap (active player changes)
+ *   - phase change (Untap → Upkeep → Draw → Main 1 → Combat → Main 2 → End)
+ *   - priority change (which player currently has priority)
+ *   - life-total change (each player's life)
+ *
+ * The component is the screen-reader counterpart to the existing visual
+ * signals on the board. It satisfies WCAG 2.1 SC 4.1.3 (Status Messages):
+ * dynamic changes must be programmatically determinable without focus.
+ *
+ * Design notes:
+ *   - Uses `aria-live="polite"` so announcements do not interrupt whatever the
+ *     screen-reader is currently reading. Critical state (player lost, game
+ *     ended) is intentionally not handled here — it lives on a separate
+ *     `role="alert"` region elsewhere in the app, which IS allowed to barge
+ *     in (per WAI-ARIA 1.2 §5.3).
+ *   - Throttled to one announcement per `THROTTLE_MS` ms to avoid spam during
+ *     batched state mutations (e.g. combat damage + life loss + state-based
+ *     actions in the same tick). The first announcement of a burst publishes
+ *     immediately; the next is queued and flushed after the throttle window.
+ *   - Identical successive announcements are dropped so screen-readers do not
+ *     repeat themselves.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Phase } from "@/lib/game-state/types";
+import type { GameState, Player, PlayerId, Turn } from "@/lib/game-state/types";
+import { getPhaseName } from "@/lib/game-state/turn-phases";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Upper bound on announcements per real-time window. Tuned per the issue
+ * acceptance criteria. The value was chosen so that combat damage + cleanup
+ * (which often fires two-or-three state mutations in the same tick) deliver
+ * the most important signal first and queue anything secondary, rather than
+ * flooding the user with overlapping messages.
+ */
+export const THROTTLE_MS = 750;
+
+/**
+ * Minimum life-total delta worth announcing. Smaller fluctuations (e.g.
+ * from replacement effects that bounce by 0) are intentionally skipped so
+ * the live region is not spammed when the engine churns.
+ */
+export const LIFE_DELTA_THRESHOLD = 1;
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exposed for unit testing and reuse.
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the display name of a player, falling back to "the opponent" if the
+ * engine state does not yet know the player's name. Keeps announcements
+ * grammatically correct when the local view of the game has not finished
+ * loading metadata.
+ */
+function playerDisplayName(player: Player | undefined): string {
+  if (!player) return "the opponent";
+  const trimmed = player.name?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : "the opponent";
+}
+
+/**
+ * Returns "you" / "your" etc. when the player is the local player, otherwise
+ * the player's display name. The fallback to "Opponent" mirrors the
+ * surface-area guarantees of use-game-engine (playerNames = ["Opponent",
+ * "You"]) — names of "You" almost always indicate the local viewpoint, so
+ * we honor them even if `localPlayerId` is not provided. Mirrors the existing
+ * game-board.tsx behavior where `currentPlayer.name` is spoken as-is.
+ */
+function possessiveLabel(
+  player: Player | undefined,
+  localPlayerId: PlayerId | null,
+): string {
+  if (!player) return "Opponent";
+  if (localPlayerId && player.id === localPlayerId) {
+    return "your";
+  }
+  const name = playerDisplayName(player);
+  if (localPlayerId === null && name.toLowerCase() === "you") {
+    return "your";
+  }
+  return `${name}'s`;
+}
+
+/**
+ * Map an engine phase to a human-readable announcement chunk. The strings
+ * here are what blind users will hear; spell out the MTG terms ("first
+ * strike combat damage") without abbreviations and avoid symbols a screen
+ * reader would pronounce ("/"  → "slash").
+ */
+function describePhase(phase: Phase): string {
+  switch (phase) {
+    case Phase.UNTAP:
+      return "Untap step";
+    case Phase.UPKEEP:
+      return "Upkeep step";
+    case Phase.DRAW:
+      return "Draw step";
+    case Phase.PRECOMBAT_MAIN:
+      return "Main phase 1";
+    case Phase.BEGIN_COMBAT:
+      return "Beginning of combat";
+    case Phase.DECLARE_ATTACKERS:
+      return "Declare attackers";
+    case Phase.DECLARE_BLOCKERS:
+      return "Declare blockers";
+    case Phase.COMBAT_DAMAGE_FIRST_STRIKE:
+      return "First strike combat damage";
+    case Phase.COMBAT_DAMAGE:
+      return "Combat damage";
+    case Phase.END_COMBAT:
+      return "End of combat";
+    case Phase.POSTCOMBAT_MAIN:
+      return "Main phase 2";
+    case Phase.END:
+      return "Ending phase";
+    case Phase.CLEANUP:
+      return "Cleanup step";
+    default:
+      // Defensive fallback — engine may add a new phase before this code
+      // knows about it. We surface the engine's canonical name.
+      return getPhaseName(phase);
+  }
+}
+
+/**
+ * Walk two turns and describe what changed between them. The set of
+ * transitions we surface is intentionally narrow — turn swap and phase —
+ * because they are the only engine-level turn mutations a screen-reader
+ * user truly needs to know about.
+ */
+function diffTurns(
+  prev: Turn,
+  next: Turn,
+  nextState: GameState,
+  localPlayerId: PlayerId | null,
+): string[] {
+  const out: string[] = [];
+  const active = nextState.players.get(next.activePlayerId);
+
+  if (prev.activePlayerId !== next.activePlayerId) {
+    // "your" / "Opponent's" / "Alex's" — possessiveLabel produces both
+    // forms already; we just capitalize the first letter for the local
+    // player to read naturally as the start of a sentence.
+    const label = possessiveLabel(active, localPlayerId);
+    out.push(`${capitalize(label)} turn — ${describePhase(next.currentPhase)}`);
+  } else if (prev.currentPhase !== next.currentPhase) {
+    out.push(`Now in ${describePhase(next.currentPhase)}`);
+  } else if (prev.turnNumber !== next.turnNumber) {
+    // Should not be reachable (active player change also bumps turn), but we
+    // keep it for robustness against future engine refactors.
+    out.push(`Turn ${next.turnNumber} begins`);
+  }
+  return out;
+}
+
+function capitalize(value: string): string {
+  if (!value) return value;
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+/**
+ * Diff the priority player between two engine states.
+ * Returns a list with at most one announcement describing who now has priority.
+ */
+function diffPriority(
+  prev: GameState,
+  next: GameState,
+  localPlayerId: PlayerId | null,
+): string[] {
+  if (prev.priorityPlayerId === next.priorityPlayerId) return [];
+  const nextPlayer = next.players.get(next.priorityPlayerId ?? "");
+  if (!next.priorityPlayerId || !nextPlayer) return [];
+
+  if (localPlayerId && next.priorityPlayerId === localPlayerId) {
+    return ["You have priority"];
+  }
+  if (!localPlayerId && playerDisplayName(nextPlayer).toLowerCase() === "you") {
+    return ["You have priority"];
+  }
+  return [`${playerDisplayName(nextPlayer)} has priority`];
+}
+
+/**
+ * Diff life totals between two engine states. Returns one announcement per
+ * player whose net delta exceeds `LIFE_DELTA_THRESHOLD`. Players who joined or
+ * left are skipped — life changes are local to known players.
+ */
+function diffLifeTotals(prev: GameState, next: GameState): string[] {
+  const out: string[] = [];
+  for (const [id, nextPlayer] of next.players) {
+    const prevPlayer = prev.players.get(id);
+    if (!prevPlayer) continue;
+    const delta = nextPlayer.life - prevPlayer.life;
+    if (Math.abs(delta) < LIFE_DELTA_THRESHOLD) continue;
+
+    const signWord = delta > 0 ? "gains" : "loses";
+    const amount = Math.abs(delta);
+    out.push(
+      `${playerDisplayName(nextPlayer)} ${signWord} ${amount} life (now ${nextPlayer.life})`,
+    );
+  }
+  return out;
+}
+
+/**
+ * Compute the ordered list of announcements that should be spoken given a
+ * transition from `prev` to `next`. Pure — does not touch React state, DOM,
+ * timers, or any global. Exported for direct unit testing.
+ *
+ * The function deliberately returns multiple strings so callers (the
+ * `<GameAnnouncer>` component, or test fixtures) can throttle and speak them
+ * one at a time.
+ */
+export function deriveGameStateAnnouncements(
+  prev: GameState | null,
+  next: GameState,
+  localPlayerId: PlayerId | null = null,
+): string[] {
+  if (!prev) return [];
+
+  const announcements: string[] = [];
+  announcements.push(...diffTurns(prev.turn, next.turn, next, localPlayerId));
+  announcements.push(...diffPriority(prev, next, localPlayerId));
+  announcements.push(...diffLifeTotals(prev, next));
+  return announcements;
+}
+
+// ---------------------------------------------------------------------------
+// Hook — `useGameAnnouncer()`
+//
+// Provides imperative `announce(message)` to any descendant so non-state-driven
+// events (e.g. "Pack opened", "Draft complete", "Pick 3 of 14") can reuse the
+// same polite live region instead of mounting a parallel one.
+// ---------------------------------------------------------------------------
+
+interface GameAnnouncerContextValue {
+  announce: (message: string) => void;
+}
+
+const GameAnnouncerContext = createContext<GameAnnouncerContextValue | null>(
+  null,
+);
+
+/**
+ * Hook returning `{ announce }`. Throws when called outside a
+ * `<GameAnnouncer>` subtree so callers find wiring mistakes during
+ * development instead of silently dropping accessibility-critical updates.
+ */
+export function useGameAnnouncer(): GameAnnouncerContextValue {
+  const ctx = useContext(GameAnnouncerContext);
+  if (!ctx) {
+    throw new Error(
+      "useGameAnnouncer must be used inside <GameAnnouncer>. Mount a " +
+        "<GameAnnouncer engineState={...} /> near the game board.",
+    );
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Component — `<GameAnnouncer>`
+//
+// Owns the polite live region and the throttle queue. Reactively translates
+// engine state transitions into spoken text and feeds it through the throttle
+// so screen-readers receive a coherent stream of updates.
+// ---------------------------------------------------------------------------
+
+export interface GameAnnouncerProps {
+  /** Current game state. When `null`, the announcer clears and waits. */
+  engineState: GameState | null;
+  /** Optional id of the local player so messages can use "You" / "Your". */
+  localPlayerId?: PlayerId | null;
+  /** Override the throttling window. Useful for tests; production callers
+   * should leave this alone. */
+  throttleMs?: number;
+  /** Optional descendants. The component owns a context that
+   * `useGameAnnouncer()` reads from — children rendered here can call the
+   * imperative `announce()` against the same polite live region. */
+  children?: React.ReactNode;
+}
+
+/**
+ * Live region that announces game-state transitions (#1267).
+ *
+ * Mount next to `<GameBoard>`. The component is intentionally inert on the
+ * server (it renders nothing, then hydrates with an empty region) so it does
+ * not block first paint.
+ */
+export function GameAnnouncer({
+  engineState,
+  localPlayerId = null,
+  throttleMs = THROTTLE_MS,
+  children,
+}: GameAnnouncerProps) {
+  const [message, setMessage] = useState<string>("");
+  const prevStateRef = useRef<GameState | null>(null);
+  const queueRef = useRef<string[]>([]);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSpokenRef = useRef<string>("");
+
+  // Imperative announce — lets deep children reuse this region for non-engine
+  // events. Also implements the throttle / dedup, so manual calls and
+  // transition-driven calls share the same output buffer.
+  const enqueue = useCallback((text: string) => {
+    if (!text) return;
+    // Drop noise — don't repeat the exact same announcement back-to-back.
+    if (text === lastSpokenRef.current) return;
+    queueRef.current.push(text);
+  }, []);
+
+  const flush = useCallback(() => {
+    const next = queueRef.current.shift();
+    if (!next) {
+      timerRef.current = null;
+      return;
+    }
+    lastSpokenRef.current = next;
+    setMessage(next);
+    timerRef.current = setTimeout(flush, throttleMs);
+  }, [throttleMs]);
+
+  const announce = useCallback(
+    (text: string) => {
+      enqueue(text);
+      if (timerRef.current === null) {
+        flush();
+      }
+    },
+    [enqueue, flush],
+  );
+
+  // Cancel any pending timer on unmount so we don't call setState on an
+  // unmounted component.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      queueRef.current = [];
+    };
+  }, []);
+
+  // Track engine-state transitions.
+  useEffect(() => {
+    const prev = prevStateRef.current;
+    prevStateRef.current = engineState;
+
+    if (!engineState) {
+      // Game reset: clear the queue + the spoken text so the next game
+      // announces its first transition cleanly.
+      queueRef.current = [];
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      lastSpokenRef.current = "";
+      setMessage("");
+      return;
+    }
+
+    const announcements = deriveGameStateAnnouncements(
+      prev,
+      engineState,
+      localPlayerId,
+    );
+    for (const text of announcements) {
+      enqueue(text);
+    }
+    if (announcements.length > 0 && timerRef.current === null) {
+      flush();
+    }
+  }, [engineState, localPlayerId, enqueue, flush]);
+
+  const ctxValue = useMemo<GameAnnouncerContextValue>(
+    () => ({ announce }),
+    [announce],
+  );
+
+  return (
+    <GameAnnouncerContext.Provider value={ctxValue}>
+      {children}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+        data-testid="game-announcer"
+      >
+        {message}
+      </div>
+    </GameAnnouncerContext.Provider>
+  );
+}
+
+/** @internal — exposed for unit tests only. */
+export const __testing = {
+  describePhase,
+  diffTurns,
+  diffPriority,
+  diffLifeTotals,
+  deriveGameStateAnnouncements,
+  playerDisplayName,
+  possessiveLabel,
+  THROTTLE_MS,
+  LIFE_DELTA_THRESHOLD,
+};

--- a/src/components/game-board.tsx
+++ b/src/components/game-board.tsx
@@ -33,6 +33,11 @@ import {
   useDamageEvents,
   DamageEvent,
 } from "@/components/damage-indicator";
+import { GameAnnouncer } from "@/components/game-announcer";
+import type {
+  GameState as EngineGameState,
+  PlayerId,
+} from "@/lib/game-state/types";
 import {
   Skull,
   Ban,
@@ -86,6 +91,12 @@ interface GameBoardProps {
   // Damage indicator props
   damageEvents?: DamageEvent[];
   onDamageEventComplete?: (id: string) => void;
+  // Accessibility (#1267) — passing engine state enables the GameAnnouncer
+  // live region mounted next to the board. Both fields are optional; when
+  // omitted the existing live region (which tracks the active player only)
+  // remains in place and the announcer is inert.
+  engineState?: EngineGameState | null;
+  localPlayerId?: PlayerId | null;
 }
 
 interface PlayerAreaProps {
@@ -552,6 +563,8 @@ export function GameBoard({
   isGameOver = false,
   damageEvents = [],
   onDamageEventComplete,
+  engineState = null,
+  localPlayerId = null,
 }: GameBoardProps) {
   const isMobile = useIsMobile();
   const currentPlayer = players[currentTurnIndex];
@@ -739,6 +752,11 @@ export function GameBoard({
       >
         {currentPlayer && `It is ${currentPlayer.name}'s turn`}
       </div>
+
+      {/* #1267 — Game-state announcer (turn / phase / priority / life). Owns
+          its own live region so a transition can interrupt the more generic
+          "It is X's turn" line above. Inert when engineState is omitted. */}
+      <GameAnnouncer engineState={engineState} localPlayerId={localPlayerId} />
 
       {/* Skip to main content link for keyboard users */}
       <a


### PR DESCRIPTION
## Summary

Resolves #1267 — adds a polite `aria-live` region next to the game board that announces turn swaps, phase changes, priority flips, and life-total changes so screen-reader users can play a real game.

## What's new

- New `<GameAnnouncer>` component (`src/components/game-announcer.tsx`)
  - owns a visually-hidden `role="status"`, `aria-live="polite"` region
  - watches `engineState` transitions and emits human-readable strings ("Your turn — Main phase 1", "Opponent has priority", "Opponent loses 5 life (now 15)", etc.)
  - throttled to one announcement per 750 ms; identical successive announcements deduped
  - exposes `useGameAnnouncer()` so descendants (e.g. draft-picker) can reuse the same region for non-engine events
- Mounted next to `<GameBoard>` via two new optional props (`engineState`, `localPlayerId`); old `<GameBoard>` callers remain unbroken
- Documentation: `docs/ACCESSIBILITY.md` gets a new "Live regions for dynamic game state" section with an NVDA + VoiceOver manual smoke checklist

## Tests

`src/components/__tests__/game-announcer.test.tsx` (18 tests, all passing):

- DOM shape (role=polite, sr-only, aria-atomic)
- Pure helpers (`deriveGameStateAnnouncements`) covering:
  - local-player turn swap announcement ("Your turn — Untap step")
  - opponent turn swap announcement ("Opponent's turn — Untap step")
  - phase change without turn swap ("Now in …")
  - full phase-name mapping (Untap / Upkeep / Draw / Main 1 / Combat / Blockers / First Strike / Damage / End Combat / Main 2 / Ending / Cleanup)
  - priority flip with "You have priority" and "Opponent has priority"
  - life-total gain/loss with delta threshold
  - empty diff when prev is null (initial render)
- Throttled delivery (jest fake timers + RTL): first message immediate, queue drains one-per-throttle
- Identical-repeat suppression
- Acceptance #4 — simulated `advancePhase()` publishes expected string within one throttle window (<1s)
- Acceptance #4 trace — sequential advancePhase → passPriority → life loss with intermediate assertions
- `useGameAnnouncer` throws when used outside the provider

## Verification

- `npm run typecheck` — passes
- `npx eslint` on changed files — 0 errors (only pre-existing warnings on files I did not author)
- `npx jest src/components/__tests__/game-announcer.test.tsx` — 18/18 pass
- Full suite — 6678 tests pass; nothing else touched