### PR TITLE
chore(deps): migrate @types/testing-library__jest-dom to v6 (drop stub)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,6 @@
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.1",
-        "@types/testing-library__jest-dom": "^5.14.9",
         "@typescript-eslint/eslint-plugin": "^8.62.1",
         "@typescript-eslint/parser": "^8.62.1",
         "@vitest/web-worker": "^4.1.9",
@@ -7478,16 +7477,6 @@
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/testing-library__jest-dom": {
-      "version": "5.14.9",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.9.tgz",
-      "integrity": "sha512-FSYhIjFlfOpGSRyVoMBMuS3ws5ehFQODymf3vlI7U1K8c7PHwWwFY7VREfmsuzHSOnoKs/9/Y983ayOs7eRzqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/jest": "*"
-      }
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "@types/qrcode": "^1.5.6",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.1",
-    "@types/testing-library__jest-dom": "^5.14.9",
     "@typescript-eslint/eslint-plugin": "^8.62.1",
     "@typescript-eslint/parser": "^8.62.1",
     "@vitest/web-worker": "^4.1.9",

--- a/src/app/(app)/deck-builder/_components/__tests__/deck-list.test.tsx
+++ b/src/app/(app)/deck-builder/_components/__tests__/deck-list.test.tsx
@@ -14,9 +14,16 @@
  *   6. Stepper interactions keep working through the virtualizer.
  */
 
-import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
 import { render, screen, fireEvent } from "@testing-library/react";
-import "@testing-library/jest-dom";
+import "@testing-library/jest-dom/jest-globals";
 
 jest.mock("@/components/ui/card", () => ({
   Card: ({ children, className }: any) => (
@@ -196,10 +203,14 @@ describe("DeckList — card control accessibility (#933)", () => {
   it("exposes accessible names for both stepper buttons", () => {
     renderList();
     expect(
-      screen.getByRole("button", { name: "Decrease quantity of Lightning Bolt" }),
+      screen.getByRole("button", {
+        name: "Decrease quantity of Lightning Bolt",
+      }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Increase quantity of Lightning Bolt" }),
+      screen.getByRole("button", {
+        name: "Increase quantity of Lightning Bolt",
+      }),
     ).toBeInTheDocument();
   });
 
@@ -228,13 +239,7 @@ describe("DeckList — card control accessibility (#933)", () => {
 describe("DeckList — virtualization (#1081)", () => {
   /** Build a constructed-sized deck spread across several categories. */
   function makeDeck(n: number): DeckCard[] {
-    const types = [
-      "Creature",
-      "Instant",
-      "Sorcery",
-      "Artifact",
-      "Land",
-    ];
+    const types = ["Creature", "Instant", "Sorcery", "Artifact", "Land"];
     return Array.from({ length: n }, (_, i) => ({
       id: `card-${i}`,
       name: `Card ${i}`,
@@ -285,7 +290,9 @@ describe("DeckList — virtualization (#1081)", () => {
     expect(screen.queryByTestId("deck-item-card-0")).toBeNull();
     const mountedIndices = screen
       .getAllByTestId(/^deck-item-card-\d+$/)
-      .map((el) => Number(el.getAttribute("data-testid")!.replace("deck-item-card-", "")));
+      .map((el) =>
+        Number(el.getAttribute("data-testid")!.replace("deck-item-card-", "")),
+      );
     expect(Math.max(...mountedIndices)).toBeGreaterThan(80);
   });
 
@@ -308,6 +315,8 @@ describe("DeckList — virtualization (#1081)", () => {
     expect(onRemoveCard).toHaveBeenCalledWith("card-0");
     fireEvent.click(screen.getByTestId("increase-quantity-card-0"));
     expect(onAddCard).toHaveBeenCalledTimes(1);
-    expect(onAddCard).toHaveBeenCalledWith(expect.objectContaining({ id: "card-0" }));
+    expect(onAddCard).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "card-0" }),
+    );
   });
 });

--- a/src/app/(app)/deck-builder/_components/__tests__/deck-stats-panel.memo.test.tsx
+++ b/src/app/(app)/deck-builder/_components/__tests__/deck-stats-panel.memo.test.tsx
@@ -10,7 +10,7 @@
 
 import { describe, it, expect, jest } from "@jest/globals";
 import { render } from "@testing-library/react";
-import "@testing-library/jest-dom";
+import "@testing-library/jest-dom/jest-globals";
 
 // `jest.mock` factories are hoisted; they may only reference bindings whose
 // names are prefixed with `mock`. The counters are read at render time, well
@@ -70,10 +70,9 @@ jest.mock("@/components/deck-statistics", () => ({
 jest.mock("@/hooks/use-deck-statistics", () => {
   // Preserve the real `getDeckSignature` (used by the panel's `React.memo`
   // comparator) while stubbing only the hook so the panel render is isolated.
-  const actual =
-    jest.requireActual<typeof import("@/hooks/use-deck-statistics")>(
-      "@/hooks/use-deck-statistics",
-    );
+  const actual = jest.requireActual<
+    typeof import("@/hooks/use-deck-statistics")
+  >("@/hooks/use-deck-statistics");
   return {
     ...actual,
     useDeckStatistics: () => ({
@@ -166,9 +165,7 @@ describe("DeckStatsPanel — memoization (issue #1083)", () => {
     );
     const initialRenderCount = mockManaRenders;
 
-    rerender(
-      <DeckStatsPanel deck={deck} format="commander" className="b" />,
-    );
+    rerender(<DeckStatsPanel deck={deck} format="commander" className="b" />);
     expect(mockManaRenders).toBeGreaterThan(initialRenderCount);
   });
 });

--- a/src/app/(app)/deck-builder/_components/__tests__/deck-stats-panel.test.tsx
+++ b/src/app/(app)/deck-builder/_components/__tests__/deck-stats-panel.test.tsx
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, jest } from "@jest/globals";
 import { render, screen, fireEvent } from "@testing-library/react";
-import "@testing-library/jest-dom";
+import "@testing-library/jest-dom/jest-globals";
 
 jest.mock("@/components/ui/card", () => ({
   Card: ({ children, className, ...props }: any) => (
@@ -109,7 +109,10 @@ describe("DeckStatsPanel — collapse toggle accessibility", () => {
       name: "Expand deck statistics",
     });
     expect(expandBtn).toHaveAttribute("aria-expanded", "false");
-    expect(expandBtn).toHaveAttribute("aria-controls", "deck-statistics-content");
+    expect(expandBtn).toHaveAttribute(
+      "aria-controls",
+      "deck-statistics-content",
+    );
   });
 
   it("exposes the controlled region via the matching id when expanded", () => {

--- a/src/app/(app)/deck-coach/_components/__tests__/coach-components.test.tsx
+++ b/src/app/(app)/deck-coach/_components/__tests__/coach-components.test.tsx
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, jest } from "@jest/globals";
 import { render, screen, fireEvent } from "@testing-library/react";
-import "@testing-library/jest-dom";
+import "@testing-library/jest-dom/jest-globals";
 
 // Mock the UI components
 jest.mock("@/components/ui/badge", () => ({

--- a/src/components/__tests__/ai-telegraph-display.test.tsx
+++ b/src/components/__tests__/ai-telegraph-display.test.tsx
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, jest } from "@jest/globals";
 import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/jest-globals";
 import {
   AiTelegraphDisplay,
   type TelegraphEntry,

--- a/src/components/__tests__/deck-statistics-charts.test.tsx
+++ b/src/components/__tests__/deck-statistics-charts.test.tsx
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, jest } from "@jest/globals";
 import { render } from "@testing-library/react";
-import "@testing-library/jest-dom";
+import "@testing-library/jest-dom/jest-globals";
 
 // Stub recharts so charts render without jsdom layout dependencies.
 jest.mock("recharts", () => ({
@@ -64,9 +64,7 @@ import {
 
 function chartIsHiddenFromAT(container: HTMLElement): boolean {
   // The decorative SVG chart must live inside an aria-hidden wrapper.
-  return (
-    container.querySelector('[aria-hidden="true"] [data-testid]') !== null
-  );
+  return container.querySelector('[aria-hidden="true"] [data-testid]') !== null;
 }
 
 describe("ManaCurveChart — screen-reader alternative", () => {

--- a/src/components/__tests__/p2p-diagnostics-panel.test.tsx
+++ b/src/components/__tests__/p2p-diagnostics-panel.test.tsx
@@ -6,7 +6,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import "@testing-library/jest-dom";
+import "@testing-library/jest-dom/jest-globals";
 
 import { P2PDiagnosticsPanel } from "../p2p-diagnostics-panel";
 import type { ICEDiagnosticsSnapshot } from "@/lib/ice-diagnostics";

--- a/src/components/chat/__tests__/chat-panel.test.tsx
+++ b/src/components/chat/__tests__/chat-panel.test.tsx
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, jest, beforeAll } from "@jest/globals";
 import { render, screen, fireEvent } from "@testing-library/react";
-import "@testing-library/jest-dom";
+import "@testing-library/jest-dom/jest-globals";
 import { DeckCoachChatPanel } from "../chat-panel";
 import type { ChatMessage } from "@/types/chat";
 


### PR DESCRIPTION
Closes #1221
Closes #1302
Child of #1301

## What
Drop the deprecated `@types/testing-library__jest-dom` stub (currently pinned at `^5.14.9`, bumped to `^6.0.0` by dependabot PR #1221) and pull matcher-type augmentation directly from `@testing-library/jest-dom/jest-globals` in each test suite.

## Why
- `@types/testing-library__jest-dom@6.0.0` is a no-op stub that only declares "please install `@testing-library/jest-dom`". The actual types ship with the runtime package (`@testing-library/jest-dom@^6.9.1`, already installed) at `types/index.d.ts` and `types/jest-globals.d.ts`.
- npm prints a deprecation warning on every install:
  > `This is a stub types definition. @testing-library/jest-dom provides its own type definitions, so you do not need this installed.`
- The dependabot PR was attempting a major-version bump of a stub package that no longer carries types. The real migration is to remove it.

## Changes
- `package.json` / `package-lock.json`: remove `@types/testing-library__jest-dom` (the v6 stub).
- 7 `*.test.tsx` files: change `import "@testing-library/jest-dom";` → `import "@testing-library/jest-dom/jest-globals";` so that Jest's Matcher interface is augmented with `TestingLibraryMatchers` at the v6 types path.
- 1 `*.test.tsx` file (`ai-telegraph-display.test.tsx`): add the import — it used `toHaveAttribute` without ever registering the matcher types.

## Verification
- `npm run typecheck` → `TypeScript: No errors found`
- `npm run lint` → 0 errors (656 warnings, baseline)
- `npx jest --ci` → **322 / 322 suites, 6 800 / 6 800 tests** (matches baseline)

## Note on dependabot
Dependabot PRs #1221 (and the regenerated #1308+) will keep targeting `@types/testing-library__jest-dom` until the package.json entry is gone from `main`. After this PR merges, dependabot will automatically stop proposing the bump (no version pin to bump).

## Closing comment for #1221
> Superseded by #<this-PR>; see #1301 for the migration plan.

## Summary by Sourcery

Remove the deprecated @types/testing-library__jest-dom dependency and update test suites to use matcher type augmentation from @testing-library/jest-dom/jest-globals.

Build:
- Drop the @types/testing-library__jest-dom dev dependency from package.json and package-lock.json.

Tests:
- Update Jest/Testing Library test files to import @testing-library/jest-dom/jest-globals for matcher augmentation, adding the import where it was previously missing.