### PR TITLE
chore(deps): migrate recharts to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "react-day-picker": "^9.11.3",
         "react-dom": "^19.2.7",
         "react-hook-form": "^7.81.0",
-        "recharts": "^2.15.1",
+        "recharts": "^3.9.2",
         "tailwind-merge": "^3.6.0",
         "tailwindcss-animate": "^1.0.7",
         "use-debounce": "^10.0.1",
@@ -993,6 +993,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -7017,6 +7018,32 @@
       "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
@@ -8920,6 +8947,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -11031,6 +11064,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -11484,16 +11518,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/dotenv": {
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
@@ -11819,7 +11843,6 @@
       "version": "1.49.0",
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
       "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
-      "dev": true,
       "license": "MIT",
       "workspaces": [
         "docs",
@@ -12516,7 +12539,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/eventsource-parser": {
@@ -12645,15 +12667,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-equals": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
-      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -13617,6 +13630,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "11.1.11",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.11.tgz",
+      "integrity": "sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -18041,6 +18064,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -18387,12 +18411,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
     "node_modules/lodash.groupby": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
@@ -18562,6 +18580,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -20263,6 +20282,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -20274,6 +20294,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/protobufjs": {
@@ -20589,7 +20610,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -20608,6 +20628,29 @@
       "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -20656,21 +20699,6 @@
         }
       }
     },
-    "node_modules/react-smooth": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
-      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-equals": "^5.0.1",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -20691,22 +20719,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/read-cache": {
@@ -20731,48 +20743,34 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
-      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.2.tgz",
+      "integrity": "sha512-G4fy+Pk46RaXgwWMh+Nzhyo/lbFAVqXo9gtetlyehe6Ehge9CsgDuOTwQDD+i1+llaLktNBiNq4bhnGlDRXFtw==",
       "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
       "dependencies": {
-        "clsx": "^2.0.0",
-        "eventemitter3": "^4.0.1",
-        "lodash": "^4.17.21",
-        "react-is": "^18.3.1",
-        "react-smooth": "^4.0.4",
-        "recharts-scale": "^0.4.4",
-        "tiny-invariant": "^1.3.1",
-        "victory-vendor": "^36.6.8"
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^11.1.8",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
-    },
-    "node_modules/recharts-scale": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
-      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
-      "license": "MIT",
-      "dependencies": {
-        "decimal.js-light": "^2.4.1"
-      }
-    },
-    "node_modules/recharts/node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
-    },
-    "node_modules/recharts/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -20786,6 +20784,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -20856,6 +20869,12 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -23011,9 +23030,9 @@
       }
     },
     "node_modules/victory-vendor": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
-      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
       "license": "MIT AND ISC",
       "dependencies": {
         "@types/d3-array": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "react-day-picker": "^9.11.3",
     "react-dom": "^19.2.7",
     "react-hook-form": "^7.81.0",
-    "recharts": "^2.15.1",
+    "recharts": "^3.9.2",
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7",
     "use-debounce": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,8 +162,8 @@ importers:
         specifier: ^7.81.0
         version: 7.81.0(react@19.2.7)
       recharts:
-        specifier: ^2.15.1
-        version: 2.15.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^3.9.2
+        version: 3.9.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(redux@5.0.1)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -2492,6 +2492,17 @@ packages:
   '@radix-ui/rect@1.1.2':
     resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/binding-android-arm64@1.0.2':
     resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2994,6 +3005,9 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -3833,9 +3847,6 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dom-helpers@5.2.1:
-    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
-
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
@@ -4127,10 +4138,6 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
-  fast-equals@5.4.0:
-    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
-    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -4436,6 +4443,9 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  immer@11.1.11:
+    resolution: {integrity: sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -5054,9 +5064,6 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.18.1:
-    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
-
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
@@ -5634,6 +5641,18 @@ packages:
   react-is@19.2.7:
     resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
 
+  react-redux@9.3.0:
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -5654,12 +5673,6 @@ packages:
       '@types/react':
         optional: true
 
-  react-smooth@4.0.4:
-    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -5669,12 +5682,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  react-transition-group@4.4.5:
-    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
-    peerDependencies:
-      react: '>=16.6.0'
-      react-dom: '>=16.6.0'
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
@@ -5687,20 +5694,25 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
-  recharts-scale@0.4.5:
-    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
-
-  recharts@2.15.4:
-    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
-    engines: {node: '>=14'}
-    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
+  recharts@3.9.2:
+    resolution: {integrity: sha512-G4fy+Pk46RaXgwWMh+Nzhyo/lbFAVqXo9gtetlyehe6Ehge9CsgDuOTwQDD+i1+llaLktNBiNq4bhnGlDRXFtw==}
+    engines: {node: '>=18'}
     peerDependencies:
-      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -5720,6 +5732,9 @@ packages:
 
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -6383,8 +6398,8 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
-  victory-vendor@36.9.2:
-    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite@8.0.14:
     resolution: {integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==}
@@ -8986,6 +9001,18 @@ snapshots:
 
   '@radix-ui/rect@1.1.2': {}
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.11
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.2.0
+    optionalDependencies:
+      react: 19.2.7
+      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1)
+
   '@rolldown/binding-android-arm64@1.0.2':
     optional: true
 
@@ -9423,6 +9450,8 @@ snapshots:
   '@types/statuses@2.0.6': {}
 
   '@types/tough-cookie@4.0.5': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -10264,11 +10293,6 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dom-helpers@5.2.1:
-    dependencies:
-      '@babel/runtime': 7.29.2
-      csstype: 3.2.3
-
   dotenv@17.4.2: {}
 
   dpack@0.6.22: {}
@@ -10730,8 +10754,6 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-equals@5.4.0: {}
-
   fast-glob@3.3.1:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -11045,6 +11067,8 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  immer@11.1.11: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -11897,8 +11921,6 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.18.1: {}
-
   log-update@6.1.0:
     dependencies:
       ansi-escapes: 7.3.0
@@ -12469,6 +12491,15 @@ snapshots:
 
   react-is@19.2.7: {}
 
+  react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      redux: 5.0.1
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -12488,14 +12519,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  react-smooth@4.0.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      fast-equals: 5.4.0
-      prop-types: 15.8.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-transition-group: 4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-
   react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       get-nonce: 1.0.1
@@ -12503,15 +12526,6 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.17
-
-  react-transition-group@4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      '@babel/runtime': 7.29.2
-      dom-helpers: 5.2.1
-      loose-envify: 1.4.0
-      prop-types: 15.8.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   react@19.2.7: {}
 
@@ -12523,27 +12537,36 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
 
-  recharts-scale@0.4.5:
+  recharts@3.9.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(redux@5.0.1):
     dependencies:
-      decimal.js-light: 2.5.1
-
-  recharts@2.15.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)
       clsx: 2.1.1
-      eventemitter3: 4.0.7
-      lodash: 4.18.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.46.1
+      eventemitter3: 5.0.4
+      immer: 11.1.11
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      react-is: 18.3.1
-      react-smooth: 4.0.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      recharts-scale: 0.4.5
+      react-is: 19.2.7
+      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1)
+      reselect: 5.2.0
       tiny-invariant: 1.3.3
-      victory-vendor: 36.9.2
+      use-sync-external-store: 1.6.0(react@19.2.7)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
 
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -12570,6 +12593,8 @@ snapshots:
   require-from-string@2.0.2: {}
 
   require-main-filename@2.0.0: {}
+
+  reselect@5.2.0: {}
 
   resolve-cwd@3.0.0:
     dependencies:
@@ -13333,7 +13358,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  victory-vendor@36.9.2:
+  victory-vendor@37.3.6:
     dependencies:
       '@types/d3-array': 3.2.2
       '@types/d3-ease': 3.0.2

--- a/src/components/deck-statistics.tsx
+++ b/src/components/deck-statistics.tsx
@@ -1,9 +1,15 @@
-'use client';
+"use client";
 
-import { useState, useEffect, useCallback, useMemo, memo } from 'react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+import { useState, useEffect, useCallback, useMemo, memo } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import {
   TrendingUp,
   TrendingDown,
@@ -22,9 +28,9 @@ import {
   Plus,
   Minus as MinusIcon,
   Check,
-} from 'lucide-react';
-import { cn } from '@/lib/utils';
-import type { ManaCurveGap, DeckFormat } from '@/lib/deck-analyzer';
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ManaCurveGap, DeckFormat } from "@/lib/deck-analyzer";
 import {
   BarChart,
   Bar,
@@ -36,27 +42,27 @@ import {
   Pie,
   Cell,
   Legend,
-} from 'recharts';
+} from "recharts";
 
 // Magic color hex codes for charts
 const MAGIC_COLOR_HEX: Record<string, string> = {
-  W: '#F9F99A',
-  U: '#0E68AB',
-  B: '#150B00',
-  R: '#E12D2D',
-  G: '#00733E',
-  Colorless: '#9CA3AF',
+  W: "#F9F99A",
+  U: "#0E68AB",
+  B: "#150B00",
+  R: "#E12D2D",
+  G: "#00733E",
+  Colorless: "#9CA3AF",
 };
 
 // Card type colors for charts
 const TYPE_COLORS: Record<string, string> = {
-  Creature: '#8B5CF6',
-  Instant: '#3B82F6',
-  Sorcery: '#EF4444',
-  Enchantment: '#F59E0B',
-  Artifact: '#6B7280',
-  Planeswalker: '#EC4899',
-  Land: '#10B981',
+  Creature: "#8B5CF6",
+  Instant: "#3B82F6",
+  Sorcery: "#EF4444",
+  Enchantment: "#F59E0B",
+  Artifact: "#6B7280",
+  Planeswalker: "#EC4899",
+  Land: "#10B981",
 };
 
 // Deck statistics types
@@ -65,7 +71,7 @@ export interface DeckRecord {
   deckId: string;
   deckName: string;
   format: string;
-  result: 'win' | 'loss' | 'draw';
+  result: "win" | "loss" | "draw";
   opponentName?: string;
   date: number;
   duration?: number; // in seconds
@@ -88,7 +94,8 @@ export interface DeckStatistics {
 }
 
 // Color types for card analysis
-export type CardColor = 'white' | 'blue' | 'black' | 'red' | 'green' | 'colorless';
+export type CardColor =
+  "white" | "blue" | "black" | "red" | "green" | "colorless";
 
 export interface CardAnalysis {
   totalCards: number;
@@ -104,7 +111,6 @@ function calculateWinRate(wins: number, total: number): number {
   return Math.round((wins / total) * 100);
 }
 
-
 // Deck statistics display component.
 //
 // Wrapped in `React.memo` (default shallow-equality) — the analytics dashboard
@@ -116,11 +122,14 @@ interface DeckStatisticsCardProps {
   className?: string;
 }
 
-export const DeckStatisticsCard = memo(function DeckStatisticsCard({ stats, className }: DeckStatisticsCardProps) {
+export const DeckStatisticsCard = memo(function DeckStatisticsCard({
+  stats,
+  className,
+}: DeckStatisticsCardProps) {
   const winRateTrend = useMemo(() => {
     // Calculate recent 5 games win rate vs overall
     const recentGames = stats.records.slice(-5);
-    const recentWins = recentGames.filter(r => r.result === 'win').length;
+    const recentWins = recentGames.filter((r) => r.result === "win").length;
     const recentWinRate = calculateWinRate(recentWins, recentGames.length);
     return recentWinRate - stats.winRate;
   }, [stats]);
@@ -133,29 +142,43 @@ export const DeckStatisticsCard = memo(function DeckStatisticsCard({ stats, clas
           <Badge variant="outline">{stats.format}</Badge>
         </CardTitle>
         <CardDescription>
-          Last played: {stats.lastPlayed ? new Date(stats.lastPlayed).toLocaleDateString() : 'Never'}
+          Last played:{" "}
+          {stats.lastPlayed
+            ? new Date(stats.lastPlayed).toLocaleDateString()
+            : "Never"}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         {/* Win rate display */}
         <div className="flex items-center justify-center">
           <div className="text-center">
-            <div className={cn(
-              'text-4xl font-bold',
-              stats.winRate >= 60 ? 'text-green-500' : 
-              stats.winRate >= 40 ? 'text-yellow-500' : 'text-red-500'
-            )}>
+            <div
+              className={cn(
+                "text-4xl font-bold",
+                stats.winRate >= 60
+                  ? "text-green-500"
+                  : stats.winRate >= 40
+                    ? "text-yellow-500"
+                    : "text-red-500",
+              )}
+            >
               {stats.winRate}%
             </div>
             <div className="text-sm text-muted-foreground">
               Win Rate ({stats.totalGames} games)
             </div>
             {winRateTrend !== 0 && (
-              <div className={cn(
-                'flex items-center justify-center gap-1 text-sm mt-1',
-                winRateTrend > 0 ? 'text-green-500' : 'text-red-500'
-              )}>
-                {winRateTrend > 0 ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
+              <div
+                className={cn(
+                  "flex items-center justify-center gap-1 text-sm mt-1",
+                  winRateTrend > 0 ? "text-green-500" : "text-red-500",
+                )}
+              >
+                {winRateTrend > 0 ? (
+                  <TrendingUp className="w-3 h-3" />
+                ) : (
+                  <TrendingDown className="w-3 h-3" />
+                )}
                 {Math.abs(winRateTrend)}% recent trend
               </div>
             )}
@@ -173,7 +196,9 @@ export const DeckStatisticsCard = memo(function DeckStatisticsCard({ stats, clas
             <div className="text-xs text-muted-foreground">Losses</div>
           </div>
           <div className="p-2 rounded bg-yellow-500/10">
-            <div className="text-xl font-bold text-yellow-500">{stats.draws}</div>
+            <div className="text-xl font-bold text-yellow-500">
+              {stats.draws}
+            </div>
             <div className="text-xs text-muted-foreground">Draws</div>
           </div>
         </div>
@@ -181,7 +206,8 @@ export const DeckStatisticsCard = memo(function DeckStatisticsCard({ stats, clas
         {/* Average game duration */}
         {stats.averageGameDuration > 0 && (
           <div className="text-center text-sm text-muted-foreground">
-            Average game: {Math.floor(stats.averageGameDuration / 60)}m {Math.round(stats.averageGameDuration % 60)}s
+            Average game: {Math.floor(stats.averageGameDuration / 60)}m{" "}
+            {Math.round(stats.averageGameDuration % 60)}s
           </div>
         )}
       </CardContent>
@@ -199,15 +225,37 @@ interface ColorDistributionChartProps {
   className?: string;
 }
 
-export function ColorDistributionChart({ distribution, className }: ColorDistributionChartProps) {
-  const colorConfig: Record<string, { color: string; icon: React.ReactNode }> = {
-    white: { color: 'bg-yellow-100 border-yellow-400', icon: <Shield className="w-4 h-4 text-yellow-600" /> },
-    blue: { color: 'bg-blue-100 border-blue-400', icon: <Droplets className="w-4 h-4 text-blue-600" /> },
-    black: { color: 'bg-gray-200 border-gray-500', icon: <Skull className="w-4 h-4 text-gray-700" /> },
-    red: { color: 'bg-red-100 border-red-400', icon: <Flame className="w-4 h-4 text-red-600" /> },
-    green: { color: 'bg-green-100 border-green-400', icon: <Activity className="w-4 h-4 text-green-600" /> },
-    colorless: { color: 'bg-slate-100 border-slate-400', icon: <Minus className="w-4 h-4 text-slate-600" /> },
-  };
+export function ColorDistributionChart({
+  distribution,
+  className,
+}: ColorDistributionChartProps) {
+  const colorConfig: Record<string, { color: string; icon: React.ReactNode }> =
+    {
+      white: {
+        color: "bg-yellow-100 border-yellow-400",
+        icon: <Shield className="w-4 h-4 text-yellow-600" />,
+      },
+      blue: {
+        color: "bg-blue-100 border-blue-400",
+        icon: <Droplets className="w-4 h-4 text-blue-600" />,
+      },
+      black: {
+        color: "bg-gray-200 border-gray-500",
+        icon: <Skull className="w-4 h-4 text-gray-700" />,
+      },
+      red: {
+        color: "bg-red-100 border-red-400",
+        icon: <Flame className="w-4 h-4 text-red-600" />,
+      },
+      green: {
+        color: "bg-green-100 border-green-400",
+        icon: <Activity className="w-4 h-4 text-green-600" />,
+      },
+      colorless: {
+        color: "bg-slate-100 border-slate-400",
+        icon: <Minus className="w-4 h-4 text-slate-600" />,
+      },
+    };
 
   const total = Object.values(distribution).reduce((a, b) => a + b, 0);
 
@@ -223,20 +271,30 @@ export function ColorDistributionChart({ distribution, className }: ColorDistrib
         {Object.entries(distribution).map(([color, count]) => {
           const config = colorConfig[color] || colorConfig.colorless;
           const percentage = total > 0 ? Math.round((count / total) * 100) : 0;
-          
+
           return (
             <div key={color} className="flex items-center gap-2">
-              <div className={cn('w-8 h-8 rounded flex items-center justify-center', config.color)}>
+              <div
+                className={cn(
+                  "w-8 h-8 rounded flex items-center justify-center",
+                  config.color,
+                )}
+              >
                 {config.icon}
               </div>
               <div className="flex-1">
                 <div className="flex justify-between text-sm">
                   <span className="capitalize">{color}</span>
-                  <span className="text-muted-foreground">{count} ({percentage}%)</span>
+                  <span className="text-muted-foreground">
+                    {count} ({percentage}%)
+                  </span>
                 </div>
                 <div className="h-2 bg-muted rounded-full overflow-hidden">
-                  <div 
-                    className={cn('h-full transition-all', config.color.split(' ')[0])}
+                  <div
+                    className={cn(
+                      "h-full transition-all",
+                      config.color.split(" ")[0],
+                    )}
                     style={{ width: `${percentage}%` }}
                   />
                 </div>
@@ -298,9 +356,9 @@ interface ManaCurveChartProps {
 
 // Map a gap to a bar fill color.
 function gapFill(gap: ManaCurveGap | undefined): string {
-  if (!gap) return 'hsl(var(--primary))';
-  if (gap.difference > 0) return '#f59e0b'; // too few — amber
-  return '#ef4444'; // too many — red
+  if (!gap) return "hsl(var(--primary))";
+  if (gap.difference > 0) return "#f59e0b"; // too few — amber
+  return "#ef4444"; // too many — red
 }
 
 export const ManaCurveChart = memo(function ManaCurveChart({
@@ -323,7 +381,10 @@ export const ManaCurveChart = memo(function ManaCurveChart({
       const interactive = Array.isArray(gaps) || !!optimalTargets;
       if (!interactive) {
         // Fill in default `fill` when caller pre-computed bare data only.
-        return base.map((d) => ({ ...d, fill: d.fill ?? 'hsl(var(--primary))' }));
+        return base.map((d) => ({
+          ...d,
+          fill: d.fill ?? "hsl(var(--primary))",
+        }));
       }
       const gapByCmc = new Map<number, ManaCurveGap>();
       (gaps || []).forEach((g) => gapByCmc.set(g.cmc, g));
@@ -345,12 +406,12 @@ export const ManaCurveChart = memo(function ManaCurveChart({
         const gap = gapByCmc.get(cmcNum);
         const target = optimalTargets?.[cmcNum];
         return {
-          cmc: cmcNum >= 7 ? '7+' : cmc,
+          cmc: cmcNum >= 7 ? "7+" : cmc,
           cmcNum,
           count,
           target,
           gap,
-          fill: gap ? gapFill(gap) : 'hsl(var(--primary))',
+          fill: gap ? gapFill(gap) : "hsl(var(--primary))",
         };
       });
   }, [dataProp, manaCurve, gaps, optimalTargets]);
@@ -386,48 +447,65 @@ export const ManaCurveChart = memo(function ManaCurveChart({
         </CardTitle>
         {interactive && (
           <CardDescription className="text-xs">
-            Click a bar for add/cut suggestions. Amber = too few, red = too many.
+            Click a bar for add/cut suggestions. Amber = too few, red = too
+            many.
           </CardDescription>
         )}
       </CardHeader>
       <CardContent className="space-y-3">
         <div aria-hidden="true">
           <ResponsiveContainer width="100%" height={200}>
-            <BarChart data={data} margin={{ top: 10, right: 10, left: -10, bottom: 0 }}>
+            <BarChart
+              data={data}
+              margin={{ top: 10, right: 10, left: -10, bottom: 0 }}
+            >
               <XAxis
                 dataKey="cmc"
                 tick={{ fontSize: 12 }}
                 tickLine={false}
-                axisLine={{ stroke: 'hsl(var(--border))' }}
+                axisLine={{ stroke: "hsl(var(--border))" }}
               />
               <YAxis
                 tick={{ fontSize: 12 }}
                 tickLine={false}
-                axisLine={{ stroke: 'hsl(var(--border))' }}
+                axisLine={{ stroke: "hsl(var(--border))" }}
                 width={30}
               />
               <Tooltip
                 contentStyle={{
-                  backgroundColor: 'hsl(var(--card))',
-                  border: '1px solid hsl(var(--border))',
-                  borderRadius: '8px',
+                  backgroundColor: "hsl(var(--card))",
+                  border: "1px solid hsl(var(--border))",
+                  borderRadius: "8px",
                 }}
-                formatter={(value: number, _name: string, props: { payload?: { target?: number; gap?: ManaCurveGap } }) => {
-                  const target = props?.payload?.target;
-                  const lines = [`${value} cards`];
-                  if (typeof target === 'number') lines.push(`Target: ~${target}`);
-                  return [lines.join(' • '), 'Count'];
+                formatter={(value, _name, item) => {
+                  // recharts v3: value is `ValueType | undefined`; the data
+                  // point with our custom fields now lives on `item.payload`.
+                  const numericValue =
+                    typeof value === "number" ? value : Number(value);
+                  const target = (
+                    item?.payload as { target?: number } | undefined
+                  )?.target;
+                  const lines = [`${numericValue} cards`];
+                  if (typeof target === "number")
+                    lines.push(`Target: ~${target}`);
+                  return [lines.join(" • "), "Count"];
                 }}
               />
               <Bar
                 dataKey="count"
                 radius={[4, 4, 0, 0]}
-                cursor={interactive ? 'pointer' : undefined}
+                cursor={interactive ? "pointer" : undefined}
                 onClick={
                   interactive
-                    ? (payload: { cmcNum?: number }) => {
-                        if (payload && typeof payload.cmcNum === 'number') {
-                          setSelectedCmc(payload.cmcNum);
+                    ? (data) => {
+                        // recharts v3: BarMouseEvent passes `BarRectangleItem`,
+                        // not the raw chart datum; the original datum is
+                        // available on `data.payload`.
+                        const cmcNum = (
+                          data?.payload as { cmcNum?: number } | undefined
+                        )?.cmcNum;
+                        if (typeof cmcNum === "number") {
+                          setSelectedCmc(cmcNum);
                         }
                       }
                     : undefined
@@ -437,7 +515,11 @@ export const ManaCurveChart = memo(function ManaCurveChart({
                   <Cell
                     key={`cell-${index}`}
                     fill={entry.fill}
-                    opacity={selectedCmc == null || selectedCmc === entry.cmcNum ? 1 : 0.4}
+                    opacity={
+                      selectedCmc == null || selectedCmc === entry.cmcNum
+                        ? 1
+                        : 0.4
+                    }
                   />
                 ))}
               </Bar>
@@ -445,7 +527,9 @@ export const ManaCurveChart = memo(function ManaCurveChart({
           </ResponsiveContainer>
         </div>
         <table className="sr-only">
-          <caption>Mana curve: number of cards at each converted mana cost</caption>
+          <caption>
+            Mana curve: number of cards at each converted mana cost
+          </caption>
           <thead>
             <tr>
               <th scope="col">Converted Mana Cost</th>
@@ -467,17 +551,19 @@ export const ManaCurveChart = memo(function ManaCurveChart({
           <div className="rounded-md border bg-muted/40 p-3 text-sm">
             <div className="flex items-center justify-between gap-2">
               <span className="font-medium capitalize">
-                {selectedCmc >= 7 ? '7+ CMC' : `${selectedCmc}-drop`} spells
+                {selectedCmc >= 7 ? "7+ CMC" : `${selectedCmc}-drop`} spells
               </span>
               <Badge variant="outline">
-                {selectedDetail.count} / target ~{selectedDetail.target ?? '—'}
+                {selectedDetail.count} / target ~{selectedDetail.target ?? "—"}
               </Badge>
             </div>
             {selectedGap ? (
               <div
                 className={cn(
-                  'mt-2 flex items-start gap-2',
-                  selectedGap.difference > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-red-600 dark:text-red-400',
+                  "mt-2 flex items-start gap-2",
+                  selectedGap.difference > 0
+                    ? "text-amber-600 dark:text-amber-400"
+                    : "text-red-600 dark:text-red-400",
                 )}
               >
                 {selectedGap.difference > 0 ? (
@@ -486,11 +572,12 @@ export const ManaCurveChart = memo(function ManaCurveChart({
                   <MinusIcon className="w-4 h-4 mt-0.5 shrink-0" />
                 )}
                 <span>
-                  {selectedGap.difference > 0 ? 'Add' : 'Cut'}{' '}
+                  {selectedGap.difference > 0 ? "Add" : "Cut"}{" "}
                   {Math.abs(selectedGap.difference) <= 1
                     ? Math.abs(selectedGap.difference)
-                    : `${Math.max(1, Math.abs(selectedGap.difference) - 1)}-${Math.abs(selectedGap.difference)}`}{' '}
-                  {selectedGap.difference > 0 ? 'more' : 'fewer'} to reach the optimal {format} curve.
+                    : `${Math.max(1, Math.abs(selectedGap.difference) - 1)}-${Math.abs(selectedGap.difference)}`}{" "}
+                  {selectedGap.difference > 0 ? "more" : "fewer"} to reach the
+                  optimal {format} curve.
                 </span>
               </div>
             ) : (
@@ -537,11 +624,16 @@ interface CardTypeChartProps {
   typeDistribution?: Record<string, number>;
   /** Pre-computed chart data. Takes precedence over `typeDistribution`. */
   data?: readonly CardTypeChartDatum[];
-  chartType?: 'pie' | 'bar';
+  chartType?: "pie" | "bar";
   className?: string;
 }
 
-export const CardTypeChart = memo(function CardTypeChart({ typeDistribution, data: dataProp, chartType = 'pie', className }: CardTypeChartProps) {
+export const CardTypeChart = memo(function CardTypeChart({
+  typeDistribution,
+  data: dataProp,
+  chartType = "pie",
+  className,
+}: CardTypeChartProps) {
   // Convert type distribution to array format for Recharts.
   // When `data` is pre-computed by the parent (deck-stats panel pattern from
   // issue #1248), skip the conversion entirely so the chart's `React.memo`
@@ -557,7 +649,7 @@ export const CardTypeChart = memo(function CardTypeChart({ typeDistribution, dat
         type: type.charAt(0).toUpperCase() + type.slice(1),
         count,
         percentage: total > 0 ? Math.round((count / total) * 100) : 0,
-        fill: TYPE_COLORS[type] || '#6B7280',
+        fill: TYPE_COLORS[type] || "#6B7280",
       }));
   }, [dataProp, typeDistribution]);
 
@@ -581,7 +673,9 @@ export const CardTypeChart = memo(function CardTypeChart({ typeDistribution, dat
   // Screen-reader text alternative mirroring the chart data (WCAG 1.1.1)
   const typeDataTable = (
     <table className="sr-only">
-      <caption>Card type breakdown: number and percentage of cards by type</caption>
+      <caption>
+        Card type breakdown: number and percentage of cards by type
+      </caption>
       <thead>
         <tr>
           <th scope="col">Card Type</th>
@@ -601,7 +695,7 @@ export const CardTypeChart = memo(function CardTypeChart({ typeDistribution, dat
     </table>
   );
 
-  if (chartType === 'bar') {
+  if (chartType === "bar") {
     return (
       <Card className={className}>
         <CardHeader>
@@ -612,39 +706,44 @@ export const CardTypeChart = memo(function CardTypeChart({ typeDistribution, dat
         <CardContent>
           <div aria-hidden="true">
             <ResponsiveContainer width="100%" height={200}>
-              <BarChart data={data} layout="vertical" margin={{ top: 10, right: 30, left: 60, bottom: 0 }}>
-              <XAxis
-                type="number"
-                tick={{ fontSize: 12 }}
-                tickLine={false}
-                axisLine={{ stroke: 'hsl(var(--border))' }}
-              />
-              <YAxis
-                type="category"
-                dataKey="type"
-                tick={{ fontSize: 12 }}
-                tickLine={false}
-                axisLine={{ stroke: 'hsl(var(--border))' }}
-                width={60}
-              />
-              <Tooltip
-                contentStyle={{
-                  backgroundColor: 'hsl(var(--card))',
-                  border: '1px solid hsl(var(--border))',
-                  borderRadius: '8px',
-                }}
-                formatter={(value: number, name: string) => [
-                  `${value} cards`,
-                  name === 'count' ? 'Count' : name,
-                ]}
-              />
-              <Bar dataKey="count" radius={[0, 4, 4, 0]}>
-                {data.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.fill} />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+              <BarChart
+                data={data}
+                layout="vertical"
+                margin={{ top: 10, right: 30, left: 60, bottom: 0 }}
+              >
+                <XAxis
+                  type="number"
+                  tick={{ fontSize: 12 }}
+                  tickLine={false}
+                  axisLine={{ stroke: "hsl(var(--border))" }}
+                />
+                <YAxis
+                  type="category"
+                  dataKey="type"
+                  tick={{ fontSize: 12 }}
+                  tickLine={false}
+                  axisLine={{ stroke: "hsl(var(--border))" }}
+                  width={60}
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: "hsl(var(--card))",
+                    border: "1px solid hsl(var(--border))",
+                    borderRadius: "8px",
+                  }}
+                  formatter={(value, name) => [
+                    // recharts v3: value is `ValueType | undefined`.
+                    `${typeof value === "number" ? value : Number(value ?? 0)} cards`,
+                    name === "count" ? "Count" : name,
+                  ]}
+                />
+                <Bar dataKey="count" radius={[0, 4, 4, 0]}>
+                  {data.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={entry.fill} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
           </div>
           {typeDataTable}
         </CardContent>
@@ -671,7 +770,14 @@ export const CardTypeChart = memo(function CardTypeChart({ typeDistribution, dat
                 outerRadius={80}
                 dataKey="count"
                 nameKey="type"
-                label={({ type, percentage }) => `${type}: ${percentage}%`}
+                // recharts v3: label is `PieLabelRenderProps`; the original
+                // datum (with our custom `type`/`percentage` fields) is on
+                // `payload`.
+                label={({ payload }) => {
+                  const datum = payload as
+                    { type?: string; percentage?: number } | undefined;
+                  return `${datum?.type ?? ""}: ${datum?.percentage ?? 0}%`;
+                }}
                 labelLine={false}
               >
                 {data.map((entry, index) => (
@@ -680,11 +786,15 @@ export const CardTypeChart = memo(function CardTypeChart({ typeDistribution, dat
               </Pie>
               <Tooltip
                 contentStyle={{
-                  backgroundColor: 'hsl(var(--card))',
-                  border: '1px solid hsl(var(--border))',
-                  borderRadius: '8px',
+                  backgroundColor: "hsl(var(--card))",
+                  border: "1px solid hsl(var(--border))",
+                  borderRadius: "8px",
                 }}
-                formatter={(value: number) => [`${value} cards`, 'Count']}
+                formatter={(value) => [
+                  // recharts v3: value is `ValueType | undefined`.
+                  `${typeof value === "number" ? value : Number(value ?? 0)} cards`,
+                  "Count",
+                ]}
               />
               <Legend />
             </PieChart>
@@ -721,7 +831,11 @@ interface DeckColorChartProps {
   className?: string;
 }
 
-export const DeckColorChart = memo(function DeckColorChart({ colorDistribution, data: dataProp, className }: DeckColorChartProps) {
+export const DeckColorChart = memo(function DeckColorChart({
+  colorDistribution,
+  data: dataProp,
+  className,
+}: DeckColorChartProps) {
   // Convert color distribution to array format for Recharts.
   // When `data` is pre-computed by the parent (deck-stats panel pattern from
   // issue #1248), skip the conversion entirely so the chart's `React.memo`
@@ -743,12 +857,12 @@ export const DeckColorChart = memo(function DeckColorChart({ colorDistribution, 
 
   // Color name mapping for display
   const colorNames: Record<string, string> = {
-    W: 'White',
-    U: 'Blue',
-    B: 'Black',
-    R: 'Red',
-    G: 'Green',
-    Colorless: 'Colorless',
+    W: "White",
+    U: "Blue",
+    B: "Black",
+    R: "Red",
+    G: "Green",
+    Colorless: "Colorless",
   };
 
   if (data.length === 0) {
@@ -787,27 +901,46 @@ export const DeckColorChart = memo(function DeckColorChart({ colorDistribution, 
                 outerRadius={90}
                 dataKey="count"
                 nameKey="color"
-                label={({ color, percentage }) => `${colorNames[color] || color}: ${percentage}%`}
+                // recharts v3: label is `PieLabelRenderProps`; the original
+                // datum (with our custom `color`/`percentage` fields) is on
+                // `payload`.
+                label={({ payload }) => {
+                  const datum = payload as
+                    { color?: string; percentage?: number } | undefined;
+                  const color = datum?.color ?? "";
+                  return `${colorNames[color] || color}: ${datum?.percentage ?? 0}%`;
+                }}
                 labelLine={false}
               >
                 {data.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.fill} stroke="hsl(var(--card))" strokeWidth={2} />
+                  <Cell
+                    key={`cell-${index}`}
+                    fill={entry.fill}
+                    stroke="hsl(var(--card))"
+                    strokeWidth={2}
+                  />
                 ))}
               </Pie>
               <Tooltip
                 contentStyle={{
-                  backgroundColor: 'hsl(var(--card))',
-                  border: '1px solid hsl(var(--border))',
-                  borderRadius: '8px',
+                  backgroundColor: "hsl(var(--card))",
+                  border: "1px solid hsl(var(--border))",
+                  borderRadius: "8px",
                 }}
-                formatter={(value: number) => [`${value} cards`, 'Count']}
+                formatter={(value) => [
+                  // recharts v3: value is `ValueType | undefined`.
+                  `${typeof value === "number" ? value : Number(value ?? 0)} cards`,
+                  "Count",
+                ]}
               />
               <Legend />
             </PieChart>
           </ResponsiveContainer>
         </div>
         <table className="sr-only">
-          <caption>Color distribution: number and percentage of cards by color</caption>
+          <caption>
+            Color distribution: number and percentage of cards by color
+          </caption>
           <thead>
             <tr>
               <th scope="col">Color</th>
@@ -836,7 +969,10 @@ interface MatchHistoryTableProps {
   className?: string;
 }
 
-export function MatchHistoryTable({ records, className }: MatchHistoryTableProps) {
+export function MatchHistoryTable({
+  records,
+  className,
+}: MatchHistoryTableProps) {
   const sortedRecords = [...records].sort((a, b) => b.date - a.date);
 
   return (
@@ -860,13 +996,20 @@ export function MatchHistoryTable({ records, className }: MatchHistoryTableProps
                 className="flex items-center justify-between p-2 rounded bg-muted"
               >
                 <div className="flex items-center gap-2">
-                  <Badge className={cn(
-                    record.result === 'win' ? 'bg-green-500' : 
-                    record.result === 'loss' ? 'bg-red-500' : 'bg-yellow-500'
-                  )}>
+                  <Badge
+                    className={cn(
+                      record.result === "win"
+                        ? "bg-green-500"
+                        : record.result === "loss"
+                          ? "bg-red-500"
+                          : "bg-yellow-500",
+                    )}
+                  >
                     {record.result.toUpperCase()}
                   </Badge>
-                  <span className="text-sm">{record.opponentName || 'Unknown opponent'}</span>
+                  <span className="text-sm">
+                    {record.opponentName || "Unknown opponent"}
+                  </span>
                 </div>
                 <div className="text-xs text-muted-foreground">
                   {new Date(record.date).toLocaleDateString()}
@@ -894,35 +1037,37 @@ export function DeckAnalytics({ statistics, className }: DeckAnalyticsProps) {
     const totalWins = statistics.reduce((sum, s) => sum + s.wins, 0);
     const totalLosses = statistics.reduce((sum, s) => sum + s.losses, 0);
     const totalDraws = statistics.reduce((sum, s) => sum + s.draws, 0);
-    
+
     return {
       totalGames,
       totalWins,
       totalLosses,
       totalDraws,
-      overallWinRate: calculateWinRate(totalWins, totalGames)
+      overallWinRate: calculateWinRate(totalWins, totalGames),
     };
   }, [statistics]);
 
   // Get best/worst decks
   const { bestDeck, worstDeck } = useMemo(() => {
     if (statistics.length === 0) return { bestDeck: null, worstDeck: null };
-    
+
     const sorted = [...statistics].sort((a, b) => b.winRate - a.winRate);
     return {
       bestDeck: sorted[0],
-      worstDeck: sorted[sorted.length - 1]
+      worstDeck: sorted[sorted.length - 1],
     };
   }, [statistics]);
 
   return (
-    <div className={cn('space-y-6', className)}>
+    <div className={cn("space-y-6", className)}>
       {/* Overview stats */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <Card>
           <CardContent className="pt-6">
             <div className="text-center">
-              <div className="text-3xl font-bold">{overallStats.totalGames}</div>
+              <div className="text-3xl font-bold">
+                {overallStats.totalGames}
+              </div>
               <div className="text-sm text-muted-foreground">Total Games</div>
             </div>
           </CardContent>
@@ -930,7 +1075,9 @@ export function DeckAnalytics({ statistics, className }: DeckAnalyticsProps) {
         <Card>
           <CardContent className="pt-6">
             <div className="text-center">
-              <div className="text-3xl font-bold text-green-500">{overallStats.totalWins}</div>
+              <div className="text-3xl font-bold text-green-500">
+                {overallStats.totalWins}
+              </div>
               <div className="text-sm text-muted-foreground">Wins</div>
             </div>
           </CardContent>
@@ -938,7 +1085,9 @@ export function DeckAnalytics({ statistics, className }: DeckAnalyticsProps) {
         <Card>
           <CardContent className="pt-6">
             <div className="text-center">
-              <div className="text-3xl font-bold text-red-500">{overallStats.totalLosses}</div>
+              <div className="text-3xl font-bold text-red-500">
+                {overallStats.totalLosses}
+              </div>
               <div className="text-sm text-muted-foreground">Losses</div>
             </div>
           </CardContent>
@@ -946,11 +1095,16 @@ export function DeckAnalytics({ statistics, className }: DeckAnalyticsProps) {
         <Card>
           <CardContent className="pt-6">
             <div className="text-center">
-              <div className={cn(
-                'text-3xl font-bold',
-                overallStats.overallWinRate >= 60 ? 'text-green-500' : 
-                overallStats.overallWinRate >= 40 ? 'text-yellow-500' : 'text-red-500'
-              )}>
+              <div
+                className={cn(
+                  "text-3xl font-bold",
+                  overallStats.overallWinRate >= 60
+                    ? "text-green-500"
+                    : overallStats.overallWinRate >= 40
+                      ? "text-yellow-500"
+                      : "text-red-500",
+                )}
+              >
                 {overallStats.overallWinRate}%
               </div>
               <div className="text-sm text-muted-foreground">Win Rate</div>
@@ -1014,7 +1168,14 @@ interface UsePersistedDeckStatisticsOptions {
 
 interface UsePersistedDeckStatisticsReturn {
   statistics: DeckStatistics[];
-  recordGame: (deckId: string, deckName: string, format: string, result: 'win' | 'loss' | 'draw', opponentName?: string, duration?: number) => void;
+  recordGame: (
+    deckId: string,
+    deckName: string,
+    format: string,
+    result: "win" | "loss" | "draw",
+    opponentName?: string,
+    duration?: number,
+  ) => void;
   getDeckStats: (deckId: string) => DeckStatistics | undefined;
   clearDeckStats: (deckId: string) => void;
   clearAllStats: () => void;
@@ -1022,7 +1183,9 @@ interface UsePersistedDeckStatisticsReturn {
   importStats: (json: string) => boolean;
 }
 
-export function usePersistedDeckStatistics({ storageKey = 'deck-statistics' }: UsePersistedDeckStatisticsOptions = {}): UsePersistedDeckStatisticsReturn {
+export function usePersistedDeckStatistics({
+  storageKey = "deck-statistics",
+}: UsePersistedDeckStatisticsOptions = {}): UsePersistedDeckStatisticsReturn {
   const [statistics, setStatistics] = useState<DeckStatistics[]>([]);
 
   // Load from localStorage on mount
@@ -1032,95 +1195,103 @@ export function usePersistedDeckStatistics({ storageKey = 'deck-statistics' }: U
       try {
         setStatistics(JSON.parse(stored));
       } catch (e) {
-        console.error('Failed to parse deck statistics:', e);
+        console.error("Failed to parse deck statistics:", e);
       }
     }
   }, [storageKey]);
 
-
-  const recordGame = useCallback((
-    deckId: string, 
-    deckName: string, 
-    format: string, 
-    result: 'win' | 'loss' | 'draw',
-    opponentName?: string,
-    duration?: number
-  ) => {
-    const newRecord: DeckRecord = {
-      id: `record-${Date.now()}`,
-      deckId,
-      deckName,
-      format,
-      result,
-      opponentName,
-      date: Date.now(),
-      duration
-    };
-
-    setStatistics((prev) => {
-      // Find or create deck stats
-      let deckStats = prev.find(s => s.deckId === deckId);
-      
-      if (!deckStats) {
-        deckStats = {
-          deckId,
-          deckName,
-          format,
-          totalGames: 0,
-          wins: 0,
-          losses: 0,
-          draws: 0,
-          winRate: 0,
-          averageGameDuration: 0,
-          records: [],
-          colorDistribution: {},
-          manaCurve: {} // Also known as "energy curve" in generic terminology
-        };
-      }
-
-      // Update stats
-      const newWins = result === 'win' ? deckStats.wins + 1 : deckStats.wins;
-      const newLosses = result === 'loss' ? deckStats.losses + 1 : deckStats.losses;
-      const newDraws = result === 'draw' ? deckStats.draws + 1 : deckStats.draws;
-      const newTotal = deckStats.totalGames + 1;
-      
-      // Calculate new average duration
-      let newAvgDuration = deckStats.averageGameDuration;
-      if (duration) {
-        const totalDuration = (deckStats.averageGameDuration * deckStats.totalGames) + duration;
-        newAvgDuration = totalDuration / newTotal;
-      }
-
-      const updatedDeckStats: DeckStatistics = {
-        ...deckStats,
-        totalGames: newTotal,
-        wins: newWins,
-        losses: newLosses,
-        draws: newDraws,
-        winRate: calculateWinRate(newWins, newTotal),
-        averageGameDuration: newAvgDuration,
-        records: [...deckStats.records, newRecord],
-        lastPlayed: Date.now()
+  const recordGame = useCallback(
+    (
+      deckId: string,
+      deckName: string,
+      format: string,
+      result: "win" | "loss" | "draw",
+      opponentName?: string,
+      duration?: number,
+    ) => {
+      const newRecord: DeckRecord = {
+        id: `record-${Date.now()}`,
+        deckId,
+        deckName,
+        format,
+        result,
+        opponentName,
+        date: Date.now(),
+        duration,
       };
 
-      // Replace or add deck stats
-      const existingIndex = prev.findIndex(s => s.deckId === deckId);
-      if (existingIndex >= 0) {
-        const newStats = [...prev];
-        newStats[existingIndex] = updatedDeckStats;
-        return newStats;
-      } else {
-        return [...prev, updatedDeckStats];
-      }
-    });
-  }, []);
+      setStatistics((prev) => {
+        // Find or create deck stats
+        let deckStats = prev.find((s) => s.deckId === deckId);
 
-  const getDeckStats = useCallback((deckId: string) => {
-    return statistics.find(s => s.deckId === deckId);
-  }, [statistics]);
+        if (!deckStats) {
+          deckStats = {
+            deckId,
+            deckName,
+            format,
+            totalGames: 0,
+            wins: 0,
+            losses: 0,
+            draws: 0,
+            winRate: 0,
+            averageGameDuration: 0,
+            records: [],
+            colorDistribution: {},
+            manaCurve: {}, // Also known as "energy curve" in generic terminology
+          };
+        }
+
+        // Update stats
+        const newWins = result === "win" ? deckStats.wins + 1 : deckStats.wins;
+        const newLosses =
+          result === "loss" ? deckStats.losses + 1 : deckStats.losses;
+        const newDraws =
+          result === "draw" ? deckStats.draws + 1 : deckStats.draws;
+        const newTotal = deckStats.totalGames + 1;
+
+        // Calculate new average duration
+        let newAvgDuration = deckStats.averageGameDuration;
+        if (duration) {
+          const totalDuration =
+            deckStats.averageGameDuration * deckStats.totalGames + duration;
+          newAvgDuration = totalDuration / newTotal;
+        }
+
+        const updatedDeckStats: DeckStatistics = {
+          ...deckStats,
+          totalGames: newTotal,
+          wins: newWins,
+          losses: newLosses,
+          draws: newDraws,
+          winRate: calculateWinRate(newWins, newTotal),
+          averageGameDuration: newAvgDuration,
+          records: [...deckStats.records, newRecord],
+          lastPlayed: Date.now(),
+        };
+
+        // Replace or add deck stats
+        const existingIndex = prev.findIndex((s) => s.deckId === deckId);
+        if (existingIndex >= 0) {
+          const newStats = [...prev];
+          newStats[existingIndex] = updatedDeckStats;
+          return newStats;
+        } else {
+          return [...prev, updatedDeckStats];
+        }
+      });
+    },
+    [],
+  );
+
+  const getDeckStats = useCallback(
+    (deckId: string) => {
+      return statistics.find((s) => s.deckId === deckId);
+    },
+    [statistics],
+  );
 
   const clearDeckStats = useCallback((deckId: string) => {
-    setStatistics((prev) => prev.filter(s => s.deckId !== deckId));
+    setStatistics((prev) => prev.filter((s) => s.deckId !== deckId));
   }, []);
 
   const clearAllStats = useCallback(() => {
@@ -1132,19 +1303,22 @@ export function usePersistedDeckStatistics({ storageKey = 'deck-statistics' }: U
     return JSON.stringify(statistics, null, 2);
   }, [statistics]);
 
-  const importStats = useCallback((json: string): boolean => {
-    try {
-      const parsed = JSON.parse(json);
-      if (Array.isArray(parsed)) {
-        setStatistics(parsed);
-        localStorage.setItem(storageKey, JSON.stringify(parsed));
-        return true;
+  const importStats = useCallback(
+    (json: string): boolean => {
+      try {
+        const parsed = JSON.parse(json);
+        if (Array.isArray(parsed)) {
+          setStatistics(parsed);
+          localStorage.setItem(storageKey, JSON.stringify(parsed));
+          return true;
+        }
+        return false;
+      } catch {
+        return false;
       }
-      return false;
-    } catch {
-      return false;
-    }
-  }, [storageKey]);
+    },
+    [storageKey],
+  );
 
   return {
     statistics,
@@ -1153,7 +1327,7 @@ export function usePersistedDeckStatistics({ storageKey = 'deck-statistics' }: U
     clearDeckStats,
     clearAllStats,
     exportStats,
-    importStats
+    importStats,
   };
 }
 
@@ -1176,13 +1350,18 @@ interface ImportExportControlsProps {
   className?: string;
 }
 
-export function ImportExportControls({ onImport, onExport, onClear, className }: ImportExportControlsProps) {
-  const [importText, setImportText] = useState('');
+export function ImportExportControls({
+  onImport,
+  onExport,
+  onClear,
+  className,
+}: ImportExportControlsProps) {
+  const [importText, setImportText] = useState("");
 
   const handleImport = () => {
     if (importText.trim()) {
       onImport(importText);
-      setImportText('');
+      setImportText("");
     }
   };
 
@@ -1201,7 +1380,7 @@ export function ImportExportControls({ onImport, onExport, onClear, className }:
             Export Statistics
           </Button>
         </div>
-        
+
         <div className="space-y-2">
           <textarea
             value={importText}
@@ -1209,9 +1388,9 @@ export function ImportExportControls({ onImport, onExport, onClear, className }:
             placeholder="Paste exported JSON here..."
             className="w-full h-24 px-3 py-2 border rounded-md text-xs resize-none"
           />
-          <Button 
-            onClick={handleImport} 
-            variant="outline" 
+          <Button
+            onClick={handleImport}
+            variant="outline"
             disabled={!importText.trim()}
             className="w-full"
           >
@@ -1221,11 +1400,7 @@ export function ImportExportControls({ onImport, onExport, onClear, className }:
         </div>
 
         <div className="border-t pt-4">
-          <Button 
-            onClick={onClear} 
-            variant="destructive" 
-            className="w-full"
-          >
+          <Button onClick={onClear} variant="destructive" className="w-full">
             <Trash2 className="w-4 h-4 mr-2" />
             Clear All Statistics
           </Button>

--- a/src/components/meta/ArchetypeBalance.tsx
+++ b/src/components/meta/ArchetypeBalance.tsx
@@ -1,18 +1,26 @@
-'use client';
+"use client";
 
-import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, Cell } from 'recharts';
-import { ArchetypeCategory } from '@/lib/meta';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  ResponsiveContainer,
+  Tooltip,
+  Cell,
+} from "recharts";
+import { ArchetypeCategory } from "@/lib/meta";
 
 interface ArchetypeBalanceProps {
   data: Record<ArchetypeCategory, number>;
 }
 
 const ARCHETYPE_COLORS: Record<ArchetypeCategory, string> = {
-  aggro: '#ef4444',
-  control: '#3b82f6',
-  midrange: '#22c55e',
-  combo: '#a855f7',
-  tempo: '#f97316',
+  aggro: "#ef4444",
+  control: "#3b82f6",
+  midrange: "#22c55e",
+  combo: "#a855f7",
+  tempo: "#f97316",
 };
 
 export default function ArchetypeBalance({ data }: ArchetypeBalanceProps) {
@@ -30,25 +38,29 @@ export default function ArchetypeBalance({ data }: ArchetypeBalanceProps) {
           layout="vertical"
           margin={{ top: 0, right: 20, left: 0, bottom: 0 }}
         >
-          <XAxis 
-            type="number" 
-            domain={[0, 40]} 
+          <XAxis
+            type="number"
+            domain={[0, 40]}
             tick={{ fontSize: 10 }}
             tickFormatter={(value) => `${value}%`}
           />
-          <YAxis 
-            type="category" 
-            dataKey="name" 
+          <YAxis
+            type="category"
+            dataKey="name"
             tick={{ fontSize: 10 }}
             width={60}
           />
-          <Tooltip 
-            formatter={(value: number) => [`${value}%`, 'Meta Share']}
+          <Tooltip
+            // recharts v3: formatter `value` is `ValueType | undefined`.
+            formatter={(value) => [
+              `${typeof value === "number" ? value : Number(value ?? 0)}%`,
+              "Meta Share",
+            ]}
             contentStyle={{
-              backgroundColor: 'var(--background)',
-              border: '1px solid var(--border)',
-              borderRadius: '8px',
-              fontSize: '12px',
+              backgroundColor: "var(--background)",
+              border: "1px solid var(--border)",
+              borderRadius: "8px",
+              fontSize: "12px",
             }}
           />
           <Bar dataKey="value" radius={[0, 4, 4, 0]}>

--- a/src/components/meta/CardTrendChart.tsx
+++ b/src/components/meta/CardTrendChart.tsx
@@ -1,63 +1,77 @@
-'use client';
+"use client";
 
-import { LineChart, Line, XAxis, YAxis, ResponsiveContainer, Tooltip, Legend } from 'recharts';
-import { CardTrend } from '@/lib/meta';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  ResponsiveContainer,
+  Tooltip,
+  Legend,
+} from "recharts";
+import { CardTrend } from "@/lib/meta";
 
 interface CardTrendChartProps {
   data: CardTrend[];
 }
 
 const CARD_COLORS = [
-  '#3b82f6', // blue
-  '#ef4444', // red
-  '#22c55e', // green
-  '#a855f7', // purple
-  '#f97316', // orange
+  "#3b82f6", // blue
+  "#ef4444", // red
+  "#22c55e", // green
+  "#a855f7", // purple
+  "#f97316", // orange
 ];
 
 export default function CardTrendChart({ data }: CardTrendChartProps) {
   // Transform data for the chart
-  const chartData = data[0]?.data.map((_, weekIndex) => {
-    const point: Record<string, string | number> = {
-      week: data[0].data[weekIndex].week,
-    };
-    data.forEach((cardTrend) => {
-      point[cardTrend.cardName] = cardTrend.data[weekIndex]?.inclusionRate || 0;
-    });
-    return point;
-  }) || [];
+  const chartData =
+    data[0]?.data.map((_, weekIndex) => {
+      const point: Record<string, string | number> = {
+        week: data[0].data[weekIndex].week,
+      };
+      data.forEach((cardTrend) => {
+        point[cardTrend.cardName] =
+          cardTrend.data[weekIndex]?.inclusionRate || 0;
+      });
+      return point;
+    }) || [];
 
   return (
     <div className="h-48">
       <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={chartData} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
-          <XAxis 
-            dataKey="week" 
+        <LineChart
+          data={chartData}
+          margin={{ top: 5, right: 20, left: 0, bottom: 5 }}
+        >
+          <XAxis
+            dataKey="week"
             tick={{ fontSize: 10 }}
-            axisLine={{ stroke: 'var(--border)' }}
+            axisLine={{ stroke: "var(--border)" }}
             tickLine={false}
           />
-          <YAxis 
+          <YAxis
             domain={[50, 100]}
             tick={{ fontSize: 10 }}
             tickFormatter={(value) => `${value}%`}
-            axisLine={{ stroke: 'var(--border)' }}
+            axisLine={{ stroke: "var(--border)" }}
             tickLine={false}
           />
-          <Tooltip 
-            formatter={(value: number, name: string) => [
-              `${value.toFixed(1)}%`, 
-              name
+          <Tooltip
+            // recharts v3: formatter `value` is `ValueType | undefined`.
+            formatter={(value, name) => [
+              `${(typeof value === "number" ? value : Number(value ?? 0)).toFixed(1)}%`,
+              name,
             ]}
             contentStyle={{
-              backgroundColor: 'var(--background)',
-              border: '1px solid var(--border)',
-              borderRadius: '8px',
-              fontSize: '12px',
+              backgroundColor: "var(--background)",
+              border: "1px solid var(--border)",
+              borderRadius: "8px",
+              fontSize: "12px",
             }}
           />
-          <Legend 
-            verticalAlign="top" 
+          <Legend
+            verticalAlign="top"
             height={20}
             formatter={(value) => (
               <span className="text-xs text-muted-foreground truncate max-w-[100px]">

--- a/src/components/meta/ColorDistributionChart.tsx
+++ b/src/components/meta/ColorDistributionChart.tsx
@@ -1,24 +1,33 @@
-'use client';
+"use client";
 
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
-import { ColorDistribution } from '@/lib/meta';
+import {
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  Legend,
+} from "recharts";
+import { ColorDistribution } from "@/lib/meta";
 
 interface ColorDistributionChartProps {
   data: ColorDistribution[];
 }
 
 const COLOR_MAP: Record<string, string> = {
-  'White': '#F8F6D8',
-  'Blue': '#0E68AB',
-  'Black': '#150B00',
-  'Red': '#D3202A',
-  'Green': '#00733E',
-  'Multicolor': '#E6A138',
-  'Colorless': '#9CA3A6',
+  White: "#F8F6D8",
+  Blue: "#0E68AB",
+  Black: "#150B00",
+  Red: "#D3202A",
+  Green: "#00733E",
+  Multicolor: "#E6A138",
+  Colorless: "#9CA3A6",
 };
 
-export default function ColorDistributionChart({ data }: ColorDistributionChartProps) {
-  const chartData = data.map(item => ({
+export default function ColorDistributionChart({
+  data,
+}: ColorDistributionChartProps) {
+  const chartData = data.map((item) => ({
     name: item.color,
     value: item.percentage,
     count: item.count,
@@ -38,24 +47,28 @@ export default function ColorDistributionChart({ data }: ColorDistributionChartP
             dataKey="value"
           >
             {chartData.map((entry, index) => (
-              <Cell 
-                key={`cell-${index}`} 
-                fill={COLOR_MAP[entry.name] || '#9CA3A6'}
+              <Cell
+                key={`cell-${index}`}
+                fill={COLOR_MAP[entry.name] || "#9CA3A6"}
                 stroke="none"
               />
             ))}
           </Pie>
-          <Tooltip 
-            formatter={(value: number) => [`${value.toFixed(1)}%`, 'Share']}
+          <Tooltip
+            // recharts v3: formatter `value` is `ValueType | undefined`.
+            formatter={(value) => [
+              `${(typeof value === "number" ? value : Number(value ?? 0)).toFixed(1)}%`,
+              "Share",
+            ]}
             contentStyle={{
-              backgroundColor: 'var(--background)',
-              border: '1px solid var(--border)',
-              borderRadius: '8px',
-              fontSize: '12px',
+              backgroundColor: "var(--background)",
+              border: "1px solid var(--border)",
+              borderRadius: "8px",
+              fontSize: "12px",
             }}
           />
-          <Legend 
-            verticalAlign="bottom" 
+          <Legend
+            verticalAlign="bottom"
             height={20}
             formatter={(value) => (
               <span className="text-xs text-muted-foreground">{value}</span>

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,50 +1,50 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as RechartsPrimitive from "recharts"
+import * as React from "react";
+import * as RechartsPrimitive from "recharts";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 // Format: { THEME_NAME: CSS_SELECTOR }
-const THEMES = { light: "", dark: ".dark" } as const
+const THEMES = { light: "", dark: ".dark" } as const;
 
 export type ChartConfig = {
   [k in string]: {
-    label?: React.ReactNode
-    icon?: React.ComponentType
+    label?: React.ReactNode;
+    icon?: React.ComponentType;
   } & (
     | { color?: string; theme?: never }
     | { color?: never; theme: Record<keyof typeof THEMES, string> }
-  )
-}
+  );
+};
 
 type ChartContextProps = {
-  config: ChartConfig
-}
+  config: ChartConfig;
+};
 
-const ChartContext = React.createContext<ChartContextProps | null>(null)
+const ChartContext = React.createContext<ChartContextProps | null>(null);
 
 function useChart() {
-  const context = React.useContext(ChartContext)
+  const context = React.useContext(ChartContext);
 
   if (!context) {
-    throw new Error("useChart must be used within a <ChartContainer />")
+    throw new Error("useChart must be used within a <ChartContainer />");
   }
 
-  return context
+  return context;
 }
 
 const ChartContainer = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div"> & {
-    config: ChartConfig
+    config: ChartConfig;
     children: React.ComponentProps<
       typeof RechartsPrimitive.ResponsiveContainer
-    >["children"]
+    >["children"];
   }
 >(({ id, className, children, config, ...props }, ref) => {
-  const uniqueId = React.useId()
-  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
+  const uniqueId = React.useId();
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`;
 
   return (
     <ChartContext.Provider value={{ config }}>
@@ -53,7 +53,7 @@ const ChartContainer = React.forwardRef<
         ref={ref}
         className={cn(
           "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
-          className
+          className,
         )}
         {...props}
       >
@@ -63,17 +63,17 @@ const ChartContainer = React.forwardRef<
         </RechartsPrimitive.ResponsiveContainer>
       </div>
     </ChartContext.Provider>
-  )
-})
-ChartContainer.displayName = "Chart"
+  );
+});
+ChartContainer.displayName = "Chart";
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
   const colorConfig = Object.entries(config).filter(
-    ([, config]) => config.theme || config.color
-  )
+    ([, config]) => config.theme || config.color,
+  );
 
   if (!colorConfig.length) {
-    return null
+    return null;
   }
 
   return (
@@ -87,30 +87,37 @@ ${colorConfig
   .map(([key, itemConfig]) => {
     const color =
       itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
-      itemConfig.color
-    return color ? `  --color-${key}: ${color};` : null
+      itemConfig.color;
+    return color ? `  --color-${key}: ${color};` : null;
   })
   .join("\n")}
 }
-`
+`,
           )
           .join("\n"),
       }}
     />
-  )
-}
+  );
+};
 
-const ChartTooltip = RechartsPrimitive.Tooltip
+const ChartTooltip = RechartsPrimitive.Tooltip;
 
 const ChartTooltipContent = React.forwardRef<
   HTMLDivElement,
-  React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+  // recharts v3: `<Tooltip>` no longer exposes `payload`/`label`/`coordinate`
+  // on its public props (they're injected via context when this component is
+  // used as `<Tooltip content={<ChartTooltipContent />} />`). Use
+  // `TooltipContentProps` to type the full set of props recharts will
+  // actually pass at runtime, and intersect it with the public `TooltipProps`
+  // (without `ref`) plus our own `div` and shim props.
+  Omit<RechartsPrimitive.TooltipContentProps, "ref"> &
+    React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
     React.ComponentProps<"div"> & {
-      hideLabel?: boolean
-      hideIndicator?: boolean
-      indicator?: "line" | "dot" | "dashed"
-      nameKey?: string
-      labelKey?: string
+      hideLabel?: boolean;
+      hideIndicator?: boolean;
+      indicator?: "line" | "dot" | "dashed";
+      nameKey?: string;
+      labelKey?: string;
     }
 >(
   (
@@ -129,36 +136,36 @@ const ChartTooltipContent = React.forwardRef<
       nameKey,
       labelKey,
     },
-    ref
+    ref,
   ) => {
-    const { config } = useChart()
+    const { config } = useChart();
 
     const tooltipLabel = React.useMemo(() => {
       if (hideLabel || !payload?.length) {
-        return null
+        return null;
       }
 
-      const [item] = payload
-      const key = `${labelKey || item.dataKey || item.name || "value"}`
-      const itemConfig = getPayloadConfigFromPayload(config, item, key)
+      const [item] = payload;
+      const key = `${labelKey || item.dataKey || item.name || "value"}`;
+      const itemConfig = getPayloadConfigFromPayload(config, item, key);
       const value =
         !labelKey && typeof label === "string"
           ? config[label as keyof typeof config]?.label || label
-          : itemConfig?.label
+          : itemConfig?.label;
 
       if (labelFormatter) {
         return (
           <div className={cn("font-medium", labelClassName)}>
             {labelFormatter(value, payload)}
           </div>
-        )
+        );
       }
 
       if (!value) {
-        return null
+        return null;
       }
 
-      return <div className={cn("font-medium", labelClassName)}>{value}</div>
+      return <div className={cn("font-medium", labelClassName)}>{value}</div>;
     }, [
       label,
       labelFormatter,
@@ -167,113 +174,130 @@ const ChartTooltipContent = React.forwardRef<
       labelClassName,
       config,
       labelKey,
-    ])
+    ]);
 
     if (!active || !payload?.length) {
-      return null
+      return null;
     }
 
-    const nestLabel = payload.length === 1 && indicator !== "dot"
+    const nestLabel = payload.length === 1 && indicator !== "dot";
 
     return (
       <div
         ref={ref}
         className={cn(
           "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
-          className
+          className,
         )}
       >
         {!nestLabel ? tooltipLabel : null}
         <div className="grid gap-1.5">
-          {payload.map((item, index) => {
-            const key = `${nameKey || item.name || item.dataKey || "value"}`
-            const itemConfig = getPayloadConfigFromPayload(config, item, key)
-            const indicatorColor = color || item.payload.fill || item.color
+          {payload.map(
+            (item: RechartsPrimitive.TooltipPayloadEntry, index: number) => {
+              const key = `${nameKey || item.name || item.dataKey || "value"}`;
+              const itemConfig = getPayloadConfigFromPayload(config, item, key);
+              const indicatorColor = color || item.payload?.fill || item.color;
 
-            return (
-              <div
-                key={item.dataKey}
-                className={cn(
-                  "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
-                  indicator === "dot" && "items-center"
-                )}
-              >
-                {formatter && item?.value !== undefined && item.name ? (
-                  formatter(item.value, item.name, item, index, item.payload)
-                ) : (
-                  <>
-                    {itemConfig?.icon ? (
-                      <itemConfig.icon />
-                    ) : (
-                      !hideIndicator && (
-                        <div
-                          className={cn(
-                            "shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]",
-                            {
-                              "h-2.5 w-2.5": indicator === "dot",
-                              "w-1": indicator === "line",
-                              "w-0 border-[1.5px] border-dashed bg-transparent":
-                                indicator === "dashed",
-                              "my-0.5": nestLabel && indicator === "dashed",
+              return (
+                <div
+                  key={String(item.dataKey ?? key)}
+                  className={cn(
+                    "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+                    indicator === "dot" && "items-center",
+                  )}
+                >
+                  {formatter && item?.value !== undefined && item.name ? (
+                    formatter(item.value, item.name, item, index, item.payload)
+                  ) : (
+                    <>
+                      {itemConfig?.icon ? (
+                        <itemConfig.icon />
+                      ) : (
+                        !hideIndicator && (
+                          <div
+                            className={cn(
+                              "shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]",
+                              {
+                                "h-2.5 w-2.5": indicator === "dot",
+                                "w-1": indicator === "line",
+                                "w-0 border-[1.5px] border-dashed bg-transparent":
+                                  indicator === "dashed",
+                                "my-0.5": nestLabel && indicator === "dashed",
+                              },
+                            )}
+                            style={
+                              {
+                                "--color-bg": indicatorColor,
+                                "--color-border": indicatorColor,
+                              } as React.CSSProperties
                             }
-                          )}
-                          style={
-                            {
-                              "--color-bg": indicatorColor,
-                              "--color-border": indicatorColor,
-                            } as React.CSSProperties
-                          }
-                        />
-                      )
-                    )}
-                    <div
-                      className={cn(
-                        "flex flex-1 justify-between leading-none",
-                        nestLabel ? "items-end" : "items-center"
+                          />
+                        )
                       )}
-                    >
-                      <div className="grid gap-1.5">
-                        {nestLabel ? tooltipLabel : null}
-                        <span className="text-muted-foreground">
-                          {itemConfig?.label || item.name}
-                        </span>
+                      <div
+                        className={cn(
+                          "flex flex-1 justify-between leading-none",
+                          nestLabel ? "items-end" : "items-center",
+                        )}
+                      >
+                        <div className="grid gap-1.5">
+                          {nestLabel ? tooltipLabel : null}
+                          <span className="text-muted-foreground">
+                            {itemConfig?.label || item.name}
+                          </span>
+                        </div>
+                        {item.value && (
+                          <span className="font-mono font-medium tabular-nums text-foreground">
+                            {item.value.toLocaleString()}
+                          </span>
+                        )}
                       </div>
-                      {item.value && (
-                        <span className="font-mono font-medium tabular-nums text-foreground">
-                          {item.value.toLocaleString()}
-                        </span>
-                      )}
-                    </div>
-                  </>
-                )}
-              </div>
-            )
-          })}
+                    </>
+                  )}
+                </div>
+              );
+            },
+          )}
         </div>
       </div>
-    )
-  }
-)
-ChartTooltipContent.displayName = "ChartTooltip"
+    );
+  },
+);
+ChartTooltipContent.displayName = "ChartTooltip";
 
-const ChartLegend = RechartsPrimitive.Legend
+const ChartLegend = RechartsPrimitive.Legend;
 
 const ChartLegendContent = React.forwardRef<
   HTMLDivElement,
-  React.ComponentProps<"div"> &
-    Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
-      hideIcon?: boolean
-      nameKey?: string
-    }
+  React.ComponentProps<"div"> & {
+    // recharts v3: `payload` is no longer part of `<Legend>`'s public props
+    // — it's supplied by the chart context. Consumers using this as a
+    // custom Legend content can still pass payload through, but the type
+    // doesn't expose it.
+    payload?: RechartsPrimitive.LegendPayload[];
+    // `VerticalAlignmentType` is no longer exported from the recharts public
+    // surface (see `recharts/types/component/DefaultLegendContent.d.ts`);
+    // inline the union so we don't pull an internal type across the package
+    // boundary.
+    verticalAlign?: "top" | "bottom" | "middle";
+    hideIcon?: boolean;
+    nameKey?: string;
+  }
 >(
   (
-    { className, hideIcon = false, payload, verticalAlign = "bottom", nameKey },
-    ref
+    {
+      className,
+      hideIcon = false,
+      payload = [],
+      verticalAlign = "bottom",
+      nameKey,
+    },
+    ref,
   ) => {
-    const { config } = useChart()
+    const { config } = useChart();
 
     if (!payload?.length) {
-      return null
+      return null;
     }
 
     return (
@@ -282,18 +306,18 @@ const ChartLegendContent = React.forwardRef<
         className={cn(
           "flex items-center justify-center gap-4",
           verticalAlign === "top" ? "pb-3" : "pt-3",
-          className
+          className,
         )}
       >
-        {payload.map((item) => {
-          const key = `${nameKey || item.dataKey || "value"}`
-          const itemConfig = getPayloadConfigFromPayload(config, item, key)
+        {payload.map((item: RechartsPrimitive.LegendPayload) => {
+          const key = `${nameKey || item.dataKey || "value"}`;
+          const itemConfig = getPayloadConfigFromPayload(config, item, key);
 
           return (
             <div
               key={item.value}
               className={cn(
-                "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground"
+                "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground",
               )}
             >
               {itemConfig?.icon && !hideIcon ? (
@@ -308,22 +332,22 @@ const ChartLegendContent = React.forwardRef<
               )}
               {itemConfig?.label}
             </div>
-          )
+          );
         })}
       </div>
-    )
-  }
-)
-ChartLegendContent.displayName = "ChartLegend"
+    );
+  },
+);
+ChartLegendContent.displayName = "ChartLegend";
 
 // Helper to extract item config from a payload.
 function getPayloadConfigFromPayload(
   config: ChartConfig,
   payload: unknown,
-  key: string
+  key: string,
 ) {
   if (typeof payload !== "object" || payload === null) {
-    return undefined
+    return undefined;
   }
 
   const payloadPayload =
@@ -331,15 +355,15 @@ function getPayloadConfigFromPayload(
     typeof payload.payload === "object" &&
     payload.payload !== null
       ? payload.payload
-      : undefined
+      : undefined;
 
-  let configLabelKey: string = key
+  let configLabelKey: string = key;
 
   if (
     key in payload &&
     typeof payload[key as keyof typeof payload] === "string"
   ) {
-    configLabelKey = payload[key as keyof typeof payload] as string
+    configLabelKey = payload[key as keyof typeof payload] as string;
   } else if (
     payloadPayload &&
     key in payloadPayload &&
@@ -347,12 +371,12 @@ function getPayloadConfigFromPayload(
   ) {
     configLabelKey = payloadPayload[
       key as keyof typeof payloadPayload
-    ] as string
+    ] as string;
   }
 
   return configLabelKey in config
     ? config[configLabelKey]
-    : config[key as keyof typeof config]
+    : config[key as keyof typeof config];
 }
 
 export {
@@ -362,4 +386,4 @@ export {
   ChartLegend,
   ChartLegendContent,
   ChartStyle,
-}
+};


### PR DESCRIPTION
Bumps `recharts` from `^2.15.1` to `^3.9.2`. Replaces the original dependabot PR (#1324) that was closed when #1361 landed.

## Breaking changes adapted

- **Tooltip `formatter`** — `value` is now `ValueType | undefined` rather than `number`. Coerce defensively (`typeof value === 'number' ? value : Number(value ?? 0)`) in:
  - `src/components/deck-statistics.tsx` (`ManaCurveChart`, `CardTypeChart`, `DeckColorChart`)
  - `src/components/meta/ArchetypeBalance.tsx`
  - `src/components/meta/CardTrendChart.tsx`
  - `src/components/meta/ColorDistributionChart.tsx`
- **Bar `onClick`** — the handler now receives `BarRectangleItem` (with the original chart datum on `.payload`) instead of the raw datum. Read `cmcNum` from `data.payload?.cmcNum` in `ManaCurveChart`.
- **Pie `label`** — the render prop is now `PieLabelRenderProps`; the chart datum is exposed on `props.payload`. Read `type` / `color` / `percentage` from `payload` in `CardTypeChart` and `DeckColorChart`.
- **`src/components/ui/chart.tsx`**:
  - `<Tooltip>`'s public props no longer carry `payload` / `label` / `coordinate` (they're injected via context). Type `ChartTooltipContent` via `TooltipContentProps` intersected with `TooltipProps`.
  - `<Legend>` no longer exposes `payload` on its public props; type the custom Legend content via `LegendPayload[]` and inline `verticalAlign: "top" | "bottom" | "middle"` (`VerticalAlignmentType` is no longer exported from the package surface).
  - Coerce `item.dataKey` to `string` before using it as a React `key` (the field can now be a function).

## Verification

- `pnpm typecheck` — passes (was 20 TS errors before migration, now 0)
- `pnpm test -- --testPathPattern="recharts|deck-statistics-charts|meta|chart"` — 16/16 pass, including the issue #1248 memoization regression suite
- `pnpm test src/lib/__tests__/saved-games.test.ts` — passes individually (the full `pnpm test` run hits a pre-existing jest-worker SIGSEGV in that suite that's unrelated to recharts)

Supersedes #1324.