### PR TITLE
fix: resolve #1393 — derive userId server-side in /api/ai-proxy

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = "2.13.4";
+const PACKAGE_VERSION = "2.14.6";
 const INTEGRITY_CHECKSUM = "4db4a41e972cec1b64cc569c66952d82";
 const IS_MOCKED_RESPONSE = Symbol("isMockedResponse");
 const activeClientIds = new Set();

--- a/src/app/api/ai-proxy/__tests__/route.test.ts
+++ b/src/app/api/ai-proxy/__tests__/route.test.ts
@@ -391,7 +391,7 @@ describe("POST /api/ai-proxy — rate limiting", () => {
     expect(getRateLimitHeaders).toHaveBeenCalled();
   });
 
-  it("uses x-forwarded-for as the client identifier when no userId is given", async () => {
+  it("uses x-forwarded-for as the client identifier only behind a trusted proxy", async () => {
     getProviderConfig.mockReturnValue({
       provider: "openai",
       apiKey: "sk-test",
@@ -409,22 +409,28 @@ describe("POST /api/ai-proxy — rate limiting", () => {
       usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
     });
 
-    await POST(
-      makeRequest(
-        {
-          provider: "openai",
-          endpoint: "/chat",
-          body: { messages: [{ role: "user", content: "hi" }] },
-        },
-        "http://localhost/api/ai-proxy",
-        { "x-forwarded-for": "203.0.113.5, 10.0.0.1" },
-      ),
-    );
-
-    expect(enforceRateLimit).toHaveBeenCalledWith(
-      "ip:203.0.113.5",
-      expect.any(Object),
-    );
+    const prev = process.env.TRUSTED_PROXY;
+    process.env.TRUSTED_PROXY = "true";
+    try {
+      await POST(
+        makeRequest(
+          {
+            provider: "openai",
+            endpoint: "/chat",
+            body: { messages: [{ role: "user", content: "hi" }] },
+          },
+          "http://localhost/api/ai-proxy",
+          { "x-forwarded-for": "203.0.113.5, 10.0.0.1" },
+        ),
+      );
+      expect(enforceRateLimit).toHaveBeenCalledWith(
+        "ip:203.0.113.5",
+        expect.any(Object),
+      );
+    } finally {
+      if (prev === undefined) delete process.env.TRUSTED_PROXY;
+      else process.env.TRUSTED_PROXY = prev;
+    }
   });
 });
 
@@ -562,5 +568,150 @@ describe("POST /api/ai-proxy — internal errors", () => {
     const data = (await (res as unknown as TestResponse).json()) as any;
     expect(data.errorCode).toBe("INTERNAL_ERROR");
     expect(data.error).toBe("sdk exploded");
+  });
+});
+
+// ----------------------------------------------------------------------------
+// POST /api/ai-proxy — Issue #1393: do not trust client-supplied userId
+// ----------------------------------------------------------------------------
+
+describe("POST /api/ai-proxy — userId trust (Issue #1393)", () => {
+  beforeEach(() => {
+    getProviderConfig.mockReturnValue({
+      provider: "openai",
+      apiKey: "sk-test",
+      enabled: true,
+      rateLimit: { maxRequests: 100, windowMs: 60_000 },
+    });
+    enforceRateLimit.mockReturnValue({
+      success: true,
+      remaining: 99,
+      resetAt: Date.now() + 60_000,
+    });
+    generateText.mockResolvedValue({
+      text: "ok",
+      finishReason: "stop",
+      usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+    });
+  });
+
+  it("ignores a rotating body userId — all requests map to ONE rate-limit key", async () => {
+    // An attacker sending userId: "bot-1", "bot-2", … from the same source
+    // must NOT get a fresh bucket per request.
+    for (let i = 1; i <= 50; i++) {
+      await POST(
+        makeRequest(
+          {
+            provider: "openai",
+            endpoint: "/chat",
+            body: { messages: [{ role: "user", content: "hi" }] },
+            userId: `bot-${i}`,
+          },
+          "http://localhost/api/ai-proxy",
+          { "user-agent": "attacker/1.0" },
+        ),
+      );
+    }
+
+    // Every call used the same UA-derived key (no request.ip in the test
+    // harness, no TRUSTED_PROXY), so there must be exactly one distinct key.
+    const keys = new Set(enforceRateLimit.mock.calls.map((c: any[]) => c[0]));
+    expect(keys.size).toBe(1);
+    expect([...keys][0]).toMatch(/^session:/);
+    // None of the keys are the attacker-controlled "user:bot-N".
+    expect([...keys][0]).not.toContain("bot");
+  });
+
+  it("does not propagate body userId into the rate-limit key", async () => {
+    await POST(
+      makeRequest({
+        provider: "openai",
+        endpoint: "/chat",
+        body: { messages: [] },
+        userId: "attacker-123",
+      }),
+    );
+    const key = enforceRateLimit.mock.calls[0][0] as string;
+    expect(key).not.toContain("attacker-123");
+    expect(key.startsWith("user:")).toBe(false);
+  });
+
+  it("ignores x-forwarded-for when TRUSTED_PROXY is not set", async () => {
+    const prev = process.env.TRUSTED_PROXY;
+    delete process.env.TRUSTED_PROXY;
+    try {
+      await POST(
+        makeRequest(
+          {
+            provider: "openai",
+            endpoint: "/chat",
+            body: { messages: [] },
+          },
+          "http://localhost/api/ai-proxy",
+          {
+            "x-forwarded-for": "198.51.100.7",
+            "user-agent": "curl/8.0",
+          },
+        ),
+      );
+      const key = enforceRateLimit.mock.calls[0][0] as string;
+      // The spoofable XFF value must not appear in the bucket key.
+      expect(key).not.toContain("198.51.100.7");
+      expect(key.startsWith("ip:")).toBe(false);
+      expect(key.startsWith("session:")).toBe(true);
+    } finally {
+      if (prev !== undefined) process.env.TRUSTED_PROXY = prev;
+    }
+  });
+
+  it("honors x-forwarded-for when TRUSTED_PROXY=true is set", async () => {
+    const prev = process.env.TRUSTED_PROXY;
+    process.env.TRUSTED_PROXY = "true";
+    try {
+      await POST(
+        makeRequest(
+          {
+            provider: "openai",
+            endpoint: "/chat",
+            body: { messages: [] },
+          },
+          "http://localhost/api/ai-proxy",
+          { "x-forwarded-for": "203.0.113.9" },
+        ),
+      );
+      expect(enforceRateLimit).toHaveBeenCalledWith(
+        "ip:203.0.113.9",
+        expect.any(Object),
+      );
+    } finally {
+      if (prev === undefined) delete process.env.TRUSTED_PROXY;
+      else process.env.TRUSTED_PROXY = prev;
+    }
+  });
+
+  it("prefers request.ip over forwarded headers when present", async () => {
+    const prev = process.env.TRUSTED_PROXY;
+    process.env.TRUSTED_PROXY = "true";
+    try {
+      const req = makeRequest(
+        {
+          provider: "openai",
+          endpoint: "/chat",
+          body: { messages: [] },
+        },
+        "http://localhost/api/ai-proxy",
+        { "x-forwarded-for": "203.0.113.9" },
+      );
+      // Simulate Next.js runtime setting the verified peer IP.
+      (req as unknown as { ip: string }).ip = "100.64.0.1";
+      await POST(req);
+      expect(enforceRateLimit).toHaveBeenCalledWith(
+        "ip:100.64.0.1",
+        expect.any(Object),
+      );
+    } finally {
+      if (prev === undefined) delete process.env.TRUSTED_PROXY;
+      else process.env.TRUSTED_PROXY = prev;
+    }
   });
 });

--- a/src/app/api/ai-proxy/route.ts
+++ b/src/app/api/ai-proxy/route.ts
@@ -1,20 +1,18 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { streamText, generateText } from 'ai';
-import { getAIModel } from '@/ai/providers/factory';
-import { AIProvider } from '@/ai/providers/types';
-import { searchCardsTool } from '@/ai/tools/card-search';
+import { NextRequest, NextResponse } from "next/server";
+import { streamText, generateText } from "ai";
+import { getAIModel } from "@/ai/providers/factory";
+import { AIProvider } from "@/ai/providers/types";
+import { searchCardsTool } from "@/ai/tools/card-search";
 import {
   getProviderConfig,
   getConfiguredProviders,
-} from '@/lib/server-api-key-storage';
+} from "@/lib/server-api-key-storage";
 import {
   enforceRateLimit,
   RateLimitError,
   getRateLimitHeaders,
-} from '@/lib/server-rate-limiter';
-import {
-  UsageLogger,
-} from '@/lib/server-usage-logger';
+} from "@/lib/server-rate-limiter";
+import { UsageLogger } from "@/lib/server-usage-logger";
 
 /**
  * AI Proxy API Route
@@ -22,7 +20,7 @@ import {
  */
 
 // Use force-dynamic to prevent response buffering
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 /**
  * Request body for AI proxy
@@ -60,34 +58,34 @@ interface AIProxyResponse {
 export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
     const { searchParams } = new URL(request.url);
-    const action = searchParams.get('action');
+    const action = searchParams.get("action");
 
     // Get configured providers
     const configuredProviders = getConfiguredProviders();
 
-    if (action === 'status') {
+    if (action === "status") {
       return NextResponse.json({
         success: true,
         serverProxyEnabled: true,
         configuredProviders,
-        availableProviders: ['google', 'openai', 'anthropic', 'zaic', 'custom'],
+        availableProviders: ["google", "openai", "anthropic", "zaic", "custom"],
       });
     }
 
     // Default: return basic status
     return NextResponse.json({
       success: true,
-      message: 'AI Proxy is running (Vercel AI SDK enabled)',
+      message: "AI Proxy is running (Vercel AI SDK enabled)",
       configuredProviders,
     });
   } catch (error) {
-    console.error('AI Proxy GET error:', error);
+    console.error("AI Proxy GET error:", error);
     return NextResponse.json(
       {
         success: false,
-        error: error instanceof Error ? error.message : 'Unknown error',
+        error: error instanceof Error ? error.message : "Unknown error",
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
@@ -95,9 +93,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 /**
  * POST /api/ai-proxy - Proxy AI provider requests using Vercel AI SDK
  */
-export async function POST(request: NextRequest): Promise<NextResponse | Response> {
-  const userId = 'anonymous'; // Fallback
-  
+export async function POST(
+  request: NextRequest,
+): Promise<NextResponse | Response> {
   try {
     // Parse request body
     let body: AIProxyRequest;
@@ -105,38 +103,68 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
       body = await request.json();
     } catch (error) {
       return NextResponse.json(
-        { success: false, error: 'Invalid JSON body', errorCode: 'INVALID_JSON' },
-        { status: 400 }
+        {
+          success: false,
+          error: "Invalid JSON body",
+          errorCode: "INVALID_JSON",
+        },
+        { status: 400 },
       );
     }
 
-    const { provider, model: modelId, body: providerBody, userId: reqUserId } = body;
-    const currentUserId = reqUserId || userId;
+    // Issue #1393: derive identity server-side ONLY. A client-supplied userId
+    // must never seed the rate-limit key (rotating it bypasses the limit) nor
+    // usage attribution. This app has no auth layer yet, so the honest value
+    // is 'anonymous'; the rate-limit key uses a verified IP / UA fingerprint
+    // computed by getClientIdentifier() from request metadata, never the body.
+    const { provider, model: modelId, body: providerBody } = body;
+    const currentUserId = "anonymous";
 
     // Validate provider
-    if (!provider || !['google', 'openai', 'anthropic', 'zaic', 'custom'].includes(provider)) {
+    if (
+      !provider ||
+      !["google", "openai", "anthropic", "zaic", "custom"].includes(provider)
+    ) {
       return NextResponse.json(
-        { success: false, error: 'Invalid or missing provider', errorCode: 'INVALID_PROVIDER' },
-        { status: 400 }
+        {
+          success: false,
+          error: "Invalid or missing provider",
+          errorCode: "INVALID_PROVIDER",
+        },
+        { status: 400 },
       );
     }
 
     // Initialize logger with correct provider
-    const usageLogger = new UsageLogger(currentUserId, provider as AIProvider, body.endpoint);
-    usageLogger.setModel(modelId || 'unknown');
+    const usageLogger = new UsageLogger(
+      currentUserId,
+      provider as AIProvider,
+      body.endpoint,
+    );
+    usageLogger.setModel(modelId || "unknown");
 
     // Check if provider is configured on server
     const providerConfig = getProviderConfig(provider as AIProvider);
     if (!providerConfig || !providerConfig.enabled) {
-      await usageLogger.markFailure('Provider not configured on server', 'PROVIDER_NOT_CONFIGURED').save();
+      await usageLogger
+        .markFailure(
+          "Provider not configured on server",
+          "PROVIDER_NOT_CONFIGURED",
+        )
+        .save();
       return NextResponse.json(
-        { success: false, error: `Provider ${provider} is not configured`, errorCode: 'PROVIDER_NOT_CONFIGURED' },
-        { status: 503 }
+        {
+          success: false,
+          error: `Provider ${provider} is not configured`,
+          errorCode: "PROVIDER_NOT_CONFIGURED",
+        },
+        { status: 503 },
       );
     }
 
-    // Get client identifier for rate limiting
-    const clientId = getClientIdentifier(request, currentUserId);
+    // Get client identifier for rate limiting — derived solely from
+    // server-verified request metadata (Issue #1393).
+    const clientId = getClientIdentifier(request);
 
     // Check rate limit
     let rateLimitResult;
@@ -144,18 +172,28 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
       rateLimitResult = enforceRateLimit(clientId, providerConfig.rateLimit);
     } catch (error) {
       if (error instanceof RateLimitError) {
-        await usageLogger.markFailure('Rate limit exceeded', 'RATE_LIMIT_EXCEEDED').save();
+        await usageLogger
+          .markFailure("Rate limit exceeded", "RATE_LIMIT_EXCEEDED")
+          .save();
         return NextResponse.json(
-          { success: false, error: error.message, errorCode: 'RATE_LIMIT_EXCEEDED', retryAfter: error.retryAfter },
-          { 
+          {
+            success: false,
+            error: error.message,
+            errorCode: "RATE_LIMIT_EXCEEDED",
+            retryAfter: error.retryAfter,
+          },
+          {
             status: 429,
-            headers: getRateLimitHeaders({ 
-              success: false, 
-              remaining: 0, 
-              resetAt: Date.now() + (error.retryAfter * 1000),
-              retryAfter: error.retryAfter 
-            }, providerConfig.rateLimit)
-          }
+            headers: getRateLimitHeaders(
+              {
+                success: false,
+                remaining: 0,
+                resetAt: Date.now() + error.retryAfter * 1000,
+                retryAfter: error.retryAfter,
+              },
+              providerConfig.rateLimit,
+            ),
+          },
         );
       }
       throw error;
@@ -163,7 +201,7 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
 
     // Check for streaming request
     const isStreaming = providerBody?.stream === true;
-    
+
     // Get the model instance from our factory (async — dynamic SDK imports, Issue #1022)
     const model = await getAIModel(provider, modelId);
 
@@ -178,13 +216,15 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
           searchCards: searchCardsTool,
         },
         temperature: (providerBody.temperature as number) ?? 0.7,
-        maxOutputTokens: (providerBody.max_tokens as number) || (providerBody.maxTokens as number),
+        maxOutputTokens:
+          (providerBody.max_tokens as number) ||
+          (providerBody.maxTokens as number),
         onFinish: async (finishResult) => {
           // Log usage on completion - usage is now a Promise in AI SDK v6
           const usage = await finishResult.usage;
           usageLogger.setTokenUsage(
             usage.inputTokens ?? 0,
-            usage.outputTokens ?? 0
+            usage.outputTokens ?? 0,
           );
           await usageLogger.markSuccess().save();
         },
@@ -201,13 +241,18 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
           searchCards: searchCardsTool,
         },
         temperature: (providerBody.temperature as number) ?? 0.7,
-        maxOutputTokens: (providerBody.max_tokens as number) || (providerBody.maxTokens as number),
+        maxOutputTokens:
+          (providerBody.max_tokens as number) ||
+          (providerBody.maxTokens as number),
       });
 
       // AI SDK v6: usage is now a Promise with inputTokens/outputTokens
       const usage = await result.usage;
       const totalTokens = (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
-      usageLogger.setTokenUsage(usage.inputTokens ?? 0, usage.outputTokens ?? 0);
+      usageLogger.setTokenUsage(
+        usage.inputTokens ?? 0,
+        usage.outputTokens ?? 0,
+      );
       await usageLogger.markSuccess().save();
 
       // Return in a format compatible with what extractContentFromResponse expects
@@ -216,7 +261,7 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
         choices: [
           {
             message: {
-              role: 'assistant',
+              role: "assistant",
               content: result.text,
             },
             finish_reason: result.finishReason,
@@ -229,45 +274,77 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
         },
       };
 
-      return NextResponse.json({
-        success: true,
-        data: legacyData,
-        usage: {
-          inputTokens: usage.inputTokens ?? 0,
-          outputTokens: usage.outputTokens ?? 0,
-          totalTokens: totalTokens,
+      return NextResponse.json(
+        {
+          success: true,
+          data: legacyData,
+          usage: {
+            inputTokens: usage.inputTokens ?? 0,
+            outputTokens: usage.outputTokens ?? 0,
+            totalTokens: totalTokens,
+          },
+          rateLimit: {
+            remaining: rateLimitResult.remaining,
+            resetAt: rateLimitResult.resetAt,
+          },
         },
-        rateLimit: {
-          remaining: rateLimitResult.remaining,
-          resetAt: rateLimitResult.resetAt,
+        {
+          headers: getRateLimitHeaders(
+            rateLimitResult,
+            providerConfig.rateLimit,
+          ),
         },
-      }, {
-        headers: getRateLimitHeaders(rateLimitResult, providerConfig.rateLimit),
-      });
+      );
     }
   } catch (error) {
-    console.error('AI Proxy POST error:', error);
+    console.error("AI Proxy POST error:", error);
     return NextResponse.json(
-      { success: false, error: error instanceof Error ? error.message : 'Internal server error', errorCode: 'INTERNAL_ERROR' },
-      { status: 500 }
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Internal server error",
+        errorCode: "INTERNAL_ERROR",
+      },
+      { status: 500 },
     );
   }
 }
 
 /**
- * Get client identifier for rate limiting
+ * Derive a stable, *server-verified* rate-limit key for the request.
+ *
+ * Issue #1393: the previous implementation trusted a client-supplied `userId`
+ * and the raw `x-forwarded-for` header, both of which an attacker can rotate
+ * per request to dodge the per-user / per-IP rate limit. This version only
+ * honours identifiers the server can verify:
+ *
+ *   1. `request.ip` — set by the Next.js runtime / Vercel from the actual TCP
+ *      peer; not client-spoofable.
+ *   2. Forwarded headers, *only* when the operator has set `TRUSTED_PROXY=true`
+ *      to assert the deployment sits behind a reverse proxy that overwrites
+ *      those headers.
+ *   3. A coarse user-agent fingerprint as a last resort.
+ *
+ * The function never reads the request body, so a client cannot influence its
+ * own rate-limit bucket.
  */
-function getClientIdentifier(request: NextRequest, userId?: string): string {
-  if (userId && userId !== 'anonymous') {
-    return `user:${userId}`;
+function getClientIdentifier(request: NextRequest): string {
+  // 1. Next.js' verified peer IP (set by Vercel / configured runtime).
+  const directIp = (request as unknown as { ip?: string }).ip;
+  if (directIp) return `ip:${directIp}`;
+
+  // 2. Forwarded headers are only meaningful behind a trusted proxy the
+  //    operator has explicitly opted in to. Without this flag the headers are
+  //    fully client-controlled and must not seed a bucket.
+  if (process.env.TRUSTED_PROXY === "true") {
+    const forwardedFor = request.headers.get("x-forwarded-for");
+    if (forwardedFor) return `ip:${forwardedFor.split(",")[0].trim()}`;
+    const realIp = request.headers.get("x-real-ip");
+    if (realIp) return `ip:${realIp}`;
   }
 
-  const forwardedFor = request.headers.get('x-forwarded-for');
-  const realIp = request.headers.get('x-real-ip');
-  
-  if (forwardedFor) return `ip:${forwardedFor.split(',')[0].trim()}`;
-  if (realIp) return `ip:${realIp}`;
-
-  const userAgent = request.headers.get('user-agent') || 'unknown';
-  return `session:${userAgent.substring(0, 20)}`;
+  // 3. Last-resort fallback: a coarse user-agent fingerprint. Stable per
+  //    client, coarse across clients sharing a UA — acceptable when no IP is
+  //    available (e.g. local dev).
+  const userAgent = request.headers.get("user-agent") || "unknown";
+  return `session:${userAgent.substring(0, 32)}`;
 }


### PR DESCRIPTION
Resolves #1393. The `/api/ai-proxy` POST route no longer trusts a client-supplied `userId`. userId is now derived from the server session (request metadata only). Includes regression tests.

## Changes
- Removed `reqUserId` destructuring from the request body — `currentUserId` is now the server-derived constant `'anonymous'` (this app has no auth layer yet).
- `getClientIdentifier(request)` no longer accepts a userId and never reads the body. It derives the rate-limit key from:
  1. `request.ip` (Next.js/Vercel verified peer IP — not spoofable)
  2. `x-forwarded-for`/`x-real-ip` **only** when `TRUSTED_PROXY=true` is set
  3. Coarse user-agent fingerprint as last resort
- A client can no longer rotate `userId` (or `X-Forwarded-For`) per request to dodge the per-user/per-IP rate limit.

## Notes
- The `maxKeys: 10,000` ceiling in `enforceRateLimit` was already satisfied (`RateLimitStore` uses `lru-cache` with `max: 10000`), so no change was needed there.
- No auth system exists in this app, so a 401-on-missing-session path is not applicable; identity is honestly labeled `'anonymous'` until v1.8 auth lands. The rate-limit key remains a verified IP/UA fingerprint regardless.