### PR TITLE
chore(deps): migrate @ai-sdk/openai to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@ai-sdk/anthropic": "^3.0.58",
-        "@ai-sdk/google": "^3.0.43",
-        "@ai-sdk/openai": "^3.0.41",
+        "@ai-sdk/anthropic": "^4.0.0",
+        "@ai-sdk/google": "^4.0.0",
+        "@ai-sdk/openai": "^4.0.2",
         "@ai-sdk/react": "^3.0.118",
         "@hookform/resolvers": "^4.1.3",
         "@huggingface/transformers": "^3.8.1",
@@ -39,7 +39,7 @@
         "@radix-ui/react-toast": "^1.2.18",
         "@radix-ui/react-tooltip": "^1.2.11",
         "@tanstack/react-virtual": "^3.14.5",
-        "ai": "^6.0.116",
+        "ai": "^7.0.15",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "comlink": "^4.4.2",
@@ -118,65 +118,185 @@
       "license": "MIT"
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.71",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.71.tgz",
-      "integrity": "sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-4.0.8.tgz",
+      "integrity": "sha512-ZqT9kLxS2Cbo/4juwtEGbYyP0jNQTnUUKy2nQ8Vn28xqNu50+TukO/oCEWCpm18YbQq7N+hr6ClJs/ATTFpBTg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23"
+        "@ai-sdk/provider": "4.0.2",
+        "@ai-sdk/provider-utils": "5.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.2.tgz",
+      "integrity": "sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.5.tgz",
+      "integrity": "sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.104",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.104.tgz",
-      "integrity": "sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.12.tgz",
+      "integrity": "sha512-Y7Fy8xJwPz7ZC0DhSQG3HIVk+drup42hrIj6yqKlib3CxwiR0F7nYyUI8+kPrEtbZEoyKoRstvT4/o0HEyFBHA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23",
+        "@ai-sdk/provider": "4.0.2",
+        "@ai-sdk/provider-utils": "5.0.5",
         "@vercel/oidc": "3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.2.tgz",
+      "integrity": "sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.5.tgz",
+      "integrity": "sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "3.0.64",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.64.tgz",
-      "integrity": "sha512-CbR82EgGPNrj/6q0HtclwuCqe0/pDShyv3nWDP/A9DroujzWXnLMlUJVrgPOsg4b40zQCwwVs2XSKCxvt/4QaA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-4.0.8.tgz",
+      "integrity": "sha512-GELd0RkltieuODzr6tfnEOIufeooctYpGUNxujeh+zrChbHUkX2K6Li4h2EAfizctkY4k3JvC93dU9eh2QxzoQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23"
+        "@ai-sdk/provider": "4.0.2",
+        "@ai-sdk/provider-utils": "5.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.2.tgz",
+      "integrity": "sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.5.tgz",
+      "integrity": "sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.53",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
-      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.7.tgz",
+      "integrity": "sha512-55K0j8RRjcKosUvIl8u/+SMaS1wedq77xN2iuhlOvB/USbIgSmjkWKV9lqGhhp+Qxhnm3qg5NzrqOI1jmra9fQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23"
+        "@ai-sdk/provider": "4.0.2",
+        "@ai-sdk/provider-utils": "5.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.2.tgz",
+      "integrity": "sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.5.tgz",
+      "integrity": "sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -227,6 +347,41 @@
       },
       "peerDependencies": {
         "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
+      }
+    },
+    "node_modules/@ai-sdk/react/node_modules/@ai-sdk/gateway": {
+      "version": "3.0.104",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.104.tgz",
+      "integrity": "sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react/node_modules/ai": {
+      "version": "6.0.168",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.168.tgz",
+      "integrity": "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.104",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4213,6 +4368,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@orama/orama": {
       "version": "3.1.18",
       "resolved": "https://registry.npmjs.org/@orama/orama/-/orama-3.1.18.tgz",
@@ -8142,6 +8306,12 @@
         "vitest": "4.1.9"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
@@ -8195,30 +8365,50 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.168",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.168.tgz",
-      "integrity": "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==",
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.15.tgz",
+      "integrity": "sha512-7406MUy9O5sIhwOgxEWuoj+td3XUGgG96SBt6pmBU4t4sQ2fpnDx5UnHaXT2HUTXl5GorbWz/MfCrSPRz0QJqw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.104",
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23",
-        "@opentelemetry/api": "1.9.0"
+        "@ai-sdk/gateway": "4.0.12",
+        "@ai-sdk/provider": "4.0.2",
+        "@ai-sdk/provider-utils": "5.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/ai/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+    "node_modules/ai/node_modules/@ai-sdk/provider": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.2.tgz",
+      "integrity": "sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=22"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.5.tgz",
+      "integrity": "sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.58",
-    "@ai-sdk/google": "^3.0.43",
-    "@ai-sdk/openai": "^3.0.41",
+    "@ai-sdk/anthropic": "^4.0.0",
+    "@ai-sdk/google": "^4.0.0",
+    "@ai-sdk/openai": "^4.0.2",
     "@ai-sdk/react": "^3.0.118",
     "@hookform/resolvers": "^4.1.3",
     "@huggingface/transformers": "^3.8.1",
@@ -71,7 +71,7 @@
     "@radix-ui/react-toast": "^1.2.18",
     "@radix-ui/react-tooltip": "^1.2.11",
     "@tanstack/react-virtual": "^3.14.5",
-    "ai": "^6.0.116",
+    "ai": "^7.0.15",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "comlink": "^4.4.2",


### PR DESCRIPTION
Closes #1216
Closes #1307
Child of #1301

## What
Bump `@ai-sdk/openai` to v4. v4 ships the new `LanguageModelV4` from `@ai-sdk/provider` v4, so the sibling packages and the streaming core (`ai`) need to move to their V4-compatible major versions too.

## Why
- v4 of `@ai-sdk/openai` depends on `@ai-sdk/provider@4.0.2` and returns `LanguageModelV4`. If `anthropic` / `google` stay at v3, their `createAnthropic` / `createGoogleGenerativeAI` calls return `LanguageModelV3`, and `getAIModel`'s dynamic-import-style return type collapses to the union `V4 | V3`, which no caller can satisfy.
- `ai@6.x` (streamText / streamObject) is the last major on V3; `ai@7.x` is the V4-aligned major.

## Changes
- `package.json` / `package-lock.json`:
  - `@ai-sdk/openai` `^3.0.41` → `^4.0.2`
  - `@ai-sdk/anthropic` `^3.0.58` → `^4.0.0`
  - `@ai-sdk/google` `^3.0.43` → `^4.0.0`
  - `ai` `^6.0.116` → `^7.0.15`

## No-code-change items
- `src/ai/providers/factory.ts` — `createOpenAI` is still exported in v4, so the existing factory code (lines 44, 67, 75) and the existing `createOpenAI({ apiKey })` calls keep working without source edits.
- `src/ai/providers/__tests__/factory.test.ts` and `src/ai/providers/factory.test.ts` — the jest/vitest mocks of `createOpenAI` keep working because the named export survives.

## Verification
- `npm run typecheck` → clean.
- `npm run lint` → 0 errors (baseline warnings only).
- `npx jest --ci` → **322 / 322 suites, 6 800 / 6 800 tests**.

## Closing comment for #1216
> Superseded by #<this-PR>; see #1301 for the migration plan.

## Summary by Sourcery

Update AI-related SDK dependencies to their v4-compatible majors and adopt ai v7 to align with LanguageModelV4.

Enhancements:
- Align anthropic, google, and openai SDK packages with provider v4 to ensure consistent LanguageModelV4 usage.

Build:
- Bump @ai-sdk/anthropic, @ai-sdk/google, @ai-sdk/openai, and ai package versions in package.json and lockfile to their latest v4/v7 releases.