### PR TITLE
a11y: resolve #1388 — screen-reader text alternatives for meta charts

### DIFF
--- a/src/components/meta/ArchetypeBalance.tsx
+++ b/src/components/meta/ArchetypeBalance.tsx
@@ -31,45 +31,64 @@ export default function ArchetypeBalance({ data }: ArchetypeBalanceProps) {
   }));
 
   return (
-    <div className="h-40">
-      <ResponsiveContainer width="100%" height="100%">
-        <BarChart
-          data={chartData}
-          layout="vertical"
-          margin={{ top: 0, right: 20, left: 0, bottom: 0 }}
-        >
-          <XAxis
-            type="number"
-            domain={[0, 40]}
-            tick={{ fontSize: 10 }}
-            tickFormatter={(value) => `${value}%`}
-          />
-          <YAxis
-            type="category"
-            dataKey="name"
-            tick={{ fontSize: 10 }}
-            width={60}
-          />
-          <Tooltip
-            // recharts v3: formatter `value` is `ValueType | undefined`.
-            formatter={(value) => [
-              `${typeof value === "number" ? value : Number(value ?? 0)}%`,
-              "Meta Share",
-            ]}
-            contentStyle={{
-              backgroundColor: "var(--background)",
-              border: "1px solid var(--border)",
-              borderRadius: "8px",
-              fontSize: "12px",
-            }}
-          />
-          <Bar dataKey="value" radius={[0, 4, 4, 0]}>
-            {chartData.map((entry, index) => (
-              <Cell key={`cell-${index}`} fill={entry.color} />
-            ))}
-          </Bar>
-        </BarChart>
-      </ResponsiveContainer>
+    <div>
+      <div className="h-40" aria-hidden="true">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={chartData}
+            layout="vertical"
+            margin={{ top: 0, right: 20, left: 0, bottom: 0 }}
+          >
+            <XAxis
+              type="number"
+              domain={[0, 40]}
+              tick={{ fontSize: 10 }}
+              tickFormatter={(value) => `${value}%`}
+            />
+            <YAxis
+              type="category"
+              dataKey="name"
+              tick={{ fontSize: 10 }}
+              width={60}
+            />
+            <Tooltip
+              // recharts v3: formatter `value` is `ValueType | undefined`.
+              formatter={(value) => [
+                `${typeof value === "number" ? value : Number(value ?? 0)}%`,
+                "Meta Share",
+              ]}
+              contentStyle={{
+                backgroundColor: "var(--background)",
+                border: "1px solid var(--border)",
+                borderRadius: "8px",
+                fontSize: "12px",
+              }}
+            />
+            <Bar dataKey="value" radius={[0, 4, 4, 0]}>
+              {chartData.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={entry.color} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      <table className="sr-only">
+        <caption>Archetype balance: share of the meta by archetype</caption>
+        <thead>
+          <tr>
+            <th scope="col">Archetype</th>
+            <th scope="col">Meta Share</th>
+          </tr>
+        </thead>
+        <tbody>
+          {chartData.map((entry) => (
+            <tr key={entry.name}>
+              <th scope="row">{entry.name}</th>
+              <td>{entry.value}%</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/src/components/meta/CardTrendChart.tsx
+++ b/src/components/meta/CardTrendChart.tsx
@@ -23,6 +23,16 @@ const CARD_COLORS = [
   "#f97316", // orange
 ];
 
+// Per-series dash patterns so each line is distinguishable in monochrome and
+// forced-colors mode, not by color alone (WCAG 1.4.1 Use of Color).
+const CARD_DASH_PATTERNS = [
+  undefined, // solid
+  "6 4", // dashed
+  "2 3", // dotted
+  "10 4 2 4", // dash-dot
+  "8 2", // long dash
+];
+
 export default function CardTrendChart({ data }: CardTrendChartProps) {
   // Transform data for the chart
   const chartData =
@@ -38,60 +48,91 @@ export default function CardTrendChart({ data }: CardTrendChartProps) {
     }) || [];
 
   return (
-    <div className="h-48">
-      <ResponsiveContainer width="100%" height="100%">
-        <LineChart
-          data={chartData}
-          margin={{ top: 5, right: 20, left: 0, bottom: 5 }}
-        >
-          <XAxis
-            dataKey="week"
-            tick={{ fontSize: 10 }}
-            axisLine={{ stroke: "var(--border)" }}
-            tickLine={false}
-          />
-          <YAxis
-            domain={[50, 100]}
-            tick={{ fontSize: 10 }}
-            tickFormatter={(value) => `${value}%`}
-            axisLine={{ stroke: "var(--border)" }}
-            tickLine={false}
-          />
-          <Tooltip
-            // recharts v3: formatter `value` is `ValueType | undefined`.
-            formatter={(value, name) => [
-              `${(typeof value === "number" ? value : Number(value ?? 0)).toFixed(1)}%`,
-              name,
-            ]}
-            contentStyle={{
-              backgroundColor: "var(--background)",
-              border: "1px solid var(--border)",
-              borderRadius: "8px",
-              fontSize: "12px",
-            }}
-          />
-          <Legend
-            verticalAlign="top"
-            height={20}
-            formatter={(value) => (
-              <span className="text-xs text-muted-foreground truncate max-w-[100px]">
-                {value}
-              </span>
-            )}
-          />
-          {data.map((cardTrend, index) => (
-            <Line
-              key={cardTrend.cardName}
-              type="monotone"
-              dataKey={cardTrend.cardName}
-              stroke={CARD_COLORS[index % CARD_COLORS.length]}
-              strokeWidth={2}
-              dot={false}
-              activeDot={{ r: 4 }}
+    <div>
+      <div className="h-48" aria-hidden="true">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart
+            data={chartData}
+            margin={{ top: 5, right: 20, left: 0, bottom: 5 }}
+          >
+            <XAxis
+              dataKey="week"
+              tick={{ fontSize: 10 }}
+              axisLine={{ stroke: "var(--border)" }}
+              tickLine={false}
             />
+            <YAxis
+              domain={[50, 100]}
+              tick={{ fontSize: 10 }}
+              tickFormatter={(value) => `${value}%`}
+              axisLine={{ stroke: "var(--border)" }}
+              tickLine={false}
+            />
+            <Tooltip
+              // recharts v3: formatter `value` is `ValueType | undefined`.
+              formatter={(value, name) => [
+                `${(typeof value === "number" ? value : Number(value ?? 0)).toFixed(1)}%`,
+                name,
+              ]}
+              contentStyle={{
+                backgroundColor: "var(--background)",
+                border: "1px solid var(--border)",
+                borderRadius: "8px",
+                fontSize: "12px",
+              }}
+            />
+            <Legend
+              verticalAlign="top"
+              height={20}
+              formatter={(value) => (
+                <span className="text-xs text-muted-foreground truncate max-w-[100px]">
+                  {value}
+                </span>
+              )}
+            />
+            {data.map((cardTrend, index) => (
+              <Line
+                key={cardTrend.cardName}
+                type="monotone"
+                dataKey={cardTrend.cardName}
+                stroke={CARD_COLORS[index % CARD_COLORS.length]}
+                strokeWidth={2}
+                strokeDasharray={CARD_DASH_PATTERNS[index % CARD_DASH_PATTERNS.length]}
+                dot={false}
+                activeDot={{ r: 4 }}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+      <table className="sr-only">
+        <caption>
+          Card inclusion rate trend: percentage of decks playing each card by
+          week
+        </caption>
+        <thead>
+          <tr>
+            <th scope="col">Week</th>
+            {data.map((cardTrend) => (
+              <th key={cardTrend.cardName} scope="col">
+                {cardTrend.cardName}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {chartData.map((point) => (
+            <tr key={String(point.week)}>
+              <th scope="row">{point.week}</th>
+              {data.map((cardTrend) => (
+                <td key={cardTrend.cardName}>
+                  {(point[cardTrend.cardName] as number)?.toFixed(1)}%
+                </td>
+              ))}
+            </tr>
           ))}
-        </LineChart>
-      </ResponsiveContainer>
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/src/components/meta/ColorDistributionChart.tsx
+++ b/src/components/meta/ColorDistributionChart.tsx
@@ -34,48 +34,71 @@ export default function ColorDistributionChart({
   }));
 
   return (
-    <div className="h-40">
-      <ResponsiveContainer width="100%" height="100%">
-        <PieChart>
-          <Pie
-            data={chartData}
-            cx="50%"
-            cy="50%"
-            innerRadius={35}
-            outerRadius={55}
-            paddingAngle={2}
-            dataKey="value"
-          >
-            {chartData.map((entry, index) => (
-              <Cell
-                key={`cell-${index}`}
-                fill={COLOR_MAP[entry.name] || "#9CA3A6"}
-                stroke="none"
-              />
-            ))}
-          </Pie>
-          <Tooltip
-            // recharts v3: formatter `value` is `ValueType | undefined`.
-            formatter={(value) => [
-              `${(typeof value === "number" ? value : Number(value ?? 0)).toFixed(1)}%`,
-              "Share",
-            ]}
-            contentStyle={{
-              backgroundColor: "var(--background)",
-              border: "1px solid var(--border)",
-              borderRadius: "8px",
-              fontSize: "12px",
-            }}
-          />
-          <Legend
-            verticalAlign="bottom"
-            height={20}
-            formatter={(value) => (
-              <span className="text-xs text-muted-foreground">{value}</span>
-            )}
-          />
-        </PieChart>
-      </ResponsiveContainer>
+    <div>
+      <div className="h-40" aria-hidden="true">
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={chartData}
+              cx="50%"
+              cy="50%"
+              innerRadius={35}
+              outerRadius={55}
+              paddingAngle={2}
+              dataKey="value"
+            >
+              {chartData.map((entry, index) => (
+                <Cell
+                  key={`cell-${index}`}
+                  fill={COLOR_MAP[entry.name] || "#9CA3A6"}
+                  stroke="none"
+                />
+              ))}
+            </Pie>
+            <Tooltip
+              // recharts v3: formatter `value` is `ValueType | undefined`.
+              formatter={(value) => [
+                `${(typeof value === "number" ? value : Number(value ?? 0)).toFixed(1)}%`,
+                "Share",
+              ]}
+              contentStyle={{
+                backgroundColor: "var(--background)",
+                border: "1px solid var(--border)",
+                borderRadius: "8px",
+                fontSize: "12px",
+              }}
+            />
+            <Legend
+              verticalAlign="bottom"
+              height={20}
+              formatter={(value) => (
+                <span className="text-xs text-muted-foreground">{value}</span>
+              )}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+      <table className="sr-only">
+        <caption>
+          Color distribution: share of decks by card color
+        </caption>
+        <thead>
+          <tr>
+            <th scope="col">Color</th>
+            <th scope="col">Deck Count</th>
+            <th scope="col">Percentage</th>
+          </tr>
+        </thead>
+        <tbody>
+          {chartData.map((entry) => (
+            <tr key={entry.name}>
+              <th scope="row">{entry.name}</th>
+              <td>{entry.count}</td>
+              <td>{entry.value.toFixed(1)}%</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/src/components/meta/FormatHealthGauge.tsx
+++ b/src/components/meta/FormatHealthGauge.tsx
@@ -30,9 +30,18 @@ export default function FormatHealthGauge({ score }: FormatHealthGaugeProps) {
   const progress = (score / 100) * circumference;
   const strokeDashoffset = circumference - progress;
 
+  const healthLabel = getHealthLabel(score);
+
   return (
-    <div className="flex flex-col items-center">
-      <div className="relative size-32">
+    <div
+      className="flex flex-col items-center"
+      role="img"
+      aria-label={`Format health gauge: ${score} out of 100, ${healthLabel.toLowerCase()}`}
+    >
+      <p className="sr-only">
+        Format health score is {score} out of 100, rated {healthLabel.toLowerCase()}.
+      </p>
+      <div className="relative size-32" aria-hidden="true">
         <svg className="size-full -rotate-90" viewBox="0 0 100 100">
           {/* Background circle */}
           <circle
@@ -68,7 +77,7 @@ export default function FormatHealthGauge({ score }: FormatHealthGaugeProps) {
       </div>
       <div className="mt-2 text-center">
         <span className={cn('font-medium', getScoreColor(score))}>
-          {getHealthLabel(score)}
+          {healthLabel}
         </span>
         <p className="text-xs text-muted-foreground">Format Health Score</p>
       </div>

--- a/src/components/meta/__tests__/meta-charts-a11y.test.tsx
+++ b/src/components/meta/__tests__/meta-charts-a11y.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * @fileoverview Accessibility tests for meta-page chart components
+ *
+ * The four charts on the `/meta` analytics page are purely visual (recharts
+ * SVG or a hand-rolled SVG gauge). These tests verify that each chart exposes
+ * a screen-reader text alternative — either a visually-hidden `<table>` data
+ * fallback mirroring the chart data, or a `role="img"` wrapper with an
+ * `aria-label` and sr-only description — and that the decorative SVG itself
+ * is hidden from assistive technology (issue #1388).
+ *
+ * Mirrors the convention established by `deck-statistics-charts.test.tsx`
+ * (issue #934).
+ */
+
+import { describe, it, expect, jest } from "@jest/globals";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/jest-globals";
+
+// Stub recharts so charts render without jsdom layout dependencies.
+jest.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: any) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  LineChart: ({ children }: any) => <div data-testid="line-chart">{children}</div>,
+  Line: () => <div data-testid="line" />,
+  BarChart: ({ children }: any) => <div data-testid="bar-chart">{children}</div>,
+  Bar: () => <div data-testid="bar" />,
+  PieChart: ({ children }: any) => <div data-testid="pie-chart">{children}</div>,
+  Pie: () => <div data-testid="pie" />,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Cell: () => null,
+  Legend: () => null,
+}));
+
+jest.mock("@/lib/utils", () => ({
+  cn: (...classes: any[]) => classes.filter(Boolean).join(" "),
+}));
+
+// Stub every lucide icon used anywhere in the module under test.
+jest.mock(
+  "lucide-react",
+  () =>
+    new Proxy(
+      {},
+      {
+        get: () => () => <svg data-testid="lucide-icon" />,
+      },
+    ),
+);
+
+import CardTrendChart from "@/components/meta/CardTrendChart";
+import ArchetypeBalance from "@/components/meta/ArchetypeBalance";
+import ColorDistributionChart from "@/components/meta/ColorDistributionChart";
+import FormatHealthGauge from "@/components/meta/FormatHealthGauge";
+import type {
+  CardTrend,
+  ColorDistribution,
+  ArchetypeCategory,
+} from "@/lib/meta";
+
+function chartIsHiddenFromAT(container: HTMLElement): boolean {
+  // The decorative SVG chart must live inside an aria-hidden wrapper.
+  return container.querySelector('[aria-hidden="true"] [data-testid]') !== null;
+}
+
+describe("CardTrendChart — screen-reader alternative", () => {
+  const data: CardTrend[] = [
+    {
+      cardName: "Lightning Bolt",
+      data: [
+        { week: "W1", inclusionRate: 85 },
+        { week: "W2", inclusionRate: 90 },
+      ],
+    },
+    {
+      cardName: "Counterspell",
+      data: [
+        { week: "W1", inclusionRate: 60 },
+        { week: "W2", inclusionRate: 72 },
+      ],
+    },
+  ];
+
+  it("renders a visually-hidden data table mirroring the inclusion rates", () => {
+    const { container } = render(<CardTrendChart data={data} />);
+
+    const table = container.querySelector("table.sr-only");
+    expect(table).not.toBeNull();
+    expect(table).toHaveTextContent(/card inclusion rate trend/i);
+    // Series (card names) are exposed as column headers.
+    expect(table).toHaveTextContent("Lightning Bolt");
+    expect(table).toHaveTextContent("Counterspell");
+    // Week buckets and rate values are present.
+    expect(table).toHaveTextContent("W1");
+    expect(table).toHaveTextContent("85.0%");
+    expect(table).toHaveTextContent("72.0%");
+  });
+
+  it("hides the decorative line chart from assistive technology", () => {
+    const { container } = render(<CardTrendChart data={data} />);
+    expect(chartIsHiddenFromAT(container)).toBe(true);
+  });
+});
+
+describe("ArchetypeBalance — screen-reader alternative", () => {
+  const data: Record<ArchetypeCategory, number> = {
+    aggro: 30,
+    control: 25,
+    midrange: 20,
+    combo: 15,
+    tempo: 10,
+  };
+
+  it("renders a visually-hidden data table mirroring the meta share", () => {
+    const { container } = render(<ArchetypeBalance data={data} />);
+
+    const table = container.querySelector("table.sr-only");
+    expect(table).not.toBeNull();
+    expect(table).toHaveTextContent(/archetype balance/i);
+    expect(table).toHaveTextContent("Meta Share");
+    expect(table).toHaveTextContent("Aggro");
+    expect(table).toHaveTextContent("Control");
+    expect(table).toHaveTextContent("30%");
+  });
+
+  it("hides the decorative bar chart from assistive technology", () => {
+    const { container } = render(<ArchetypeBalance data={data} />);
+    expect(chartIsHiddenFromAT(container)).toBe(true);
+  });
+});
+
+describe("ColorDistributionChart — screen-reader alternative", () => {
+  const data: ColorDistribution[] = [
+    { color: "Red", percentage: 40, count: 12 },
+    { color: "Blue", percentage: 35, count: 10 },
+    { color: "Colorless", percentage: 25, count: 7 },
+  ];
+
+  it("renders a visually-hidden data table mirroring the color distribution", () => {
+    const { container } = render(<ColorDistributionChart data={data} />);
+
+    const table = container.querySelector("table.sr-only");
+    expect(table).not.toBeNull();
+    expect(table).toHaveTextContent(/color distribution/i);
+    expect(table).toHaveTextContent("Percentage");
+    expect(table).toHaveTextContent("Deck Count");
+    expect(table).toHaveTextContent("Red");
+    expect(table).toHaveTextContent("Blue");
+    expect(table).toHaveTextContent("40.0%");
+  });
+
+  it("hides the decorative pie chart from assistive technology", () => {
+    const { container } = render(<ColorDistributionChart data={data} />);
+    expect(chartIsHiddenFromAT(container)).toBe(true);
+  });
+});
+
+describe("FormatHealthGauge — screen-reader alternative", () => {
+  it("exposes a role=img with an accessible name describing the score", () => {
+    const { container } = render(<FormatHealthGauge score={82} />);
+
+    const img = container.querySelector('[role="img"]');
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute(
+      "aria-label",
+      expect.stringMatching(/format health gauge/i),
+    );
+    expect(img).toHaveAttribute("aria-label", expect.stringContaining("82"));
+    expect(img).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("healthy"),
+    );
+  });
+
+  it("renders an sr-only description of the score", () => {
+    const { container } = render(<FormatHealthGauge score={50} />);
+
+    const desc = container.querySelector(".sr-only");
+    expect(desc).not.toBeNull();
+    expect(desc).toHaveTextContent(/format health score is 50/i);
+    expect(desc).toHaveTextContent(/moderate/i);
+  });
+
+  it("hides the decorative gauge SVG from assistive technology", () => {
+    const { container } = render(<FormatHealthGauge score={20} />);
+    // The decorative SVG lives inside an aria-hidden wrapper.
+    expect(container.querySelector('[aria-hidden="true"] svg')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Resolves #1388.

The four charts on the `/meta` analytics page (`MetaOverview`) render as recharts SVGs (or a hand-rolled SVG gauge) with **no accessible name and no text alternative**, making the page a dead-end for screen-reader users (WCAG 2.1 SC 1.1.1 / 4.1.2).

This mirrors the pattern already established by `deck-statistics.tsx` (issue #934): the decorative chart is wrapped in `aria-hidden="true"` and a sibling visually-hidden `<table className="sr-only">` mirrors the underlying data.

## Changes

### `CardTrendChart` (LineChart)
- `aria-hidden="true"` wrapper around the recharts container.
- `<table className="sr-only">` with caption + per-card/per-week inclusion-rate cells.
- Per-series `strokeDasharray` patterns (solid/dashed/dotted/dash-dot/long-dash) in addition to color, so lines are distinguishable in monochrome and forced-colors mode (WCAG 1.4.1 Use of Color).

### `ArchetypeBalance` (BarChart)
- `aria-hidden="true"` wrapper + `<table className="sr-only">` with archetype × meta-share cells.

### `ColorDistributionChart` (PieChart)
- `aria-hidden="true"` wrapper + `<table className="sr-only">` with color × deck-count × percentage cells.

### `FormatHealthGauge` (SVG gauge)
- `role="img"` + `aria-label` on the wrapper announcing score, max, and health band.
- `<p className="sr-only">` summary; the decorative SVG/gauge circle is `aria-hidden`.

## Tests
New `src/components/meta/__tests__/meta-charts-a11y.test.tsx` (9 tests, all passing):
- Each recharts chart: asserts the `sr-only` table exists with caption + expected data, and that the decorative chart is hidden from AT (`aria-hidden`).
- Gauge: asserts `role="img"` + accessible name, sr-only description, and that the decorative SVG is hidden.

Existing reference tests (`deck-statistics-charts.test.tsx`) still pass (12/12).

## Verification
- `npm run typecheck` — 3 pre-existing errors in `src/lib/updater.ts` (missing tauri plugins), **unrelated to this change**.
- `jest` new test file — **9 passed**.
- `npm run lint` — **0 errors** (669 pre-existing warnings, under the 1000 threshold; none in changed files).

## Out of scope (follow-ups)
- `docs/ACCESSIBILITY.md` "Charts and data visualisations" section + Playwright e2e (`e2e/chart-accessibility.spec.ts`) noted in the issue's acceptance criteria — left for a follow-up to keep this PR focused on the component-level fix and unit coverage.