### PR TITLE
fix: resolve #1495 — invalid github.inputs in mobile-build.yml

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -28,7 +28,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
Closes #1495

## Context

The Workflow Lint (`actionlint`) failure described in this issue was caused by
invalid `github.inputs.*` context references in `mobile-build.yml`. However,
**that root cause was already fixed on `main`** by an earlier CI PR (commit
`914d23a`, "ci: resolve the workflow-lint tracking issue — add standalone
Workflow Lint job with actionlint"), which set the three cited locations to the
correct `inputs.*` form:

- `mobile-build.yml:48` → `${{ inputs.build_type }}`
- `mobile-build.yml:55` → `inputs.platform == 'all' || inputs.platform == 'ios'`
- `mobile-build.yml:127` → `inputs.platform == 'all' || inputs.platform == 'android'`

I verified the current state against the **exact** actionlint version CI pins
(`rhysd/actionlint@v1.7.7`):

```
$ actionlint .github/workflows/*.yml
$ echo $?
0
```

A repo-wide grep confirms **zero** `github.inputs.*` references remain anywhere
under `.github/workflows/`. The Workflow Lint job is green for the
`github.inputs` anti-pattern.

## What this PR changes

The issue also carries a secondary, in-scope recommendation: align the
`NODE_VERSION` env var to the repo standard. This PR applies it.

- `.github/workflows/mobile-build.yml`: `env.NODE_VERSION: '20'` → `'22'`.

The rest of the repo standardized on **Node 22** — the shared
`.github/actions/setup-node-npm-ci/action.yml` composite defaults
`node-version` to `'22'`, the main CI workflow uses 22, and `AGENTS.md`
documents Node 22 as authoritative. The mobile-build workflow was the lone
outlier still pinned to 20. Bumping it removes the inconsistency. No direct
`npm ci` and no `actions/setup-node@v1-5` are introduced; both build jobs still
bootstrap via the shared `./.github/actions/setup-node-npm-ci` composite action.

## Validation

- `actionlint` v1.7.7 (CI-pinned) — **exit 0** on all workflows, before and
  after this change.
- `npm run lint` not meaningful here: `node_modules` is not installed in the
  worktree and `eslint` targets `src/` only (not `.github/`), so YAML is
  unaffected. This is a YAML/config-only change; no TypeScript is touched, so
  `typecheck`/`test` are unaffected.

## Note

If the intent was for this issue to track the original `github.inputs` breakage
alone, it can likely be closed as already-resolved; this PR tidies the remaining
recommendation the issue calls out.