### PR TITLE
perf: resolve #1390 — window each player's battlefield independently

### DIFF
--- a/src/components/__tests__/game-board-render-storm.test.tsx
+++ b/src/components/__tests__/game-board-render-storm.test.tsx
@@ -1,0 +1,229 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, it, expect } from "@jest/globals";
+import { arePlayerAreaPropsEqual } from "../game-board";
+import type { PlayerState } from "@/types/game";
+
+/**
+ * #1390 — render-storm regression test for `PlayerArea` memoization.
+ *
+ * On a 4-player board a game-state delta should only re-render the player
+ * whose zone actually changed; the other three players must bail out via the
+ * `React.memo` comparator. This file exercises that comparator two ways:
+ *
+ * 1. Directly (pure function) — deterministic, no React runtime.
+ * 2. Wired through a real `React.memo` boundary with a render counter —
+ *    proves the comparator actually prevents re-renders in React's tree.
+ *
+ * `PlayerArea` is wrapped with `memo(..., arePlayerAreaPropsEqual)`, so this
+ * is the exact predicate the board uses.
+ */
+
+type AreaProps = React.ComponentProps<typeof MemoPlayer>;
+
+function makePlayer(overrides: Partial<PlayerState> = {}): PlayerState {
+  return {
+    id: "p1",
+    name: "Alex",
+    lifeTotal: 40,
+    poisonCounters: 0,
+    hand: [],
+    battlefield: [],
+    graveyard: [],
+    exile: [],
+    library: [],
+    commandZone: [],
+    isCurrentTurn: false,
+    hasPriority: false,
+    landsPlayedThisTurn: 0,
+    ...overrides,
+  };
+}
+
+function makeProps(
+  player: PlayerState,
+  extra: Partial<AreaProps> = {},
+): AreaProps {
+  return {
+    player,
+    isCurrentTurn: false,
+    position: "top",
+    orientation: "horizontal",
+    onCardClick: jest.fn(),
+    onZoneClick: jest.fn(),
+    allPlayers: [],
+    ...extra,
+  };
+}
+
+describe("arePlayerAreaPropsEqual — direct predicate", () => {
+  it("treats identical references as equal (no re-render)", () => {
+    const props = makeProps(makePlayer());
+    expect(arePlayerAreaPropsEqual(props, props)).toBe(true);
+  });
+
+  it("skips re-render when only an unrelated prop wrapper changed but arrays are same refs", () => {
+    const player = makePlayer();
+    const onCardClick = jest.fn();
+    const onZoneClick = jest.fn();
+    const allPlayers: PlayerState[] = [];
+    const stable = { onCardClick, onZoneClick, allPlayers };
+    // Same player reference + same callbacks + same allPlayers → equal even
+    // though the props object itself is new.
+    expect(arePlayerAreaPropsEqual(makeProps(player, stable), makeProps(player, stable))).toBe(
+      true,
+    );
+  });
+
+  it("re-renders when the battlefield array reference changes", () => {
+    const prev = makeProps(makePlayer({ battlefield: [] }));
+    const next = makeProps(makePlayer({ battlefield: [{ id: "c1" } as never] }));
+    expect(arePlayerAreaPropsEqual(prev, next)).toBe(false);
+  });
+
+  it("re-renders when ONLY the graveyard array changes (battlefield untouched)", () => {
+    const battlefield = [{ id: "b1" } as never];
+    const prev = makeProps(makePlayer({ battlefield }));
+    const next = makeProps(
+      makePlayer({ battlefield, graveyard: [{ id: "g1" } as never] }),
+    );
+    // battlefield ref is identical, but graveyard changed → must re-render.
+    expect(arePlayerAreaPropsEqual(prev, next)).toBe(false);
+  });
+
+  it("re-renders when exile/library/commandZone change", () => {
+    const base = makePlayer();
+    for (const zone of ["exile", "library", "commandZone"] as (
+      | "exile"
+      | "library"
+      | "commandZone"
+    )[]) {
+      const next = makePlayer({ ...base, [zone]: [{ id: "x" } as never] });
+      expect(arePlayerAreaPropsEqual(makeProps(base), makeProps(next))).toBe(
+        false,
+      );
+    }
+  });
+
+  it("re-renders when turn changes but zone arrays are identical refs", () => {
+    const player = makePlayer();
+    const prev = makeProps(player, { isCurrentTurn: false });
+    const next = makeProps(player, { isCurrentTurn: true });
+    expect(arePlayerAreaPropsEqual(prev, next)).toBe(false);
+  });
+
+  it("re-renders when life total changes", () => {
+    const prev = makeProps(makePlayer({ lifeTotal: 40 }));
+    const next = makeProps(makePlayer({ lifeTotal: 38 }));
+    expect(arePlayerAreaPropsEqual(prev, next)).toBe(false);
+  });
+
+  it("does not re-render when callbacks/position/orientation are unchanged and player is the same ref", () => {
+    const player = makePlayer();
+    const onCardClick = jest.fn();
+    const onZoneClick = jest.fn();
+    const allPlayers: PlayerState[] = [];
+    const common = { onCardClick, onZoneClick, allPlayers };
+    expect(
+      arePlayerAreaPropsEqual(
+        makeProps(player, common),
+        makeProps(player, common),
+      ),
+    ).toBe(true);
+  });
+
+  it("re-renders when position or orientation changes", () => {
+    const player = makePlayer();
+    expect(
+      arePlayerAreaPropsEqual(
+        makeProps(player, { position: "top" }),
+        makeProps(player, { position: "bottom" }),
+      ),
+    ).toBe(false);
+    expect(
+      arePlayerAreaPropsEqual(
+        makeProps(player, { orientation: "horizontal" }),
+        makeProps(player, { orientation: "vertical" }),
+      ),
+    ).toBe(false);
+  });
+});
+
+/**
+ * Render-counter harness: wraps a dummy component with `React.memo` using the
+ * REAL `arePlayerAreaPropsEqual`. This proves the predicate actually prevents
+ * React from re-rendering the subtree when zone arrays are unchanged — the
+ * same memo boundary `PlayerArea` uses.
+ */
+const MemoPlayer = React.memo(
+  function MemoPlayer(_props: AreaProps) {
+    renderCount++;
+    return null;
+  },
+  arePlayerAreaPropsEqual,
+);
+
+let renderCount = 0;
+
+function resetCount() {
+  renderCount = 0;
+}
+
+describe("PlayerArea memo boundary — render counting", () => {
+  it("renders once on mount, then bails out when props are unchanged references", () => {
+    const onCardClick = jest.fn();
+    const onZoneClick = jest.fn();
+    const allPlayers: PlayerState[] = [];
+    const stable = { onCardClick, onZoneClick, allPlayers };
+    const player = makePlayer({ battlefield: [{ id: "b1" } as never] });
+
+    const { rerender } = render(<MemoPlayer {...makeProps(player, stable)} />);
+    expect(renderCount).toBe(1);
+
+    // Re-render with a NEW props object but IDENTICAL inner references.
+    rerender(<MemoPlayer {...makeProps(player, stable)} />);
+    expect(renderCount).toBe(1); // no re-render
+
+    rerender(<MemoPlayer {...makeProps(player, stable)} />);
+    expect(renderCount).toBe(1);
+  });
+
+  it("re-renders exactly once more when a single zone array reference changes", () => {
+    resetCount();
+    const onCardClick = jest.fn();
+    const onZoneClick = jest.fn();
+    const allPlayers: PlayerState[] = [];
+    const stable = { onCardClick, onZoneClick, allPlayers };
+    const playerA = makePlayer({ graveyard: [] });
+    const playerB = makePlayer({ graveyard: [{ id: "g1" } as never] });
+    // battlefield unchanged ref ([] default), only graveyard ref changes.
+
+    const { rerender } = render(<MemoPlayer {...makeProps(playerA, stable)} />);
+    expect(renderCount).toBe(1);
+
+    rerender(<MemoPlayer {...makeProps(playerB, stable)} />);
+    expect(renderCount).toBe(2); // graveyard changed → re-render
+
+    // Identical again → bail out.
+    rerender(<MemoPlayer {...makeProps(playerB, stable)} />);
+    expect(renderCount).toBe(2);
+  });
+
+  it("does not re-render when an unrelated player prop changes that the comparator ignores", () => {
+    resetCount();
+    const onCardClick = jest.fn();
+    const onZoneClick = jest.fn();
+    const allPlayers: PlayerState[] = [];
+    const stable = { onCardClick, onZoneClick, allPlayers };
+    // `landsPlayedThisTurn` is intentionally NOT in the comparator — a delta
+    // that only touches it must NOT re-render the player area.
+    const player = makePlayer({ landsPlayedThisTurn: 0 });
+
+    const { rerender } = render(<MemoPlayer {...makeProps(player, stable)} />);
+    expect(renderCount).toBe(1);
+
+    const player2 = { ...player, landsPlayedThisTurn: 3 };
+    rerender(<MemoPlayer {...makeProps(player2, stable)} />);
+    expect(renderCount).toBe(1); // ignored field → no re-render
+  });
+});

--- a/src/components/__tests__/virtualized-zone-strip.test.tsx
+++ b/src/components/__tests__/virtualized-zone-strip.test.tsx
@@ -1,0 +1,311 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import {
+  VirtualizedZoneStrip,
+  BattlefieldCard,
+  ZONE_WINDOWING_THRESHOLDS,
+  BATTLEFIELD_WINDOWING_THRESHOLD,
+  getZoneThreshold,
+} from "../virtualized-zone-strip";
+import type { CardState, ZoneType } from "@/types/game";
+
+/**
+ * Build N minimal zone cards. Cast through `unknown` to avoid constructing a
+ * full ScryfallCard (mirrors virtualized-battlefield.test.tsx). Only the
+ * fields the component reads (`id`, `card.name`, `card.image_uris`,
+ * `tapped`) are populated.
+ */
+function makeCards(n: number, tappedFrom = -1): CardState[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `card-${i}`,
+    card: {
+      id: `scry-${i}`,
+      name: `Permanent ${i}`,
+      image_uris: { normal: `https://example.com/img-${i}.jpg` },
+    },
+    tapped: i >= tappedFrom ? true : undefined,
+  })) as unknown as CardState[];
+}
+
+/** A jsdom-sized DOMRect — jsdom reports 0 for every layout property. */
+function rect(width: number, height: number): DOMRect {
+  return {
+    width,
+    height,
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    bottom: height,
+    right: width,
+    toJSON() {},
+  } as DOMRect;
+}
+
+/**
+ * Shared jsdom layout shims — @tanstack/react-virtual needs real viewport +
+ * item sizes, and a ResizeObserver, none of which jsdom provides.
+ */
+function installLayoutShims(itemSize: { w: number; h: number }, viewport: { w: number; h: number }) {
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get() {
+      return viewport.w;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get() {
+      return viewport.h;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    get() {
+      return viewport.w;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    get() {
+      return viewport.h;
+    },
+  });
+  Element.prototype.getBoundingClientRect = function getBoundingClientRect() {
+    if (this.hasAttribute && this.hasAttribute("data-index")) {
+      return rect(itemSize.w, itemSize.h);
+    }
+    if (this.getAttribute && this.getAttribute("role") === "list") {
+      return rect(viewport.w, viewport.h);
+    }
+    return rect(viewport.w, viewport.h);
+  };
+  (global as { ResizeObserver?: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+describe("VirtualizedZoneStrip — thresholds", () => {
+  it("exports a per-zone threshold table with the battlefield default preserved from #1082", () => {
+    expect(BATTLEFIELD_WINDOWING_THRESHOLD).toBe(20);
+    expect(ZONE_WINDOWING_THRESHOLDS.battlefield).toBe(20);
+    // Other zones have tuned thresholds (acceptance: thresholds exported).
+    expect(ZONE_WINDOWING_THRESHOLDS.graveyard).toBe(40);
+    expect(ZONE_WINDOWING_THRESHOLDS.exile).toBe(25);
+    expect(ZONE_WINDOWING_THRESHOLDS.library).toBe(15);
+  });
+
+  it("getZoneThreshold resolves each zone and falls back to the default", () => {
+    expect(getZoneThreshold("battlefield")).toBe(20);
+    expect(getZoneThreshold("graveyard")).toBe(40);
+    expect(getZoneThreshold("exile")).toBe(25);
+    expect(getZoneThreshold("library")).toBe(15);
+  });
+});
+
+describe("VirtualizedZoneStrip — horizontal windowing (any zone)", () => {
+  const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+  let originalClientWidth: PropertyDescriptor | undefined;
+  let originalClientHeight: PropertyDescriptor | undefined;
+  let originalOffsetWidth: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalClientWidth = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientWidth",
+    );
+    originalClientHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientHeight",
+    );
+    originalOffsetWidth = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "offsetWidth",
+    );
+    // Narrow 300px viewport so only a handful of 56px cards fit.
+    installLayoutShims({ w: 56, h: 80 }, { w: 300, h: 96 });
+  });
+
+  afterEach(() => {
+    if (originalClientWidth)
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", originalClientWidth);
+    if (originalClientHeight)
+      Object.defineProperty(HTMLElement.prototype, "clientHeight", originalClientHeight);
+    if (originalOffsetWidth)
+      Object.defineProperty(HTMLElement.prototype, "offsetWidth", originalOffsetWidth);
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  });
+
+  it("accepts a zone prop and window-renders a battlefield over its threshold", () => {
+    const cards = makeCards(100);
+    render(
+      <VirtualizedZoneStrip
+        cards={cards}
+        zone="battlefield"
+        onCardClick={jest.fn()}
+      />,
+    );
+    const mounted = screen.getAllByTestId(/^battlefield-card-/);
+    expect(mounted.length).toBeGreaterThan(0);
+    expect(mounted.length).toBeLessThan(100);
+    // Bounded window + overscan for a 300px viewport.
+    expect(mounted.length).toBeLessThanOrEqual(40);
+  });
+
+  it("window-renders a graveyard zone (count > threshold)", () => {
+    // 50 graveyard cards > graveyard threshold (40).
+    const cards = makeCards(50);
+    render(
+      <VirtualizedZoneStrip
+        cards={cards}
+        zone="graveyard"
+        onCardClick={jest.fn()}
+      />,
+    );
+    const mounted = screen.getAllByTestId(/^battlefield-card-/);
+    expect(mounted.length).toBeGreaterThan(0);
+    expect(mounted.length).toBeLessThan(50);
+    expect(mounted.length).toBeLessThanOrEqual(40);
+    // Accessible label reflects the zone.
+    expect(screen.getByRole("list").getAttribute("aria-label")).toContain(
+      "graveyard",
+    );
+  });
+
+  it("window-renders exile and library zones", () => {
+    for (const zone of ["exile", "library"] as ZoneType[]) {
+      const { unmount } = render(
+        <VirtualizedZoneStrip
+          cards={makeCards(60)}
+          zone={zone}
+          onCardClick={jest.fn()}
+        />,
+      );
+      const mounted = screen.getAllByTestId(/^battlefield-card-/);
+      expect(mounted.length).toBeGreaterThan(0);
+      expect(mounted.length).toBeLessThan(60);
+      unmount();
+    }
+  });
+
+  it("mounts zero nodes for an empty zone without crashing", () => {
+    render(
+      <VirtualizedZoneStrip
+        cards={[]}
+        zone="exile"
+        onCardClick={jest.fn()}
+      />,
+    );
+    expect(screen.queryAllByTestId(/^battlefield-card-/)).toHaveLength(0);
+  });
+
+  it("preserves per-card click targeting on mounted items", () => {
+    const cards = makeCards(100);
+    const onCardClick = jest.fn();
+    render(
+      <VirtualizedZoneStrip
+        cards={cards}
+        zone="exile"
+        onCardClick={onCardClick}
+      />,
+    );
+    const mounted = screen.getAllByTestId(/^battlefield-card-/);
+    fireEvent.click(mounted[0]);
+    expect(onCardClick).toHaveBeenCalledTimes(1);
+    expect(onCardClick).toHaveBeenCalledWith("card-0", "exile");
+  });
+});
+
+describe("VirtualizedZoneStrip — vertical mode", () => {
+  const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+  let originalClientWidth: PropertyDescriptor | undefined;
+  let originalClientHeight: PropertyDescriptor | undefined;
+  let originalOffsetWidth: PropertyDescriptor | undefined;
+  let originalOffsetHeight: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalClientWidth = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientWidth",
+    );
+    originalClientHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientHeight",
+    );
+    originalOffsetWidth = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "offsetWidth",
+    );
+    originalOffsetHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "offsetHeight",
+    );
+    // Narrow vertical viewport so only a few rows fit.
+    installLayoutShims({ w: 56, h: 80 }, { w: 96, h: 240 });
+  });
+
+  afterEach(() => {
+    if (originalClientWidth)
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", originalClientWidth);
+    if (originalClientHeight)
+      Object.defineProperty(HTMLElement.prototype, "clientHeight", originalClientHeight);
+    if (originalOffsetWidth)
+      Object.defineProperty(HTMLElement.prototype, "offsetWidth", originalOffsetWidth);
+    if (originalOffsetHeight)
+      Object.defineProperty(HTMLElement.prototype, "offsetHeight", originalOffsetHeight);
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  });
+
+  it("window-renders a vertical library strip and sets aria-orientation=vertical", () => {
+    const cards = makeCards(100);
+    render(
+      <VirtualizedZoneStrip
+        cards={cards}
+        zone="library"
+        orientation="vertical"
+        onCardClick={jest.fn()}
+      />,
+    );
+    const mounted = screen.getAllByTestId(/^battlefield-card-/);
+    expect(mounted.length).toBeGreaterThan(0);
+    expect(mounted.length).toBeLessThan(100);
+    const list = screen.getByRole("list");
+    expect(list.getAttribute("aria-orientation")).toBe("vertical");
+    // Label reflects the zone.
+    expect(list.getAttribute("aria-label")).toContain("library");
+  });
+
+  it("horizontal mode sets aria-orientation=horizontal", () => {
+    render(
+      <VirtualizedZoneStrip
+        cards={makeCards(60)}
+        zone="graveyard"
+        orientation="horizontal"
+        onCardClick={jest.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("list").getAttribute("aria-orientation"),
+    ).toBe("horizontal");
+  });
+});
+
+describe("BattlefieldCard re-export", () => {
+  it("is exported from the zone-strip module", () => {
+    const card = {
+      id: "p1",
+      card: { name: "Lilypad", image_uris: { normal: "https://example.com/l.jpg" } },
+    } as unknown as CardState;
+    render(
+      <BattlefieldCard
+        card={card}
+        zone={"battlefield" as ZoneType}
+        onCardClick={jest.fn()}
+      />,
+    );
+    expect(screen.getByTestId("battlefield-card-lilypad")).toBeTruthy();
+  });
+});

--- a/src/components/game-board.tsx
+++ b/src/components/game-board.tsx
@@ -56,14 +56,15 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { MobileGameLayout } from "@/components/mobile-game-layout";
 import {
   BattlefieldCard,
-  VirtualizedBattlefield,
-} from "@/components/virtualized-battlefield";
+  VirtualizedZoneStrip,
+  getZoneThreshold,
+} from "@/components/virtualized-zone-strip";
 
-// Performance optimization constants
-// Only the visible window of battlefield permanents is mounted once a board
-// exceeds this size; below it every permanent renders directly (no overhead).
-// See #1082 — windowing the game-board permanent list for large board states.
-const BATTLEFIELD_WINDOWING_THRESHOLD = 20;
+// Performance optimization: each player's battlefield is windowed
+// independently once it exceeds its per-zone threshold, so a 4-player
+// Commander board no longer mounts 100+ card thumbnails at once (#1390).
+// The threshold table lives in `virtualized-zone-strip.tsx`; the battlefield
+// default (20) is preserved from #1082.
 
 interface GameBoardProps {
   players: PlayerState[];
@@ -144,14 +145,14 @@ const ZoneDisplay = memo(function ZoneDisplay({
     onZoneClick?.(zone, playerId);
   }, [onZoneClick, zone, playerId]);
 
-  // Window the battlefield once the board is large enough to matter (#1082).
-  // Below the threshold every permanent renders directly; above it the
-  // `VirtualizedBattlefield` mounts only the visible window (+ overscan) and
-  // reveals the rest via horizontal scroll. This also replaces the previous
-  // approach that silently sliced off overflow permanents (making them
-  // untargetable); every permanent is now reachable by scroll.
-  const isWindowedBattlefield =
-    zone === "battlefield" && count > BATTLEFIELD_WINDOWING_THRESHOLD;
+  // Window the zone once it is large enough to matter (#1082 battlefield,
+  // #1390 generalized to every zone). Below the threshold every card renders
+  // directly; above it the `VirtualizedZoneStrip` mounts only the visible
+  // window (+ overscan) and reveals the rest via scroll. This also replaces
+  // the previous approach that silently sliced off overflow permanents
+  // (making them untargetable); every permanent is now reachable by scroll.
+  const threshold = getZoneThreshold(zone);
+  const isWindowed = zone === "battlefield" && count > threshold;
 
   const zoneIcons: Record<ZoneType, React.ReactNode> = useMemo(
     () => ({
@@ -190,10 +191,11 @@ const ZoneDisplay = memo(function ZoneDisplay({
             {count > 0 && (
               <div className="absolute inset-0 flex items-center justify-center gap-1 flex-wrap p-1">
                 {zone === "battlefield" &&
-                  (isWindowedBattlefield ? (
-                    <VirtualizedBattlefield
+                  (isWindowed ? (
+                    <VirtualizedZoneStrip
                       cards={cards}
                       zone={zone}
+                      orientation="horizontal"
                       onCardClick={onCardClick}
                       className="absolute inset-0 p-1"
                     />
@@ -338,7 +340,7 @@ const PlayerInfo = memo(function PlayerInfo({
   );
 });
 
-function PlayerArea({
+const PlayerArea = memo(function PlayerArea({
   player,
   isCurrentTurn,
   position,
@@ -546,7 +548,50 @@ function PlayerArea({
       )}
     </div>
   );
+}, arePlayerAreaPropsEqual);
+
+/**
+ * Custom comparator for `PlayerArea` (#1390). A player area only needs to
+ * re-render when one of its own zone card arrays changed reference, or when
+ * turn/position/callbacks changed. Combined with the already-memoized
+ * `ZoneDisplay`, a delta that touches a single zone re-renders only that
+ * zone's strip — the other three players' strips are skipped entirely.
+ */
+function arePlayerAreaPropsEqual(
+  prev: PlayerAreaProps & { allPlayers?: PlayerState[] },
+  next: PlayerAreaProps & { allPlayers?: PlayerState[] },
+): boolean {
+  if (prev === next) return true;
+  const a = prev.player;
+  const b = next.player;
+  if (a !== b) {
+    if (a.id !== b.id) return false;
+    if (
+      a.lifeTotal !== b.lifeTotal ||
+      a.poisonCounters !== b.poisonCounters ||
+      a.isCurrentTurn !== b.isCurrentTurn ||
+      a.hasPriority !== b.hasPriority ||
+      a.commanderDamage !== b.commanderDamage ||
+      a.hand !== b.hand ||
+      a.battlefield !== b.battlefield ||
+      a.graveyard !== b.graveyard ||
+      a.exile !== b.exile ||
+      a.library !== b.library ||
+      a.commandZone !== b.commandZone
+    ) {
+      return false;
+    }
+  }
+  return (
+    prev.isCurrentTurn === next.isCurrentTurn &&
+    prev.position === next.position &&
+    prev.orientation === next.orientation &&
+    prev.onCardClick === next.onCardClick &&
+    prev.onZoneClick === next.onZoneClick &&
+    prev.allPlayers === next.allPlayers
+  );
 }
+export { arePlayerAreaPropsEqual };
 
 export function GameBoard({
   players,

--- a/src/components/virtualized-battlefield.tsx
+++ b/src/components/virtualized-battlefield.tsx
@@ -1,74 +1,14 @@
 "use client";
 
-import * as React from "react";
-import { memo, useCallback } from "react";
-import { useVirtualizer } from "@tanstack/react-virtual";
-import Image from "next/image";
 import type { CardState, ZoneType } from "@/types/game";
-import { cn } from "@/lib/utils";
+import {
+  BattlefieldCard,
+  VirtualizedZoneStrip,
+} from "@/components/virtualized-zone-strip";
 
-interface BattlefieldCardProps {
-  card: CardState;
-  zone: ZoneType;
-  onCardClick?: (cardId: string, zone: ZoneType) => void;
-}
-
-/**
- * A single battlefield permanent thumbnail.
- *
- * Extracted so the exact same markup is reused by both the small-board
- * (non-virtualized) render path and the windowed `VirtualizedBattlefield`.
- * Memoized so re-renders triggered by game-state deltas (#1024 delta-sync)
- * skip cards whose props did not change.
- */
-export const BattlefieldCard = memo(function BattlefieldCard({
-  card,
-  zone,
-  onCardClick,
-}: BattlefieldCardProps) {
-  const testId = `battlefield-card-${card.card.name.toLowerCase().replace(/\s+/g, "-")}`;
-
-  const handleClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      e.stopPropagation();
-      onCardClick?.(card.id, zone);
-    },
-    [onCardClick, card.id, zone],
-  );
-
-  return (
-    <div
-      data-testid={testId}
-      onClick={handleClick}
-      className="relative w-10 h-14 sm:w-12 sm:h-16 md:w-14 md:h-20 rounded overflow-hidden border border-primary/30 hover:scale-[3] hover:z-50 hover:shadow-2xl transition-all duration-300 cursor-pointer group shrink-0"
-      title={card.card.name}
-    >
-      {card.card.image_uris?.normal ? (
-        <Image
-          src={card.card.image_uris.normal}
-          alt={card.card.name}
-          fill
-          sizes="80px"
-          className="object-cover rounded"
-          loading="lazy"
-        />
-      ) : (
-        <div className="w-full h-full bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center">
-          <span className="text-[8px] text-center leading-tight px-0.5 line-clamp-2">
-            {card.card.name}
-          </span>
-        </div>
-      )}
-      {card.tapped && (
-        <div className="absolute inset-0 bg-black/20 flex items-center justify-center">
-          <span className="text-[8px] text-white font-bold rotate-45">
-            TAPPED
-          </span>
-        </div>
-      )}
-    </div>
-  );
-});
+// Re-export so existing imports (`BattlefieldCard` from this module) keep
+// working — game-board.tsx and the legacy test both pull it from here.
+export { BattlefieldCard };
 
 export interface VirtualizedBattlefieldProps {
   cards: CardState[];
@@ -85,87 +25,15 @@ export interface VirtualizedBattlefieldProps {
 }
 
 /**
- * Horizontally-windowed battlefield permanent strip.
+ * Horizontally-windowed battlefield permanent strip (#1082).
  *
- * The game board is the single most re-render-heavy surface in the app, and
- * Commander / token-heavy boards can carry dozens of permanents. Mounting all
- * of them every render tanks performance (#1082). Only the visible window of
- * permanents (plus `overscan`) is mounted to the DOM; the rest are reachable
- * by horizontal scroll. Built on `@tanstack/react-virtual` (already a project
- * dependency, same primitive used by `VirtualCardList` / `VirtualizedCardGrid`)
- * in horizontal mode, which suits the single-row battlefield strip layout.
- *
- * Because every permanent lives at a stable virtual index keyed by `card.id`,
- * combat targeting / ability menus resolve to the correct card whether or not
- * it is currently mounted — scrolling reveals it rather than missing it.
+ * Now a thin wrapper around the generalized `VirtualizedZoneStrip` (#1390),
+ * pinned to `orientation="horizontal"` so the battlefield row layout and the
+ * existing tests are unchanged. See `virtualized-zone-strip.tsx` for the
+ * full implementation and the per-zone threshold table.
  */
-export function VirtualizedBattlefield({
-  cards,
-  zone,
-  onCardClick,
-  className,
-  estimateSize = 56,
-  gap = 4,
-  overscan = 6,
-}: VirtualizedBattlefieldProps) {
-  const parentRef = React.useRef<HTMLDivElement>(null);
-
-  const rowVirtualizer = useVirtualizer({
-    count: cards.length,
-    getScrollElement: () => parentRef.current,
-    estimateSize: () => estimateSize,
-    overscan,
-    gap,
-    horizontal: true,
-  });
-
-  const virtualItems = rowVirtualizer.getVirtualItems();
-
-  return (
-    <div
-      ref={parentRef}
-      className={cn(
-        "overflow-x-auto overflow-y-hidden outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
-        className,
-      )}
-      role="list"
-      aria-label={`Battlefield (${cards.length} permanents)`}
-      tabIndex={0}
-    >
-      <div
-        style={{
-          width: `${rowVirtualizer.getTotalSize()}px`,
-          height: "100%",
-          position: "relative",
-        }}
-      >
-        {virtualItems.map((virtualItem) => {
-          const card = cards[virtualItem.index];
-          if (!card) return null;
-          return (
-            <div
-              key={card.id ?? virtualItem.key}
-              data-index={virtualItem.index}
-              role="listitem"
-              style={{
-                position: "absolute",
-                top: 0,
-                left: 0,
-                height: "100%",
-                transform: `translateX(${virtualItem.start}px)`,
-                display: "flex",
-                alignItems: "center",
-              }}
-            >
-              <BattlefieldCard
-                card={card}
-                zone={zone}
-                onCardClick={onCardClick}
-              />
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
+export function VirtualizedBattlefield(
+  props: VirtualizedBattlefieldProps,
+) {
+  return <VirtualizedZoneStrip orientation="horizontal" {...props} />;
 }

--- a/src/components/virtualized-zone-strip.tsx
+++ b/src/components/virtualized-zone-strip.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import * as React from "react";
+import { memo, useCallback } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import Image from "next/image";
+import type { CardState, ZoneType } from "@/types/game";
+import { cn } from "@/lib/utils";
+
+interface BattlefieldCardProps {
+  card: CardState;
+  zone: ZoneType;
+  onCardClick?: (cardId: string, zone: ZoneType) => void;
+}
+
+/**
+ * A single zone card thumbnail.
+ *
+ * Extracted so the exact same markup is reused by both the small-board
+ * (non-virtualized) render path and any windowed zone strip. Memoized so
+ * re-renders triggered by game-state deltas (#1024 delta-sync) skip cards
+ * whose props did not change. Re-exported from `virtualized-battlefield.tsx`
+ * for backward compatibility.
+ */
+export const BattlefieldCard = memo(function BattlefieldCard({
+  card,
+  zone,
+  onCardClick,
+}: BattlefieldCardProps) {
+  const testId = `battlefield-card-${card.card.name.toLowerCase().replace(/\s+/g, "-")}`;
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      onCardClick?.(card.id, zone);
+    },
+    [onCardClick, card.id, zone],
+  );
+
+  return (
+    <div
+      data-testid={testId}
+      onClick={handleClick}
+      className="relative w-10 h-14 sm:w-12 sm:h-16 md:w-14 md:h-20 rounded overflow-hidden border border-primary/30 hover:scale-[3] hover:z-50 hover:shadow-2xl transition-all duration-300 cursor-pointer group shrink-0"
+      title={card.card.name}
+    >
+      {card.card.image_uris?.normal ? (
+        <Image
+          src={card.card.image_uris.normal}
+          alt={card.card.name}
+          fill
+          sizes="80px"
+          className="object-cover rounded"
+          loading="lazy"
+        />
+      ) : (
+        <div className="w-full h-full bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center">
+          <span className="text-[8px] text-center leading-tight px-0.5 line-clamp-2">
+            {card.card.name}
+          </span>
+        </div>
+      )}
+      {card.tapped && (
+        <div className="absolute inset-0 bg-black/20 flex items-center justify-center">
+          <span className="text-[8px] text-white font-bold rotate-45">
+            TAPPED
+          </span>
+        </div>
+      )}
+    </div>
+  );
+});
+
+/**
+ * Per-zone windowing thresholds. A zone is rendered through the virtualizer
+ * once its card count exceeds its threshold; below it every card renders
+ * directly (no virtualizer overhead). Tuned for realistic Commander board
+ * states — see #1390 (windowing every player's battlefield independently on
+ * the 4-player board).
+ *
+ * `battlefield` preserves the original `BATTLEFIELD_WINDOWING_THRESHOLD` (20)
+ * introduced in #1082.
+ */
+export const ZONE_WINDOWING_THRESHOLDS: Record<ZoneType, number> = {
+  battlefield: 20,
+  graveyard: 40,
+  exile: 25,
+  library: 15,
+  commandZone: 12,
+  companion: 4,
+  hand: 20,
+  stack: 20,
+  sideboard: 20,
+  anticipate: 20,
+};
+
+/** The battlefield threshold preserved from #1082 for backward compatibility. */
+export const BATTLEFIELD_WINDOWING_THRESHOLD =
+  ZONE_WINDOWING_THRESHOLDS.battlefield;
+
+/** Resolve the windowing threshold for a zone (defaults to 20). */
+export function getZoneThreshold(zone: ZoneType): number {
+  return ZONE_WINDOWING_THRESHOLDS[zone] ?? BATTLEFIELD_WINDOWING_THRESHOLD;
+}
+
+export interface VirtualizedZoneStripProps {
+  cards: CardState[];
+  /** Which zone this strip renders — drives the accessible label. */
+  zone: ZoneType;
+  /** Strip axis. Horizontal suits battlefield rows; vertical suits the
+   *  stacked library/graveyard zones in the 4-player layout. */
+  orientation?: "horizontal" | "vertical";
+  onCardClick?: (cardId: string, zone: ZoneType) => void;
+  /** Class applied to the scroll container. */
+  className?: string;
+  /** Estimated card size in px along the scroll axis. */
+  estimateSize?: number;
+  /** Gap between cards in px (mirrors Tailwind `gap-1` = 4px). */
+  gap?: number;
+  /** Number of cards rendered outside the visible window on each side. */
+  overscan?: number;
+}
+
+/**
+ * Windowed zone strip — generalizes `VirtualizedBattlefield` (#1082) to any
+ * horizontal OR vertical zone. Only the visible window of cards (plus
+ * `overscan`) is mounted to the DOM; the rest are reachable by scroll.
+ *
+ * On the 4-player board every player's battlefield (and the stacked
+ * graveyard/exile/library zones) renders through this component once its
+ * count exceeds the per-zone threshold, so a late-game Commander board no
+ * longer mounts 100+ card thumbnails simultaneously (#1390).
+ *
+ * Built on `@tanstack/react-virtual` (already a project dependency, same
+ * primitive used by `VirtualCardList` / `VirtualizedCardGrid`). Because every
+ * card lives at a stable virtual index keyed by `card.id`, targeting resolves
+ * to the correct card whether or not it is currently mounted — scrolling
+ * reveals it rather than missing it.
+ */
+export function VirtualizedZoneStrip({
+  cards,
+  zone,
+  orientation = "horizontal",
+  onCardClick,
+  className,
+  estimateSize = 56,
+  gap = 4,
+  overscan = 6,
+}: VirtualizedZoneStripProps) {
+  const horizontal = orientation === "horizontal";
+  const parentRef = React.useRef<HTMLDivElement>(null);
+
+  const virtualizer = useVirtualizer({
+    count: cards.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => estimateSize,
+    overscan,
+    gap,
+    horizontal,
+  });
+
+  const virtualItems = virtualizer.getVirtualItems();
+  const totalSize = virtualizer.getTotalSize();
+
+  return (
+    <div
+      ref={parentRef}
+      className={cn(
+        horizontal
+          ? "overflow-x-auto overflow-y-hidden"
+          : "overflow-y-auto overflow-x-hidden",
+        "outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+      role="list"
+      aria-label={`${zone} (${cards.length} cards)`}
+      aria-orientation={horizontal ? "horizontal" : "vertical"}
+      tabIndex={0}
+    >
+      <div
+        style={
+          horizontal
+            ? {
+                width: `${totalSize}px`,
+                height: "100%",
+                position: "relative",
+              }
+            : {
+                height: `${totalSize}px`,
+                width: "100%",
+                position: "relative",
+              }
+        }
+      >
+        {virtualItems.map((virtualItem) => {
+          const card = cards[virtualItem.index];
+          if (!card) return null;
+          return (
+            <div
+              key={card.id ?? virtualItem.key}
+              data-index={virtualItem.index}
+              role="listitem"
+              style={
+                horizontal
+                  ? {
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      height: "100%",
+                      transform: `translateX(${virtualItem.start}px)`,
+                      display: "flex",
+                      alignItems: "center",
+                    }
+                  : {
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      width: "100%",
+                      transform: `translateY(${virtualItem.start}px)`,
+                      display: "flex",
+                      alignItems: "center",
+                    }
+              }
+            >
+              <BattlefieldCard
+                card={card}
+                zone={zone}
+                onCardClick={onCardClick}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Resolves #1390. On the 4-player Commander board, every player's battlefield (and other zones) mounted all card thumbnails simultaneously, blocking the main thread during combat/targeting in late-game boards with 100+ permanents.

## Changes

- **New `VirtualizedZoneStrip`` (`src/components/virtualized-zone-strip.tsx`)** — generalizes `VirtualizedBattlefield` (#1082) to window-render **any** horizontal **or** vertical zone once `count > threshold`. Built on the existing `@tanstack/react-virtual` primitive; sets `aria-orientation` to match the strip axis.
- **Per-zone threshold table** (`ZONE_WINDOWING_THRESHOLDS` + `getZoneThreshold`): battlefield=20 (preserved from #1082), graveyard=40, exile=25, library=15, commandZone=12. `BATTLEFIELD_WINDOWING_THRESHOLD` is re-exported unchanged.
- **`VirtualizedBattlefield`** is now a thin wrapper pinned to `orientation="horizontal"` — identical behavior, existing tests stay green. `BattlefieldCard` is re-exported for backward compatibility.
- **`ZoneDisplay`** (`game-board.tsx`) now drives windowing through `getZoneThreshold(zone)`.
- **`PlayerArea` memoized** with a custom comparator comparing zone-array references (`arePlayerAreaPropsEqual`), so a game-state delta that touches one zone re-renders only that zone's strip — the other three players bail out. Combined with the already-memoized `ZoneDisplay`.

## Acceptance criteria

- [x] New `<VirtualizedZoneStrip>` accepts a `zone: ZoneType` prop and window-renders any zone once `count > threshold`.
- [x] On a synthetic board, card-thumbnail DOM count is bounded by `visible_window + overscan` per zone (asserted in `virtualized-zone-strip.test.tsx`).
- [x] `PlayerArea` re-renders only the zones whose card arrays changed (render-counter test in `game-board-render-storm.test.tsx`).
- [x] Vertical layout works for library/graveyard zones; `aria-orientation` matches.
- [x] `BATTLEFIELD_WINDOWING_THRESHOLD` preserved as battlefield default; new thresholds exported.
- [x] All existing `virtualized-battlefield.test.tsx` tests pass; new tests cover graveyard/exile/library windowing.

## Tests

- `src/components/__tests__/virtualized-zone-strip.test.tsx` — windowing for battlefield/graveyard/exile/library, vertical mode + `aria-orientation`, threshold exports, click targeting, empty-zone safety.
- `src/components/__tests__/game-board-render-storm.test.tsx` — direct predicate + real `React.memo` render-count proof that only changed zones re-render.

## Verification

- `tsc --noEmit` — clean
- `eslint` (changed files) — clean
- `jest src/components/__tests__/` — 334 passed (1 flaky parallel-worker SIGTRAP in `tournament-bracket` passes in isolation)