### PR TITLE
chore(deps): migrate lucide-react to v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "dotenv": "^17.3.1",
         "embla-carousel-react": "^8.6.0",
         "lru-cache": "^11.5.1",
-        "lucide-react": "^0.575.0",
+        "lucide-react": "^1.23.0",
         "next": "^16.2.10",
         "next-intl": "^4.13.1",
         "pako": "^2.2.0",
@@ -18580,9 +18580,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.575.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.575.0.tgz",
-      "integrity": "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.23.0.tgz",
+      "integrity": "sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "dotenv": "^17.3.1",
     "embla-carousel-react": "^8.6.0",
     "lru-cache": "^11.5.1",
-    "lucide-react": "^0.575.0",
+    "lucide-react": "^1.23.0",
     "next": "^16.2.10",
     "next-intl": "^4.13.1",
     "pako": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,8 +129,8 @@ importers:
         specifier: ^11.5.1
         version: 11.5.1
       lucide-react:
-        specifier: ^0.575.0
-        version: 0.575.0(react@19.2.7)
+        specifier: ^1.23.0
+        version: 1.23.0(react@19.2.7)
       next:
         specifier: ^16.2.10
         version: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -5079,8 +5079,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@0.575.0:
-    resolution: {integrity: sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg==}
+  lucide-react@1.23.0:
+    resolution: {integrity: sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -11923,7 +11923,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.575.0(react@19.2.7):
+  lucide-react@1.23.0(react@19.2.7):
     dependencies:
       react: 19.2.7
 


### PR DESCRIPTION
Bumps lucide-react from ^0.575.0 to ^1.23.0.

## What changed
- package.json: `lucide-react` bumped to `^1.23.0`
- package-lock.json + pnpm-lock.yaml regenerated

## Code adaptations
**None.** A full audit of all 162 unique lucide-react imports across 145 source files shows every name is present in v1:
- 160 imports are direct v1 exports (e.g. `Activity`, `ArrowDown`, `FlaskConical`)
- The remaining 2 are local renames (`Skull as PoisonIcon`, used in `game-board.tsx` and `mobile-game-layout.tsx` for MTG poison counter UI) and the `type LucideIcon` type import — all of these still resolve in v1.

## v0 -> v1 breaking change review
The single notable breaking change is the **removal of brand icons** (Chromium, Codepen, Codesandbox, Dribbble, Facebook, Figma, Framer, Github, Gitlab, Instagram, LinkedIn, Pocket, RailSymbol, Slack). Verified that none of these are imported anywhere in `src/`.

## Verification
- `pnpm typecheck`: clean
- `pnpm test`: 362 suites / 7594 tests pass

Supersedes #1323 (dependabot PR closed when the batch PR #1361 was closed).

## Summary by Sourcery

Build:
- Update lucide-react dependency in package.json to ^1.23.0 and refresh package-lock.json and pnpm-lock.yaml to match.