### PR TITLE
chore(deps): migrate @hookform/resolvers to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ai-sdk/google": "^4.0.0",
         "@ai-sdk/openai": "^4.0.8",
         "@ai-sdk/react": "^3.0.118",
-        "@hookform/resolvers": "^4.1.3",
+        "@hookform/resolvers": "^5.4.0",
         "@huggingface/transformers": "^4.2.0",
         "@orama/orama": "^3.1.18",
         "@orama/plugin-data-persistence": "^3.1.18",
@@ -2479,15 +2479,15 @@
       }
     },
     "node_modules/@hookform/resolvers": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-4.1.3.tgz",
-      "integrity": "sha512-Jsv6UOWYTrEFJ/01ZrnwVXs7KDvP8XIo115i++5PWvNkNvkrsTfGiLS6w+eJ57CYtUtDQalUWovCZDHFJ8u1VQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
+      "integrity": "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/utils": "^0.3.0"
       },
       "peerDependencies": {
-        "react-hook-form": "^7.0.0"
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@huggingface/jinja": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@ai-sdk/google": "^4.0.0",
     "@ai-sdk/openai": "^4.0.8",
     "@ai-sdk/react": "^3.0.118",
-    "@hookform/resolvers": "^4.1.3",
+    "@hookform/resolvers": "^5.4.0",
     "@huggingface/transformers": "^4.2.0",
     "@orama/orama": "^3.1.18",
     "@orama/plugin-data-persistence": "^3.1.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.0.118
         version: 3.0.192(react@19.2.7)(zod@4.4.3)
       '@hookform/resolvers':
-        specifier: ^4.1.3
-        version: 4.1.3(react-hook-form@7.81.0(react@19.2.7))
+        specifier: ^5.4.0
+        version: 5.4.0(react-hook-form@7.81.0(react@19.2.7))
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0
@@ -1045,10 +1045,10 @@ packages:
   '@formatjs/intl-localematcher@0.8.10':
     resolution: {integrity: sha512-P/IC3qws3jH+1fEs+o0RIFgXKRaQlFehjS5W0FPAqdo6hgzawLl+eD0q0JjheQ3XtoOe5n8WSYfX06KQZI/QJA==}
 
-  '@hookform/resolvers@4.1.3':
-    resolution: {integrity: sha512-Jsv6UOWYTrEFJ/01ZrnwVXs7KDvP8XIo115i++5PWvNkNvkrsTfGiLS6w+eJ57CYtUtDQalUWovCZDHFJ8u1VQ==}
+  '@hookform/resolvers@5.4.0':
+    resolution: {integrity: sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==}
     peerDependencies:
-      react-hook-form: ^7.0.0
+      react-hook-form: ^7.55.0
 
   '@huggingface/jinja@0.5.9':
     resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
@@ -7537,7 +7537,7 @@ snapshots:
     dependencies:
       '@formatjs/fast-memoize': 3.1.6
 
-  '@hookform/resolvers@4.1.3(react-hook-form@7.81.0(react@19.2.7))':
+  '@hookform/resolvers@5.4.0(react-hook-form@7.81.0(react@19.2.7))':
     dependencies:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.81.0(react@19.2.7)


### PR DESCRIPTION
Bumps `@hookform/resolvers` from `^4.1.3` to `^5.4.0`.

## Summary

- Version bump in `package.json` (`^4.1.3` -> `^5.4.0`)
- Regenerated `package-lock.json` and `pnpm-lock.yaml`
- **No source code adaptations required**: the dependency is declared
  in `package.json` but is not imported anywhere in `src/` (only
  `react-hook-form` core is used via `src/components/ui/form.tsx`).

## v5 compatibility

v5 requires `react-hook-form@^7.55.0` (we have `7.81.0` ✓) and gained
Zod 4 support in v5.1.0 (we have `zod@^4.4.3` ✓). Per-validator
imports (`@hookform/resolvers/zod`) are now preferred over the root
import — not relevant here since the package isn't currently imported.

## Verification

- `pnpm typecheck` → No errors
- `pnpm test` → 362 suites / 7594 tests passing

Supersedes #1321. Pre-existing CI blockers on main are fixed in
ed8d192 and 7851fa1.

## Summary by Sourcery

Build:
- Bump @hookform/resolvers dependency from v4.1.3 to v5.4.0 and regenerate lockfiles.