### PR TITLE
chore(deps): migrate dexie-react-hooks to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "comlink": "^4.4.2",
         "date-fns": "^4.4.0",
         "dexie": "^4.4.4",
-        "dexie-react-hooks": "^1.1.7",
+        "dexie-react-hooks": "^4.4.0",
         "dotenv": "^17.3.1",
         "embla-carousel-react": "^8.6.0",
         "lru-cache": "^11.5.1",
@@ -8875,6 +8875,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -11408,13 +11409,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/dexie-react-hooks": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/dexie-react-hooks/-/dexie-react-hooks-1.1.7.tgz",
-      "integrity": "sha512-Lwv5W0Hk+uOW3kGnsU9GZoR1er1B7WQ5DSdonoNG+focTNeJbHW6vi6nBoX534VKI3/uwHebYzSw1fwY6a7mTw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/dexie-react-hooks/-/dexie-react-hooks-4.4.0.tgz",
+      "integrity": "sha512-ObLXBS5+4BJU8vtSvBx6b9fY6zZYgniAtwxzjCHsUQadgbqYN6935X2/1TWw4Rf2N1aZV1io5/ziox4vKuxABA==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@types/react": ">=16",
-        "dexie": "^3.2 || ^4.0.1-alpha",
+        "dexie": ">=4.2.0-alpha.1 <5.0.0",
         "react": ">=16"
       }
     },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "comlink": "^4.4.2",
     "date-fns": "^4.4.0",
     "dexie": "^4.4.4",
-    "dexie-react-hooks": "^1.1.7",
+    "dexie-react-hooks": "^4.4.0",
     "dotenv": "^17.3.1",
     "embla-carousel-react": "^8.6.0",
     "lru-cache": "^11.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,8 +117,8 @@ importers:
         specifier: ^4.4.4
         version: 4.4.4
       dexie-react-hooks:
-        specifier: ^1.1.7
-        version: 1.1.7(@types/react@19.2.17)(dexie@4.4.4)(react@19.2.7)
+        specifier: ^4.4.0
+        version: 4.4.0(dexie@4.4.4)(react@19.2.7)
       dotenv:
         specifier: ^17.3.1
         version: 17.4.2
@@ -3794,11 +3794,10 @@ packages:
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
-  dexie-react-hooks@1.1.7:
-    resolution: {integrity: sha512-Lwv5W0Hk+uOW3kGnsU9GZoR1er1B7WQ5DSdonoNG+focTNeJbHW6vi6nBoX534VKI3/uwHebYzSw1fwY6a7mTw==}
+  dexie-react-hooks@4.4.0:
+    resolution: {integrity: sha512-ObLXBS5+4BJU8vtSvBx6b9fY6zZYgniAtwxzjCHsUQadgbqYN6935X2/1TWw4Rf2N1aZV1io5/ziox4vKuxABA==}
     peerDependencies:
-      '@types/react': '>=16'
-      dexie: ^3.2 || ^4.0.1-alpha
+      dexie: '>=4.2.0-alpha.1 <5.0.0'
       react: '>=16'
 
   dexie@4.4.4:
@@ -10238,9 +10237,8 @@ snapshots:
 
   detect-node@2.1.0: {}
 
-  dexie-react-hooks@1.1.7(@types/react@19.2.17)(dexie@4.4.4)(react@19.2.7):
+  dexie-react-hooks@4.4.0(dexie@4.4.4)(react@19.2.7):
     dependencies:
-      '@types/react': 19.2.17
       dexie: 4.4.4
       react: 19.2.7
 


### PR DESCRIPTION
Bumps dexie-react-hooks from ^1.1.7 to ^4.4.0 (triple-major jump).

## Research findings
- `useLiveQuery` signature is **identical** between v1 and v4 (same overloads)
- v4 barrel adds `useDocument`, `useSuspendingLiveQuery`, `useSuspendingObservable` (purely additive)
- v4 peer dep `dexie: >=4.2.0-alpha.1 <5.0.0` is satisfied by current `dexie@^4.4.4`
- New dual ESM/CJS `exports` field for cleaner bundling
- Repository-wide grep finds **zero** source usages of the package, so no code adaptations were required

## Changes
- `package.json`: `dexie-react-hooks: ^1.1.7` -> `^4.4.0`
- `pnpm-lock.yaml`: regenerated via `pnpm install --lockfile-only`
- `package-lock.json`: regenerated via `npm install --package-lock-only`

## Verification
- `pnpm typecheck`: clean (no errors)
- `pnpm test`: 362 suites / 7594 tests pass

Supersedes #1322.

## Summary by Sourcery

Build:
- Bump dexie-react-hooks from ^1.1.7 to ^4.4.0 in package.json and regenerate pnpm and npm lockfiles to reflect the new version.