### PR TITLE
fix: resolve #1399 - wire macOS notarytool signing and hardenedRuntime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,22 +152,125 @@ jobs:
         run: npm install -g @tauri-apps/cli@latest
         if: success()
 
-      # Build Tauri macOS app (Universal)
-      # Note: For proper code signing and notarization, configure APPLE_SIGNING_IDENTITY, 
-      # APPLE_ID, APPLE_PASSWORD, and APPLE_TEAM_ID secrets in your repository.
-      # Without these, ad-hoc signing will be used (app will work but won't pass Gatekeeper).
-      # We always use build without --ci to skip notarization which requires Apple credentials.
-      # Issue #1403: the updater signing envvars must also be present here so
-      # the .app.tar.gz updater artifact (Tauri 2 emits this for macOS) gets
-      # a matching .sig; otherwise the manifest cannot validate macOS
-      # updates and the desktop client silently skips them.
+      # Build Tauri macOS app (Universal).
+      #
+      # Code signing is driven by the APPLE_SIGNING_IDENTITY environment
+      # variable (Tauri reads it when `bundle.macOS.signingIdentity` is
+      # null in tauri.conf.json). Hardened Runtime is enabled in
+      # `bundle.macOS.hardenedRuntime` so the binary is eligible for
+      # notarization through `xcrun notarytool` in the next steps.
+      #
+      # Issue #1403: the updater signing envvars must also be present
+      # here so the .app.tar.gz updater artifact (Tauri 2 emits this for
+      # macOS) gets a matching .sig; otherwise the manifest cannot
+      # validate macOS updates and the desktop client silently skips
+      # them.
+      # Issue #1399: when APPLE_ID/APPLE_PASSWORD/APPLE_TEAM_ID are set
+      # in the `Releases` GitHub Environment, the steps below submit the
+      # .app and .dmg to notarytool and staple the ticket so the
+      # artifact passes Gatekeeper on a fresh macOS install. The steps
+      # self-skip when the secrets are absent so contributors can still
+      # run ad-hoc builds on their own fork.
       - name: Build Tauri macOS app (Universal)
         run: tauri build --target universal-apple-darwin
         if: success()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+
+      # Issue #1399: notarize the macOS .app bundle. Without a stapled
+      # notarization ticket a fresh macOS Sequoia/Sonoma install blocks
+      # the .dmg with Gatekeeper's "damaged or can't be opened" wall.
+      # The entire step is skipped if any of the three Apple secrets are
+      # missing so PR builds from forks (or pre-secret org runs) still
+      # ship the .app/.dmg unsigned-notarized rather than failing.
+      - name: Locate signed .app bundle
+        id: locate_app
+        if: success() && env.APPLE_ID != '' && env.APPLE_PASSWORD != '' && env.APPLE_TEAM_ID != ''
+        run: |
+          set -euo pipefail
+          APP_DIR="src-tauri/target/universal-apple-darwin/release/bundle/macos"
+          if [[ ! -d "$APP_DIR" ]]; then
+            echo "::error::No .app bundle produced under $APP_DIR"
+            exit 1
+          fi
+          # Use -print -quit (BSD find) so the assignment is null-safe
+          # when zero or many matches exist.
+          APP="$(find "$APP_DIR" -maxdepth 1 -name '*.app' -print -quit)"
+          if [[ -z "$APP" ]]; then
+            echo "::error::Could not find a .app bundle in $APP_DIR"
+            exit 1
+          fi
+          echo "app-path=$APP" >> "$GITHUB_OUTPUT"
+          echo "Located app bundle: $APP"
+
+      - name: Submit .app bundle to notarytool
+        if: steps.locate_app.conclusion == 'success'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          xcrun notarytool submit "${{ steps.locate_app.outputs.app-path }}" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+
+      - name: Staple notarization ticket onto .app bundle
+        if: steps.locate_app.conclusion == 'success'
+        run: |
+          set -euo pipefail
+          xcrun stapler staple "${{ steps.locate_app.outputs.app-path }}"
+
+      - name: Locate signed .dmg
+        id: locate_dmg
+        if: steps.locate_app.conclusion == 'success'
+        run: |
+          set -euo pipefail
+          DMG_DIR="src-tauri/target/universal-apple-darwin/release/bundle/dmg"
+          DMG="$(find "$DMG_DIR" -maxdepth 1 -name '*.dmg' -print -quit)"
+          if [[ -z "$DMG" ]]; then
+            echo "::error::Could not find a .dmg in $DMG_DIR"
+            exit 1
+          fi
+          echo "dmg-path=$DMG" >> "$GITHUB_OUTPUT"
+          echo "Located dmg: $DMG"
+
+      - name: Submit .dmg to notarytool
+        if: steps.locate_dmg.conclusion == 'success'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          xcrun notarytool submit "${{ steps.locate_dmg.outputs.dmg-path }}" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+
+      - name: Staple notarization ticket onto .dmg
+        if: steps.locate_dmg.conclusion == 'success'
+        run: |
+          set -euo pipefail
+          xcrun stapler staple "${{ steps.locate_dmg.outputs.dmg-path }}"
+
+      # Diagnostic: surface a one-line summary even when notarization was
+      # skipped so a future maintainer can spot a missing-secret run
+      # without re-reading the full workflow log.
+      - name: Notarization status
+        if: always()
+        run: |
+          if [[ "${{ steps.locate_app.conclusion }}" == "success" ]]; then
+            echo "::notice::macOS notarization completed for ${{ steps.locate_app.outputs.app-path }}"
+          else
+            echo "::warning::macOS notarization skipped — APPLE_ID/APPLE_PASSWORD/APPLE_TEAM_ID secrets are not configured. See docs/RELEASE_RUNBOOK.md §5."
+          fi
 
       - name: Upload macOS DMG
         uses: actions/upload-artifact@v7

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -34,18 +34,18 @@ The release workflow lives at `.github/workflows/release.yml`.
 All secrets live under **Settings → Secrets and variables → Actions** on
 the `Releases` GitHub Environment (never repository-wide).
 
-| Secret | Owner | Scope | Notes |
-|---|---|---|---|
-| `TAURI_SIGNING_PRIVATE_KEY` | Release lead | All | base64 of `.key` from `tauri signer generate -p "$PW"`. Rotated yearly. |
-| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Release lead | All | Password used above. Stored in 1Password. |
-| `WINDOWS_CERTIFICATE` | Release lead | Win | base64 of `.pfx`. Use EV or Azure Trusted Signing — see §4. |
-| `WINDOWS_CERTIFICATE_PASSWORD` | Release lead | Win | `.pfx` export password. |
-| `APPLE_SIGNING_IDENTITY` | Release lead | macOS | `Developer ID Application: Planar Nexus (TEAMID)`. |
-| `APPLE_ID` | Release lead | macOS | Apple ID email for notarytool. |
-| `APPLE_PASSWORD` | Release lead | macOS | App-specific password (NOT the Apple ID password). |
-| `APPLE_TEAM_ID` | Release lead | macOS | 10-char team identifier. |
-| `GPG_SIGNING_KEY_FINGERPRINT` | Release lead | Linux | 40-char subkey fingerprint for `.deb`/`.rpm` signing. |
-| `GPG_SIGNING_KEY_PASSPHRASE` | Release lead | Linux | Passphrase for the above key. |
+| Secret                               | Owner        | Scope | Notes                                                                   |
+| ------------------------------------ | ------------ | ----- | ----------------------------------------------------------------------- |
+| `TAURI_SIGNING_PRIVATE_KEY`          | Release lead | All   | base64 of `.key` from `tauri signer generate -p "$PW"`. Rotated yearly. |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Release lead | All   | Password used above. Stored in 1Password.                               |
+| `WINDOWS_CERTIFICATE`                | Release lead | Win   | base64 of `.pfx`. Use EV or Azure Trusted Signing — see §4.             |
+| `WINDOWS_CERTIFICATE_PASSWORD`       | Release lead | Win   | `.pfx` export password.                                                 |
+| `APPLE_SIGNING_IDENTITY`             | Release lead | macOS | `Developer ID Application: Planar Nexus (TEAMID)`.                      |
+| `APPLE_ID`                           | Release lead | macOS | Apple ID email for notarytool.                                          |
+| `APPLE_PASSWORD`                     | Release lead | macOS | App-specific password (NOT the Apple ID password).                      |
+| `APPLE_TEAM_ID`                      | Release lead | macOS | 10-char team identifier.                                                |
+| `GPG_SIGNING_KEY_FINGERPRINT`        | Release lead | Linux | 40-char subkey fingerprint for `.deb`/`.rpm` signing.                   |
+| `GPG_SIGNING_KEY_PASSPHRASE`         | Release lead | Linux | Passphrase for the above key.                                           |
 
 Secrets are **never** echoed in logs. The `notify-failure` job posts the
 runbook URL so on-call can recover without reading secrets.
@@ -55,15 +55,15 @@ runbook URL so on-call can recover without reading secrets.
 A new release engineer must complete every row before their first tag
 push.
 
-| Step | Action | Verified |
-|---|---|---|
-| 1 | Added as environment reviewer on `Releases` | ☐ |
-| 2 | Added to `@anchapin/planar-nexus` team with `Maintain` role | ☐ |
-| 3 | Received 1Password vault invite; downloaded Tauri `.key` and `.pfx` locally for dry-run | ☐ |
-| 4 | Created an Apple Developer app-specific password at <https://appleid.apple.com> | ☐ |
-| 5 | Ran `docs/RELEASE_DRY_RUN.md` end-to-end on a throwaway `v0.0.0-rc.X` tag | ☐ |
-| 6 | Confirmed GitHub notification routing for `release.yml` failures | ☐ |
-| 7 | Read this runbook end-to-end | ☐ |
+| Step | Action                                                                                  | Verified |
+| ---- | --------------------------------------------------------------------------------------- | -------- |
+| 1    | Added as environment reviewer on `Releases`                                             | ☐        |
+| 2    | Added to `@anchapin/planar-nexus` team with `Maintain` role                             | ☐        |
+| 3    | Received 1Password vault invite; downloaded Tauri `.key` and `.pfx` locally for dry-run | ☐        |
+| 4    | Created an Apple Developer app-specific password at <https://appleid.apple.com>         | ☐        |
+| 5    | Ran `docs/RELEASE_DRY_RUN.md` end-to-end on a throwaway `v0.0.0-rc.X` tag               | ☐        |
+| 6    | Confirmed GitHub notification routing for `release.yml` failures                        | ☐        |
+| 7    | Read this runbook end-to-end                                                            | ☐        |
 
 ## 4. Windows Code-Signing Flow
 
@@ -87,31 +87,56 @@ fed in as a base64 secret and rehydrated at build time.
    ```
 5. Tauri reads `bundle.windows.certificateThumbprint` +
    `timestampUrl` from `src-tauri/tauri.conf.json` — keep `http://
-   timestamp.digicert.com` or move to `http://timestamp.sectigo.com`.
+timestamp.digicert.com` or move to `http://timestamp.sectigo.com`.
 6. EV certs on a USB token cannot leave the host; rotate the matrix to
    `windows-2019` self-hosted runner with the token attached.
 
 ## 5. macOS Code-Signing & Notarization Flow
 
-`tauri build --target universal-apple-darwin` calls `codesign` then
-`notarytool`. Entitlements live in
+`tauri build --target universal-apple-darwin` calls `codesign` (using
+`APPLE_SIGNING_IDENTITY`) and then the release workflow submits the
+resulting `.app` and `.dmg` to `xcrun notarytool` before stapling.
+Hardened Runtime is permanently enabled in
+`src-tauri/tauri.conf.json` (`bundle.macOS.hardenedRuntime: true`) —
+without it, the notarization ticket Apple issues is unusable on a fresh
+macOS install. Entitlements live in
 [`/src-tauri/entitlements.plist`](../../src-tauri/entitlements.plist).
 
-1. Generate a `Developer ID Application` cert in App Store Connect.
-2. Save the identity name (e.g. `Developer ID Application: Planar Nexus
-   (TEAMID)`) into `APPLE_SIGNING_IDENTITY`.
-3. Create an app-specific password and store in `APPLE_PASSWORD`.
-4. In `release.yml::build-macos` add, *after* `tauri build`:
-   ```bash
-   APP="src-tauri/target/universal-apple-darwin/release/bundle/macos/Planar-Nexus.app"
-   xcrun notarytool submit "$APP" --apple-id "$APPLE_ID" \
-     --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
-   xcrun stapler staple "$APP"
-   ```
-5. Verify: `xcrun stapler validate "$APP"` and
-   `spctl --assess --verbose=4 "$APP"` — both must return `accepted`.
-6. Zip the app *after* stapling: `ditto -c -k --sequesterRsrc --keepParent
-   "$APP" Planar-Nexus.zip` for direct download alongside the DMG.
+> **Status (issue #1399):** the workflow wiring (notarytool submit +
+> stapler + `hardenedRuntime: true`) is live. Until the four `APPLE_*`
+> secrets in §2 are populated in the `Releases` GitHub Environment, the
+> notarization steps self-skip and the build still emits a DMG — it just
+> won't pass Gatekeeper on a fresh install. This is a docs/secret
+> rollout gap, not a code gap.
+
+1. Generate a `Developer ID Application` certificate in App Store
+   Connect (or via Xcode → Settings → Accounts → Manage Certificates).
+2. Save the **identity name** as printed by `security find-identity -v
+-p codesigning` (e.g. `Developer ID Application: Planar Nexus
+(TEAMID)`) into `APPLE_SIGNING_IDENTITY`.
+3. Create an **app-specific password** at
+   <https://appleid.apple.com/account/manage/security> and store it as
+   `APPLE_PASSWORD`. **Never reuse the Apple-ID password.**
+4. Set the team's 10-character identifier as `APPLE_TEAM_ID` (find it in
+   App Store Connect → Membership).
+5. Set the Apple ID email address as `APPLE_ID`.
+6. The workflow in `.github/workflows/release.yml::build-macos` runs
+   `xcrun notarytool submit` followed by `xcrun stapler staple` for both
+   the `.app` and `.dmg`. Re-check after any signing-identity rotation.
+7. Verify a tagged build locally with
+   `xcrun stapler validate "Planar-Nexus.app"` and
+   `spctl --assess --verbose=4 "Planar-Nexus.app"` — both must return
+   `accepted`.
+8. Zip the .app _after_ stapling (optional, for direct download):
+   `ditto -c -k --sequesterRsrc --keepParent Planar-Nexus.app
+Planar-Nexus.zip`.
+
+> **Alternative: App Store Connect API key.** If you switch from an
+> Apple-ID password to an API key, replace the three
+> `--apple-id/--password/--team-id` flags with
+> `--key /path/to/AuthKey.p8 --key-id "$APPLE_API_KEY_ID" --issuer
+"$APPLE_API_ISSUER_ID"` in the workflow. The `tauri.conf.json`
+> changes for this issue remain unchanged.
 
 ## 6. Linux Packaging & GPG Signing
 
@@ -153,20 +178,20 @@ in.
    Save the **public key** into `tauri.conf.json` → `plugins.updater.pubkey`.
 2. Host the manifest at e.g.
    `https://github.com/anchapin/planar-nexus/releases/latest/download/
-   update.json`. List it under `plugins.updater.endpoints`.
+update.json`. List it under `plugins.updater.endpoints`.
 3. To rotate: generate a new keypair, update `pubkey`, ship a release
    signed by **both** the old and new keys (Tauri supports multiple
    pubkeys during overlap), then drop the old one after 90 days.
 
 ## 8. Troubleshooting
 
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| `signtool` `0x800B0100` | Cert expired or wrong chain | Re-export `.pfx` with full chain, re-upload secret |
-| `notarytool` `Package Invalid` | Entitlements misaligned | Diff `entitlements.plist` against last green build |
-| `gpg: signing failed: No passphrase` | Secret missing in `Releases` env | Re-add `GPG_SIGNING_KEY_PASSPHRASE` |
-| Build green but Gatekeeper rejects | Staple step skipped | Re-run stapling, rebuild DMG |
-| Updater never fires | Empty `pubkey`/`endpoints` | Complete §7 before tagging |
+| Symptom                              | Likely cause                     | Fix                                                |
+| ------------------------------------ | -------------------------------- | -------------------------------------------------- |
+| `signtool` `0x800B0100`              | Cert expired or wrong chain      | Re-export `.pfx` with full chain, re-upload secret |
+| `notarytool` `Package Invalid`       | Entitlements misaligned          | Diff `entitlements.plist` against last green build |
+| `gpg: signing failed: No passphrase` | Secret missing in `Releases` env | Re-add `GPG_SIGNING_KEY_PASSPHRASE`                |
+| Build green but Gatekeeper rejects   | Staple step skipped              | Re-run stapling, rebuild DMG                       |
+| Updater never fires                  | Empty `pubkey`/`endpoints`       | Complete §7 before tagging                         |
 
 ## 9. Rollback Procedure
 
@@ -180,12 +205,12 @@ in.
 
 ## 10. Signing-Key Rotation Policy
 
-| Key | Max age | Trigger |
-|---|---|---|
-| Tauri updater key | 2 years | Planned; on key-compromise escalate to immediate |
-| Windows code-signing cert | 1 year (EV hardware) / 3 years (Azure TS) | Vendor expiry; immediate on tamper |
-| Apple Developer ID | 5 years | Apple expiry; immediate on tamper |
-| GPG maintainer key | 2 years | Planned; immediate on tamper |
+| Key                       | Max age                                   | Trigger                                          |
+| ------------------------- | ----------------------------------------- | ------------------------------------------------ |
+| Tauri updater key         | 2 years                                   | Planned; on key-compromise escalate to immediate |
+| Windows code-signing cert | 1 year (EV hardware) / 3 years (Azure TS) | Vendor expiry; immediate on tamper               |
+| Apple Developer ID        | 5 years                                   | Apple expiry; immediate on tamper                |
+| GPG maintainer key        | 2 years                                   | Planned; immediate on tamper                     |
 
 **Compromise playbook** (any key): (a) revoke the key with the vendor;
 (b) publish a `SECURITY.md` advisory; (c) re-cut all three platforms

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,10 +50,10 @@
       "minimumSystemVersion": "10.15",
       "frameworks": [],
       "exceptionDomain": "",
-      "signingIdentity": "-",
+      "signingIdentity": null,
       "providerShortName": null,
       "entitlements": "entitlements.plist",
-      "hardenedRuntime": false,
+      "hardenedRuntime": true,
       "dmg": {
         "appPosition": {
           "x": 180,

--- a/tests/macos-notarization-wiring.test.ts
+++ b/tests/macos-notarization-wiring.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Smoke tests for the macOS code-signing + notarization wiring
+ * (issue #1399).
+ *
+ * Asserts the contracts documented in the issue acceptance criteria that
+ * can be checked without spinning up macOS or a Tauri build:
+ *
+ *   1. `src-tauri/tauri.conf.json` `bundle.macOS.hardenedRuntime` is
+ *      `true` (a hard requirement for `notarytool` since 2023 — without
+ *      it, Apple refuses the submission even if every secret is set).
+ *   2. `src-tauri/tauri.conf.json` `bundle.macOS.signingIdentity` is
+ *      not pinned to ad-hoc (`"-"`); it must defer to the
+ *      `APPLE_SIGNING_IDENTITY` env var so CI can inject the real
+ *      identity at build time. A literal `"-"` here would force the
+ *      hardened-runtime build to abort with `IdentityNotFound`.
+ *   3. `.github/workflows/release.yml::build-macos` runs a Tauri build
+ *      with `APPLE_SIGNING_IDENTITY` injected.
+ *   4. The same job calls `xcrun notarytool submit` and
+ *      `xcrun stapler staple` for both the `.app` and `.dmg` artifacts.
+ *   5. The notarize/staple steps skip gracefully when the Apple-ID
+ *      secrets are missing so contributors without org access still get
+ *      an unsigned-but-uploaded DMG.
+ *   6. `docs/RELEASE_RUNBOOK.md` §5 documents the `APPLE_ID`,
+ *      `APPLE_TEAM_ID`, `APPLE_PASSWORD` secrets so the on-call release
+ *      engineer can find them in one place.
+ *
+ * The tests run in plain Node (no Tauri runtime required) so they fail
+ * fast in CI — same convention as `tests/updater-wiring.test.ts`.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const TAURI_CONF = path.join(REPO_ROOT, "src-tauri", "tauri.conf.json");
+const RELEASE_YML = path.join(REPO_ROOT, ".github", "workflows", "release.yml");
+const RUNBOOK = path.join(REPO_ROOT, "docs", "RELEASE_RUNBOOK.md");
+
+function readJson(file: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
+}
+
+function readText(file: string): string {
+  return fs.readFileSync(file, "utf8");
+}
+
+describe("macOS notarization wiring (issue #1399)", () => {
+  const conf = readJson(TAURI_CONF) as {
+    bundle?: {
+      macOS?: {
+        hardenedRuntime?: boolean;
+        signingIdentity?: string | null;
+      };
+    };
+  };
+  const mac = conf.bundle?.macOS ?? {};
+  const releaseYml = readText(RELEASE_YML);
+  const runbook = readText(RUNBOOK);
+
+  // ---------------------------------------------------------------------
+  // 1+2 — tauri.conf.json bundle.macOS shape
+  // ---------------------------------------------------------------------
+
+  test("bundle.macOS.hardenedRuntime is true (required for notarytool)", () => {
+    // `false` is the previous (regressed) state that issue #1399 is
+    // closing. Anything other than `true` — including a missing key —
+    // breaks notarization even with valid Apple credentials.
+    expect(mac.hardenedRuntime).toBe(true);
+  });
+
+  test("bundle.macOS.signingIdentity is not pinned to ad-hoc ('-')", () => {
+    // A literal '-' here would force `codesign` to sign ad-hoc even
+    // when APPLE_SIGNING_IDENTITY is set, and Apple's hardened-runtime
+    // check rejects ad-hoc identities. Leave it null (or unset) so the
+    // env var is authoritative.
+    expect(
+      mac.signingIdentity === undefined || mac.signingIdentity === null,
+    ).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------
+  // 3+4+5 — .github/workflows/release.yml shape
+  // ---------------------------------------------------------------------
+
+  test("release.yml build-macos step injects APPLE_SIGNING_IDENTITY", () => {
+    // Sanity-check that the env is plumbed through to the tauri build
+    // step. Without it, hardened-runtime=true will trip the lack-of-
+    // signing-identity abort regardless of the global env.
+    const buildJob = releaseYml.slice(
+      releaseYml.indexOf("build-macos:"),
+      releaseYml.indexOf("build-linux:"),
+    );
+    expect(buildJob).toContain("APPLE_SIGNING_IDENTITY");
+    expect(buildJob).toContain("secrets.APPLE_SIGNING_IDENTITY");
+    expect(buildJob).toContain("tauri build --target universal-apple-darwin");
+  });
+
+  test("release.yml build-macos submits the .app to notarytool and staples it", () => {
+    const buildJob = releaseYml.slice(
+      releaseYml.indexOf("build-macos:"),
+      releaseYml.indexOf("build-linux:"),
+    );
+
+    // notrytool submit + wait for the .app. The shell command uses YAML
+    // block-scalar continuations (`\\\n`) so the regex tolerates
+    // either one-line or `\`-continued invocations.
+    expect(buildJob).toMatch(
+      /notarytool\s+submit[\s\S]*?--apple-id\s+"\$APPLE_ID"[\s\S]*?--password\s+"\$APPLE_PASSWORD"[\s\S]*?--team-id\s+"\$APPLE_TEAM_ID"[\s\S]*?--wait/m,
+    );
+    // stapler staple step keyed off the same locate_app outputs
+    expect(buildJob).toContain("xcrun stapler staple");
+    expect(buildJob).toContain("steps.locate_app.outputs.app-path");
+  });
+
+  test("release.yml build-macos submits the .dmg to notarytool and staples it", () => {
+    // The DMG also needs to be notarized so a fresh user who double-
+    // clicks the .dmg (the recommended install path on macOS) doesn't
+    // trigger Gatekeeper.
+    const buildJob = releaseYml.slice(
+      releaseYml.indexOf("build-macos:"),
+      releaseYml.indexOf("build-linux:"),
+    );
+    expect(buildJob).toContain("steps.locate_dmg.outputs.dmg-path");
+    expect(buildJob).toMatch(
+      /notarytool\s+submit[^\n]*steps\.locate_dmg\.outputs\.dmg-path/m,
+    );
+    expect(buildJob).toMatch(
+      /stapler\s+staple[^\n]*steps\.locate_dmg\.outputs\.dmg-path/m,
+    );
+  });
+
+  test("release.yml notarization steps skip gracefully when Apple secrets are missing", () => {
+    // The release pipeline must NOT fail when the org hasn't yet set
+    // APPLE_ID/APPLE_PASSWORD/APPLE_TEAM_ID. A clear, deliberate
+    // conditional skip is required so a fresh-tags-on-fork workflow
+    // run still ships a DMG (just un-notarized).
+    const buildJob = releaseYml.slice(
+      releaseYml.indexOf("build-macos:"),
+      releaseYml.indexOf("build-linux:"),
+    );
+    expect(buildJob).toContain("secrets.APPLE_ID");
+    expect(buildJob).toContain("secrets.APPLE_PASSWORD");
+    expect(buildJob).toContain("secrets.APPLE_TEAM_ID");
+    // The notice/warning at end of the job documents the skip so the
+    // on-call release engineer can tell from the GH Actions UI that the
+    // DMG is intentionally unsigned.
+    expect(buildJob).toMatch(/::warning::macOS notarization skipped/);
+  });
+
+  // ---------------------------------------------------------------------
+  // 6 — docs/RELEASE_RUNBOOK.md
+  // ---------------------------------------------------------------------
+
+  test("RELEASE_RUNBOOK.md §5 documents the Apple notarization secrets", () => {
+    // The on-call release engineer needs to be able to find the four
+    // required secrets (§2 inventory) and the workflow behavior (§5
+    // flow) in one place, without grepping through the workflow yaml.
+    const section5 = runbook.slice(
+      runbook.indexOf("## 5. macOS Code-Signing"),
+      runbook.indexOf("## 6. Linux Packaging"),
+    );
+    expect(section5).toContain("APPLE_ID");
+    expect(section5).toContain("APPLE_TEAM_ID");
+    expect(section5).toContain("APPLE_PASSWORD");
+    // The §5 flow must mention the actual concrete xcrun invocations so
+    // a future operator grepping the runbook sees the exact commands.
+    expect(section5).toContain("xcrun notarytool submit");
+    expect(section5).toContain("xcrun stapler staple");
+    // Hardened runtime is mentioned by name — without it the runbook is
+    // incomplete guidance for whoever re-validates the next rotation.
+    expect(section5).toMatch(/hardened\s*runtime/i);
+  });
+
+  test("RELEASE_RUNBOOK.md §2 secrets inventory lists the three Apple secrets", () => {
+    // The single-row inventory must keep §2 and §5 in sync — if §5
+    // adds a secret, the table has to mention it too.
+    expect(runbook).toMatch(/\|\s*`APPLE_ID`\s*\|/);
+    expect(runbook).toMatch(/\|\s*`APPLE_PASSWORD`\s*\|/);
+    expect(runbook).toMatch(/\|\s*`APPLE_TEAM_ID`\s*\|/);
+    expect(runbook).toMatch(/\|\s*`APPLE_SIGNING_IDENTITY`\s*\|/);
+  });
+});


### PR DESCRIPTION
Resolves #1399.

- src-tauri/tauri.conf.json: bundle.macOS.hardenedRuntime=true (was false) and signingIdentity=null so APPLE_SIGNING_IDENTITY drives codesign. Ad-hoc signing + hardened runtime is invalid, so both knobs had to flip together.

- .github/workflows/release.yml (build-macos): after `tauri build --target universal-apple-darwin`, add locate/submit/staple steps for both the .app and .dmg via `xcrun notarytool submit --apple-id --password --team-id --wait` and `xcrun stapler staple`. Steps self-skip when APPLE_ID/APPLE_PASSWORD/APPLE_TEAM_ID secrets are absent so PRs from forks still ship a DMG. APPLE_SIGNING_IDENTITY is now injected into the tauri build env. A one-line ::notice/::warning summary step surfaces skip-vs-success in the Actions UI.

- docs/RELEASE_RUNBOOK.md: §5 documents the concrete workflow alignment (notarytool submit + stapler staple, hardened runtime is permanent) plus the four APPLE_* secrets required in the Releases environment. §2 inventory unchanged (the three APPLE_* secrets were already documented).

- tests/macos-notarization-wiring.test.ts: 8 smoke tests pinning the bundle.macOS shape, the workflow yaml invariants (notarytool + stapler + APPLE_SIGNING_IDENTITY + graceful skip + ::warning marker), and the runbook documentation coverage for the four APPLE_* secrets and the concrete xcrun invocations.

NOTE: the Apple secrets (APPLE_ID, APPLE_PASSWORD, APPLE_TEAM_ID, APPLE_SIGNING_IDENTITY) are not yet populated in the org's `Releases` GitHub Environment. Until they are, the notarization steps self-skip and the build still emits an unsigned DMG. This PR contains the workflow + config + tests wiring only; the secret rollout is a separate docs/owner action tracked in §5.