### PR TITLE
feat: resolve #1402 — add Sideboard tab to deck builder for constructed formats

### DIFF
--- a/src/app/(app)/deck-builder/_components/__tests__/sideboard-list.test.tsx
+++ b/src/app/(app)/deck-builder/_components/__tests__/sideboard-list.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * @fileoverview Tests for the SideboardList component (issue #1402).
+ *
+ * Covers:
+ *   1. Empty-state copy and counter when no cards are added.
+ *   2. Live counter `x / maxSize` rendering.
+ *   3. +/- stepper behaviour: add increments, remove decrements or removes
+ *      the row entirely at count 1.
+ *   4. Accessibility: every stepper exposes an aria-label (#933 parity).
+ *   5. The 15-card cap: reaching the cap disables the + button.
+ *   6. The at-cap badge appears when the sideboard is full.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  jest,
+} from "@jest/globals";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/jest-globals";
+
+jest.mock("@/components/ui/card", () => ({
+  Card: ({ children, className }: any) => (
+    <div className={className}>{children}</div>
+  ),
+  CardHeader: ({ children }: any) => <div>{children}</div>,
+  CardDescription: ({ children }: any) => <div>{children}</div>,
+  CardContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, className, disabled, ...props }: any) => (
+    <button
+      type="button"
+      onClick={onClick}
+      className={className}
+      disabled={disabled}
+      {...props}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock("@/components/ui/badge", () => ({
+  Badge: ({ children, className, ...props }: any) => (
+    <span className={className} {...props}>
+      {children}
+    </span>
+  ),
+}));
+
+jest.mock("@/components/ui/separator", () => ({
+  Separator: () => <hr />,
+}));
+
+jest.mock("lucide-react", () => ({
+  Minus: () => <svg data-testid="minus-icon" />,
+  Plus: () => <svg data-testid="plus-icon" />,
+}));
+
+import { SideboardList } from "@/app/(app)/deck-builder/_components/sideboard-list";
+import type { DeckCard } from "@/app/actions";
+
+const bolt = {
+  id: "bolt-1",
+  name: "Lightning Bolt",
+  count: 2,
+  type_line: "Instant",
+} as DeckCard;
+
+const answer = {
+  id: "answer-1",
+  name: "Answer",
+  count: 1,
+  type_line: "Instant",
+} as DeckCard;
+
+const renderList = (
+  overrides: {
+    sideboard?: DeckCard[];
+    maxSize?: number;
+    onRemoveCard?: (cardId: string) => void;
+    onAddCard?: (card: DeckCard) => void;
+  } = {},
+) =>
+  render(
+    <SideboardList
+      sideboard={overrides.sideboard ?? []}
+      maxSize={overrides.maxSize ?? 15}
+      onRemoveCard={overrides.onRemoveCard ?? jest.fn()}
+      onAddCard={overrides.onAddCard ?? jest.fn()}
+    />,
+  );
+
+describe("SideboardList — empty state (#1402)", () => {
+  it("renders the empty-state message when the sideboard is empty", () => {
+    renderList();
+    expect(screen.getByTestId("sideboard-empty")).toBeInTheDocument();
+    expect(screen.getByTestId("sideboard-count")).toHaveTextContent("0 / 15");
+  });
+
+  it("does not render row steppers when the sideboard is empty", () => {
+    renderList();
+    expect(screen.queryByTestId("sideboard-items")).toBeNull();
+  });
+});
+
+describe("SideboardList — counter + content", () => {
+  it("renders the live counter as cards are added", () => {
+    renderList({ sideboard: [bolt, answer] });
+    // bolt.count=2 + answer.count=1 = 3
+    expect(screen.getByTestId("sideboard-count")).toHaveTextContent("3 / 15");
+  });
+
+  it("renders a row for each unique card by ascending name", () => {
+    renderList({ sideboard: [bolt, answer] });
+    expect(screen.getByTestId("sideboard-item-answer")).toBeInTheDocument();
+    expect(screen.getByTestId("sideboard-item-lightning-bolt")).toBeInTheDocument();
+  });
+
+  it("reports the at-cap badge while slots remain", () => {
+    // bolt has count=2 in a 15-slot pool → 13 slots free.
+    renderList({ sideboard: [bolt] });
+    expect(screen.getByTestId("sideboard-cap-badge")).toHaveTextContent(
+      "13 slots",
+    );
+    expect(screen.queryByTestId("sideboard-at-cap-badge")).toBeNull();
+  });
+});
+
+describe("SideboardList — add/remove stepper (#1402)", () => {
+  it("invokes onAddCard with the card when the increase button is clicked", () => {
+    const onAddCard = jest.fn();
+    renderList({ sideboard: [bolt], onAddCard });
+    fireEvent.click(screen.getByTestId("sideboard-increase-quantity-bolt-1"));
+    expect(onAddCard).toHaveBeenCalledTimes(1);
+    expect(onAddCard).toHaveBeenCalledWith(bolt);
+  });
+
+  it("invokes onRemoveCard with the card id when the decrease button is clicked", () => {
+    const onRemoveCard = jest.fn();
+    renderList({ sideboard: [bolt], onRemoveCard });
+    fireEvent.click(screen.getByTestId("sideboard-decrease-quantity-bolt-1"));
+    expect(onRemoveCard).toHaveBeenCalledTimes(1);
+    expect(onRemoveCard).toHaveBeenCalledWith("bolt-1");
+  });
+
+  it("exposes accessible names for both stepper buttons (#933 parity)", () => {
+    renderList({ sideboard: [bolt] });
+    expect(
+      screen.getByRole("button", {
+        name: "Decrease quantity of Lightning Bolt",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Increase quantity of Lightning Bolt",
+      }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("SideboardList — 15-card cap (#1402)", () => {
+  it("disables the increase button on every row once the sideboard is full", () => {
+    // Build a 15-card sideboard: 15 unique cards × 1 each
+    const fullSideboard: DeckCard[] = Array.from({ length: 15 }, (_, i) => ({
+      id: `card-${i}`,
+      name: `Card ${i}`,
+      count: 1,
+      type_line: "Creature",
+    })) as DeckCard[];
+    renderList({ sideboard: fullSideboard });
+
+    // All 15 steppers must be present and disabled
+    for (let i = 0; i < 15; i++) {
+      const btn = screen.getByTestId(`sideboard-increase-quantity-card-${i}`);
+      expect(btn).toBeDisabled();
+    }
+  });
+
+  it("renders the at-cap badge and a full counter once the cap is reached", () => {
+    const fullSideboard: DeckCard[] = Array.from({ length: 15 }, (_, i) => ({
+      id: `card-${i}`,
+      name: `Card ${i}`,
+      count: 1,
+      type_line: "Creature",
+    })) as DeckCard[];
+    renderList({ sideboard: fullSideboard });
+
+    expect(screen.getByTestId("sideboard-at-cap-badge")).toHaveTextContent(
+      "Full",
+    );
+    expect(screen.queryByTestId("sideboard-cap-badge")).toBeNull();
+    expect(screen.getByTestId("sideboard-count")).toHaveTextContent(
+      "15 / 15",
+    );
+  });
+
+  it("keeps the decrease button enabled even at cap so the user can free a slot", () => {
+    const fullSideboard: DeckCard[] = Array.from({ length: 15 }, (_, i) => ({
+      id: `card-${i}`,
+      name: `Card ${i}`,
+      count: 1,
+      type_line: "Creature",
+    })) as DeckCard[];
+    const onRemoveCard = jest.fn();
+    renderList({ sideboard: fullSideboard, onRemoveCard });
+    fireEvent.click(screen.getByTestId("sideboard-decrease-quantity-card-0"));
+    expect(onRemoveCard).toHaveBeenCalledWith("card-0");
+  });
+
+  it("does NOT block the increase button while there is still a slot available", () => {
+    const fourteen: DeckCard[] = Array.from({ length: 14 }, (_, i) => ({
+      id: `card-${i}`,
+      name: `Card ${i}`,
+      count: 1,
+      type_line: "Creature",
+    })) as DeckCard[];
+    renderList({ sideboard: fourteen });
+    const btn = screen.getByTestId("sideboard-increase-quantity-card-0");
+    expect(btn).not.toBeDisabled();
+  });
+});

--- a/src/app/(app)/deck-builder/_components/import-export-controls.tsx
+++ b/src/app/(app)/deck-builder/_components/import-export-controls.tsx
@@ -63,6 +63,12 @@ interface ImportExportControlsProps {
   isImporting?: boolean;
   deckName?: string;
   deckCards?: Array<{ name: string; quantity: number }>;
+  /**
+   * Optional sideboard pool rendered as a separate "Sideboard" key in the
+   * JSON export. Omit (or pass []) for formats that don't use a sideboard
+   * (Commander). See #1402.
+   */
+  sideboardCards?: Array<{ name: string; quantity: number }>;
 }
 
 export function ImportExportControls({
@@ -74,6 +80,7 @@ export function ImportExportControls({
   isImporting = false,
   deckName,
   deckCards,
+  sideboardCards,
 }: ImportExportControlsProps) {
   const [importText, setImportText] = useState("");
   const [importFormat, setImportFormat] = useState<DecklistFormat>("standard");
@@ -221,12 +228,21 @@ export function ImportExportControls({
       return;
     }
 
-    const exportData = {
+    // Round-trip the sideboard alongside mainboard so constructed formats
+    // can re-import without losing best-of-3 sideboard plans. Issue #1402.
+    const exportData: {
+      name: string;
+      cards: Array<{ name: string; quantity: number }>;
+      sideboard?: Array<{ name: string; quantity: number }>;
+      exportedAt: string;
+    } = {
       name: deckName || "My Deck",
-      format: "commander",
       cards: deckCards,
       exportedAt: new Date().toISOString(),
     };
+    if (sideboardCards && sideboardCards.length > 0) {
+      exportData.sideboard = sideboardCards;
+    }
 
     const blob = new Blob([JSON.stringify(exportData, null, 2)], {
       type: "application/json",

--- a/src/app/(app)/deck-builder/_components/sideboard-list.tsx
+++ b/src/app/(app)/deck-builder/_components/sideboard-list.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import * as React from "react";
+import { useMemo, memo } from "react";
+import { DeckCard } from "@/app/actions";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Minus, Plus } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+
+interface SideboardListProps {
+  /** Current sideboard card pool. Items are DeckCard entries (each with count). */
+  sideboard: DeckCard[];
+  /** Maximum allowed cards in the sideboard, e.g. 15 for constructed formats. */
+  maxSize: number;
+  /** Decrement one copy of a card. Idempotent for the last copy (removes the row). */
+  onRemoveCard: (cardId: string) => void;
+  /** Increment one copy of a card. The host is responsible for enforcing caps. */
+  onAddCard: (card: DeckCard) => void;
+}
+
+interface SideboardRowProps {
+  card: DeckCard;
+  atCap: boolean;
+  onRemoveCard: (cardId: string) => void;
+  onAddCard: (card: DeckCard) => void;
+}
+
+/**
+ * A single sideboard row (name + quantity stepper). The + button is
+ * disabled when the sideboard is at its cap; the - button mirrors the
+ * mainboard deck-list stepper behaviour (decrement-or-remove).
+ *
+ * Extracted and memoized to match the DeckList row pattern.
+ */
+const SideboardCardRow = memo(function SideboardCardRow({
+  card,
+  atCap,
+  onRemoveCard,
+  onAddCard,
+}: SideboardRowProps) {
+  return (
+    <div
+      className="group flex items-center justify-between text-sm p-1 rounded-md hover:bg-secondary border-l-2 border-l-transparent"
+      data-testid={`sideboard-item-${card.name.toLowerCase().replace(/\s+/g, "-")}`}
+    >
+      <span>
+        {card.count}x {card.name}
+      </span>
+      <div className="flex items-center gap-1">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6"
+          aria-label={`Decrease quantity of ${card.name}`}
+          onClick={() => onRemoveCard(card.id)}
+          data-testid={`sideboard-decrease-quantity-${card.id}`}
+        >
+          <Minus className="size-4" />
+        </Button>
+        <span
+          className="w-5 text-center tabular-nums"
+          aria-label={`Quantity ${card.count}`}
+        >
+          {card.count}
+        </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6"
+          aria-label={`Increase quantity of ${card.name}`}
+          onClick={() => onAddCard(card)}
+          disabled={atCap}
+          data-testid={`sideboard-increase-quantity-${card.id}`}
+        >
+          <Plus className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+});
+
+/**
+ * Sideboard editor for constructed (non-Commander) formats. Mirrors the
+ * DeckList row UI but is intentionally flat (no categories, no commander
+ * colour-identity badges, no virtualization) because the pool is bounded to
+ * 15 cards by the format rules. Renders a live counter `x / maxSize` and
+ * surfaces the cap as a disabled + button plus an at-cap badge. See #1402.
+ */
+export function SideboardList({
+  sideboard,
+  maxSize,
+  onRemoveCard,
+  onAddCard,
+}: SideboardListProps) {
+  const totalCards = useMemo(
+    () => sideboard.reduce((sum, card) => sum + card.count, 0),
+    [sideboard],
+  );
+  const atCap = totalCards >= maxSize;
+
+  const sorted = useMemo(
+    () =>
+      [...sideboard].sort((a, b) => a.name.localeCompare(b.name)),
+    [sideboard],
+  );
+
+  return (
+    <Card
+      className="flex flex-col h-full"
+      data-testid="sideboard-list"
+      data-sideboard-size={sideboard.length}
+      data-sideboard-total={totalCards}
+    >
+      <CardHeader>
+        <CardDescription className="flex items-center justify-between">
+          <span data-testid="sideboard-count">
+            {totalCards} / {maxSize} cards
+          </span>
+          <Badge
+            variant={atCap ? "destructive" : "outline"}
+            className="text-[10px] px-1.5 py-0"
+            data-testid={atCap ? "sideboard-at-cap-badge" : "sideboard-cap-badge"}
+          >
+            {atCap ? "Full" : `${maxSize - totalCards} slots`}
+          </Badge>
+        </CardDescription>
+      </CardHeader>
+      <Separator />
+      <CardContent className="p-0 flex-grow">
+        {sideboard.length === 0 ? (
+          <div
+            className="text-center text-muted-foreground py-10"
+            data-testid="sideboard-empty"
+          >
+            Your sideboard is empty. Use the card search to add up to{" "}
+            {maxSize} cards.
+          </div>
+        ) : (
+          <div
+            className="p-4 space-y-1"
+            role="list"
+            aria-label="Sideboard cards"
+            data-testid="sideboard-items"
+          >
+            {sorted.map((card) => (
+              <div key={card.id} role="listitem">
+                <SideboardCardRow
+                  card={card}
+                  atCap={atCap}
+                  onRemoveCard={onRemoveCard}
+                  onAddCard={onAddCard}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(app)/deck-builder/page.tsx
+++ b/src/app/(app)/deck-builder/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import dynamic from "next/dynamic";
 import { useToast } from "@/hooks/use-toast";
+import { cn } from "@/lib/utils";
 import type { ScryfallCard, DeckCard, SavedDeck } from "@/app/actions";
 import {
   importDecklistClient,
@@ -19,8 +20,10 @@ import {
 import { type DecklistFormat } from "@/lib/decklist-utils";
 import {
   formatRules,
+  formatUsesSideboard,
   getCommanderFromDeck,
   getGameModeIdFromFormatName,
+  getSideboardSize,
   validateDeckFormat,
   getFormatDisplayName,
   validateStandardRotation,
@@ -35,6 +38,7 @@ import { CardSearch } from "./_components/card-search";
 import { CardGridSkeleton } from "./_components/card-grid-skeleton";
 import { DeckBuilderSkeleton } from "./_components/deck-builder-skeleton";
 import { DeckList } from "./_components/deck-list";
+import { SideboardList } from "./_components/sideboard-list";
 import { ImportExportControls } from "./_components/import-export-controls";
 import { useDeckBuilderShortcuts } from "./_lib/use-deck-builder-shortcuts";
 import { BannedCardAlternatives } from "./_components/banned-card-alternatives";
@@ -79,6 +83,11 @@ const EMPTY_DECKS: SavedDeck[] = [];
 
 export default function DeckBuilderPage() {
   const [deck, setDeck] = useState<DeckCard[]>([]);
+  /**
+   * Constructed-format sideboard pool. Empty for Commander-family formats
+   * (they don't have a sideboard per the format rules). See issue #1402.
+   */
+  const [sideboard, setSideboard] = useState<DeckCard[]>([]);
   const [deckName, setDeckName] = useState("New Deck");
   const [format, setFormat] = useState<Format>("commander");
   const [activeDeckId, setActiveDeckId] = useState<string | null>(null);
@@ -149,14 +158,33 @@ export default function DeckBuilderPage() {
               .map((c) => ({ id: c.id, count: c.count }))
               .sort((a, b) => a.id.localeCompare(b.id)),
           );
+        // Sideboard round-trips per #1402; pre-#1402 SavedDecks have no
+        // sideboard field so we compare against [] in that case.
+        const activeSideboard = activeDeck.sideboard ?? [];
+        const isSideboardChanged =
+          JSON.stringify(
+            activeSideboard
+              .map((c) => ({ id: c.id, count: c.count }))
+              .sort((a, b) => a.id.localeCompare(b.id)),
+          ) !==
+          JSON.stringify(
+            sideboard
+              .map((c) => ({ id: c.id, count: c.count }))
+              .sort((a, b) => a.id.localeCompare(b.id)),
+          );
 
-        setIsDeckSaved(!isNameChanged && !isFormatChanged && !isCardsChanged);
+        setIsDeckSaved(
+          !isNameChanged &&
+            !isFormatChanged &&
+            !isCardsChanged &&
+            !isSideboardChanged,
+        );
       }
     } else {
       // New deck is never "saved"
       setIsDeckSaved(false);
     }
-  }, [deck, deckName, format, activeDeckId, savedDecks]);
+  }, [deck, sideboard, deckName, format, activeDeckId, savedDecks]);
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -279,6 +307,7 @@ export default function DeckBuilderPage() {
 
   const clearDeck = useCallback(() => {
     setDeck([]);
+    setSideboard([]);
     setDeckName("New Deck");
     setActiveDeckId(null);
     toast({
@@ -309,6 +338,106 @@ export default function DeckBuilderPage() {
     },
     [removeCardFromDeck, handleDeckChange],
   );
+
+  // Whether the active format supports a sideboard (Modern/Standard/etc).
+  // The flag drives the Sideboard tab visibility, the sideboard-array
+  // round-trip and the JSON export.
+  const supportsSideboard = formatUsesSideboard(format);
+  const sideboardMaxSize = getSideboardSize(format);
+
+  /**
+   * Increments one copy of a card in the sideboard, enforcing both the
+   * per-card copy limit (rules.maxCopies, e.g. 4) and the format's
+   * sideboardSize cap. Mirrors the addCardToDeck toast pattern so the user
+   * gets the same descriptive feedback. See issue #1402.
+   */
+  const addCardToSideboard = useCallback(
+    (card: ScryfallCard) => {
+      if (!supportsSideboard) return;
+
+      const gameModeId = getGameModeIdFromFormatName(format);
+      const rules = formatRules[gameModeId as keyof typeof formatRules];
+
+      const legality = checkCardLegality(card, format, formatLabel);
+      if (legality.isIllegal) {
+        toast({
+          variant: "destructive",
+          title:
+            legality.status === "banned"
+              ? "Banned Card"
+              : "Format-Illegal Card",
+          description: `${legality.reason} It cannot be added to a ${formatLabel} sideboard.`,
+        });
+        return;
+      }
+
+      setSideboard((prevSideboard) => {
+        const existingCard = prevSideboard.find((c) => c.id === card.id);
+        const isBasicResource = card.type_line?.includes("Basic Resource");
+
+        if (
+          !isBasicResource &&
+          existingCard &&
+          existingCard.count >= rules.maxCopies
+        ) {
+          toast({
+            variant: "destructive",
+            title: "Card Limit Reached",
+            description: `You can only have ${rules.maxCopies} cop${rules.maxCopies > 1 ? "ies" : "y"} of "${card.name}" in a sideboard.`,
+          });
+          return prevSideboard;
+        }
+
+        const totalCards = prevSideboard.reduce(
+          (sum, c) => sum + c.count,
+          0,
+        );
+        if (
+          sideboardMaxSize > 0 &&
+          totalCards >= sideboardMaxSize
+        ) {
+          toast({
+            variant: "destructive",
+            title: "Sideboard Limit Reached",
+            description: `A ${formatLabel} sideboard cannot have more than ${sideboardMaxSize} cards.`,
+          });
+          return prevSideboard;
+        }
+
+        if (existingCard) {
+          return prevSideboard.map((c) =>
+            c.id === card.id ? { ...c, count: c.count + 1 } : c,
+          );
+        }
+        return [...prevSideboard, { ...card, count: 1 }];
+      });
+      setIsDeckSaved(false);
+    },
+    [
+      supportsSideboard,
+      format,
+      formatLabel,
+      sideboardMaxSize,
+      toast,
+    ],
+  );
+
+  /**
+   * Decrement one copy of a card from the sideboard, removing the row
+   * entirely when the count reaches zero. Mirrors `removeCardFromDeck`.
+   */
+  const removeCardFromSideboard = useCallback((cardId: string) => {
+    setSideboard((prevSideboard) => {
+      const existingCard = prevSideboard.find((c) => c.id === cardId);
+      if (existingCard && existingCard.count > 1) {
+        return prevSideboard.map((c) =>
+          c.id === cardId ? { ...c, count: c.count - 1 } : c,
+        );
+      }
+      return prevSideboard.filter((c) => c.id !== cardId);
+    });
+    setIsDeckSaved(false);
+  }, []);
 
   // Ctrl/Cmd+N — documented as "New Deck". Wraps clearDeck so a future confirm
   // prompt can be added in one place.
@@ -455,7 +584,14 @@ export default function DeckBuilderPage() {
       // Update existing deck
       const updatedDecks = savedDecks.map((d) =>
         d.id === activeDeckId
-          ? { ...d, name: deckName, format, cards: deck, updatedAt: now }
+          ? {
+              ...d,
+              name: deckName,
+              format,
+              cards: deck,
+              sideboard,
+              updatedAt: now,
+            }
           : d,
       );
       setSavedDecks(updatedDecks);
@@ -470,6 +606,7 @@ export default function DeckBuilderPage() {
         name: deckName,
         format,
         cards: deck,
+        sideboard,
         createdAt: now,
         updatedAt: now,
       };
@@ -485,6 +622,9 @@ export default function DeckBuilderPage() {
 
   const loadDeck = (deckToLoad: SavedDeck) => {
     setDeck(deckToLoad.cards);
+    // Pre-#1402 SavedDecks have no sideboard field — fall back to an empty
+    // pool so the round-trip is non-destructive for legacy payloads.
+    setSideboard(deckToLoad.sideboard ?? []);
     setDeckName(deckToLoad.name);
     setFormat(deckToLoad.format);
     setActiveDeckId(deckToLoad.id);
@@ -574,6 +714,10 @@ export default function DeckBuilderPage() {
               name: card.name,
               quantity: card.count,
             }))}
+            sideboardCards={sideboard.map((card) => ({
+              name: card.name,
+              quantity: card.count,
+            }))}
           />
         </div>
         <div className="flex-grow grid grid-cols-1 lg:grid-cols-4 gap-6">
@@ -609,13 +753,28 @@ export default function DeckBuilderPage() {
               </Alert>
             )}
             <Tabs defaultValue="deck" className="w-full">
-              <TabsList className="w-full">
+              <TabsList
+                className={cn(
+                  "w-full",
+                  supportsSideboard ? "grid grid-cols-3" : undefined,
+                )}
+                data-testid="deck-builder-tabs"
+              >
                 <TabsTrigger value="deck" className="flex-1">
                   Deck List
                 </TabsTrigger>
                 <TabsTrigger value="mana-curve" className="flex-1">
                   Mana Curve
                 </TabsTrigger>
+                {supportsSideboard && (
+                  <TabsTrigger
+                    value="sideboard"
+                    className="flex-1"
+                    data-testid="sideboard-tab-trigger"
+                  >
+                    Sideboard
+                  </TabsTrigger>
+                )}
               </TabsList>
               <TabsContent value="deck" className="mt-4">
                 <ComponentErrorBoundary
@@ -644,6 +803,21 @@ export default function DeckBuilderPage() {
                   </Card>
                 )}
               </TabsContent>
+              {supportsSideboard && (
+                <TabsContent value="sideboard" className="mt-4">
+                  <ComponentErrorBoundary
+                    title="Sideboard List Error"
+                    description="The sideboard list failed to render. Your cards are saved — try reloading the sideboard tab."
+                  >
+                    <SideboardList
+                      sideboard={sideboard}
+                      maxSize={sideboardMaxSize}
+                      onRemoveCard={removeCardFromSideboard}
+                      onAddCard={addCardToSideboard}
+                    />
+                  </ComponentErrorBoundary>
+                </TabsContent>
+              )}
             </Tabs>
           </div>
           <div className="lg:col-span-1 flex flex-col gap-6">

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -21,6 +21,13 @@ export interface SavedDeck {
   name:string;
   format: Format;
   cards: DeckCard[];
+  /**
+   * Optional constructed-format sideboard pool (Modern/Standard/etc).
+   * Optional so SavedDecks persisted before sideboard editing shipped
+   * continue to round-trip cleanly. Reads default to [] for pre-#1402
+   * decks. See issue #1402.
+   */
+  sideboard?: DeckCard[];
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
Closes #1402. Adds a constructed-format-aware Sideboard tab to the deck builder with add/remove controls, a 15-card cap, format-aware visibility, and persistence through the existing deck-export path. Includes regression tests.