### PR TITLE
feat: add deck goldfish simulator for mana-curve validation

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -149,6 +149,18 @@ if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
   window.matchMedia = (query) => ({ ...mediaQueryList, media: String(query) });
 }
 
+// ResizeObserver — jsdom does not implement it, but several Radix UI primitives
+// (Slider, Switch, Progress, ...) read it at module-eval/render time via
+// @radix-ui/react-use-size. Provide a no-op so components that measure size
+// render under jsdom without throwing.
+if (typeof global.ResizeObserver === "undefined") {
+  global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
 // ============================================================================
 // Test Data Seeding Utilities
 // ============================================================================

--- a/src/app/(app)/deck-builder/_components/__tests__/goldfish-simulator.test.tsx
+++ b/src/app/(app)/deck-builder/_components/__tests__/goldfish-simulator.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview Tests for the GoldfishSimulator (issue #1439).
+ *
+ * Covers the min-cards guard (acceptance: "min-cards guard renders copy") shown
+ * when the deck is too small to deal an opening hand, plus a positive render of
+ * the simulator controls and seeded run for a sufficient deck. The real
+ * simulation logic in @/lib/goldfish-simulator is exercised end-to-end;
+ * Radix primitives render thanks to the ResizeObserver polyfill in
+ * jest.setup.js.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/jest-globals";
+import { GoldfishSimulator } from "../goldfish-simulator";
+import type { DeckCard } from "@/app/actions";
+
+function landCard(count: number): DeckCard {
+  return {
+    id: "mountain",
+    name: "Mountain",
+    cmc: 0,
+    type_line: "Basic Land — Mountain",
+    colors: [],
+    color_identity: ["R"],
+    legalities: {},
+    count,
+  } as unknown as DeckCard;
+}
+
+function spellCard(name: string, cmc: number, count: number): DeckCard {
+  return {
+    id: name.toLowerCase().replace(/\s+/g, "-"),
+    name,
+    cmc,
+    type_line: `Creature — ${name}`,
+    colors: ["R"],
+    color_identity: ["R"],
+    legalities: {},
+    count,
+  } as unknown as DeckCard;
+}
+
+describe("GoldfishSimulator min-cards guard", () => {
+  it("renders the guard when the deck has fewer than 7 cards", () => {
+    render(
+      <GoldfishSimulator deck={[landCard(3)]} format="legendary-commander" />,
+    );
+    expect(screen.getByTestId("goldfish-guard")).toBeInTheDocument();
+    expect(screen.getByText(/Add at least 7 cards/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("goldfish-simulator")).not.toBeInTheDocument();
+  });
+
+  it("mentions the format minimum card count inside the guard", () => {
+    render(
+      <GoldfishSimulator deck={[landCard(2)]} format="legendary-commander" />,
+    );
+    expect(screen.getByText(/requires 100/i)).toBeInTheDocument();
+  });
+});
+
+describe("GoldfishSimulator controls", () => {
+  it("renders the simulator controls and a seeded run for a valid deck", () => {
+    const deck = [
+      landCard(24),
+      spellCard("Goblin Guide", 1, 4),
+      spellCard("Bear", 2, 32),
+    ];
+    render(<GoldfishSimulator deck={deck} format="legendary-commander" />);
+    expect(screen.queryByTestId("goldfish-guard")).not.toBeInTheDocument();
+    expect(screen.getByTestId("goldfish-simulator")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Run goldfish simulation/i }),
+    ).toBeInTheDocument();
+    // Seeded auto-run produces statistics.
+    expect(screen.getByText(/Avg opening lands/i)).toBeInTheDocument();
+    expect(screen.getByText(/Mulligan rate/i)).toBeInTheDocument();
+  });
+
+  it("re-runs the simulation when the Run button is pressed", () => {
+    const deck = [landCard(24), spellCard("Bear", 2, 36)];
+    render(<GoldfishSimulator deck={deck} format="legendary-commander" />);
+    const runButton = screen.getByRole("button", {
+      name: /Run goldfish simulation/i,
+    });
+    // Clicking should not throw and should keep the stats surface mounted.
+    fireEvent.click(runButton);
+    expect(screen.getByText(/Avg opening lands/i)).toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/deck-builder/_components/goldfish-simulator.tsx
+++ b/src/app/(app)/deck-builder/_components/goldfish-simulator.tsx
@@ -1,0 +1,491 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Slider } from "@/components/ui/slider";
+import { Progress } from "@/components/ui/progress";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+import {
+  Dices,
+  Play,
+  Copy,
+  Check,
+  HandCoins,
+  TrendingUp,
+  Percent,
+  Sigma,
+} from "lucide-react";
+import type { DeckCard } from "@/app/actions";
+import type { Format } from "@/lib/game-rules";
+import { formatRules } from "@/lib/game-rules";
+import {
+  buildSimulationDeck,
+  runGoldfishSimulation,
+  formatGoldfishSummary,
+  type GoldfishStats,
+} from "@/lib/goldfish-simulator";
+
+/** Hard floor: an opening hand cannot be dealt from fewer than this many cards. */
+const MIN_DEALABLE_CARDS = 7;
+
+export interface GoldfishSimulatorProps {
+  deck: DeckCard[];
+  sideboard?: DeckCard[];
+  format: Format;
+  /**
+   * Incremented by the parent (via the `H` deck-builder shortcut) to request a
+   * fresh random draw. Each change re-runs the simulation with a new seed.
+   */
+  drawTrigger?: number;
+  className?: string;
+}
+
+/**
+ * Opening-hand goldfish simulator panel (issue #1439).
+ *
+ * Runs a seeded, deterministic sample of opening hands from the current deck
+ * against a passive opponent and reports mana-curve / playability statistics:
+ * average opening lands (+ stddev), a 0–7 land histogram, mulligan rate, and
+ * per-CMC on-curve cast percentage. Renders an empty-state guard when the deck
+ * is too small to deal a hand.
+ */
+export function GoldfishSimulator({
+  deck,
+  sideboard = [],
+  format,
+  drawTrigger = 0,
+  className,
+}: GoldfishSimulatorProps) {
+  const [seed, setSeed] = useState<number>(() => Date.now());
+  const [seedInput, setSeedInput] = useState<string>(() => String(seed));
+  const [sampleSize, setSampleSize] = useState<number>(100);
+  const [turns, setTurns] = useState<number>(6);
+  const [onThePlay, setOnThePlay] = useState<boolean>(true);
+  const [includeSideboard, setIncludeSideboard] = useState<boolean>(false);
+  const [copied, setCopied] = useState<boolean>(false);
+
+  const totalCards = useMemo(
+    () => deck.reduce((sum, c) => sum + (c.count || 0), 0),
+    [deck],
+  );
+  const sideboardCardCount = sideboard.reduce(
+    (sum, c) => sum + (c.count || 0),
+    0,
+  );
+  const formatMinCards = formatRules[format]?.minCards;
+
+  const simDeck = useMemo(
+    () => buildSimulationDeck(deck, sideboard, includeSideboard),
+    [deck, sideboard, includeSideboard],
+  );
+
+  const canSimulate = totalCards >= MIN_DEALABLE_CARDS;
+
+  // The simulation is pure and cheap (hundreds of trials in a few ms), so
+  // derive stats directly from the current parameters via useMemo rather than
+  // an effect. This keeps the component side-effect-free during render and
+  // recomputes deterministically whenever the deck, seed, or sample parameters
+  // change. Same seed → identical results.
+  const stats = useMemo<GoldfishStats | null>(() => {
+    if (!canSimulate) return null;
+    try {
+      return runGoldfishSimulation(simDeck, {
+        iterations: sampleSize,
+        seed,
+        turns,
+        onThePlay,
+      });
+    } catch {
+      return null;
+    }
+  }, [canSimulate, simDeck, seed, sampleSize, turns, onThePlay]);
+
+  const applySeed = useCallback((nextSeed: number) => {
+    setSeed(nextSeed);
+    setSeedInput(String(nextSeed));
+    setCopied(false);
+  }, []);
+
+  // `H` shortcut: a fresh random draw whenever the parent bumps drawTrigger.
+  useEffect(() => {
+    if (drawTrigger === 0) return;
+    applySeed(Date.now());
+  }, [drawTrigger, applySeed]);
+
+  const handleRunClick = useCallback(() => {
+    applySeed(parseSeed(seedInput));
+  }, [applySeed, seedInput]);
+
+  const handleDrawClick = useCallback(() => {
+    applySeed(Date.now());
+  }, [applySeed]);
+
+  const handleCopy = useCallback(async () => {
+    if (!stats) return;
+    const text = formatGoldfishSummary(stats);
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+    } catch {
+      setCopied(false);
+    }
+  }, [stats]);
+
+  // ---- Empty-state guard: too few cards to deal a hand ---------------------
+  if (!canSimulate) {
+    return (
+      <Card className={className} data-testid="goldfish-guard">
+        <CardHeader>
+          <CardTitle className="text-lg flex items-center gap-2">
+            <Dices className="w-5 h-5" aria-hidden="true" />
+            Hand Test
+          </CardTitle>
+          <CardDescription>
+            Sample opening hands and simulate your mana curve against a
+            goldfish.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground" role="status">
+            Add at least {MIN_DEALABLE_CARDS} cards to your deck to sample an
+            opening hand
+            {formatMinCards ? ` (${format} requires ${formatMinCards})` : ""}.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const maxHistogram = stats ? Math.max(1, ...stats.landHistogram) : 1;
+
+  return (
+    <div
+      className={cn("space-y-4", className)}
+      data-testid="goldfish-simulator"
+    >
+      {/* Controls */}
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between gap-2">
+            <CardTitle className="text-lg flex items-center gap-2">
+              <Dices className="w-5 h-5" aria-hidden="true" />
+              Hand Test
+            </CardTitle>
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={handleDrawClick}
+                aria-label="Draw another opening hand (shortcut H)"
+              >
+                <Dices className="w-4 h-4" aria-hidden="true" />
+                Draw
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleRunClick}
+                aria-label="Run goldfish simulation"
+              >
+                <Play className="w-4 h-4" aria-hidden="true" />
+                Run
+              </Button>
+            </div>
+          </div>
+          <CardDescription>
+            Seed a deterministic sample of opening hands vs. a passive opponent.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="goldfish-seed">Seed</Label>
+              <Input
+                id="goldfish-seed"
+                inputMode="numeric"
+                value={seedInput}
+                onChange={(e) => setSeedInput(e.target.value)}
+                aria-describedby="goldfish-seed-help"
+              />
+              <p
+                id="goldfish-seed-help"
+                className="text-xs text-muted-foreground"
+              >
+                Same seed reproduces the same hands.
+              </p>
+            </div>
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between">
+                <Label htmlFor="goldfish-samples">Samples: {sampleSize}</Label>
+              </div>
+              <Slider
+                id="goldfish-samples"
+                min={10}
+                max={1000}
+                step={10}
+                value={[sampleSize]}
+                onValueChange={(v) => setSampleSize(v[0] ?? 100)}
+                aria-label="Number of simulated opening hands"
+              />
+            </div>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="goldfish-turns">Turns simulated: {turns}</Label>
+              <Slider
+                id="goldfish-turns"
+                min={3}
+                max={10}
+                step={1}
+                value={[turns]}
+                onValueChange={(v) => setTurns(v[0] ?? 6)}
+                aria-label="Number of turns to simulate"
+              />
+            </div>
+            <div className="flex items-center gap-6 pt-5">
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="goldfish-play"
+                  checked={onThePlay}
+                  onCheckedChange={setOnThePlay}
+                  aria-label="On the play"
+                />
+                <Label htmlFor="goldfish-play" className="cursor-pointer">
+                  On the play
+                </Label>
+              </div>
+              {sideboardCardCount > 0 && (
+                <div className="flex items-center gap-2">
+                  <Switch
+                    id="goldfish-sideboard"
+                    checked={includeSideboard}
+                    onCheckedChange={setIncludeSideboard}
+                    aria-label="Include sideboard cards in the sample pool"
+                  />
+                  <Label
+                    htmlFor="goldfish-sideboard"
+                    className="cursor-pointer"
+                  >
+                    Sideboard
+                  </Label>
+                </div>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {stats && (
+        <div className="space-y-4" aria-live="polite">
+          {/* Summary metrics */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <SummaryCard
+              icon={<HandCoins className="w-4 h-4" aria-hidden="true" />}
+              label="Avg opening lands"
+              value={stats.avgOpeningLands.toFixed(2)}
+              hint={`σ ${stats.openingLandsStdDev.toFixed(2)}`}
+            />
+            <SummaryCard
+              icon={<Percent className="w-4 h-4" aria-hidden="true" />}
+              label="Mulligan rate"
+              value={`${(stats.mulliganRate * 100).toFixed(0)}%`}
+              hint={`avg ${stats.avgMulligans.toFixed(2)}/hand`}
+            />
+            <SummaryCard
+              icon={<Check className="w-4 h-4" aria-hidden="true" />}
+              label="Keep at 7"
+              value={`${(stats.keepAtSevenRate * 100).toFixed(0)}%`}
+            />
+            <SummaryCard
+              icon={<Sigma className="w-4 h-4" aria-hidden="true" />}
+              label="Trials"
+              value={String(stats.iterations)}
+              hint={`seed ${stats.seed}`}
+            />
+          </div>
+
+          {/* Opening land histogram */}
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm flex items-center gap-2">
+                <TrendingUp className="w-4 h-4" aria-hidden="true" />
+                Opening hand land histogram
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul
+                className="space-y-1.5"
+                aria-label="Land count distribution (0 to 7)"
+              >
+                {stats.landHistogram.map((count, lands) => (
+                  <li key={lands} className="flex items-center gap-2 text-xs">
+                    <span className="w-4 text-right tabular-nums text-muted-foreground">
+                      {lands}
+                    </span>
+                    <Progress
+                      value={(count / maxHistogram) * 100}
+                      className="h-3 flex-1"
+                      aria-label={`${count} hands with ${lands} lands`}
+                    />
+                    <span className="w-10 text-right tabular-nums">
+                      {count}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            {/* On-curve cast % */}
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm">On-curve castable</CardTitle>
+                <CardDescription>
+                  % of trials able to cast a CMC-N spell on turn N.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ul className="space-y-1.5">
+                  {Object.entries(stats.onCurveCastPercent).map(
+                    ([cmc, pct]) => (
+                      <li key={cmc} className="flex items-center gap-2 text-xs">
+                        <span className="w-16 text-muted-foreground">
+                          {cmc}-drop
+                        </span>
+                        <Progress
+                          value={pct}
+                          className="h-3 flex-1"
+                          aria-label={`${pct.toFixed(0)} percent on curve for ${cmc}-drops`}
+                        />
+                        <span className="w-12 text-right tabular-nums">
+                          {pct.toFixed(0)}%
+                        </span>
+                      </li>
+                    ),
+                  )}
+                </ul>
+              </CardContent>
+            </Card>
+
+            {/* Avg lands by turn */}
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm">Average lands by turn</CardTitle>
+                <CardDescription>
+                  Mean lands in play after each turn&apos;s land drop.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ul className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+                  {stats.avgLandsByTurn.map((avg, i) => (
+                    <li key={i} className="flex justify-between">
+                      <span className="text-muted-foreground">
+                        Turn {i + 1}
+                      </span>
+                      <span className="tabular-nums">{avg.toFixed(2)}</span>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Sample opening hand */}
+          <Card>
+            <CardHeader className="pb-2">
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-sm">Sample opening hand</CardTitle>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleCopy}
+                  aria-label="Copy simulation summary to clipboard"
+                >
+                  {copied ? (
+                    <>
+                      <Check className="w-4 h-4" aria-hidden="true" />
+                      Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="w-4 h-4" aria-hidden="true" />
+                      Copy summary
+                    </>
+                  )}
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <ul
+                className="flex flex-wrap gap-2"
+                aria-label="Sampled opening hand cards"
+              >
+                {stats.sampleHand.map((card, idx) => (
+                  <li
+                    key={`${card.id}-${idx}`}
+                    className={cn(
+                      "rounded-md border px-2 py-1 text-xs",
+                      card.isLand
+                        ? "border-amber-500/40 bg-amber-500/5"
+                        : "border-blue-500/40 bg-blue-500/5",
+                    )}
+                  >
+                    <span className="font-medium">{card.name}</span>
+                    <Separator
+                      orientation="vertical"
+                      className="mx-1 inline-block h-3"
+                    />
+                    <span className="text-muted-foreground">
+                      {card.isLand ? "Land" : `${card.cmc} CMC`}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface SummaryCardProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  hint?: string;
+}
+
+function SummaryCard({ icon, label, value, hint }: SummaryCardProps) {
+  return (
+    <Card>
+      <CardContent className="pt-4">
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          {icon}
+          {label}
+        </div>
+        <div className="mt-1 text-2xl font-bold tabular-nums">{value}</div>
+        {hint && <div className="text-xs text-muted-foreground">{hint}</div>}
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Parse a seed input string into a finite integer (falls back to Date.now()). */
+function parseSeed(raw: string): number {
+  const n = Number(raw);
+  return Number.isFinite(n) && raw.trim() !== "" ? Math.trunc(n) : Date.now();
+}
+
+export default GoldfishSimulator;

--- a/src/app/(app)/deck-builder/_lib/deck-builder-shortcuts.ts
+++ b/src/app/(app)/deck-builder/_lib/deck-builder-shortcuts.ts
@@ -4,6 +4,7 @@ export type DeckBuilderShortcutAction =
   | { type: "addCard"; card: ScryfallCard; max: boolean }
   | { type: "removeCard"; card: ScryfallCard; all: boolean }
   | { type: "newDeck" }
+  | { type: "drawSample" }
   | { type: "none" };
 
 export interface DeckBuilderShortcutContext {
@@ -32,6 +33,7 @@ export function isEditableTarget(target: EventTarget | null): boolean {
  *   Shift+-          Remove All Copies
  *   Enter            Confirm / add the focused card
  *   Ctrl/Cmd+N       New Deck
+ *   H                Draw another opening hand (Hand Test)
  *
  * On a US keyboard the unshifted "+/=" key reports "=". Shift+"=" reports "+",
  * and Shift+"-" reports "_". We therefore treat "=" as "add one" and "+" as
@@ -81,6 +83,12 @@ export function resolveDeckBuilderShortcut(
   if (key === "Enter") {
     if (!selectedCard) return { type: "none" };
     return { type: "addCard", card: selectedCard, max: false };
+  }
+
+  // H — draw another opening hand in the Hand Test goldfish simulator
+  // (issue #1439). No card selection required.
+  if (key === "h" || key === "H") {
+    return { type: "drawSample" };
   }
 
   return { type: "none" };

--- a/src/app/(app)/deck-builder/_lib/use-deck-builder-shortcuts.ts
+++ b/src/app/(app)/deck-builder/_lib/use-deck-builder-shortcuts.ts
@@ -14,6 +14,11 @@ export interface UseDeckBuilderShortcutsHandlers {
   removeCard: (card: ScryfallCard, all: boolean) => void;
   /** Create a fresh, empty deck. */
   newDeck: () => void;
+  /**
+   * Draw another opening hand in the Hand Test simulator (optional; only the
+   * deck-builder page wires this up). Issue #1439.
+   */
+  drawSample?: () => void;
 }
 
 export interface UseDeckBuilderShortcutsOptions
@@ -21,7 +26,7 @@ export interface UseDeckBuilderShortcutsOptions
 
 /**
  * Installs a scoped (window-level) keydown listener that maps the documented
- * deck-builder shortcuts (+, -, Shift++/Shift+-, Enter, Ctrl/Cmd+N) onto the
+ * deck-builder shortcuts (+, -, Shift++/Shift+-, Enter, Ctrl/Cmd+N, H) onto the
  * provided handlers. Shortcuts are suppressed while typing in form fields.
  *
  * Scoping: this hook is only mounted by the deck-builder page, so the listener
@@ -30,7 +35,7 @@ export interface UseDeckBuilderShortcutsOptions
 export function useDeckBuilderShortcuts(
   options: UseDeckBuilderShortcutsOptions,
 ): void {
-  const { selectedCard, addCard, removeCard, newDeck } = options;
+  const { selectedCard, addCard, removeCard, newDeck, drawSample } = options;
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -49,6 +54,10 @@ export function useDeckBuilderShortcuts(
           event.preventDefault();
           newDeck();
           break;
+        case "drawSample":
+          event.preventDefault();
+          drawSample?.();
+          break;
         case "none":
           break;
       }
@@ -56,5 +65,5 @@ export function useDeckBuilderShortcuts(
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [selectedCard, addCard, removeCard, newDeck]);
+  }, [selectedCard, addCard, removeCard, newDeck, drawSample]);
 }

--- a/src/app/(app)/deck-builder/page.tsx
+++ b/src/app/(app)/deck-builder/page.tsx
@@ -60,6 +60,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { SynergyProvider } from "./_components/synergy-context";
 import { DeckStatsPanel } from "./_components/deck-stats-panel";
 import { ManaCurveAnalysis } from "@/components/meta/mana-curve";
+import { GoldfishSimulator } from "./_components/goldfish-simulator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ComponentErrorBoundary } from "@/components/error-boundaries";
 
@@ -104,6 +105,9 @@ export default function DeckBuilderPage() {
   // When true, the card search hides any card that is not legal in the
   // active format. Off by default so users can still browse the full pool.
   const [formatFilter, setFormatFilter] = useState(false);
+  // Bumped by the `H` shortcut to request a fresh Hand Test opening hand in the
+  // goldfish simulator (issue #1439). The component re-runs on each change.
+  const [handTestDrawSignal, setHandTestDrawSignal] = useState(0);
   const searchInputRef = useRef<{
     focus: () => void;
     search: (q: string) => void;
@@ -388,14 +392,8 @@ export default function DeckBuilderPage() {
           return prevSideboard;
         }
 
-        const totalCards = prevSideboard.reduce(
-          (sum, c) => sum + c.count,
-          0,
-        );
-        if (
-          sideboardMaxSize > 0 &&
-          totalCards >= sideboardMaxSize
-        ) {
+        const totalCards = prevSideboard.reduce((sum, c) => sum + c.count, 0);
+        if (sideboardMaxSize > 0 && totalCards >= sideboardMaxSize) {
           toast({
             variant: "destructive",
             title: "Sideboard Limit Reached",
@@ -413,13 +411,7 @@ export default function DeckBuilderPage() {
       });
       setIsDeckSaved(false);
     },
-    [
-      supportsSideboard,
-      format,
-      formatLabel,
-      sideboardMaxSize,
-      toast,
-    ],
+    [supportsSideboard, format, formatLabel, sideboardMaxSize, toast],
   );
 
   /**
@@ -443,12 +435,21 @@ export default function DeckBuilderPage() {
   // prompt can be added in one place.
   const handleNewDeck = useCallback(() => clearDeck(), [clearDeck]);
 
-  // Documented deck-builder shortcuts: +, -, Shift++/Shift+-, Enter, Ctrl/Cmd+N.
+  // H — documented as "Draw another opening hand" for the Hand Test tab. Bumps
+  // a signal the GoldfishSimulator consumes to re-run with a fresh seed.
+  const handleDrawSample = useCallback(
+    () => setHandTestDrawSignal((n) => n + 1),
+    [],
+  );
+
+  // Documented deck-builder shortcuts: +, -, Shift++/Shift+-, Enter,
+  // Ctrl/Cmd+N, H (Hand Test).
   useDeckBuilderShortcuts({
     selectedCard,
     addCard: handleShortcutAdd,
     removeCard: handleShortcutRemove,
     newDeck: handleNewDeck,
+    drawSample: handleDrawSample,
   });
 
   // Detect banned cards in the current deck and surface curated legal
@@ -757,7 +758,7 @@ export default function DeckBuilderPage() {
               <TabsList
                 className={cn(
                   "w-full",
-                  supportsSideboard ? "grid grid-cols-3" : undefined,
+                  supportsSideboard ? "grid grid-cols-4" : "grid grid-cols-3",
                 )}
                 data-testid="deck-builder-tabs"
               >
@@ -766,6 +767,9 @@ export default function DeckBuilderPage() {
                 </TabsTrigger>
                 <TabsTrigger value="mana-curve" className="flex-1">
                   Mana Curve
+                </TabsTrigger>
+                <TabsTrigger value="hand-test" className="flex-1">
+                  Hand Test
                 </TabsTrigger>
                 {supportsSideboard && (
                   <TabsTrigger
@@ -803,6 +807,19 @@ export default function DeckBuilderPage() {
                     </CardContent>
                   </Card>
                 )}
+              </TabsContent>
+              <TabsContent value="hand-test" className="mt-4">
+                <ComponentErrorBoundary
+                  title="Hand Test Error"
+                  description="The goldfish simulator failed to render. Your deck is saved — try reloading the Hand Test tab."
+                >
+                  <GoldfishSimulator
+                    deck={deck}
+                    sideboard={sideboard}
+                    format={format}
+                    drawTrigger={handTestDrawSignal}
+                  />
+                </ComponentErrorBoundary>
               </TabsContent>
               {supportsSideboard && (
                 <TabsContent value="sideboard" className="mt-4">

--- a/src/lib/__tests__/goldfish-simulator.test.ts
+++ b/src/lib/__tests__/goldfish-simulator.test.ts
@@ -1,0 +1,406 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  mulberry32,
+  createRng,
+  shuffle,
+  buildSimulationDeck,
+  decideKeep,
+  defaultLandBounds,
+  simulateOpening,
+  simulateTurns,
+  onCurveCastable,
+  runGoldfishSimulation,
+  formatGoldfishSummary,
+  type SimCard,
+} from "../goldfish-simulator";
+import type { DeckCard } from "@/app/actions";
+
+/** Build a deck of `lands` land slots + `spells` spell slots for deterministic tests. */
+function makeDeckCard(
+  name: string,
+  cmc: number,
+  isLand: boolean,
+  count: number,
+): DeckCard {
+  return {
+    id: name.toLowerCase().replace(/\s+/g, "-"),
+    name,
+    cmc,
+    type_line: isLand ? "Land" : `Creature — ${name}`,
+    colors: [],
+    color_identity: [],
+    legalities: {},
+    count,
+  } as unknown as DeckCard;
+}
+
+function deckOf(lands: number, spells: number, spellCmc = 2): DeckCard[] {
+  return [
+    makeDeckCard("Mountain", 0, true, lands),
+    makeDeckCard("Bear", spellCmc, false, spells),
+  ];
+}
+
+const describeKeep = describe;
+
+describe("mulberry32 / createRng", () => {
+  it("is deterministic for the same seed", () => {
+    const a = mulberry32(42);
+    const b = mulberry32(42);
+    const seqA = Array.from({ length: 5 }, a);
+    const seqB = Array.from({ length: 5 }, b);
+    expect(seqA).toEqual(seqB);
+  });
+
+  it("differs for different seeds", () => {
+    const a = Array.from({ length: 5 }, mulberry32(1));
+    const b = Array.from({ length: 5 }, mulberry32(2));
+    expect(a).not.toEqual(b);
+  });
+
+  it("produces values in [0, 1)", () => {
+    const rng = mulberry32(12345);
+    const samples = Array.from({ length: 100 }, rng);
+    expect(samples.every((v) => v >= 0 && v < 1)).toBe(true);
+  });
+
+  it("createRng falls back to Math.random when no seed", () => {
+    expect(createRng()).toBe(Math.random);
+    expect(typeof createRng(7)()).toBe("number");
+  });
+});
+
+describe("shuffle", () => {
+  it("returns a permutation without mutating the input", () => {
+    const input = [1, 2, 3, 4, 5];
+    const copy = input.slice();
+    const out = shuffle(input, mulberry32(1));
+    expect(input).toEqual(copy);
+    expect(out.slice().sort()).toEqual(copy);
+  });
+
+  it("is deterministic for a fixed seed", () => {
+    const arr = ["a", "b", "c", "d", "e", "f", "g", "h"];
+    expect(shuffle(arr, mulberry32(99))).toEqual(shuffle(arr, mulberry32(99)));
+  });
+
+  it("preserves all elements", () => {
+    const arr = Array.from({ length: 20 }, (_, i) => i);
+    const out = shuffle(arr, mulberry32(5));
+    expect(out.length).toBe(20);
+    expect(new Set(out).size).toBe(20);
+  });
+});
+
+describe("buildSimulationDeck", () => {
+  it("flattens counts into one slot per physical card", () => {
+    const deck = deckOf(14, 20);
+    const sim = buildSimulationDeck(deck);
+    expect(sim.length).toBe(34);
+    expect(sim.filter((c) => c.isLand).length).toBe(14);
+    expect(sim.filter((c) => !c.isLand).length).toBe(20);
+  });
+
+  it("classifies lands by type_line and copies cmc/colors", () => {
+    const deck = [
+      makeDeckCard("Island", 0, true, 2),
+      makeDeckCard("Lightning Bolt", 1, false, 3),
+    ];
+    const sim = buildSimulationDeck(deck);
+    expect(sim[0]).toMatchObject({ name: "Island", isLand: true, cmc: 0 });
+    expect(sim[2]).toMatchObject({
+      name: "Lightning Bolt",
+      isLand: false,
+      cmc: 1,
+    });
+  });
+
+  it("optionally includes the sideboard pool", () => {
+    const main = deckOf(2, 2);
+    const board = deckOf(1, 1);
+    expect(buildSimulationDeck(main, board, false).length).toBe(4);
+    expect(buildSimulationDeck(main, board, true).length).toBe(6);
+  });
+
+  it("ignores zero/negative counts", () => {
+    const weird = [{ ...makeDeckCard("X", 1, false, 0), count: 0 }];
+    expect(buildSimulationDeck(weird)).toEqual([]);
+  });
+});
+
+describeKeep("decideKeep / defaultLandBounds", () => {
+  const land = (n: number): SimCard[] =>
+    Array.from({ length: n }, (_, i) => ({
+      id: `l${i}`,
+      name: "L",
+      cmc: 0,
+      isLand: true,
+      typeLine: "Land",
+      colors: [],
+    }));
+  const spell = (n: number): SimCard[] =>
+    Array.from({ length: n }, (_, i) => ({
+      id: `s${i}`,
+      name: "S",
+      cmc: 2,
+      isLand: false,
+      typeLine: "Creature",
+      colors: [],
+    }));
+
+  it("scales keepable bounds with hand size", () => {
+    expect(defaultLandBounds(7)).toEqual({ minLands: 2, maxLands: 5 });
+    expect(defaultLandBounds(5)).toEqual({ minLands: 1, maxLands: 4 });
+  });
+
+  it("rejects land-starved and land-flooded 7-card hands", () => {
+    expect(decideKeep([...land(1), ...spell(6)])).toBe(false);
+    expect(decideKeep([...land(0), ...spell(7)])).toBe(false);
+    expect(decideKeep([...land(6), ...spell(1)])).toBe(false);
+  });
+
+  it("keeps a reasonable 2-land/3-land/4-land 7-card opener", () => {
+    expect(decideKeep([...land(2), ...spell(5)])).toBe(true);
+    expect(decideKeep([...land(3), ...spell(4)])).toBe(true);
+    expect(decideKeep([...land(4), ...spell(3)])).toBe(true);
+  });
+
+  it("honors explicit policy overrides", () => {
+    const hand = [...land(5), ...spell(2)];
+    expect(decideKeep(hand)).toBe(true);
+    expect(decideKeep(hand, { maxLands: 4 })).toBe(false);
+    expect(decideKeep([...land(2), ...spell(5)], { minLands: 3 })).toBe(false);
+  });
+});
+
+describe("simulateOpening", () => {
+  it("keeps a keepable hand with no mulligan", () => {
+    const sim = buildSimulationDeck(deckOf(24, 36));
+    const opening = simulateOpening(sim, { rng: mulberry32(1) });
+    expect(opening.mulligansTaken).toBeGreaterThanOrEqual(0);
+    expect(opening.hand.length).toBeLessThanOrEqual(7);
+    expect(opening.openingLands).toBe(
+      opening.hand.filter((c) => c.isLand).length,
+    );
+  });
+
+  it("mulligans down to minHandSize when no hand is keepable", () => {
+    const sim = buildSimulationDeck(deckOf(24, 36));
+    const opening = simulateOpening(sim, {
+      rng: mulberry32(1),
+      minHandSize: 5,
+      mulligan: { minLands: 99, maxLands: 99, minSpells: 99 },
+    });
+    expect(opening.handSize).toBe(5);
+    expect(opening.mulligansTaken).toBe(2);
+  });
+
+  it("never mulligans below minHandSize", () => {
+    const sim = buildSimulationDeck(deckOf(24, 36));
+    const opening = simulateOpening(sim, {
+      rng: mulberry32(3),
+      minHandSize: 6,
+      mulligan: { minLands: 99, maxLands: 99 },
+    });
+    expect(opening.handSize).toBeGreaterThanOrEqual(6);
+  });
+
+  it("exposes the remaining library from the same shuffle", () => {
+    const sim = buildSimulationDeck(deckOf(20, 20));
+    const opening = simulateOpening(sim, { rng: mulberry32(2) });
+    expect(opening.library.length).toBe(sim.length);
+    expect(opening.library.slice(0, opening.hand.length)).toEqual(opening.hand);
+  });
+});
+
+describe("simulateTurns", () => {
+  function crafted(
+    landInHand: number,
+    drawPile: SimCard[],
+  ): {
+    hand: SimCard[];
+    library: SimCard[];
+  } {
+    const hand: SimCard[] = Array.from({ length: landInHand }, (_, i) => ({
+      id: `h${i}`,
+      name: "L",
+      cmc: 0,
+      isLand: true,
+      typeLine: "Land",
+      colors: [],
+    }));
+    return { hand, library: [...hand, ...drawPile] };
+  }
+  const land = (id: string): SimCard => ({
+    id,
+    name: "L",
+    cmc: 0,
+    isLand: true,
+    typeLine: "Land",
+    colors: [],
+  });
+  const spell = (id: string): SimCard => ({
+    id,
+    name: "S",
+    cmc: 2,
+    isLand: false,
+    typeLine: "Creature",
+    colors: [],
+  });
+
+  it("accumulates one land per turn on the play (skips T1 draw)", () => {
+    const { hand, library } = crafted(1, [land("d1"), land("d2"), land("d3")]);
+    const result = simulateTurns(
+      {
+        hand,
+        library,
+        handSize: hand.length,
+        mulligansTaken: 0,
+        openingLands: 1,
+      },
+      { turns: 4, onThePlay: true },
+    );
+    expect(result.landsByTurn).toEqual([1, 2, 3, 4]);
+    expect(result.drewCards).toBe(3);
+  });
+
+  it("draws on turn 1 when on the draw (one extra land drop vs. on the play)", () => {
+    const { hand, library } = crafted(1, [
+      land("d1"),
+      land("d2"),
+      spell("d3"),
+      spell("d4"),
+    ]);
+    const result = simulateTurns(
+      {
+        hand,
+        library,
+        handSize: hand.length,
+        mulligansTaken: 0,
+        openingLands: 1,
+      },
+      { turns: 4, onThePlay: false },
+    );
+    expect(result.landsByTurn).toEqual([1, 2, 3, 3]);
+    expect(result.drewCards).toBe(4);
+  });
+
+  it("stops making land drops once the hand runs out of lands", () => {
+    const { hand, library } = crafted(2, [
+      spell("d1"),
+      spell("d2"),
+      spell("d3"),
+    ]);
+    const result = simulateTurns(
+      {
+        hand,
+        library,
+        handSize: hand.length,
+        mulligansTaken: 0,
+        openingLands: 2,
+      },
+      { turns: 5, onThePlay: true },
+    );
+    expect(result.landsByTurn).toEqual([1, 2, 2, 2, 2]);
+    expect(result.drewCards).toBe(3);
+  });
+});
+
+describe("onCurveCastable", () => {
+  it("treats N lands by turn N as on-curve for a CMC-N spell", () => {
+    expect(onCurveCastable([1, 2, 3, 4], 2)).toBe(true);
+    expect(onCurveCastable([1, 1, 2, 3], 2)).toBe(false);
+    expect(onCurveCastable([2, 3, 4], 3)).toBe(true);
+  });
+
+  it("returns false for CMCs beyond the simulated turn count", () => {
+    expect(onCurveCastable([1, 2], 3)).toBe(false);
+    expect(onCurveCastable([1, 2], 0)).toBe(false);
+  });
+});
+
+describe("runGoldfishSimulation", () => {
+  const sim = buildSimulationDeck(deckOf(24, 36, 2));
+
+  it("throws when the deck cannot fill an opening hand", () => {
+    const tiny = buildSimulationDeck([makeDeckCard("L", 0, true, 3)]);
+    expect(() =>
+      runGoldfishSimulation(tiny, { seed: 1, iterations: 5 }),
+    ).toThrow(/Cannot simulate/);
+  });
+
+  it("is fully deterministic for a fixed seed", () => {
+    const a = runGoldfishSimulation(sim, { seed: 1234, iterations: 50 });
+    const b = runGoldfishSimulation(sim, { seed: 1234, iterations: 50 });
+    expect(a.avgOpeningLands).toBe(b.avgOpeningLands);
+    expect(a.landHistogram).toEqual(b.landHistogram);
+    expect(a.avgLandsByTurn).toEqual(b.avgLandsByTurn);
+    expect(a.onCurveCastPercent).toEqual(b.onCurveCastPercent);
+    expect(a.sampleHand.map((c) => c.id)).toEqual(
+      b.sampleHand.map((c) => c.id),
+    );
+  });
+
+  it("aggregates land counts, histogram, and mulligan rate correctly", () => {
+    const stats = runGoldfishSimulation(sim, { seed: 7, iterations: 200 });
+    const histogramTotal = stats.landHistogram.reduce((s, n) => s + n, 0);
+    expect(histogramTotal).toBe(200);
+    expect(stats.avgOpeningLands).toBeGreaterThan(0);
+    expect(stats.avgOpeningLands).toBeLessThan(7);
+    expect(stats.mulliganRate).toBeGreaterThanOrEqual(0);
+    expect(stats.mulliganRate).toBeLessThanOrEqual(1);
+    expect(stats.keepAtSevenRate + stats.mulliganRate).toBeCloseTo(1, 5);
+  });
+
+  it("reports avgLandsByTurn as a non-decreasing average curve", () => {
+    const stats = runGoldfishSimulation(sim, {
+      seed: 9,
+      iterations: 100,
+      turns: 5,
+    });
+    expect(stats.avgLandsByTurn.length).toBe(5);
+    for (let i = 1; i < stats.avgLandsByTurn.length; i++) {
+      expect(stats.avgLandsByTurn[i]).toBeGreaterThanOrEqual(
+        stats.avgLandsByTurn[i - 1],
+      );
+    }
+  });
+
+  it("on-curve percentage decreases as CMC increases", () => {
+    const stats = runGoldfishSimulation(sim, {
+      seed: 11,
+      iterations: 200,
+      turns: 6,
+    });
+    const p1 = stats.onCurveCastPercent[1];
+    const p4 = stats.onCurveCastPercent[4];
+    expect(p1).toBeGreaterThanOrEqual(p4);
+    expect(p1).toBeGreaterThan(0);
+    expect(p4).toBeLessThanOrEqual(100);
+  });
+
+  it("tracks final hand-size distribution and sample hand", () => {
+    const stats = runGoldfishSimulation(sim, { seed: 13, iterations: 50 });
+    const distributed = stats.finalHandSizeCounts.reduce(
+      (s, n) => s + (n ?? 0),
+      0,
+    );
+    expect(distributed).toBe(50);
+    expect(stats.sampleHand.length).toBeGreaterThan(0);
+  });
+});
+
+describe("formatGoldfishSummary", () => {
+  it("includes the key metrics in a copyable plain-text block", () => {
+    const stats = runGoldfishSimulation(buildSimulationDeck(deckOf(24, 36)), {
+      seed: 1,
+      iterations: 20,
+    });
+    const text = formatGoldfishSummary(stats);
+    expect(text).toContain("Goldfish simulation");
+    expect(text).toContain("Opening lands");
+    expect(text).toContain("Mulligan rate");
+    expect(text).toContain("On-curve castable");
+    expect(text).toContain("histogram");
+  });
+});

--- a/src/lib/goldfish-simulator.ts
+++ b/src/lib/goldfish-simulator.ts
@@ -1,0 +1,466 @@
+/**
+ * @fileOverview Pure opening-hand "goldfish" simulator for the deck builder.
+ *
+ * A goldfish simulator repeatedly deals opening hands from a deck, applies a
+ * mulligan heuristic, then plays out the first several turns of land drops
+ * against a passive opponent (a "goldfish"). Aggregated over many trials it
+ * reports mana-curve / playability statistics — average lands by turn,
+ * on-curve cast percentage per CMC, mulligan rate, and an opening-land
+ * histogram — so a player can validate their mana curve without full
+ * play-testing. See issue #1439.
+ *
+ * Everything here is pure: all randomness flows through an injectable RNG,
+ * so a given seed reproduces the exact same set of trials. The rules engine
+ * (`src/lib/game-state/`) is intentionally untouched; this module only reads
+ * the deck model read-only.
+ */
+
+import type { DeckCard } from "@/app/actions";
+
+/**
+ * Pseudorandom number generator producing floats in `[0, 1)`.
+ * Injected everywhere randomness is needed so trials are reproducible.
+ */
+export type Rng = () => number;
+
+/**
+ * Seedable PRNG (mulberry32). Same seed → same deterministic sequence,
+ * which is what makes a simulation run reproducible across reloads.
+ */
+export function mulberry32(seed: number): Rng {
+  let a = seed >>> 0;
+  return function next(): number {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Build an RNG. Omit `seed` to fall back to `Math.random` (non-deterministic).
+ */
+export function createRng(seed?: number): Rng {
+  if (seed === undefined) return Math.random;
+  return mulberry32(seed);
+}
+
+/**
+ * A single physical card slot used by the simulator. Derived (read-only)
+ * from {@link DeckCard}: each copy in a deck-list entry expands to one slot.
+ */
+export interface SimCard {
+  /** Stable, per-copy id (`<cardId>-<copyIndex>`). */
+  id: string;
+  name: string;
+  cmc: number;
+  isLand: boolean;
+  typeLine: string;
+  colors: string[];
+}
+
+/**
+ * Flatten a deck (and optionally a sideboard) into one slot per physical card,
+ * classifying each as land or spell by its type line. Lands are detected by a
+ * case-insensitive "land" substring in `type_line`, matching the convention
+ * used across the rest of the deck builder.
+ */
+export function buildSimulationDeck(
+  cards: readonly DeckCard[],
+  sideboard: readonly DeckCard[] = [],
+  includeSideboard = false,
+): SimCard[] {
+  const pool = includeSideboard ? [...cards, ...sideboard] : cards;
+  const deck: SimCard[] = [];
+  for (const card of pool) {
+    const count = Math.max(0, Math.floor(card.count || 0));
+    const typeLine = card.type_line ?? "";
+    const isLand = typeLine.toLowerCase().includes("land");
+    const colors = card.colors ? [...card.colors] : [];
+    for (let i = 0; i < count; i++) {
+      deck.push({
+        id: `${card.id}-${i}`,
+        name: card.name,
+        cmc: card.cmc ?? 0,
+        isLand,
+        typeLine,
+        colors,
+      });
+    }
+  }
+  return deck;
+}
+
+/**
+ * Fisher–Yates shuffle driven by an injectable RNG. Returns a new array; the
+ * input is never mutated. With a seeded RNG the result is fully deterministic.
+ */
+export function shuffle<T>(array: readonly T[], rng: Rng = Math.random): T[] {
+  const out = array.slice();
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    const tmp = out[i];
+    out[i] = out[j];
+    out[j] = tmp;
+  }
+  return out;
+}
+
+/**
+ * Tunable keep/mulligan heuristic. Every field is optional and falls back to
+ * a sensible, hand-size-relative default.
+ */
+export interface MulliganPolicy {
+  /** Minimum land count required to keep (default scales with hand size). */
+  minLands?: number;
+  /** Maximum land count considered keepable (default scales with hand size). */
+  maxLands?: number;
+  /** Minimum non-land spells required to keep (default 1). */
+  minSpells?: number;
+}
+
+/**
+ * Default keepable land bounds for a hand of `handSize` cards, derived from
+ * the classic ~2–5 land keep for a 7-card opener and scaled down for smaller
+ * mulligan hands.
+ */
+export function defaultLandBounds(handSize: number): {
+  minLands: number;
+  maxLands: number;
+} {
+  const minLands = Math.max(1, Math.round(handSize * (2 / 7)));
+  const maxLands = Math.max(minLands, Math.round(handSize * (5 / 7)));
+  return { minLands, maxLands };
+}
+
+/**
+ * Decide whether to keep an opening hand under the given policy. A hand is
+ * kept when its land count falls within `[minLands, maxLands]` and it holds at
+ * least `minSpells` non-land cards (guards against all-land / spell-starved
+ * openers).
+ */
+export function decideKeep(
+  hand: readonly SimCard[],
+  policy: MulliganPolicy = {},
+): boolean {
+  const handSize = hand.length;
+  const bounds = defaultLandBounds(handSize);
+  const minLands = policy.minLands ?? bounds.minLands;
+  const maxLands = policy.maxLands ?? bounds.maxLands;
+  const minSpells = policy.minSpells ?? 1;
+  const lands = hand.filter((c) => c.isLand).length;
+  const spells = handSize - lands;
+  if (lands < minLands) return false;
+  if (lands > maxLands) return false;
+  if (spells < minSpells) return false;
+  return true;
+}
+
+/**
+ * Result of dealing an opening hand, including the library remainder from the
+ * same shuffle so the turn simulation can draw through it.
+ */
+export interface OpeningHandResult {
+  /** The kept opening hand. */
+  hand: SimCard[];
+  /** Full shuffled library from which `hand` was dealt (hand sits at the top). */
+  library: SimCard[];
+  /** Final hand size (reduced by each mulligan). */
+  handSize: number;
+  /** Number of mulligans taken before keeping. */
+  mulligansTaken: number;
+  /** Land count in the kept hand. */
+  openingLands: number;
+}
+
+/**
+ * Options controlling a single opening-hand deal.
+ */
+export interface OpeningHandOptions {
+  /** Initial hand size (default 7). */
+  startingHandSize?: number;
+  /** Never mulligan below this size (default 5). */
+  minHandSize?: number;
+  /** Keep/mulligan heuristic. */
+  mulligan?: MulliganPolicy;
+  /** RNG driving each shuffle. */
+  rng?: Rng;
+}
+
+/**
+ * Deal an opening hand with mulligans (Vancouver/Paris-style: each mulligan
+ * re-shuffles and re-deals one fewer card). The hand is forced kept once it
+ * reaches `minHandSize`. Returns the kept hand plus the remaining library
+ * (same shuffle) so turns can be played out.
+ */
+export function simulateOpening(
+  deck: readonly SimCard[],
+  options: OpeningHandOptions = {},
+): OpeningHandResult {
+  const starting = options.startingHandSize ?? 7;
+  const minHand = Math.max(1, options.minHandSize ?? 5);
+  const rng = options.rng ?? Math.random;
+  const policy = options.mulligan ?? {};
+  let handSize = starting;
+  let mulligansTaken = 0;
+  let library: SimCard[] = [];
+  let hand: SimCard[] = [];
+
+  while (handSize >= minHand) {
+    library = shuffle(deck, rng);
+    hand = library.slice(0, Math.min(handSize, library.length));
+    const forceKeep = handSize <= minHand;
+    if (forceKeep || decideKeep(hand, policy)) {
+      break;
+    }
+    handSize -= 1;
+    mulligansTaken += 1;
+  }
+
+  return {
+    hand,
+    library,
+    handSize,
+    mulligansTaken,
+    openingLands: hand.filter((c) => c.isLand).length,
+  };
+}
+
+/**
+ * Result of playing out land drops over the first several turns.
+ */
+export interface TurnSimulationResult {
+  /** `landsByTurn[i]` = lands in play at the end of turn `i + 1`. */
+  landsByTurn: number[];
+  /** Number of cards drawn from the library during the simulated turns. */
+  drewCards: number;
+}
+
+/**
+ * Options controlling the turn-by-turn simulation.
+ */
+export interface TurnSimulationOptions {
+  /** Number of turns to play (default 6). */
+  turns?: number;
+  /** On the play skips the turn-1 draw; on the draw draws every turn. */
+  onThePlay?: boolean;
+}
+
+/**
+ * Play out `turns` turns against a goldfish: draw (when applicable) then make
+ * the land drop if a land is in hand. Accumulates lands in play turn by turn.
+ * Mana color is intentionally ignored (a documented simplification); this
+ * validates curve/density rather than colored-pip requirements.
+ */
+export function simulateTurns(
+  opening: OpeningHandResult,
+  options: TurnSimulationOptions = {},
+): TurnSimulationResult {
+  const turns = options.turns ?? 6;
+  const onThePlay = options.onThePlay ?? true;
+  const hand = opening.hand.slice();
+  const drawPile = opening.library.slice(opening.hand.length);
+  let drawIndex = 0;
+  let landsInPlay = 0;
+  const landsByTurn: number[] = [];
+
+  for (let turn = 1; turn <= turns; turn++) {
+    const skipFirstDraw = onThePlay && turn === 1;
+    if (!skipFirstDraw && drawIndex < drawPile.length) {
+      hand.push(drawPile[drawIndex]);
+      drawIndex += 1;
+    }
+    const landIdx = hand.findIndex((c) => c.isLand);
+    if (landIdx >= 0) {
+      landsInPlay += 1;
+      hand.splice(landIdx, 1);
+    }
+    landsByTurn.push(landsInPlay);
+  }
+
+  return { landsByTurn, drewCards: drawIndex };
+}
+
+/**
+ * Whether a spell of the given CMC is "on curve" castable: a CMC-N spell is
+ * on curve when you reach N lands by turn N. Returns false for CMCs beyond
+ * the simulated turn count.
+ */
+export function onCurveCastable(
+  landsByTurn: readonly number[],
+  cmc: number,
+): boolean {
+  if (cmc < 1 || cmc > landsByTurn.length) return false;
+  return landsByTurn[cmc - 1] >= cmc;
+}
+
+/**
+ * Configuration for a full simulated sample run.
+ */
+export interface GoldfishConfig {
+  /** Number of trials to aggregate (default 100). */
+  iterations?: number;
+  /** Seed for the master RNG (default `Date.now()`). */
+  seed?: number;
+  /** Initial hand size (default 7). */
+  startingHandSize?: number;
+  /** Never mulligan below this size (default 5). */
+  minHandSize?: number;
+  /** Turns to play per trial (default 6). */
+  turns?: number;
+  /** On the play (default true). */
+  onThePlay?: boolean;
+  /** Keep/mulligan heuristic overrides. */
+  mulligan?: MulliganPolicy;
+}
+
+/**
+ * Aggregated mana-curve / playability statistics over many trials.
+ */
+export interface GoldfishStats {
+  iterations: number;
+  seed: number;
+  /** The kept opening hand of the first trial, for display. */
+  sampleHand: SimCard[];
+  /** Mean land count across kept opening hands. */
+  avgOpeningLands: number;
+  /** Population standard deviation of opening-hand land counts. */
+  openingLandsStdDev: number;
+  /** `landHistogram[i]` = number of kept hands with exactly `i` lands (0..7). */
+  landHistogram: number[];
+  /** Fraction of trials that took at least one mulligan. */
+  mulliganRate: number;
+  /** Mean mulligans per trial. */
+  avgMulligans: number;
+  /** Fraction of trials kept at the full starting hand size. */
+  keepAtSevenRate: number;
+  /** `avgLandsByTurn[i]` = mean lands in play at end of turn `i + 1`. */
+  avgLandsByTurn: number[];
+  /** `onCurveCastPercent[cmc]` = % of trials on-curve for that CMC. */
+  onCurveCastPercent: Record<number, number>;
+  /** `finalHandSizeCounts[n]` = number of trials ending at hand size `n`. */
+  finalHandSizeCounts: number[];
+}
+
+/**
+ * Run `iterations` goldfish trials and aggregate the statistics. Each trial
+ * draws its own sub-seed from the master (seeded) RNG, so a given `seed`
+ * reproduces the entire run deterministically. Throws when the deck cannot
+ * fill an opening hand (the UI enforces the format min-cards guard before
+ * calling).
+ */
+export function runGoldfishSimulation(
+  deck: readonly SimCard[],
+  config: GoldfishConfig = {},
+): GoldfishStats {
+  const iterations = config.iterations ?? 100;
+  const seed = config.seed ?? Date.now();
+  const turns = config.turns ?? 6;
+  const startingHandSize = config.startingHandSize ?? 7;
+  const minHandSize = config.minHandSize ?? 5;
+  const onThePlay = config.onThePlay ?? true;
+
+  if (deck.length < startingHandSize) {
+    throw new Error(
+      `Cannot simulate: deck has ${deck.length} cards, need at least ${startingHandSize}.`,
+    );
+  }
+
+  const masterRng = mulberry32(seed);
+  let sampleHand: SimCard[] = [];
+
+  let totalOpeningLands = 0;
+  let totalMulligans = 0;
+  let mulliganHands = 0;
+  let keptAtSeven = 0;
+  const landHistogram = new Array(8).fill(0);
+  const sumLandsByTurn = new Array(turns).fill(0);
+  const onCurveHits: Record<number, number> = {};
+  for (let cmc = 1; cmc <= turns; cmc++) onCurveHits[cmc] = 0;
+  const finalHandSizeCounts: number[] = [];
+  const openingLandsSamples: number[] = [];
+
+  for (let i = 0; i < iterations; i++) {
+    const trialSeed = Math.floor(masterRng() * 0x100000000);
+    const trialRng = mulberry32(trialSeed);
+    const opening = simulateOpening(deck, {
+      startingHandSize,
+      minHandSize,
+      mulligan: config.mulligan,
+      rng: trialRng,
+    });
+    if (i === 0) sampleHand = opening.hand;
+
+    const lands = opening.openingLands;
+    totalOpeningLands += lands;
+    openingLandsSamples.push(lands);
+    landHistogram[Math.min(7, Math.max(0, lands))] += 1;
+    totalMulligans += opening.mulligansTaken;
+    if (opening.mulligansTaken > 0) mulliganHands += 1;
+    if (opening.mulligansTaken === 0) keptAtSeven += 1;
+    finalHandSizeCounts[opening.handSize] =
+      (finalHandSizeCounts[opening.handSize] ?? 0) + 1;
+
+    const turnSim = simulateTurns(opening, { turns, onThePlay });
+    for (let t = 0; t < turns; t++) {
+      sumLandsByTurn[t] += turnSim.landsByTurn[t];
+    }
+    for (let cmc = 1; cmc <= turns; cmc++) {
+      if (onCurveCastable(turnSim.landsByTurn, cmc)) onCurveHits[cmc] += 1;
+    }
+  }
+
+  const avgOpeningLands = totalOpeningLands / iterations;
+  const variance =
+    openingLandsSamples.reduce(
+      (sum, x) => sum + (x - avgOpeningLands) ** 2,
+      0,
+    ) / iterations;
+  const openingLandsStdDev = Math.sqrt(variance);
+  const avgLandsByTurn = sumLandsByTurn.map((s) => s / iterations);
+  const onCurveCastPercent: Record<number, number> = {};
+  for (let cmc = 1; cmc <= turns; cmc++) {
+    onCurveCastPercent[cmc] = (onCurveHits[cmc] / iterations) * 100;
+  }
+
+  return {
+    iterations,
+    seed,
+    sampleHand,
+    avgOpeningLands,
+    openingLandsStdDev,
+    landHistogram,
+    mulliganRate: mulliganHands / iterations,
+    avgMulligans: totalMulligans / iterations,
+    keepAtSevenRate: keptAtSeven / iterations,
+    avgLandsByTurn,
+    onCurveCastPercent,
+    finalHandSizeCounts,
+  };
+}
+
+/**
+ * Render a {@link GoldfishStats} as a plain-text summary suitable for copying
+ * to the clipboard (and pasting into chat or the AI coach).
+ */
+export function formatGoldfishSummary(stats: GoldfishStats): string {
+  const lines: string[] = [];
+  lines.push(
+    `Goldfish simulation — ${stats.iterations} trials (seed ${stats.seed})`,
+  );
+  lines.push(
+    `Opening lands: avg ${stats.avgOpeningLands.toFixed(2)} (σ ${stats.openingLandsStdDev.toFixed(2)})`,
+  );
+  lines.push(`Mulligan rate: ${(stats.mulliganRate * 100).toFixed(0)}%`);
+  lines.push(`Keep at 7: ${(stats.keepAtSevenRate * 100).toFixed(0)}%`);
+  lines.push(
+    `Lands by turn: ${stats.avgLandsByTurn.map((v, i) => `T${i + 1} ${v.toFixed(2)}`).join(", ")}`,
+  );
+  const onCurve = Object.entries(stats.onCurveCastPercent)
+    .map(([cmc, pct]) => `${cmc}-drop ${pct.toFixed(0)}%`)
+    .join(", ");
+  lines.push(`On-curve castable: ${onCurve}`);
+  lines.push(`Opening land histogram (0-7): ${stats.landHistogram.join(", ")}`);
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

Adds an opening-hand **goldfish simulator** to the deck builder so players can validate their mana curve before play-testing. A new **Hand Test** tab repeatedly deals opening hands from the current deck, applies a mulligan heuristic, plays out the first several turns of land drops against a passive opponent (a goldfish), and reports mana-curve / playability statistics.

Closes #1439

## What's added

**Pure simulation logic — `src/lib/goldfish-simulator.ts`** (fully testable, no React, no rules-engine edits)
- Seedable PRNG (mulberry32) + injectable RNG everywhere, so a given seed reproduces the exact same set of trials.
- Fisher-Yates `shuffle` (deterministic, non-mutating).
- `buildSimulationDeck` flattens the deck (+ optional sideboard) into one slot per physical card, classifying land vs. spell by `type_line`.
- Mulligan heuristic (`decideKeep`, `simulateOpening`): Vancouver/Paris-style re-shuffle-and-re-deal, keepable land bounds scaled to hand size, never mulligans below a configurable floor.
- `simulateTurns`: draw + land-drop per turn (on the play skips the T1 draw), accumulating lands in play.
- `runGoldfishSimulation` aggregates over N trials (each trial seeded from the master RNG) into: average opening lands (+ population stddev), a 0-7 land histogram, mulligan rate, keep-at-7 rate, average lands by turn, and per-CMC on-curve cast %.

**React UI — `src/app/(app)/deck-builder/_components/goldfish-simulator.tsx`**
- New `Hand Test` tab (always visible, alongside Mana Curve / Sideboard).
- Controls: seed input, samples slider (10-1000, default 100), turns slider (3-10, default 6), on-the-play toggle, and an `Include sideboard` toggle (mirrors pre-sideboarding in-game state).
- Stats surface: summary metric cards, opening-land histogram, per-CMC on-curve cast %, average lands by turn, and a sample opening hand (color-coded land vs. spell).
- Stats are derived via `useMemo` (pure, cheap) so they stay in sync while editing the deck.
- `Copy summary to clipboard` button pastes a plain-text report into chat or the AI coach.
- Empty-state guard when the deck is too small to deal a hand (with the format minimum noted).
- Accessibility: labelled inputs/controls, `aria-label`s on buttons, histogram bars exposed via `Progress` aria-labels, and an `aria-live` stats region.

**Keyboard shortcut**
- `H` now draws another opening hand while on the deck-builder page (added to the existing shortcut resolver/hook; suppressed while typing in form fields).

**Test infra**
- Added a `ResizeObserver` no-op polyfill to `jest.setup.js` (jsdom gap) so Radix-based primitives render under jsdom — matches the existing `matchMedia` polyfill pattern.

## Tests
- `src/lib/__tests__/goldfish-simulator.test.ts` — 31 tests: PRNG determinism, shuffle, deck flattening, mulligan bounds & mulligan-to-N, turn-by-turn land accumulation (on the play vs. on the draw), on-curve math, aggregation, and clipboard summary.
- `goldfish-simulator.test.tsx` — min-cards guard, format-minimum hint, and a seeded control render (uses the real simulation end-to-end).

## Validation
- `npm run typecheck` — pass
- `npm run lint` — pass (0 errors)
- `npm test -- --testPathPatterns=goldfish` — 35 new tests pass
- Full suite: no new failures (the pre-existing `backup-compression` suite is unrelated and untouched).

## Design notes
- The rules engine (`src/lib/game-state/`) is intentionally untouched; the simulator reads the deck model read-only.
- Mana color is intentionally ignored (documented): this validates curve/density rather than colored-pip requirements, keeping the logic pure and deterministic.
- All randomness flows through an injectable, seedable RNG — same seed reproduces identical hands.