### PR TITLE
chore(ci): batch bump github actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           git config --global --add safe.directory '*'
       
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -64,7 +64,7 @@ jobs:
           git config --global --add safe.directory '*'
       
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -76,7 +76,7 @@ jobs:
         run: npm ci
       
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -127,7 +127,7 @@ jobs:
           git config --global --add safe.directory '*'
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -139,7 +139,7 @@ jobs:
         run: npm ci
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -202,7 +202,7 @@ jobs:
           git config --global --add safe.directory '*'
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -233,7 +233,7 @@ jobs:
           git config --global --add safe.directory '*'
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -266,7 +266,7 @@ jobs:
           git config --global --add safe.directory '*'
       
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -291,7 +291,7 @@ jobs:
           git config --global --add safe.directory '*'
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -326,7 +326,7 @@ jobs:
           git config --global --add safe.directory '*'
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -363,7 +363,7 @@ jobs:
           git config --global --add safe.directory '*'
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -392,13 +392,13 @@ jobs:
           git config --global --add safe.directory '*'
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo-audit install
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cargo/bin/cargo-audit
           key: cargo-audit-v0.22
@@ -474,7 +474,7 @@ jobs:
           git config --global --add safe.directory '*'
       
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,7 @@ jobs:
           git config --global --add safe.directory '*'
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         if: matrix.language == 'javascript-typescript'

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -51,7 +51,7 @@ jobs:
     if: github.event_name == 'release' || github.inputs.platform == 'all' || github.inputs.platform == 'ios'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -122,7 +122,7 @@ jobs:
     if: github.event_name == 'release' || github.inputs.platform == 'all' || github.inputs.platform == 'android'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -151,7 +151,7 @@ jobs:
           java-version: '17'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
+        uses: android-actions/setup-android@v4
 
       - name: Build Android App
         run: |
@@ -192,10 +192,10 @@ jobs:
     if: github.event_name == 'release'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -38,7 +38,7 @@ jobs:
           git config --global --add safe.directory '*'
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -120,7 +120,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -188,7 +188,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -285,10 +285,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/.github/workflows/video-derived-tests.yml
+++ b/.github/workflows/video-derived-tests.yml
@@ -31,7 +31,7 @@ jobs:
           git config --global --add safe.directory '*'
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -105,7 +105,7 @@ jobs:
 
       - name: Comment PR with results
         if: github.event_name == 'pull_request' && env.VIDEO_FIXTURES_COUNT > 0
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const count = process.env.VIDEO_FIXTURES_COUNT;
@@ -130,7 +130,7 @@ jobs:
 
       - name: Create issue on failure
         if: failure() && env.VIDEO_FIXTURES_COUNT > 0
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const count = process.env.VIDEO_FIXTURES_COUNT;
@@ -178,12 +178,12 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: video-derived-coverage
           path: coverage/


### PR DESCRIPTION
Combined dependabot version bumps for:
- actions/download-artifact 4 -> 8 (was #1314)
- actions/github-script 7 -> 9 (was #1315)
- android-actions/setup-android 2 -> 4 (was #1316)
- actions/checkout 4 -> 7 (was #1317)
- actions/cache 4 -> 6 (was #1318)

All five PRs only modified `.github/workflows/*.yml` files. Combining them into a single PR reduces CI minutes and review surface.

Supersedes #1314, #1315, #1316, #1317, #1318.

## Summary by Sourcery

Update GitHub Actions workflows to use newer versions of third-party actions across CI, release, mobile build, CodeQL, mutation, and video-derived test pipelines.

Build:
- Bump actions/checkout from v4 to v7 in all workflows.
- Bump actions/cache from v4 to v6 where used for Playwright and cargo-audit caching.
- Bump android-actions/setup-android from v2 to v4 in the mobile build workflow.
- Bump actions/download-artifact from v4 to v8 in release and test coverage workflows.
- Bump actions/github-script from v7 to v9 in video-derived test workflows.