### PR TITLE
feat: resolve #1227 — surface interactive choice for replacement/prevention effects (CR 616.1)

### DIFF
--- a/.github/workflows/video-derived-tests.yml
+++ b/.github/workflows/video-derived-tests.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           if [ -f scripts/generate-test-fixture.ts ]; then
             echo "Running test fixture generation..."
-            npx ts-node scripts/generate-test-fixture.ts --fixtures-dir src/lib/__fixtures__/video-derived
+            npx tsx scripts/generate-test-fixture.ts --fixtures-dir src/lib/__fixtures__/video-derived
           else
             echo "No fixture generation script found, skipping..."
             echo "VIDEO_FIXTURES_COUNT=0" >> $GITHUB_ENV

--- a/src/lib/game-state/__tests__/replacement-effects.test.ts
+++ b/src/lib/game-state/__tests__/replacement-effects.test.ts
@@ -16,7 +16,7 @@ import {
   createDestroyReplacementEffect,
   createAsThoughEffect,
 } from "../replacement-effects";
-import type { GameState } from "../types";
+import type { GameState, PlayerId } from "../types";
 
 // Module-level rem variable shared across all describe blocks
 let rem: ReplacementEffectManager;
@@ -1356,3 +1356,583 @@ describe("ReplacementEffectManager - Multiple Game Instances", () => {
     expect(result2.amount).toBe(20); // 5 * 4
   });
 });
+
+/**
+ * Issue #1227 — CR 616.1: when two or more non-self replacement /
+ * prevention effects could apply to the same event, the affected
+ * player or the controller of the affected permanent chooses which
+ * one applies. The previous `chooseBestEffect` silently auto-resolved
+ * via APNAP + timestamp tiebreakers; the new API surfaces a
+ * `WaitingChoice` and provides a deterministic AI heuristic.
+ */
+describe("ReplacementEffectManager - CR 616.1 Interactive Controller Choice", () => {
+  let rem: ReplacementEffectManager;
+
+  const buildCompetingDamageEffects = () => {
+    const prevention: ReplacementAbility = {
+      id: "prevent-2",
+      sourceCardId: "ward-creature",
+      controllerId: "player1",
+      effectType: "damage_prevention",
+      description: "If ~ would be dealt damage, prevent 2 of it",
+      layer: 1,
+      timestamp: 100,
+      isInstead: true,
+      canApply: (e) => e.type === "damage" && e.targetId === "creature1",
+      apply: (e) => ({
+        modified: true,
+        modifiedEvent: { ...e, amount: Math.max(0, e.amount - 2) },
+        description: "Prevented 2",
+        instead: true,
+      }),
+    };
+
+    const redirect: ReplacementAbility = {
+      id: "redirect-1",
+      sourceCardId: "shield-creature",
+      controllerId: "player2",
+      effectType: "damage_replacement",
+      description: "If ~ would be dealt damage, redirect it to player2",
+      layer: 5,
+      timestamp: 200,
+      isInstead: true,
+      canApply: (e) => e.type === "damage" && e.targetId === "creature1",
+      apply: (e) => ({
+        modified: true,
+        modifiedEvent: { ...e, targetId: "player2" as PlayerId },
+        description: "Redirected",
+        instead: true,
+      }),
+    };
+
+    return { prevention, redirect };
+  };
+
+  beforeEach(() => {
+    rem = new ReplacementEffectManager();
+  });
+
+  test("surfaces requiresChoice when two non-self replacement effects compete", () => {
+    const { prevention, redirect } = buildCompetingDamageEffects();
+    rem.registerEffect(prevention);
+    rem.registerEffect(redirect);
+
+    const event: ReplacementEvent = {
+      type: "damage",
+      amount: 4,
+      timestamp: Date.now(),
+      targetId: "creature1",
+      sourceId: "attacker",
+    };
+
+    const outcome = rem.processEventInteractive(event, undefined, {
+      affectedPlayerId: "player1",
+    });
+
+    expect(outcome.requiresChoice).toBe(true);
+    expect(outcome.candidates).toHaveLength(2);
+    expect(outcome.appliedEffects).toEqual([]);
+    expect(outcome.affectedPlayerId).toBe("player1");
+    const ids = (outcome.candidates ?? []).map((c) => c.id).sort();
+    expect(ids).toEqual(["prevent-2", "redirect-1"]);
+  });
+
+  test("does NOT surface a choice when only one non-self replacement effect applies", () => {
+    const { prevention } = buildCompetingDamageEffects();
+    rem.registerEffect(prevention);
+
+    const event: ReplacementEvent = {
+      type: "damage",
+      amount: 4,
+      timestamp: Date.now(),
+      targetId: "creature1",
+    };
+
+    const outcome = rem.processEventInteractive(event, undefined, {
+      affectedPlayerId: "player1",
+    });
+
+    expect(outcome.requiresChoice).toBe(false);
+    expect(outcome.appliedEffects).toHaveLength(1);
+    expect(outcome.appliedEffects[0].id).toBe("prevent-2");
+    expect(outcome.event.amount).toBe(2); // 4 - 2
+  });
+
+  test("does NOT surface a choice when self-replacement is the only competing effect", () => {
+    const selfReplacement: ReplacementAbility = {
+      id: "self-replace",
+      sourceCardId: "self-card",
+      controllerId: "player1",
+      effectType: "damage_replacement",
+      description: "If this creature would be dealt damage, double it",
+      layer: 5,
+      timestamp: 100,
+      isSelfReplacement: true,
+      isInstead: true,
+      canApply: (e) => e.type === "damage" && e.targetId === "creature1",
+      apply: (e) => ({
+        modified: true,
+        modifiedEvent: { ...e, amount: e.amount * 2 },
+        description: "Doubled by self",
+        instead: true,
+      }),
+    };
+    rem.registerEffect(selfReplacement);
+
+    const event: ReplacementEvent = {
+      type: "damage",
+      amount: 3,
+      timestamp: Date.now(),
+      targetId: "creature1",
+    };
+
+    const outcome = rem.processEventInteractive(event, undefined, {
+      affectedPlayerId: "player1",
+    });
+
+    expect(outcome.requiresChoice).toBe(false);
+    expect(outcome.appliedEffects).toHaveLength(1);
+    expect(outcome.event.amount).toBe(6);
+  });
+
+  test("self-replacement applies first even when non-self competition exists later", () => {
+    const selfReplacement: ReplacementAbility = {
+      id: "self-add",
+      sourceCardId: "self-card",
+      controllerId: "player1",
+      effectType: "damage_replacement",
+      description: "Self: +1",
+      layer: 5,
+      timestamp: 100,
+      isSelfReplacement: true,
+      isInstead: true,
+      canApply: (e) => e.type === "damage" && e.targetId === "creature1",
+      apply: (e) => ({
+        modified: true,
+        modifiedEvent: { ...e, amount: e.amount + 1 },
+        description: "+1",
+        instead: true,
+      }),
+    };
+    const { prevention, redirect } = buildCompetingDamageEffects();
+    rem.registerEffect(selfReplacement);
+    rem.registerEffect(prevention);
+    rem.registerEffect(redirect);
+
+    const event: ReplacementEvent = {
+      type: "damage",
+      amount: 4,
+      timestamp: Date.now(),
+      targetId: "creature1",
+    };
+
+    const outcome = rem.processEventInteractive(event, undefined, {
+      affectedPlayerId: "player1",
+    });
+
+    // Self applies first: 4 + 1 = 5. Then 2 non-self compete → choice.
+    expect(outcome.requiresChoice).toBe(true);
+    expect(outcome.appliedEffects.map((e) => e.id)).toEqual(["self-add"]);
+    expect(outcome.candidates?.map((c) => c.id).sort()).toEqual([
+      "prevent-2",
+      "redirect-1",
+    ]);
+  });
+
+  test("each competing candidate can be picked and applied individually", () => {
+    const { prevention, redirect } = buildCompetingDamageEffects();
+    rem.registerEffect(prevention);
+    rem.registerEffect(redirect);
+
+    const event: ReplacementEvent = {
+      type: "damage",
+      amount: 4,
+      timestamp: Date.now(),
+      targetId: "creature1",
+    };
+
+    // Pick the prevention effect
+    const pickedPrevention = rem.resolveReplacementChoice("prevent-2", {
+      event,
+      applied: [],
+      affectedPlayerId: "player1",
+    });
+    expect(pickedPrevention.requiresChoice).toBe(false);
+    expect(pickedPrevention.appliedEffects.map((e) => e.id)).toContain(
+      "prevent-2",
+    );
+    expect(pickedPrevention.event.amount).toBe(2);
+
+    // Pick the redirect effect on a fresh event
+    const pickedRedirect = rem.resolveReplacementChoice("redirect-1", {
+      event,
+      applied: [],
+      affectedPlayerId: "player1",
+    });
+    expect(pickedRedirect.requiresChoice).toBe(false);
+    expect(pickedRedirect.appliedEffects.map((e) => e.id)).toContain(
+      "redirect-1",
+    );
+    expect(pickedRedirect.event.targetId).toBe("player2");
+    expect(pickedRedirect.event.amount).toBe(4);
+  });
+
+  test("resolveReplacementChoice continues the chain after picking one effect", () => {
+    // Setup: one picked effect (prevention) + one follow-up effect (halve)
+    // that the chain should apply automatically without re-prompting.
+    // The CR 616.1 player choice is resolved, the picked effect applies,
+    // and the next iteration runs the follow-up by itself because no
+    // other candidates remain for that modified event.
+    const prevention: ReplacementAbility = {
+      id: "prevent-2",
+      sourceCardId: "ward-creature",
+      controllerId: "player1",
+      effectType: "damage_prevention",
+      description: "If ~ would be dealt damage, prevent 2 of it",
+      layer: 1,
+      timestamp: 100,
+      isInstead: true,
+      canApply: (e) => e.type === "damage" && e.targetId === "creature1",
+      apply: (e) => ({
+        modified: true,
+        modifiedEvent: { ...e, amount: Math.max(0, e.amount - 2) },
+        description: "Prevented 2",
+        instead: true,
+      }),
+    };
+
+    const followupHalve: ReplacementAbility = {
+      id: "halve-after",
+      sourceCardId: "post-pick-card",
+      controllerId: "player2",
+      effectType: "damage_replacement",
+      description: "After the choice, halve damage",
+      layer: 3,
+      timestamp: 300,
+      isInstead: true,
+      canApply: (e) => e.type === "damage" && e.targetId === "creature1",
+      apply: (e) => ({
+        modified: true,
+        modifiedEvent: { ...e, amount: Math.ceil(e.amount / 2) },
+        description: "Halved",
+        instead: true,
+      }),
+    };
+
+    // Single competitor (the redirect) lets us isolate the choice.
+    const redirect: ReplacementAbility = {
+      id: "redirect-only",
+      sourceCardId: "shield-creature",
+      controllerId: "player2",
+      effectType: "damage_replacement",
+      description: "redirect",
+      layer: 5,
+      timestamp: 200,
+      isInstead: true,
+      canApply: (e) =>
+        e.type === "damage" && e.targetId === "creature1" && e.amount === 4,
+      apply: (e) => ({
+        modified: true,
+        modifiedEvent: { ...e, targetId: "player2" as PlayerId },
+        description: "redirected",
+        instead: true,
+      }),
+    };
+
+    rem.registerEffect(prevention);
+    rem.registerEffect(followupHalve);
+    rem.registerEffect(redirect);
+
+    const event: ReplacementEvent = {
+      type: "damage",
+      amount: 4,
+      timestamp: Date.now(),
+      targetId: "creature1",
+    };
+
+    const outcome = rem.resolveReplacementChoice("prevent-2", {
+      event,
+      applied: [],
+      affectedPlayerId: "player1",
+    });
+
+    // Prevention reduces to 2; halve-after: ceil(2 / 2) = 1.
+    // The redirect no longer applies (its canApply requires amount === 4).
+    // The chain resumes without re-prompting.
+    expect(outcome.requiresChoice).toBe(false);
+    expect(outcome.event.amount).toBe(1);
+    expect(outcome.appliedEffects.map((e) => e.id)).toEqual([
+      "prevent-2",
+      "halve-after",
+    ]);
+  });
+
+  test("resolveReplacementChoice records the picked effect exactly once and excludes unpicked peers", () => {
+    const { prevention, redirect } = buildCompetingDamageEffects();
+    // Restrict redirect so post-pick the chain resolves automatically
+    // (no second competing effect to re-prompt).
+    const redirectScoped: ReplacementAbility = {
+      ...redirect,
+      canApply: (e) =>
+        e.type === "damage" && e.targetId === "creature1" && e.amount === 4,
+    };
+
+    rem.registerEffect(prevention);
+    rem.registerEffect(redirectScoped);
+
+    const event: ReplacementEvent = {
+      type: "damage",
+      amount: 4,
+      timestamp: Date.now(),
+      targetId: "creature1",
+    };
+
+    const outcome = rem.resolveReplacementChoice("prevent-2", {
+      event,
+      applied: [],
+      affectedPlayerId: "player1",
+    });
+
+    // The picked effect (prevent-2) is applied exactly once.
+    const pickedOccurrences = outcome.appliedEffects.filter(
+      (e) => e.id === "prevent-2",
+    ).length;
+    expect(pickedOccurrences).toBe(1);
+    // The unpicked competitor (redirect) does NOT appear in appliedEffects,
+    // because the picked effect dominated the original event and the
+    // scoped competitor can no longer apply to the modified event.
+    const unpickedOccurrences = outcome.appliedEffects.filter(
+      (e) => e.id === "redirect-1",
+    ).length;
+    expect(unpickedOccurrences).toBe(0);
+    expect(outcome.event.amount).toBe(2);
+  });
+
+  test("resolveReplacementChoice throws when the picked id is not in the candidate set", () => {
+    const { prevention, redirect } = buildCompetingDamageEffects();
+    rem.registerEffect(prevention);
+    rem.registerEffect(redirect);
+
+    const event: ReplacementEvent = {
+      type: "damage",
+      amount: 4,
+      timestamp: Date.now(),
+      targetId: "creature1",
+    };
+
+    expect(() =>
+      rem.resolveReplacementChoice("not-a-real-id", {
+        event,
+        applied: [],
+        affectedPlayerId: "player1",
+      }),
+    ).toThrow(/not-a-real-id/);
+  });
+
+  test("autoResolveReplacementChoice prefers the affected player's own effect (CR 616.1)", () => {
+    const apnapOrder: APNAPOrder = {
+      activePlayerId: "player1",
+      playerOrder: ["player1", "player2"],
+    };
+    const { prevention, redirect } = buildCompetingDamageEffects();
+    // prevention is controlled by player1 (the affected player)
+    // redirect  is controlled by player2
+
+    const picked = rem.autoResolveReplacementChoice(
+      [prevention, redirect],
+      "player1",
+      apnapOrder,
+    );
+    expect(picked).toBe("prevent-2");
+  });
+
+  test("autoResolveReplacementChoice falls back to APNAP when neither candidate is owned by the affected player", () => {
+    const apnapOrder: APNAPOrder = {
+      activePlayerId: "player1",
+      playerOrder: ["player1", "player2", "player3"],
+    };
+    const competingNonPlayer1: ReplacementAbility[] = [
+      {
+        id: "p3-effect",
+        sourceCardId: "card3",
+        controllerId: "player3",
+        effectType: "damage_replacement",
+        description: "p3",
+        layer: 5,
+        timestamp: 100,
+        isInstead: true,
+        canApply: () => true,
+        apply: (e) => ({ modified: false, description: "noop" }),
+      },
+      {
+        id: "p2-effect",
+        sourceCardId: "card2",
+        controllerId: "player2",
+        effectType: "damage_replacement",
+        description: "p2",
+        layer: 5,
+        timestamp: 100,
+        isInstead: true,
+        canApply: () => true,
+        apply: (e) => ({ modified: false, description: "noop" }),
+      },
+    ];
+    // Affected player is player2 — player2 owns one of them.
+    const picked = rem.autoResolveReplacementChoice(
+      competingNonPlayer1,
+      "player2",
+      apnapOrder,
+    );
+    expect(picked).toBe("p2-effect");
+  });
+
+  test("autoResolveReplacementChoice uses layer then timestamp tiebreaker", () => {
+    const a: ReplacementAbility = {
+      id: "layer-2-ts-200",
+      sourceCardId: "card-a",
+      controllerId: "player1",
+      effectType: "damage_replacement",
+      description: "a",
+      layer: 2,
+      timestamp: 200,
+      isInstead: true,
+      canApply: () => true,
+      apply: (e) => ({ modified: false, description: "noop" }),
+    };
+    const b: ReplacementAbility = {
+      id: "layer-1-ts-100",
+      sourceCardId: "card-b",
+      controllerId: "player1",
+      effectType: "damage_replacement",
+      description: "b",
+      layer: 1,
+      timestamp: 100,
+      isInstead: true,
+      canApply: () => true,
+      apply: (e) => ({ modified: false, description: "noop" }),
+    };
+    const picked = rem.autoResolveReplacementChoice([a, b], "player3");
+    expect(picked).toBe("layer-1-ts-100");
+  });
+
+  test("autoResolveReplacementChoice is deterministic across multiple invocations", () => {
+    const { prevention, redirect } = buildCompetingDamageEffects();
+    const apnapOrder: APNAPOrder = {
+      activePlayerId: "player1",
+      playerOrder: ["player1", "player2"],
+    };
+    const first = rem.autoResolveReplacementChoice(
+      [redirect, prevention],
+      "player1",
+      apnapOrder,
+    );
+    const second = rem.autoResolveReplacementChoice(
+      [prevention, redirect],
+      "player1",
+      apnapOrder,
+    );
+    expect(first).toBe(second);
+  });
+
+  test("createReplacementWaitingChoice builds a WaitingChoice of type choose_replacement", () => {
+    const { prevention, redirect } = buildCompetingDamageEffects();
+    const choice = rem.createReplacementWaitingChoice(
+      [prevention, redirect],
+      "player1",
+      "Pick one:",
+    );
+    expect(choice.type).toBe("choose_replacement");
+    expect(choice.playerId).toBe("player1");
+    expect(choice.choices).toHaveLength(2);
+    expect(choice.minChoices).toBe(1);
+    expect(choice.maxChoices).toBe(1);
+    expect(choice.prompt).toBe("Pick one:");
+    const labels = choice.choices.map((c) => c.label).sort();
+    expect(labels).toEqual(
+      [
+        "If ~ would be dealt damage, prevent 2 of it",
+        "If ~ would be dealt damage, redirect it to player2",
+      ].sort(),
+    );
+  });
+
+  test("getCompetingReplacementEffects returns [] when fewer than 2 non-self effects apply", () => {
+    const { prevention } = buildCompetingDamageEffects();
+    rem.registerEffect(prevention);
+
+    const event: ReplacementEvent = {
+      type: "damage",
+      amount: 4,
+      timestamp: Date.now(),
+      targetId: "creature1",
+    };
+
+    const competing = rem.getCompetingReplacementEffects(event);
+    expect(competing).toEqual([]);
+  });
+
+  test("getCompetingReplacementEffects excludes self-replacements", () => {
+    const selfReplace: ReplacementAbility = {
+      id: "self-only",
+      sourceCardId: "card-self",
+      controllerId: "player1",
+      effectType: "damage_replacement",
+      description: "self only",
+      layer: 5,
+      timestamp: 100,
+      isSelfReplacement: true,
+      isInstead: true,
+      canApply: (e) => e.type === "damage" && e.targetId === "creature1",
+      apply: (e) => ({ modified: false, description: "noop" }),
+    };
+    const { prevention } = buildCompetingDamageEffects();
+    rem.registerEffect(selfReplace);
+    rem.registerEffect(prevention);
+
+    const event: ReplacementEvent = {
+      type: "damage",
+      amount: 4,
+      timestamp: Date.now(),
+      targetId: "creature1",
+    };
+
+    const competing = rem.getCompetingReplacementEffects(event);
+    // Only the one non-self effect — not enough to trigger a choice.
+    expect(competing).toEqual([]);
+  });
+
+  test("end-to-end: AI uses autoResolve then resolveReplacementChoice with the same id", () => {
+    const { prevention, redirect } = buildCompetingDamageEffects();
+    rem.registerEffect(prevention);
+    rem.registerEffect(redirect);
+
+    const event: ReplacementEvent = {
+      type: "damage",
+      amount: 4,
+      timestamp: Date.now(),
+      targetId: "creature1",
+    };
+
+    const survey = rem.processEventInteractive(event, undefined, {
+      affectedPlayerId: "player1",
+    });
+    expect(survey.requiresChoice).toBe(true);
+    const candidates = survey.candidates ?? [];
+    expect(candidates).toHaveLength(2);
+
+    const pickedId = rem.autoResolveReplacementChoice(
+      candidates,
+      "player1",
+    );
+    const outcome = rem.resolveReplacementChoice(pickedId, {
+      event,
+      applied: [],
+      affectedPlayerId: "player1",
+    });
+
+    expect(outcome.requiresChoice).toBe(false);
+    expect(outcome.appliedEffects.map((e) => e.id)).toContain(pickedId);
+    expect(outcome.event.amount).toBeLessThanOrEqual(4);
+  });
+});
+

--- a/src/lib/game-state/keyword-actions.ts
+++ b/src/lib/game-state/keyword-actions.ts
@@ -1254,7 +1254,36 @@ export function dealDamageToCard(
     state.turn.activePlayerId,
     Array.from(state.players.keys()),
   );
-  const processedEvent = rem.processEvent(replacementEvent, apnapOrder);
+  // CR 616.1 — Use the interactive path so competing replacement /
+  // prevention effects surface a choice for the affected player's
+  // controller instead of being silently auto-resolved.
+  const interactiveOutcome = rem.processEventInteractive(
+    replacementEvent,
+    apnapOrder,
+    {
+      affectedPlayerId: card.controllerId,
+    },
+  );
+
+  if (interactiveOutcome.requiresChoice && interactiveOutcome.candidates) {
+    const waitingChoice = rem.createReplacementWaitingChoice(
+      interactiveOutcome.candidates,
+      card.controllerId,
+      "Multiple damage replacement effects could apply. Choose one:",
+    );
+    return {
+      success: true,
+      state: {
+        ...state,
+        waitingChoice,
+        lastModifiedAt: Date.now(),
+      },
+      description: `Awaiting replacement effect choice from controller of ${card.cardData.name}`,
+      affectedCards: [cardId],
+    };
+  }
+
+  const processedEvent = interactiveOutcome.event;
   const actualDamage = processedEvent.amount;
 
   // Apply damage

--- a/src/lib/game-state/replacement-effects.ts
+++ b/src/lib/game-state/replacement-effects.ts
@@ -16,7 +16,13 @@
  * @module replacement-effects
  */
 
-import { CardInstanceId, PlayerId, GameState } from "./types";
+import {
+  CardInstanceId,
+  PlayerId,
+  GameState,
+  WaitingChoice,
+  ChoiceOption,
+} from "./types";
 
 /**
  * Types of replacement/prevention effects
@@ -127,6 +133,33 @@ export interface PreventionShield {
 export interface APNAPOrder {
   activePlayerId: PlayerId;
   playerOrder: PlayerId[];
+}
+
+/** Waiting-choice discriminator for CR 616.1 replacement effect selection. */
+export const REPLACEMENT_CHOICE_TYPE = "choose_replacement" as const;
+
+/**
+ * Result of a replacement-effect-processing pass.
+ *
+ * When `requiresChoice` is true, the caller should present a
+ * `WaitingChoice` of type {@link REPLACEMENT_CHOICE_TYPE} to the player
+ * identified by `affectedPlayerId` (CR 616.1 — the affected player or the
+ * controller of the affected permanent chooses which replacement/prevention
+ * effect applies). After the player picks, call
+ * {@link ReplacementEffectManager.resolveReplacementChoice} with the picked
+ * effect id and `appliedEffectIds` to resume processing.
+ *
+ * When `requiresChoice` is false, the resolved event in `event` is final and
+ * should be applied to the game state directly.
+ */
+export interface ReplacementProcessingOutcome {
+  event: ReplacementEvent;
+  appliedEffects: ReplacementAbility[];
+  requiresChoice: boolean;
+  candidates?: ReplacementAbility[];
+  affectedPlayerId?: PlayerId;
+  /** True when the caller requested auto-resolution via the AI heuristic. */
+  autoResolved?: boolean;
 }
 
 export class ReplacementEffectManager {
@@ -305,6 +338,356 @@ export class ReplacementEffectManager {
       if (prevented > 0) currentEvent.amount -= prevented;
     }
     return currentEvent;
+  }
+
+  /**
+   * CR 616.1 — Process a replacement event with explicit player choice.
+   *
+   * Mirrors {@link processEvent} but, whenever two or more non-self
+   * replacement effects are simultaneously applicable, returns an
+   * outcome with `requiresChoice = true` and a `candidates` list instead
+   * of silently applying one. Self-replacement effects (CR 614.6 — the
+   * source's own effects) are still applied without a choice because
+   * they cannot meaningfully compete with each other on the same trigger.
+   *
+   * The caller is responsible for:
+   *  - Building a {@link WaitingChoice} via
+   *    {@link createReplacementWaitingChoice} when `requiresChoice`
+   *    is true,
+   *  - Either suspending until the affected player responds, or calling
+   *    {@link autoResolveReplacementChoice} for AI / scripted controllers,
+   *  - Resuming via {@link resolveReplacementChoice} with the picked
+   *    effect id and the `appliedEffectIds` carried in
+   *    `appliedEffects`.
+   *
+   * When the optional `context` argument carries a previously-applied
+   * effect set (carried across a choice suspension), those effects are
+   * excluded from the candidate pool so the chain resumes seamlessly.
+   */
+  processEventInteractive(
+    event: ReplacementEvent,
+    apnapOrder?: APNAPOrder,
+    context?: {
+      appliedEffectIds?: Set<string>;
+      affectedPlayerId?: PlayerId;
+      maxIterations?: number;
+    },
+  ): ReplacementProcessingOutcome {
+    const appliedEffectIds = new Set<string>(
+      context?.appliedEffectIds ?? new Set<string>(),
+    );
+    const affectedPlayerId =
+      context?.affectedPlayerId ?? (event.targetId as PlayerId | undefined);
+    const maxIterations = context?.maxIterations ?? 100;
+
+    const appliedEffects: ReplacementAbility[] = [];
+    let currentEvent = { ...event };
+    const eventTypeHistory: ReplacementEventType[] = [];
+    let iterations = 0;
+    let possibleEffects = this.getApplicableEffects(currentEvent).filter(
+      (e) => !appliedEffectIds.has(e.id),
+    );
+
+    while (possibleEffects.length > 0 && iterations < maxIterations) {
+      iterations++;
+
+      const loopDetected = this.wouldCreateLoop(
+        possibleEffects,
+        currentEvent,
+        eventTypeHistory,
+      );
+
+      if (loopDetected) {
+        console.warn(
+          `[ReplacementEffectManager.processEventInteractive] CR 614.4 loop detected after ${iterations} iterations. ` +
+            `Event type history: ${eventTypeHistory.join(" -> ")}. ` +
+            `Skipping all effects.`,
+        );
+        currentEvent.amount = 0;
+        break;
+      }
+
+      // Self-replacements always apply without prompting (CR 614.6).
+      const selfEffects = possibleEffects.filter((e) => e.isSelfReplacement);
+      const nonSelfEffects = possibleEffects.filter((e) => !e.isSelfReplacement);
+
+      if (selfEffects.length > 0) {
+        const selfSorted = [...selfEffects].sort(
+          (a, b) => a.timestamp - b.timestamp,
+        );
+        for (const eff of selfSorted) {
+          if (appliedEffectIds.has(eff.id)) continue;
+          eventTypeHistory.push(currentEvent.type);
+          const result = eff.apply(currentEvent);
+          if (result.modified && result.modifiedEvent) {
+            currentEvent = { ...result.modifiedEvent };
+            appliedEffectIds.add(eff.id);
+            appliedEffects.push(eff);
+            if (result.skipEvent) {
+              currentEvent.amount = 0;
+              break;
+            }
+          }
+        }
+        possibleEffects = this.getApplicableEffects(currentEvent).filter(
+          (e) => !appliedEffectIds.has(e.id),
+        );
+        continue;
+      }
+
+      // CR 616.1 — 2+ non-self replacement effects competing: surface
+      // an interactive choice for the affected player / permanent
+      // controller. Caller must present the WaitingChoice or call
+      // autoResolveReplacementChoice, then resolveReplacementChoice.
+      if (nonSelfEffects.length >= 2) {
+        return {
+          event: currentEvent,
+          appliedEffects,
+          requiresChoice: true,
+          candidates: [...nonSelfEffects],
+          affectedPlayerId,
+        };
+      }
+
+      // Exactly one non-self effect — apply it and continue.
+      const only = nonSelfEffects[0];
+      eventTypeHistory.push(currentEvent.type);
+      const result = only.apply(currentEvent);
+      if (result.modified && result.modifiedEvent) {
+        currentEvent = { ...result.modifiedEvent };
+        appliedEffectIds.add(only.id);
+        appliedEffects.push(only);
+        if (result.skipEvent) {
+          currentEvent.amount = 0;
+          break;
+        }
+      }
+      possibleEffects = this.getApplicableEffects(currentEvent).filter(
+        (e) => !appliedEffectIds.has(e.id),
+      );
+    }
+
+    if (iterations >= maxIterations) {
+      console.warn(
+        `[ReplacementEffectManager.processEventInteractive] Max iterations (${maxIterations}) reached. ` +
+          `Event type history: ${eventTypeHistory.join(" -> ")}. ` +
+          `This may indicate an undetected loop.`,
+      );
+    }
+
+    if (
+      currentEvent.type === "damage" &&
+      currentEvent.amount > 0 &&
+      currentEvent.targetId
+    ) {
+      const prevented = this.usePreventionShield(
+        currentEvent.targetId,
+        currentEvent.amount,
+      );
+      if (prevented > 0) currentEvent.amount -= prevented;
+    }
+
+    return {
+      event: currentEvent,
+      appliedEffects,
+      requiresChoice: false,
+      affectedPlayerId,
+    };
+  }
+
+  /**
+   * CR 616.1 — Return the non-self replacement effects that are
+   * currently competing to apply to `event`. The affected player /
+   * permanent controller chooses between them via
+   * {@link resolveReplacementChoice} (human) or
+   * {@link autoResolveReplacementChoice} (AI).
+   *
+   * Exposed so callers can build the candidate list (e.g., for UI
+   * prompts) without invoking the full processing pipeline.
+   */
+  getCompetingReplacementEffects(
+    event: ReplacementEvent,
+    appliedEffectIds: Set<string> = new Set(),
+  ): ReplacementAbility[] {
+    const applicable = this.getApplicableEffects(event).filter(
+      (e) => !appliedEffectIds.has(e.id),
+    );
+    const nonSelf = applicable.filter((e) => !e.isSelfReplacement);
+    return nonSelf.length >= 2 ? nonSelf : [];
+  }
+
+  /**
+   * CR 616.1 — Apply the player-picked candidate and continue
+   * processing the remaining chain without re-prompting for the same
+   * event.
+   *
+   * The `applied` array must include every effect already applied on a
+   * previous iteration of the same event (so the picked effect cannot
+   * fire twice and previously-applied self-replacements remain
+   * applied). The returned outcome marks `autoResolved: false` and
+   * carries the resumed event.
+   */
+  resolveReplacementChoice(
+    pickedEffectId: string,
+    context: {
+      event: ReplacementEvent;
+      applied: string[];
+      affectedPlayerId?: PlayerId;
+      apnapOrder?: APNAPOrder;
+      maxIterations?: number;
+    },
+  ): ReplacementProcessingOutcome {
+    const appliedIds = new Set<string>(context.applied);
+
+    const candidates = this.getApplicableEffects(context.event).filter(
+      (e) => !appliedIds.has(e.id) && !e.isSelfReplacement,
+    );
+
+    if (candidates.length < 2) {
+      // Caller invoked resolveReplacementChoice without an actual
+      // competition — fall back to interactive processing so behaviour
+      // remains well-defined (no silent skip, deterministic outcome).
+      return this.processEventInteractive(context.event, context.apnapOrder, {
+        appliedEffectIds: appliedIds,
+        affectedPlayerId: context.affectedPlayerId,
+        maxIterations: context.maxIterations,
+      });
+    }
+
+    const picked = candidates.find((e) => e.id === pickedEffectId);
+    if (!picked) {
+      throw new Error(
+        `[ReplacementEffectManager.resolveReplacementChoice] ${pickedEffectId} is not in the candidate set: ` +
+          `${candidates.map((c) => c.id).join(", ")}`,
+      );
+    }
+
+    const appliedEffects: ReplacementAbility[] = [];
+    let currentEvent = { ...context.event };
+    appliedIds.add(picked.id);
+    appliedEffects.push(picked);
+
+    const result = picked.apply(currentEvent);
+    if (result.modified && result.modifiedEvent) {
+      currentEvent = { ...result.modifiedEvent };
+      if (result.skipEvent) currentEvent.amount = 0;
+    }
+
+    if (currentEvent.amount > 0) {
+      const continuation = this.processEventInteractive(
+        currentEvent,
+        context.apnapOrder,
+        {
+          appliedEffectIds: appliedIds,
+          affectedPlayerId: context.affectedPlayerId,
+          maxIterations: context.maxIterations,
+        },
+      );
+      appliedEffects.push(...continuation.appliedEffects);
+      currentEvent = { ...continuation.event };
+      return {
+        event: currentEvent,
+        appliedEffects,
+        requiresChoice: continuation.requiresChoice,
+        candidates: continuation.candidates,
+        affectedPlayerId: continuation.affectedPlayerId,
+        autoResolved: false,
+      };
+    }
+
+    return {
+      event: currentEvent,
+      appliedEffects,
+      requiresChoice: false,
+      affectedPlayerId: context.affectedPlayerId,
+      autoResolved: false,
+    };
+  }
+
+  /**
+   * CR 616.1 — Deterministic AI heuristic for picking one replacement
+   * effect from a competing candidate set.
+   *
+   * Tiebreaker order:
+   *  1. Self-replacements (defensive — should not be in non-self set,
+   *     but they're cheapest if a caller mis-classifies an effect).
+   *  2. The affected player's own effects (the most natural CR 616.1
+   *     interpretation: the player who is being targeted picks one of
+   *     their own replacement effects first).
+   *  3. APNAP order (active player last by default; both candidates
+   *     already pass through this filter).
+   *  4. Lower layer first (CR 614.5 — modification layer).
+   *  5. Earliest timestamp first.
+   *
+   * The heuristic is purely deterministic so an AI controller reaches
+   * the same decision every time on an identical game state, which
+   * matters for replay determinism and event sourcing.
+   */
+  autoResolveReplacementChoice(
+    candidates: ReplacementAbility[],
+    affectedPlayerId: PlayerId,
+    apnapOrder?: APNAPOrder,
+  ): string {
+    if (candidates.length === 0) {
+      throw new Error(
+        "[ReplacementEffectManager.autoResolveReplacementChoice] empty candidate set",
+      );
+    }
+    const sorted = [...candidates].sort((a, b) => {
+      if (a.isSelfReplacement && !b.isSelfReplacement) return -1;
+      if (!a.isSelfReplacement && b.isSelfReplacement) return 1;
+      if (
+        a.controllerId === affectedPlayerId &&
+        b.controllerId !== affectedPlayerId
+      )
+        return -1;
+      if (
+        b.controllerId === affectedPlayerId &&
+        a.controllerId !== affectedPlayerId
+      )
+        return 1;
+      if (apnapOrder) {
+        const aIndex = apnapOrder.playerOrder.indexOf(a.controllerId);
+        const bIndex = apnapOrder.playerOrder.indexOf(b.controllerId);
+        if (aIndex !== -1 && bIndex !== -1 && aIndex !== bIndex)
+          return aIndex - bIndex;
+      }
+      if (a.layer !== b.layer) return a.layer - b.layer;
+      return a.timestamp - b.timestamp;
+    });
+    return sorted[0].id;
+  }
+
+  /**
+   * Build a {@link WaitingChoice} prompting the affected player to
+   * pick one of the supplied competing replacement effects.
+   * Used by callers when {@link processEventInteractive} returns
+   * `requiresChoice: true`.
+   */
+  createReplacementWaitingChoice(
+    candidates: ReplacementAbility[],
+    affectedPlayerId: PlayerId,
+    prompt?: string,
+  ): WaitingChoice {
+    const options: ChoiceOption[] = candidates.map((effect) => ({
+      label: effect.description,
+      value: effect.id,
+      isValid: true,
+    }));
+    return {
+      type: REPLACEMENT_CHOICE_TYPE,
+      playerId: affectedPlayerId,
+      stackObjectId: null,
+      prompt:
+        prompt ??
+        (candidates.length === 1
+          ? `Apply replacement effect: ${candidates[0].description}?`
+          : "Multiple replacement effects could apply. Choose one:"),
+      choices: options,
+      minChoices: 1,
+      maxChoices: 1,
+      presentedAt: Date.now(),
+    };
   }
 
   /**

--- a/src/lib/game-state/types.ts
+++ b/src/lib/game-state/types.ts
@@ -766,7 +766,8 @@ export interface WaitingChoice {
     | "blockers"
     | "ordering"
     | "priority"
-    | "choose_legend";
+    | "choose_legend"
+    | "choose_replacement";
   /** ID of player who needs to make this choice */
   playerId: PlayerId;
   /** ID of the stack object this choice is for */


### PR DESCRIPTION
Fixes #1227

## Summary by Sourcery

Introduce an interactive replacement/prevention effect resolution flow aligned with CR 616.1 and integrate it into damage handling.

New Features:
- Add interactive replacement-effect processing that can surface player choices and return a structured processing outcome.
- Expose utilities to query competing non-self replacement effects and build WaitingChoice prompts for replacement selection.
- Provide an AI heuristic to auto-resolve competing replacement effects deterministically when needed.

Enhancements:
- Update damage keyword action to use the interactive replacement pipeline and suspend with a WaitingChoice when multiple replacement effects compete.
- Extend WaitingChoice types to include a new choose_replacement discriminator for replacement-effect choices.

Tests:
- Add comprehensive tests covering interactive replacement resolution, self vs non-self precedence, AI auto-resolution behavior, and WaitingChoice construction.