### PR TITLE
refactor: resolve #1398 — reconcile PlayerState/GameState type fragmentation

### DIFF
--- a/src/components/__tests__/icon-button-a11y.test.tsx
+++ b/src/components/__tests__/icon-button-a11y.test.tsx
@@ -4,7 +4,7 @@ import { SpectatorView } from "../spectator-view";
 import {
   LifeAdjustment,
   CounterAdjustment,
-  type JudgePlayerState,
+  type JudgeViewPlayer,
 } from "../judge-tools";
 import type { Spectator, SpectatorPermissions } from "@/lib/spectator";
 
@@ -18,10 +18,10 @@ if (typeof globalThis.ResizeObserver === "undefined") {
   (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = RO;
 }
 
-const basePlayer: JudgePlayerState = {
+const basePlayer: JudgeViewPlayer = {
   id: "p1",
   name: "Alice",
-  life: 20,
+  lifeTotal: 20,
   poisonCounters: 0,
   energyCounters: 2,
   isActive: true,

--- a/src/components/judge-tools.tsx
+++ b/src/components/judge-tools.tsx
@@ -33,16 +33,14 @@ import {
   Zap,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import type { PlayerState, GameState } from "@/types/game";
 
 // Judge role types
 export type JudgeRole = "judge" | "head-judge" | "spectator-privileged";
 
 // Warning/Penalty types
 export type PenaltyType =
-  | "warning"
-  | "game-loss"
-  | "match-loss"
-  | "disqualification";
+  "warning" | "game-loss" | "match-loss" | "disqualification";
 
 export interface Warning {
   id: string;
@@ -55,24 +53,34 @@ export interface Warning {
   issuedBy: string;
 }
 
-// Player state for judge intervention
-export interface JudgePlayerState {
-  id: string;
-  name: string;
-  life: number;
-  poisonCounters: number;
-  energyCounters: number;
+// Player view-model for the judge panel. Derived from the canonical
+// `PlayerState` in `@/types/game` (issue #1398) to eliminate the duplicate
+// `PlayerState` declaration that caused "Duplicate identifier" errors when a
+// sibling component imported the canonical type. The canonical `PlayerState`
+// uses `lifeTotal`; the judge panel historically exposed this as `life` for
+// UI brevity, but the view-model uses the canonical field name so the two
+// stay structurally aligned. The judge panel adds `isActive` and an optional
+// `energyCounters` (canonical PlayerState has neither today).
+export type JudgeViewPlayer = Pick<
+  PlayerState,
+  "id" | "name" | "lifeTotal" | "poisonCounters"
+> & {
+  energyCounters?: number;
   isActive: boolean;
-}
+};
 
-// Game state for inspection
-export interface JudgeGameState {
+// Game-state view-model for the judge panel. Canonical `GameState` tracks
+// the active player as `players[currentTurnPlayerIndex]` and does not carry
+// a `step` field, so the judge panel keeps its own view-model rather than
+// aliasing the canonical type. The `players` array uses `JudgeViewPlayer`
+// so all duplicate interface declarations are gone (issue #1398).
+export interface JudgeViewGameState {
   turn: number;
   phase: string;
   step: string;
   activePlayerId: string;
   priorityPlayerId: string;
-  players: JudgePlayerState[];
+  players: JudgeViewPlayer[];
 }
 
 // Judge tools configuration
@@ -193,7 +201,7 @@ export function WarningLog({
 
 // Life adjustment component
 interface LifeAdjustmentProps {
-  player: JudgePlayerState;
+  player: JudgeViewPlayer;
   onAdjust: (playerId: string, amount: number) => void;
   disabled?: boolean;
 }
@@ -209,7 +217,7 @@ export function LifeAdjustment({
         variant="outline"
         size="icon"
         onClick={() => onAdjust(player.id, -1)}
-        disabled={disabled || player.life <= 0}
+        disabled={disabled || player.lifeTotal <= 0}
         className="h-8 w-8"
         aria-label="Decrease life"
       >
@@ -219,14 +227,16 @@ export function LifeAdjustment({
         <Heart
           className={cn(
             "w-4 h-4",
-            player.life > 10
+            player.lifeTotal > 10
               ? "text-green-500"
-              : player.life > 5
+              : player.lifeTotal > 5
                 ? "text-yellow-500"
                 : "text-red-500",
           )}
         />
-        <span className="font-bold text-lg w-8 text-center">{player.life}</span>
+        <span className="font-bold text-lg w-8 text-center">
+          {player.lifeTotal}
+        </span>
       </div>
       <Button
         variant="outline"
@@ -246,7 +256,9 @@ export function LifeAdjustment({
             variant="outline"
             size="sm"
             onClick={() => onAdjust(player.id, amount)}
-            disabled={disabled || (player.life + amount <= 0 && amount < 0)}
+            disabled={
+              disabled || (player.lifeTotal + amount <= 0 && amount < 0)
+            }
             className="h-7 text-xs"
           >
             {amount > 0 ? "+" : ""}
@@ -260,7 +272,7 @@ export function LifeAdjustment({
 
 // Counter adjustment component
 interface CounterAdjustmentProps {
-  player: JudgePlayerState;
+  player: JudgeViewPlayer;
   counterType: "poison" | "energy";
   onAdjust: (
     playerId: string,
@@ -277,7 +289,9 @@ export function CounterAdjustment({
   disabled,
 }: CounterAdjustmentProps) {
   const value =
-    counterType === "poison" ? player.poisonCounters : player.energyCounters;
+    counterType === "poison"
+      ? player.poisonCounters
+      : (player.energyCounters ?? 0);
   const icon =
     counterType === "poison" ? (
       <Skull className="w-4 h-4 text-purple-500" />
@@ -317,7 +331,7 @@ export function CounterAdjustment({
 
 // Game state inspector component
 interface GameStateInspectorProps {
-  gameState: JudgeGameState;
+  gameState: JudgeViewGameState;
   className?: string;
 }
 
@@ -383,14 +397,14 @@ export function GameStateInspector({
                   <Heart
                     className={cn(
                       "w-3 h-3",
-                      player.life > 10
+                      player.lifeTotal > 10
                         ? "text-green-500"
-                        : player.life > 5
+                        : player.lifeTotal > 5
                           ? "text-yellow-500"
                           : "text-red-500",
                     )}
                   />
-                  <span>{player.life}</span>
+                  <span>{player.lifeTotal}</span>
                 </div>
                 {player.poisonCounters > 0 && (
                   <div className="flex items-center gap-1">
@@ -514,7 +528,7 @@ export function IssuePenalty({
 // Main Judge Panel component
 interface JudgePanelProps {
   config: JudgeToolsConfig;
-  gameState: JudgeGameState;
+  gameState: JudgeViewGameState;
   warnings: Warning[];
   onConfigChange: (config: JudgeToolsConfig) => void;
   onLifeAdjust: (playerId: string, amount: number) => void;

--- a/src/components/replay-viewer.tsx
+++ b/src/components/replay-viewer.tsx
@@ -1,23 +1,23 @@
-'use client';
+"use client";
 
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { cn } from '@/lib/utils';
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { cn } from "@/lib/utils";
 import {
   generateShareableURL,
   decodeReplayFromURL,
   copyShareableLink,
   exportReplayToFile,
   importReplayFromFile,
-  getEstimatedURLLength
-} from '@/lib/replay-sharing';
-import type { Replay } from '@/lib/game-state/replay';
-import { sanitizeCardText } from '@/lib/security/sanitize-text';
+  getEstimatedURLLength,
+} from "@/lib/replay-sharing";
+import type { Replay } from "@/lib/game-state/replay";
+import { sanitizeCardText } from "@/lib/security/sanitize-text";
 
 /**
  * Replay Viewer Component
- * 
+ *
  * Issue #291: Feature: Add replay system with shareable links
- * 
+ *
  * Provides:
  * - Game replay recording
  * - Replay playback controls (play, pause, step, speed)
@@ -29,7 +29,7 @@ import { sanitizeCardText } from '@/lib/security/sanitize-text';
 const PLAYBACK_SPEEDS = [0.5, 1, 1.5, 2, 4] as const;
 
 // Game state type for replay viewer - use the actual GameState type
-import type { GameState as ReplayGameState } from '@/lib/game-state/types';
+import type { GameState as ReplayGameState } from "@/lib/game-state/types";
 
 // Replay viewer props
 export interface ReplayViewerProps {
@@ -39,8 +39,11 @@ export interface ReplayViewerProps {
   className?: string;
 }
 
-// Replay player state
-interface PlayerState {
+// Replay player media-controls state — distinct from the canonical MTG
+// `PlayerState` in `@/types/game`. Issue #1398: previously named `PlayerState`
+// and collided with the canonical import path; renamed to make its semantics
+// (HTML5-media-style scrubber) explicit.
+interface ReplayPlayerControls {
   isPlaying: boolean;
   position: number;
   speed: number;
@@ -48,24 +51,24 @@ interface PlayerState {
 }
 
 // Main replay viewer component
-export function ReplayViewer({ 
-  replay, 
-  onPositionChange, 
+export function ReplayViewer({
+  replay,
+  onPositionChange,
   onStateChange,
-  className 
+  className,
 }: ReplayViewerProps) {
-  const [playerState, setPlayerState] = useState<PlayerState>({
+  const [playerState, setPlayerState] = useState<ReplayPlayerControls>({
     isPlaying: false,
     position: 0,
     speed: 1,
     volume: 1,
   });
-  
+
   const [showShareDialog, setShowShareDialog] = useState(false);
   const [shareUrl, setShareUrl] = useState<string | null>(null);
   const [copySuccess, setCopySuccess] = useState(false);
   const [showActionList, setShowActionList] = useState(false);
-  
+
   const playbackRef = useRef<NodeJS.Timeout | null>(null);
   const totalActions = replay?.totalActions || 0;
 
@@ -73,7 +76,7 @@ export function ReplayViewer({
   useEffect(() => {
     if (playerState.isPlaying && replay) {
       playbackRef.current = setInterval(() => {
-        setPlayerState(prev => {
+        setPlayerState((prev) => {
           const newPosition = prev.position + 1;
           if (newPosition >= totalActions) {
             return { ...prev, isPlaying: false, position: totalActions - 1 };
@@ -93,44 +96,72 @@ export function ReplayViewer({
         clearInterval(playbackRef.current);
       }
     };
-  }, [playerState.isPlaying, playerState.speed, replay, totalActions, onPositionChange, onStateChange]);
+  }, [
+    playerState.isPlaying,
+    playerState.speed,
+    replay,
+    totalActions,
+    onPositionChange,
+    onStateChange,
+  ]);
 
   // Play/pause toggle
   const togglePlay = useCallback(() => {
     if (!replay) return;
-    
+
     if (playerState.position >= totalActions - 1 && !playerState.isPlaying) {
       // Restart from beginning if at end
-      setPlayerState(prev => ({ ...prev, position: 0, isPlaying: true }));
+      setPlayerState((prev) => ({ ...prev, position: 0, isPlaying: true }));
       onPositionChange?.(0);
       const action = replay.actions[0];
       if (action) {
         onStateChange?.(action.resultingState);
       }
     } else {
-      setPlayerState(prev => ({ ...prev, isPlaying: !prev.isPlaying }));
+      setPlayerState((prev) => ({ ...prev, isPlaying: !prev.isPlaying }));
     }
-  }, [replay, playerState.position, playerState.isPlaying, totalActions, onPositionChange, onStateChange]);
+  }, [
+    replay,
+    playerState.position,
+    playerState.isPlaying,
+    totalActions,
+    onPositionChange,
+    onStateChange,
+  ]);
 
   // Step forward
   const stepForward = useCallback(() => {
     if (!replay || playerState.position >= totalActions - 1) return;
-    
+
     const newPosition = playerState.position + 1;
-    setPlayerState(prev => ({ ...prev, position: newPosition, isPlaying: false }));
+    setPlayerState((prev) => ({
+      ...prev,
+      position: newPosition,
+      isPlaying: false,
+    }));
     onPositionChange?.(newPosition);
     const action = replay.actions[newPosition];
     if (action) {
       onStateChange?.(action.resultingState);
     }
-  }, [replay, playerState.position, totalActions, onPositionChange, onStateChange]);
+  }, [
+    replay,
+    playerState.position,
+    totalActions,
+    onPositionChange,
+    onStateChange,
+  ]);
 
   // Step backward
   const stepBackward = useCallback(() => {
     if (!replay || playerState.position <= 0) return;
-    
+
     const newPosition = playerState.position - 1;
-    setPlayerState(prev => ({ ...prev, position: newPosition, isPlaying: false }));
+    setPlayerState((prev) => ({
+      ...prev,
+      position: newPosition,
+      isPlaying: false,
+    }));
     onPositionChange?.(newPosition);
     const action = replay.actions[newPosition];
     if (action) {
@@ -139,27 +170,34 @@ export function ReplayViewer({
   }, [replay, playerState.position, onPositionChange, onStateChange]);
 
   // Jump to position
-  const jumpToPosition = useCallback((position: number) => {
-    if (!replay) return;
-    
-    const validPosition = Math.max(0, Math.min(position, totalActions - 1));
-    setPlayerState(prev => ({ ...prev, position: validPosition, isPlaying: false }));
-    onPositionChange?.(validPosition);
-    const action = replay.actions[validPosition];
-    if (action) {
-      onStateChange?.(action.resultingState);
-    }
-  }, [replay, totalActions, onPositionChange, onStateChange]);
+  const jumpToPosition = useCallback(
+    (position: number) => {
+      if (!replay) return;
+
+      const validPosition = Math.max(0, Math.min(position, totalActions - 1));
+      setPlayerState((prev) => ({
+        ...prev,
+        position: validPosition,
+        isPlaying: false,
+      }));
+      onPositionChange?.(validPosition);
+      const action = replay.actions[validPosition];
+      if (action) {
+        onStateChange?.(action.resultingState);
+      }
+    },
+    [replay, totalActions, onPositionChange, onStateChange],
+  );
 
   // Change speed
   const changeSpeed = useCallback((speed: number) => {
-    setPlayerState(prev => ({ ...prev, speed }));
+    setPlayerState((prev) => ({ ...prev, speed }));
   }, []);
 
   // Generate shareable link
   const handleShare = useCallback(async () => {
     if (!replay) return;
-    
+
     const url = generateShareableURL(replay);
     if (url) {
       setShareUrl(url);
@@ -173,7 +211,7 @@ export function ReplayViewer({
   // Copy link to clipboard
   const handleCopyLink = useCallback(async () => {
     if (!shareUrl || !replay) return;
-    
+
     const success = await copyShareableLink(replay);
     if (success) {
       setCopySuccess(true);
@@ -198,16 +236,18 @@ export function ReplayViewer({
     const seconds = Math.floor(ms / 1000);
     const minutes = Math.floor(seconds / 60);
     const hours = Math.floor(minutes / 60);
-    
+
     if (hours > 0) {
-      return `${hours}:${String(minutes % 60).padStart(2, '0')}:${String(seconds % 60).padStart(2, '0')}`;
+      return `${hours}:${String(minutes % 60).padStart(2, "0")}:${String(seconds % 60).padStart(2, "0")}`;
     }
-    return `${minutes}:${String(seconds % 60).padStart(2, '0')}`;
+    return `${minutes}:${String(seconds % 60).padStart(2, "0")}`;
   }, []);
 
   if (!replay) {
     return (
-      <div className={cn('p-4 bg-card border rounded-lg text-center', className)}>
+      <div
+        className={cn("p-4 bg-card border rounded-lg text-center", className)}
+      >
         <p className="text-muted-foreground">No replay loaded</p>
         <p className="text-sm text-muted-foreground mt-1">
           Start a game to record a replay
@@ -220,13 +260,19 @@ export function ReplayViewer({
   const currentReplay = replay;
 
   return (
-    <div className={cn('flex flex-col gap-4 p-4 bg-card border rounded-lg', className)}>
+    <div
+      className={cn(
+        "flex flex-col gap-4 p-4 bg-card border rounded-lg",
+        className,
+      )}
+    >
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
           <h3 className="font-semibold text-lg">Game Replay</h3>
           <p className="text-sm text-muted-foreground">
-            {currentReplay.metadata.format} • {currentReplay.metadata.playerNames.join(' vs ')}
+            {currentReplay.metadata.format} •{" "}
+            {currentReplay.metadata.playerNames.join(" vs ")}
           </p>
         </div>
         <div className="flex gap-2">
@@ -263,7 +309,7 @@ export function ReplayViewer({
             {totalActions}
           </span>
         </div>
-        
+
         {/* Action description */}
         {currentAction && (
           <div className="text-sm text-center text-muted-foreground">
@@ -281,8 +327,18 @@ export function ReplayViewer({
           className="p-2 hover:bg-muted rounded disabled:opacity-50"
           title="Skip to start"
         >
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M11 19l-7-7 7-7m8 14l-7-7 7-7"
+            />
           </svg>
         </button>
 
@@ -293,8 +349,18 @@ export function ReplayViewer({
           className="p-2 hover:bg-muted rounded disabled:opacity-50"
           title="Step backward"
         >
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0019 16V8a1 1 0 00-1.6-.8l-5.333 4zM4.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0011 16V8a1 1 0 00-1.6-.8l-5.334 4z" />
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0019 16V8a1 1 0 00-1.6-.8l-5.333 4zM4.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0011 16V8a1 1 0 00-1.6-.8l-5.334 4z"
+            />
           </svg>
         </button>
 
@@ -302,16 +368,41 @@ export function ReplayViewer({
         <button
           onClick={togglePlay}
           className="p-3 bg-primary text-primary-foreground rounded-full hover:bg-primary/90"
-          title={playerState.isPlaying ? 'Pause' : 'Play'}
+          title={playerState.isPlaying ? "Pause" : "Play"}
         >
           {playerState.isPlaying ? (
-            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
             </svg>
           ) : (
-            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
             </svg>
           )}
         </button>
@@ -323,8 +414,18 @@ export function ReplayViewer({
           className="p-2 hover:bg-muted rounded disabled:opacity-50"
           title="Step forward"
         >
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.933 12.8a1 1 0 000-1.6L6.6 7.2A1 1 0 005 8v8a1 1 0 001.6.8l5.333-4zM19.933 12.8a1 1 0 000-1.6l-5.333-4A1 1 0 0013 8v8a1 1 0 001.6.8l5.333-4z" />
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M11.933 12.8a1 1 0 000-1.6L6.6 7.2A1 1 0 005 8v8a1 1 0 001.6.8l5.333-4zM19.933 12.8a1 1 0 000-1.6l-5.333-4A1 1 0 0013 8v8a1 1 0 001.6.8l5.333-4z"
+            />
           </svg>
         </button>
 
@@ -335,8 +436,18 @@ export function ReplayViewer({
           className="p-2 hover:bg-muted rounded disabled:opacity-50"
           title="Skip to end"
         >
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 5l7 7-7 7M5 5l7 7-7 7" />
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M13 5l7 7-7 7M5 5l7 7-7 7"
+            />
           </svg>
         </button>
       </div>
@@ -350,10 +461,10 @@ export function ReplayViewer({
               key={speed}
               onClick={() => changeSpeed(speed)}
               className={cn(
-                'px-2 py-1 text-xs rounded',
+                "px-2 py-1 text-xs rounded",
                 playerState.speed === speed
-                  ? 'bg-primary text-primary-foreground'
-                  : 'bg-muted hover:bg-muted/80'
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-muted hover:bg-muted/80",
               )}
             >
               {speed}x
@@ -364,23 +475,22 @@ export function ReplayViewer({
 
       {/* Game info */}
       <div className="flex items-center justify-between text-xs text-muted-foreground border-t pt-3">
-        <div>
-          Turn {currentAction?.resultingState?.turn?.turnNumber || 1}
-        </div>
+        <div>Turn {currentAction?.resultingState?.turn?.turnNumber || 1}</div>
         <div>
           {currentReplay.metadata.winners ? (
             <span className="text-green-500">
-              Winner: {currentReplay.metadata.winners.join(', ')}
+              Winner: {currentReplay.metadata.winners.join(", ")}
             </span>
           ) : (
-            'In progress'
+            "In progress"
           )}
         </div>
         <div>
           {formatDuration(
-            currentReplay.metadata.gameEndDate 
-              ? currentReplay.metadata.gameEndDate - currentReplay.metadata.gameStartDate
-              : Date.now() - currentReplay.metadata.gameStartDate
+            currentReplay.metadata.gameEndDate
+              ? currentReplay.metadata.gameEndDate -
+                  currentReplay.metadata.gameStartDate
+              : Date.now() - currentReplay.metadata.gameStartDate,
           )}
         </div>
       </div>
@@ -390,7 +500,7 @@ export function ReplayViewer({
         onClick={() => setShowActionList(!showActionList)}
         className="text-sm text-primary hover:underline"
       >
-        {showActionList ? 'Hide' : 'Show'} action history
+        {showActionList ? "Hide" : "Show"} action history
       </button>
 
       {/* Action list */}
@@ -401,10 +511,10 @@ export function ReplayViewer({
               key={action.sequenceNumber}
               onClick={() => jumpToPosition(index)}
               className={cn(
-                'w-full text-left px-2 py-1 rounded text-sm',
+                "w-full text-left px-2 py-1 rounded text-sm",
                 index === playerState.position
-                  ? 'bg-primary/20 text-primary'
-                  : 'hover:bg-muted'
+                  ? "bg-primary/20 text-primary"
+                  : "hover:bg-muted",
               )}
             >
               <span className="text-muted-foreground mr-2">
@@ -421,7 +531,7 @@ export function ReplayViewer({
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div className="bg-card border rounded-lg p-6 max-w-md w-full mx-4">
             <h3 className="font-semibold text-lg mb-4">Share Replay</h3>
-            
+
             {shareUrl ? (
               <div className="space-y-4">
                 <p className="text-sm text-muted-foreground">
@@ -437,13 +547,13 @@ export function ReplayViewer({
                   <button
                     onClick={handleCopyLink}
                     className={cn(
-                      'px-4 py-2 rounded text-sm',
-                      copySuccess 
-                        ? 'bg-green-500 text-white'
-                        : 'bg-primary text-primary-foreground'
+                      "px-4 py-2 rounded text-sm",
+                      copySuccess
+                        ? "bg-green-500 text-white"
+                        : "bg-primary text-primary-foreground",
                     )}
                   >
-                    {copySuccess ? 'Copied!' : 'Copy'}
+                    {copySuccess ? "Copied!" : "Copy"}
                   </button>
                 </div>
                 <p className="text-xs text-muted-foreground">
@@ -453,7 +563,8 @@ export function ReplayViewer({
             ) : (
               <div className="space-y-4">
                 <p className="text-sm text-muted-foreground">
-                  This replay is too large to share via URL. Export it as a file instead:
+                  This replay is too large to share via URL. Export it as a file
+                  instead:
                 </p>
                 <button
                   onClick={handleExport}
@@ -463,7 +574,7 @@ export function ReplayViewer({
                 </button>
               </div>
             )}
-            
+
             <button
               onClick={() => setShowShareDialog(false)}
               className="mt-4 w-full px-4 py-2 bg-muted rounded hover:bg-muted/80"
@@ -485,39 +596,47 @@ export interface ReplayListProps {
   className?: string;
 }
 
-export function ReplayList({ replays, onSelect, onDelete, className }: ReplayListProps) {
+export function ReplayList({
+  replays,
+  onSelect,
+  onDelete,
+  className,
+}: ReplayListProps) {
   const [importing, setImporting] = useState(false);
 
-  const handleImport = useCallback(async (file: File) => {
-    setImporting(true);
-    try {
-      const replay = await importReplayFromFile(file);
-      if (replay) {
-        onSelect(replay);
+  const handleImport = useCallback(
+    async (file: File) => {
+      setImporting(true);
+      try {
+        const replay = await importReplayFromFile(file);
+        if (replay) {
+          onSelect(replay);
+        }
+      } catch (error) {
+        console.error("Failed to import replay:", error);
+      } finally {
+        setImporting(false);
       }
-    } catch (error) {
-      console.error('Failed to import replay:', error);
-    } finally {
-      setImporting(false);
-    }
-  }, [onSelect]);
+    },
+    [onSelect],
+  );
 
   const formatDate = (timestamp: number) => {
     return new Date(timestamp).toLocaleDateString(undefined, {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
     });
   };
 
   return (
-    <div className={cn('space-y-4', className)}>
+    <div className={cn("space-y-4", className)}>
       {/* Import button */}
       <div className="flex justify-end">
         <label className="px-4 py-2 bg-primary text-primary-foreground rounded cursor-pointer hover:bg-primary/90">
-          {importing ? 'Importing...' : 'Import Replay'}
+          {importing ? "Importing..." : "Import Replay"}
           <input
             type="file"
             accept=".json"
@@ -546,14 +665,15 @@ export function ReplayList({ replays, onSelect, onDelete, className }: ReplayLis
             >
               <div>
                 <h4 className="font-medium">
-                  {replay.metadata.format} - {replay.metadata.playerNames.join(' vs ')}
+                  {replay.metadata.format} -{" "}
+                  {replay.metadata.playerNames.join(" vs ")}
                 </h4>
                 <p className="text-sm text-muted-foreground">
                   {formatDate(replay.createdAt)} • {replay.totalActions} actions
                 </p>
                 {replay.metadata.winners && (
                   <p className="text-sm text-green-500">
-                    Winner: {replay.metadata.winners.join(', ')}
+                    Winner: {replay.metadata.winners.join(", ")}
                   </p>
                 )}
               </div>
@@ -566,8 +686,18 @@ export function ReplayList({ replays, onSelect, onDelete, className }: ReplayLis
                     }}
                     className="p-2 text-destructive hover:bg-destructive/10 rounded"
                   >
-                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                      />
                     </svg>
                   </button>
                 )}
@@ -583,27 +713,27 @@ export function ReplayList({ replays, onSelect, onDelete, className }: ReplayLis
 // Hook for managing replay storage
 export function useReplayStorage() {
   const [replays, setReplays] = useState<Replay[]>([]);
-  const STORAGE_KEY = 'planar-nexus-replays';
+  const STORAGE_KEY = "planar-nexus-replays";
 
   // Load replays from localStorage
   useEffect(() => {
-    if (typeof window === 'undefined') return;
-    
+    if (typeof window === "undefined") return;
+
     try {
       const stored = localStorage.getItem(STORAGE_KEY);
       if (stored) {
         setReplays(JSON.parse(stored));
       }
     } catch (error) {
-      console.error('Failed to load replays:', error);
+      console.error("Failed to load replays:", error);
     }
   }, []);
 
   // Save replay
   const saveReplay = useCallback((replay: Replay) => {
-    setReplays(prev => {
+    setReplays((prev) => {
       const updated = [...prev, replay];
-      if (typeof window !== 'undefined') {
+      if (typeof window !== "undefined") {
         localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
       }
       return updated;
@@ -612,9 +742,9 @@ export function useReplayStorage() {
 
   // Delete replay
   const deleteReplay = useCallback((replayId: string) => {
-    setReplays(prev => {
-      const updated = prev.filter(r => r.id !== replayId);
-      if (typeof window !== 'undefined') {
+    setReplays((prev) => {
+      const updated = prev.filter((r) => r.id !== replayId);
+      if (typeof window !== "undefined") {
         localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
       }
       return updated;
@@ -624,7 +754,7 @@ export function useReplayStorage() {
   // Clear all replays
   const clearReplays = useCallback(() => {
     setReplays([]);
-    if (typeof window !== 'undefined') {
+    if (typeof window !== "undefined") {
       localStorage.removeItem(STORAGE_KEY);
     }
   }, []);
@@ -644,10 +774,10 @@ export function useReplayFromURL() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (typeof window === 'undefined') return;
+    if (typeof window === "undefined") return;
 
     const urlParams = new URLSearchParams(window.location.search);
-    const encoded = urlParams.get('replay');
+    const encoded = urlParams.get("replay");
 
     if (encoded) {
       try {
@@ -655,10 +785,10 @@ export function useReplayFromURL() {
         if (decoded) {
           setReplay(decoded);
         } else {
-          setError('Failed to decode replay from URL');
+          setError("Failed to decode replay from URL");
         }
       } catch {
-        setError('Invalid replay data in URL');
+        setError("Invalid replay data in URL");
       }
     }
 

--- a/src/types/__tests__/type-aliases.test.ts
+++ b/src/types/__tests__/type-aliases.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Type-reconciliation guard (issue #1398).
+ *
+ * Locks the post-refactor invariant: `PlayerState` and `GameState` are the
+ * canonical domain types and live ONLY in `src/types/game.ts`. Any component
+ * or module that needs a view-specific shape must derive it from the
+ * canonical types (via `Pick`, `Partial`, or `& { … }`) rather than
+ * redeclaring an interface under the same name.
+ *
+ * If a future contributor adds a parallel `interface PlayerState` (or
+ * resurrects `interface JudgePlayerState` etc.) this test fails and the
+ * regression is caught before it ships.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+type DeclarationKind = "interface" | "type";
+
+interface Declaration {
+  kind: DeclarationKind;
+  name: string;
+  file: string;
+  line: number;
+}
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SRC_ROOT = path.join(REPO_ROOT, "src");
+const TYPES_DIR = path.join(SRC_ROOT, "types");
+const CANONICAL_GAME_TYPES = path.join(TYPES_DIR, "game.ts");
+
+const TARGETS = ["PlayerState", "GameState"] as const;
+const FORBIDDEN_NAMES = ["JudgePlayerState", "JudgeGameState"] as const;
+
+function walk(dir: string, files: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, files);
+    } else if (/\.(ts|tsx)$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function findDeclarations(): Declaration[] {
+  const declarations: Declaration[] = [];
+  const re = /^(export\s+)?(interface|type)\s+([A-Za-z0-9_]+)\b/;
+  for (const file of walk(SRC_ROOT)) {
+    const source = fs.readFileSync(file, "utf8");
+    const lines = source.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const match = lines[i].match(re);
+      if (!match) continue;
+      const kind = match[2] as DeclarationKind;
+      const name = match[3];
+      declarations.push({ kind, name, file, line: i + 1 });
+    }
+  }
+  return declarations;
+}
+
+describe("PlayerState / GameState canonical types (issue #1398)", () => {
+  it("re-exports PlayerState and GameState from src/types/game.ts", () => {
+    // Interfaces are erased at runtime, so we can't introspect them directly.
+    // Assert against the source file: this is the canonical home.
+    const source = fs.readFileSync(CANONICAL_GAME_TYPES, "utf8");
+    expect(source).toMatch(/export\s+interface\s+PlayerState\b/);
+    expect(source).toMatch(/export\s+interface\s+GameState\b/);
+  });
+
+  it("declares no duplicate PlayerState/GameState in UI surfaces (components & app routes)", () => {
+    // Scope: this guard targets the regression that #1398 was filed against —
+    // a `replay-viewer.tsx` declaring `interface PlayerState` that collided
+    // with the canonical import, and a `judge-tools.tsx` doing the same.
+    //
+    // Out of scope (intentional, distinct domain shapes, each with many
+    // importers and tracked in follow-up cleanup):
+    //   - src/ai/types.ts: AI evaluation view-model (hand?/board?/life?/...)
+    //   - src/lib/game-state/types.ts: engine internal state (gameId/players/cards/...)
+    //   - src/test-utils/factories/game-state.ts: test factory view-model
+    //
+    // The test asserts no UI-layer (components or app routes) redeclares the
+    // canonical type name. Renaming the 3 out-of-scope declarations to distinct
+    // domain names is a follow-up.
+    const offenders = findDeclarations().filter(
+      (d) =>
+        (TARGETS as readonly string[]).includes(d.name) &&
+        path.resolve(d.file) !== path.resolve(CANONICAL_GAME_TYPES) &&
+        (d.file.includes("/src/components/") || d.file.includes("/src/app/")),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("does not redeclare the legacy JudgePlayerState / JudgeGameState interfaces", () => {
+    const offenders = findDeclarations().filter((d) =>
+      (FORBIDDEN_NAMES as readonly string[]).includes(d.name),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("src/components/replay-viewer.tsx no longer declares a PlayerState interface", () => {
+    const replayViewer = path.join(SRC_ROOT, "components", "replay-viewer.tsx");
+    const source = fs.readFileSync(replayViewer, "utf8");
+    // The replay-viewer's scrubber state is now `ReplayPlayerControls`.
+    // A bare `interface PlayerState` would collide with the canonical type
+    // (this is the exact regression #1398 was filed against).
+    expect(source).not.toMatch(/^interface\s+PlayerState\b/m);
+    expect(source).toMatch(/interface\s+ReplayPlayerControls\b/);
+  });
+
+  it("src/components/judge-tools.tsx imports from the canonical location", () => {
+    const judgeTools = path.join(SRC_ROOT, "components", "judge-tools.tsx");
+    const source = fs.readFileSync(judgeTools, "utf8");
+    expect(source).toMatch(
+      /import\s+type\s*\{[^}]*\bPlayerState\b[^}]*\}\s+from\s+["']@\/types\/game["']/,
+    );
+    expect(source).toMatch(/JudgeViewPlayer/);
+    expect(source).toMatch(/JudgeViewGameState/);
+  });
+});

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,19 +1,42 @@
 import { ScryfallCard } from "@/app/actions";
 
 /**
- * Game state types for the Planar Nexus game board
+ * Game state types for the Planar Nexus game board.
+ *
+ * `PlayerState` and `GameState` are the canonical domain types — do not
+ * redeclare them locally. If you need a view-specific shape (e.g. for a
+ * judge panel or replay scrubber), derive it from these via `Pick`,
+ * `Partial`, or `& { … }`. See issue #1398.
  */
 
 export type PlayerCount = 1 | 2 | 4;
 
-export type GameFormat = "commander" | "standard" | "modern" | "pioneer" | "legacy" | "vintage" | "pauper";
+export type GameFormat =
+  | "commander"
+  | "standard"
+  | "modern"
+  | "pioneer"
+  | "legacy"
+  | "vintage"
+  | "pauper";
 
-export type TurnPhase = "beginning" | "precombat_main" | "combat" | "postcombat_main" | "end";
+export type TurnPhase =
+  "beginning" | "precombat_main" | "combat" | "postcombat_main" | "end";
 
-export type ZoneType = "battlefield" | "hand" | "graveyard" | "exile" | "library" | "commandZone" | "companion" | "stack" | "sideboard" | "anticipate";
+export type ZoneType =
+  | "battlefield"
+  | "hand"
+  | "graveyard"
+  | "exile"
+  | "library"
+  | "commandZone"
+  | "companion"
+  | "stack"
+  | "sideboard"
+  | "anticipate";
 
 // Team-related types for 2v2 mode
-export type TeamId = 'team-a' | 'team-b';
+export type TeamId = "team-a" | "team-b";
 
 export interface TeamState {
   id: TeamId;


### PR DESCRIPTION
Resolves #1398. Unifies duplicate PlayerState/GameState declarations across src/components/replay-viewer.tsx and src/components/judge-tools.tsx onto the canonical src/types/game.ts source-of-truth.

- replay-viewer.tsx: renames its scrubber-state interface PlayerState → ReplayPlayerControls (different shape; the original collision was always a name conflict).
- judge-tools.tsx: replaces JudgePlayerState/JudgeGameState with JudgeViewPlayer (derived Pick from canonical PlayerState) and JudgeViewGameState (kept separate because canonical GameState tracks activePlayer as players[currentTurnPlayerIndex] and has no step field).
- icon-button-a11y test fixture updated for new name + lifeTotal field.
- src/types/game.ts: header comment locks the post-refactor invariant.
- src/types/__tests__/type-aliases.test.ts: new guard test fails CI on regression. Scoped to src/components/ and src/app/ (the issue's actual scope); the 3 intentional domain-distinct declarations in src/ai/types.ts (AI view-model), src/lib/game-state/types.ts (engine internals), and src/test-utils/factories/game-state.ts (test factory) are out of scope for this issue and will be addressed in follow-up cleanup.

Typecheck clean (tsc --noEmit). 9 tests pass (5 new guard + 4 existing icon-button-a11y).