### PR TITLE
fix: resolve #1240 — balance card-swap suggestions when adds exceed removes

### DIFF
--- a/src/ai/flows/__tests__/ai-meta-analysis.test.ts
+++ b/src/ai/flows/__tests__/ai-meta-analysis.test.ts
@@ -296,12 +296,14 @@ describe("analyzeMetaAndSuggest — quantity rebalancing", () => {
       (s, c) => s + c.quantity,
       0,
     );
-    // adds stayed at 2; removals (originally 5) were trimmed to <= adds.
+    // Issue #1240: adds and removes must net to an equal count for a valid
+    // 1-for-1 swap. adds stayed at 2; removals (originally 5) were trimmed
+    // down to match.
     expect(addCount).toBe(2);
-    expect(removeCount).toBeLessThanOrEqual(addCount);
+    expect(removeCount).toBe(2);
   });
 
-  it("leaves removals untouched when adds already meet or exceed them", async () => {
+  it("trims additions down to match removals when adds exceed removes (issue #1240)", async () => {
     mockedAnalyzeMeta.mockReturnValue(
       baseResult({
         recommendations: [
@@ -309,17 +311,89 @@ describe("analyzeMetaAndSuggest — quantity rebalancing", () => {
             title: "More Adds",
             description:
               "Your deck is naturally strong against Burn. Enhance this advantage.",
-            cardsToAdd: [{ name: "Bolt", quantity: 4 }],
+            cardsToAdd: [
+              { name: "Bolt", quantity: 3 },
+              { name: "Skullcrack", quantity: 2 },
+            ],
             cardsToRemove: [{ name: "Bad", quantity: 1 }],
             matchup: { against: "Burn", strategy: "Race" },
           },
         ],
       }),
     );
+
     const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
+    const addCount = out.cardSuggestions.cardsToAdd.reduce(
+      (s, c) => s + c.quantity,
+      0,
+    );
+    const removeCount = out.cardSuggestions.cardsToRemove.reduce(
+      (s, c) => s + c.quantity,
+      0,
+    );
+    // The pre-#1240 code only handled removeCount > addCount and let this
+    // case leak through, growing the deck above its legal size. Adds (5)
+    // must now be trimmed down to match the single removal.
+    expect(removeCount).toBe(1);
+    expect(addCount).toBe(1);
     expect(out.cardSuggestions.cardsToRemove).toEqual([
       { name: "Bad", quantity: 1, reason: expect.any(String) },
     ]);
+  });
+
+  it("keeps both lists in balance for representative constructed decklists", async () => {
+    // 60-card Modern shell where the heuristic overshoots on the add side —
+    // a classic case the pre-#1240 bug would have silently shipped as a
+    // 62-card deck suggestion.
+    mockedAnalyzeMeta.mockReturnValue(
+      baseResult({
+        recommendations: [
+          {
+            title: "Pressure Lifegain",
+            description:
+              "Your deck struggles against Tron. Address these weaknesses.",
+            cardsToAdd: [
+              { name: "Skullcrack", quantity: 3 },
+              { name: "Searing Blaze", quantity: 2 },
+            ],
+            cardsToRemove: [{ name: "Lava Spike", quantity: 1 }],
+            matchup: { against: "Tron", strategy: "Race them down" },
+          },
+        ],
+      }),
+    );
+
+    const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
+    const addCount = out.cardSuggestions.cardsToAdd.reduce(
+      (s, c) => s + c.quantity,
+      0,
+    );
+    const removeCount = out.cardSuggestions.cardsToRemove.reduce(
+      (s, c) => s + c.quantity,
+      0,
+    );
+    expect(addCount).toBe(removeCount);
+    expect(addCount).toBeGreaterThan(0);
+  });
+
+  it("produces no add/remove when both lists start empty", async () => {
+    mockedAnalyzeMeta.mockReturnValue(
+      baseResult({
+        recommendations: [
+          {
+            title: "No swap",
+            description:
+              "Your deck is naturally strong against Burn. Enhance this advantage.",
+            cardsToAdd: [],
+            cardsToRemove: [],
+            matchup: { against: "Burn", strategy: "Race" },
+          },
+        ],
+      }),
+    );
+    const out = await analyzeMetaAndSuggest({ decklist: DECKLIST, format: "modern" });
+    expect(out.cardSuggestions.cardsToAdd).toEqual([]);
+    expect(out.cardSuggestions.cardsToRemove).toEqual([]);
   });
 });
 

--- a/src/ai/flows/ai-meta-analysis.ts
+++ b/src/ai/flows/ai-meta-analysis.ts
@@ -216,13 +216,22 @@ async function buildHeuristicOutput(
     }
   }
 
-  // Ensure equal counts in card suggestions
-  const addCount = validatedOutput.cardSuggestions.cardsToAdd.reduce((sum, c) => sum + c.quantity, 0);
-  const removeCount = validatedOutput.cardSuggestions.cardsToRemove.reduce((sum, c) => sum + c.quantity, 0);
+  // Ensure equal counts in card suggestions. Constructed formats require a
+  // 1-for-1 swap: any imbalance between additions and removals would change
+  // the deck size. Issue #1240 made this rebalance symmetric — the previous
+  // implementation only trimmed removals when removeCount > addCount and let
+  // the inverse case leak through (e.g. a 60-card deck → 62 cards).
+  const sumQuantity = (cards: CardSuggestion[]): number =>
+    cards.reduce((sum, c) => sum + c.quantity, 0);
+
+  let addCount = sumQuantity(validatedOutput.cardSuggestions.cardsToAdd);
+  let removeCount = sumQuantity(validatedOutput.cardSuggestions.cardsToRemove);
 
   if (addCount !== removeCount) {
-    // Adjust removals to match additions
-    while (validatedOutput.cardSuggestions.cardsToRemove.reduce((sum, c) => sum + c.quantity, 0) > addCount) {
+    // Trim removals down to match additions when removals exceed adds.
+    while (
+      sumQuantity(validatedOutput.cardSuggestions.cardsToRemove) > addCount
+    ) {
       const last = validatedOutput.cardSuggestions.cardsToRemove.pop();
       if (last) {
         last.quantity = Math.max(0, last.quantity - 1);
@@ -230,6 +239,40 @@ async function buildHeuristicOutput(
           validatedOutput.cardSuggestions.cardsToRemove.push(last);
         }
       }
+    }
+    removeCount = sumQuantity(validatedOutput.cardSuggestions.cardsToRemove);
+
+    // Symmetric: trim additions down to match removals when adds exceed
+    // removals. Without this branch the heuristic could suggest a plan that
+    // grows the deck above its legal size, which is not actionable in any
+    // constructed format.
+    while (
+      sumQuantity(validatedOutput.cardSuggestions.cardsToAdd) > removeCount
+    ) {
+      const last = validatedOutput.cardSuggestions.cardsToAdd.pop();
+      if (last) {
+        last.quantity = Math.max(0, last.quantity - 1);
+        if (last.quantity > 0) {
+          validatedOutput.cardSuggestions.cardsToAdd.push(last);
+        }
+      }
+    }
+    addCount = sumQuantity(validatedOutput.cardSuggestions.cardsToAdd);
+  }
+
+  // Final invariant: addCount must equal removeCount whenever at least one
+  // side is non-empty. Both zero is a legitimate "no actionable swap" result.
+  if (
+    addCount !== removeCount &&
+    (addCount > 0 || removeCount > 0)
+  ) {
+    // Defensive: if quantities somehow became 0 on one side after trimming,
+    // collapse to the non-empty side so the returned plan is still a valid
+    // 1-for-1 swap.
+    if (addCount === 0 && removeCount > 0) {
+      validatedOutput.cardSuggestions.cardsToAdd = [];
+    } else if (removeCount === 0 && addCount > 0) {
+      validatedOutput.cardSuggestions.cardsToRemove = [];
     }
   }
 


### PR DESCRIPTION
## Summary by Sourcery

Enforce balanced 1-for-1 card swap suggestions in constructed formats by symmetrically trimming both additions and removals so deck size is preserved, and add tests covering over-add, empty-list, and representative deck scenarios.

Bug Fixes:
- Fix imbalance where suggested card additions could exceed removals, leading to illegal increased deck sizes in constructed formats.

Tests:
- Expand quantity rebalancing tests to cover cases where additions exceed removals, representative constructed decklists, and empty add/remove lists.