### PR TITLE
docs: add repo-specific guidance section to the agents guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,71 @@
+# Planar Nexus — Agent Guide
+
+Digital Magic: The Gathering tabletop: deck builder, AI deck coach, AI opponent, and P2P multiplayer. Next.js 16 (App Router) + React 19 web app, wrapped in a Tauri 2 desktop shell (`src-tauri/`). All source under `src/`.
+
+## Commands
+
+Package manager is **npm** (`package-lock.json` + CI `npm ci`, Node 22). Ignore `pnpm-lock.yaml` — it is stale; npm is authoritative.
+
+- `npm run dev` — dev server on **port 9002** (not 3000). Playwright boots the same port.
+- `npm run typecheck` — `tsc --noEmit`. Run before lint/test.
+- `npm run lint` — `eslint src --max-warnings 1000` (warnings do NOT fail; only errors gate).
+- `npm test` — Jest. One file: `npm test -- --testPathPattern=layer-system`. One test by name: `--testNamePattern="..."`.
+- `npm run test:coverage` then `npm run test:coverage:ratchet` — coverage floor auto-bumps; see Testing below.
+- `npm run test:e2e` — Playwright (boots dev server automatically).
+- `npm run mutate:<module>` — Stryker on one rules module (e.g. `mutate:layer-system`). Avoid full `npm run test:mutation` unless you have ~40 min.
+- `npm run a11y:contrast` — color-contrast gate enforced in CI.
+- `npm run simulate` — runs only the AI simulation suite (`src/ai/__tests__/simulation/`).
+- Desktop: `npm run build:tauri` (= `tauri build`, runs `npm run build` first).
+
+## Pre-commit & commits (enforced by husky)
+
+- `pre-commit`: `lint-staged` runs eslint --fix + `tsc --noEmit` + prettier on staged files. A staged file that fails typecheck **blocks the commit**.
+- `commit-msg`: commitlint, conventional commits only. Header **lowercase**, **min 10 chars**. Allowed types only: `feat fix docs style refactor test chore revert`.
+
+## CI gate (`.github/workflows/ci.yml`)
+
+A PR's build job waits on **all** of: test, lint, typecheck, commitlint, mutation-test (scoped), security audit, cargo-audit, a11y-contrast, e2e, workflow-lint. Failing any one blocks merge. Run `typecheck && lint && test` locally before pushing.
+
+## Architecture (not obvious from filenames)
+
+- **App Router**: `src/app/(app)/` is a route group of protected routes sharing a layout (`dashboard`, `deck-builder`, `deck-coach`, `single-player`, `multiplayer`). `src/app/api/` holds route handlers: `ai-proxy`, `chat`, `deck-import`, `signaling`.
+- **`src/app/actions.ts` is misnamed**: it exports _client-side_ wrappers around AI flows, not Next.js server actions.
+- **Rules engine** lives in `src/lib/game-state/` — a large MTG rules implementation (layer-system, replacement-effects, trigger-system, state-based-actions, spell-casting, combat, mana, …). This is the correctness-critical core and the only place mutation testing runs.
+- **AI**: multi-provider via Vercel AI SDK (`@ai-sdk/openai|anthropic|google|react`) with a unified proxy route at `src/app/api/ai-proxy/`; Genkit flows in `src/ai/flows/` (deck-coach-review, opponent-generation). Provider keys in `.env` (`OPENAI_* / ANTHROPIC_* / GOOGLE_* / ZAI_*`). Deck coaching has a heuristic fallback that needs **no** API key.
+- **Persistence**: IndexedDB via Dexie (`dexie-react-hooks`); tests use `fake-indexeddb`.
+- **Card search**: full-text via `@orama/orama`; card data sourced from Scryfall.
+- **Multiplayer**: PeerJS (WebRTC) + the signaling API route; TURN relay via `NEXT_PUBLIC_TURN_*` env.
+- **UI**: shadcn/ui (`components.json`; aliases `@/components`, `@/lib/utils`, `@/components/ui`) + Tailwind v4 + lucide-react icons. Merge classes with `cn()` from `@/lib/utils`.
+- Path alias `@/*` → `src/*` (mirrors `tsconfig.json` and `jest.config.js`).
+
+## Testing quirks (hard-won)
+
+- Jest env is `jsdom` with `ts-jest`. **`@orama/*` is mapped to its CommonJS dist in `jest.config.js` `moduleNameMapper`** — do not remove; the ESM build breaks the jsdom resolver.
+- **Coverage thresholds are enforced in CI and ratcheted.** `jest.config.js` `coverageThreshold.global` is rewritten upward by `scripts/ratchet-coverage.js` (`npm run test:coverage:ratchet`). Never hand-raise a threshold above _measured_ coverage or CI fails; re-measure first. Target is 70%.
+- **`scripts/qa-coverage-gate.js`** fails CI if any `it.todo` remains in `src/lib/game-state/__tests__/qa-coverage-holes.test.ts` (rows GS-RT-1..13 must have real tests).
+- Tests are co-located in `__tests__/` dirs; cross-module integration tests live in repo-root `tests/` (discovered via `jest.config.js` roots).
+- **Video-derived fixtures**: `scripts/generate-test-fixture.ts` turns `src/lib/__fixtures__/video-derived/` JSON into Jest tests. Edits under `src/lib/game-state/**` or `__fixtures__/**` trigger the `video-derived-tests` workflow.
+- **Playwright** auto-sets `planar-nexus:onboarded=true` in localStorage to suppress the onboarding-tour backdrop (it would intercept pointer events). `e2e/onboarding.spec.ts` clears it via `forceFreshVisitor()`. Cross-browser: chromium / firefox / webkit.
+- API mocking uses **MSW** (`src/test-utils/msw/`); DOM assertions via React Testing Library (`jest.setup.js`).
+
+## Tauri / desktop gotchas
+
+- `tauri build` runs `npm run build` (`beforeBuildCommand`) and serves `../.next`. Dev uses `devUrl` `localhost:9002`.
+- **`tauri-plugin-single-instance` must be the FIRST plugin registered** in `src-tauri/src/lib.rs` (issue #1441); a Rust regression test enforces this.
+- **Keep `next.config.ts` image hosts (`REMOTE_IMAGE_HOSTS`) in sync with `src-tauri/tauri.conf.json` CSP `img-src`** — the `csp-audit` test asserts they match (issue #1273).
+- Rust: edition 2021, MSRV 1.77.2. `cargo audit` runs in CI (local mirror: `scripts/`). Updater + single-instance plugins are desktop-only.
+
+## Environment
+
+Copy `.env.example` → `.env`. AI keys are optional (heuristic fallback works). `NEXT_PUBLIC_TURN_*` recommended for production P2P. See `docs/API.md` for AI config.
+
+## Canonical docs (read these, don't guess)
+
+- `docs/TESTING.md` — canonical testing guide (root `TESTING.md` redirects there).
+- `CLAUDE.md` — broader architecture notes, but **partly stale**: it says "Next.js 15" and references a "non-existent `./game-state`" file. Actual is Next 16 and `src/lib/game-state/` is a large, live module. Trust code over `CLAUDE.md` where they differ.
+
+---
+
 # context-mode — MANDATORY routing rules
 
 You have context-mode MCP tools available. These rules are NOT optional — they protect your context window from flooding. A single unrouted command can dump 56 KB into context and waste the entire session.


### PR DESCRIPTION
## What

Adds a repo-specific **Agent Guide** to the top of `AGENTS.md`. The file previously contained only the generic context-mode routing block — zero guidance for working in this repo.

## Why

Future OpenCode sessions ramp up faster and avoid hard-won mistakes. Every line answers: *would an agent likely miss this without help?*

## Highlights

- **Commands agents guess wrong**: npm is authoritative (`pnpm-lock.yaml` is stale), dev server runs on **port 9002** (not 3000), `lint` uses `--max-warnings 1000`, single-test/`mutate:<module>` shortcuts.
- **Traps**: `src/app/actions.ts` is misnamed (client wrappers, not server actions); Jest `@orama/*` CommonJS mapper must stay; coverage thresholds are **ratcheted & enforced**; husky `pre-commit` typechecks staged files; commitlint is lowercase + min-10-chars + 8 types only.
- **Architecture not obvious from filenames**: the `src/lib/game-state/` rules engine is the correctness-critical (mutation-tested) core; multi-provider AI via Vercel AI SDK + Genkit flows; Dexie/IndexedDB persistence; PeerJS P2P.
- **Tauri gotchas**: single-instance plugin must register first (#1441); `next.config.ts` image hosts must stay in sync with `tauri.conf.json` CSP `img-src` (#1273).
- **Stale-doc flag**: warns that `CLAUDE.md` says "Next.js 15" and a "non-existent game-state" module (actual: Next 16, large live `src/lib/game-state/`).

The pre-existing context-mode routing block is preserved verbatim below a `---` divider (verified working, intentionally placed).

## Verification

- All guidance verified against executable sources (`package.json`, `jest.config.js`, `playwright.config.ts`, CI workflows, husky hooks, Tauri config).
- Docs-only change — no code, tests, or config touched.

## Summary by Sourcery

Documentation:
- Introduce a detailed Planar Nexus agent guide at the top of AGENTS.md covering commands, architecture, testing, Tauri desktop caveats, environment setup, and canonical docs, while preserving existing context-mode routing rules.