### PR TITLE
chore(deps): migrate date-fns to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "comlink": "^4.4.2",
-        "date-fns": "^3.6.0",
+        "date-fns": "^4.4.0",
         "dexie": "^4.4.4",
         "dexie-react-hooks": "^1.1.7",
         "dotenv": "^17.3.1",
@@ -9619,9 +9619,9 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -16383,16 +16383,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/react-day-picker/node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "comlink": "^4.4.2",
-    "date-fns": "^3.6.0",
+    "date-fns": "^4.4.0",
     "dexie": "^4.4.4",
     "dexie-react-hooks": "^1.1.7",
     "dotenv": "^17.3.1",

--- a/src/app/(app)/set-browser/page.tsx
+++ b/src/app/(app)/set-browser/page.tsx
@@ -1,9 +1,9 @@
 /**
  * Set Browser - MTG Set Selection for Limited Modes
- * 
+ *
  * Phase 14: Foundation
  * Requirements: SET-01, SET-02, SET-03
- * 
+ *
  * Features:
  * - Browse all MTG sets sorted by release date or name
  * - Display card count for each set
@@ -15,7 +15,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { format } from "date-fns";
+import { format } from "date-fns/format";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -43,18 +43,22 @@ import {
   getSetTypeDisplayName,
   filterPlayableSets,
 } from "@/lib/limited/set-service";
-import type { ScryfallSet, SetSortOption, LimitedMode } from "@/lib/limited/types";
+import type {
+  ScryfallSet,
+  SetSortOption,
+  LimitedMode,
+} from "@/lib/limited/types";
 
 export default function SetBrowserPage() {
   const router = useRouter();
-  
+
   // State
   const [sets, setSets] = useState<ScryfallSet[]>([]);
   const [filteredSets, setFilteredSets] = useState<ScryfallSet[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [sortOption, setSortOption] = useState<SetSortOption>("release_date");
-  
+
   // Selection state
   const [selectedSet, setSelectedSet] = useState<ScryfallSet | null>(null);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -66,10 +70,10 @@ export default function SetBrowserPage() {
       try {
         setIsLoading(true);
         setError(null);
-        
+
         const allSets = await fetchAllSets();
         const playableSets = filterPlayableSets(allSets);
-        
+
         setSets(playableSets);
         setFilteredSets(sortSets(playableSets, sortOption));
       } catch (err) {
@@ -102,7 +106,7 @@ export default function SetBrowserPage() {
     if (!selectedSet) return;
 
     const setCode = selectedSet.code.toLowerCase();
-    
+
     if (selectedMode === "sealed") {
       router.push(`/sealed?set=${setCode}`);
     } else {
@@ -132,7 +136,7 @@ export default function SetBrowserPage() {
             Choose a Magic: The Gathering set for Draft or Sealed
           </p>
         </div>
-        
+
         {/* Sort Controls */}
         <div className="flex items-center gap-3">
           <span className="text-sm text-muted-foreground">Sort by:</span>
@@ -192,7 +196,7 @@ export default function SetBrowserPage() {
           <div className="mb-4 text-sm text-muted-foreground">
             Showing {filteredSets.length} sets
           </div>
-          
+
           <ScrollArea className="flex-1">
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 pb-6">
               {filteredSets.map((set) => (
@@ -251,10 +255,7 @@ function SetCard({ set, onClick, formatReleaseDate }: SetCardProps) {
             {set.code.toUpperCase()}
           </div>
         )}
-        <Badge
-          variant="secondary"
-          className="absolute top-2 right-2"
-        >
+        <Badge variant="secondary" className="absolute top-2 right-2">
           {set.card_count} cards
         </Badge>
       </div>


### PR DESCRIPTION
Closes #1218
Closes #1304
Child of #1301

## What
Bump `date-fns` from `^3.6.0` → `^4.4.0` and switch the lone call site to the per-function subpath import that v4 prefers for tree-shaking.

## Why
- date-fns v4 keeps the top-level barrel working but recommends the per-function subpath for clearer tree-shaking and smaller bundles.
- The dependabot PR was failing in E2E because the bundler still pulled the barrel by default; using the subpath avoids that.

## Changes
- `package.json` / `package-lock.json`: bump `date-fns` to `^4.4.0`.
- `src/app/(app)/set-browser/page.tsx`: `import { format } from "date-fns"` → `import { format } from "date-fns/format"`.

## Verification
- `npm run typecheck` → clean.
- `npm run lint` → 0 errors (656 warnings, baseline).
- `npx jest --ci` → **322 / 322 suites, 6 800 / 6 800 tests**.
- `npm run build` → Next.js build succeeds.

## Closing comment for #1218
> Superseded by #<this-PR>; see #1301 for the migration plan.

## Summary by Sourcery

Migrate the application to use date-fns v4 and update the remaining call site to the recommended per-function import path.

Enhancements:
- Update the set browser page to import date formatting from the date-fns/format subpath and apply minor JSX/whitespace formatting cleanup.

Build:
- Bump the date-fns dependency from v3.6.0 to v4.4.0 in package.json and package-lock.json.