### PR TITLE
test: add jest suites for trading/replay/game-history (0%→85-98% coverage)

### DIFF
--- a/src/lib/__tests__/game-history.test.ts
+++ b/src/lib/__tests__/game-history.test.ts
@@ -1,47 +1,377 @@
 /**
- * Game history tests
+ * @fileoverview Game history persistence tests (issue #1432).
+ *
+ * Pins the real save/restore contract of `src/lib/game-history.ts` across
+ * three orthogonal axes required by the issue:
+ *   1. Save/restore round-trips (sync localStorage + async IndexedDB paths)
+ *   2. Version/schema handling — the loader performs NO validation, it casts
+ *      `JSON.parse(stored) as GameRecord[]` (QA report §3.9). We pin that
+ *      real behavior so a future safe-parse migration is a visible diff.
+ *   3. Adversarial JSON — malformed, non-array, prototype-pollution-ish and
+ *      oversized payloads. The sync loader catches and returns []; the
+ *      un-validated cast is documented via the schema-mismatch tests.
+ *
+ * `fake-indexeddb` (loaded in jest.setup.js) backs the async path.
  */
 
-import { getAllGameRecords, getPlayerStats, getRecentGames, clearGameHistory } from '../game-history';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+import {
+  GameRecord,
+  GameResult,
+  GameMode,
+  getAllGameRecords,
+  getAllGameRecordsAsync,
+  saveGameRecord,
+  getPlayerStats,
+  getRecentGames,
+  clearGameHistory,
+  createGameRecord,
+} from "../game-history";
 
-describe('game-history', () => {
-  beforeEach(() => {
-    clearGameHistory();
+const STORAGE_KEY = "planar-nexus-game-history";
+
+/** Build a representative record with the optional fields populated. */
+function makeRecord(overrides: Partial<GameRecord> = {}): GameRecord {
+  return {
+    id: `game-${Math.random().toString(36).slice(2)}`,
+    date: 1_700_000_000_000,
+    mode: "vs_ai",
+    result: "win",
+    playerDeck: "mono-red",
+    opponentDeck: "mono-blue",
+    difficulty: "hard",
+    turns: 12,
+    playerLifeAtEnd: 18,
+    opponentLifeAtEnd: 0,
+    mulligans: 1,
+    notes: "kept a risky hand",
+    mistakes: ["attacked into a blocker"],
+    summary: "close game",
+    ...overrides,
+  };
+}
+
+/** Write a raw value to the localStorage slot the module reads from. */
+function seedLocalStorage(raw: string): void {
+  localStorage.setItem(STORAGE_KEY, raw);
+}
+
+describe("game-history", () => {
+  beforeEach(async () => {
+    localStorage.clear();
+    await clearGameHistory();
+    jest.restoreAllMocks();
   });
 
-  afterEach(() => {
-    clearGameHistory();
+  afterEach(async () => {
+    await clearGameHistory();
+    localStorage.clear();
+    jest.restoreAllMocks();
   });
 
-  describe('getAllGameRecords', () => {
-    it('should return empty array initially', () => {
-      const records = getAllGameRecords();
-      expect(Array.isArray(records)).toBe(true);
+  // ---------------------------------------------------------------------
+  // Legacy smoke tests (preserved from the original suite so we never lose
+  // the "module loads and returns arrays" floor).
+  // ---------------------------------------------------------------------
+  describe("smoke", () => {
+    it("getAllGameRecords returns an empty array initially", () => {
+      expect(getAllGameRecords()).toEqual([]);
+    });
+
+    it("getPlayerStats returns a stats object", () => {
+      expect(getPlayerStats()).toBeDefined();
+      expect(getPlayerStats().totalGames).toBe(0);
+    });
+
+    it("getRecentGames respects the limit parameter", () => {
+      expect(getRecentGames(5).length).toBeLessThanOrEqual(5);
+    });
+
+    it("clearGameHistory does not throw", async () => {
+      await expect(clearGameHistory()).resolves.not.toThrow();
     });
   });
 
-  describe('getPlayerStats', () => {
-    it('should return stats object', () => {
+  // ---------------------------------------------------------------------
+  // 1. Save / restore round-trips
+  // ---------------------------------------------------------------------
+  describe("save/restore round-trip (sync localStorage path)", () => {
+    it("round-trips a fully-populated record through getAllGameRecords", async () => {
+      const record = makeRecord();
+      await saveGameRecord(record);
+
+      const restored = getAllGameRecords();
+      expect(restored).toHaveLength(1);
+      expect(restored[0]).toEqual(record);
+    });
+
+    it("prepends new records (most-recent-first ordering)", async () => {
+      const first = makeRecord({ id: "g1", date: 100 });
+      const second = makeRecord({ id: "g2", date: 200 });
+      await saveGameRecord(first);
+      await saveGameRecord(second);
+
+      const restored = getAllGameRecords();
+      expect(restored.map((r) => r.id)).toEqual(["g2", "g1"]);
+    });
+
+    it("caps the history at 1000 entries (unshift + splice(1000))", async () => {
+      // Seed 1000 records in storage order [seed-0 .. seed-999].
+      const records: GameRecord[] = Array.from({ length: 1000 }, (_, i) =>
+        makeRecord({ id: `seed-${i}`, date: i }),
+      );
+      seedLocalStorage(JSON.stringify(records));
+
+      // saveGameRecord does: read(1000) → unshift(newest) → 1001 → splice(1000)
+      // which drops the LAST array element (seed-999), keeping the newest up front.
+      const newest = makeRecord({ id: "newest", date: 9999 });
+      await saveGameRecord(newest);
+
+      const restored = getAllGameRecords();
+      expect(restored).toHaveLength(1000);
+      expect(restored[0].id).toBe("newest");
+      // The tail entry (seed-999) is what gets spliced off.
+      expect(restored.some((r) => r.id === "seed-999")).toBe(false);
+      // seed-0 survives near the front (index 1).
+      expect(restored[1].id).toBe("seed-0");
+    });
+
+    it("round-trips records carrying optional actions/mistakes/summary", async () => {
+      const record = makeRecord({
+        actions: [
+          {
+            type: "cast_spell",
+            playerId: "p1",
+            timestamp: 1,
+            data: { cardId: "c1" },
+          },
+        ],
+        mistakes: ["a", "b"],
+        summary: "text",
+      });
+      await saveGameRecord(record);
+      expect(getAllGameRecords()[0]).toEqual(record);
+    });
+  });
+
+  describe("save/restore round-trip (async IndexedDB path)", () => {
+    it("round-trips a record through getAllGameRecordsAsync via IndexedDB", async () => {
+      const record = makeRecord({ id: "async-1" });
+      await saveGameRecord(record);
+
+      const restored = await getAllGameRecordsAsync();
+      expect(restored).toHaveLength(1);
+      expect(restored[0]).toEqual(record);
+    });
+
+    it("sorts the IndexedDB path by date descending", async () => {
+      await saveGameRecord(makeRecord({ id: "old", date: 100 }));
+      await saveGameRecord(makeRecord({ id: "new", date: 500 }));
+
+      const restored = await getAllGameRecordsAsync();
+      expect(restored.map((r) => r.id)).toEqual(["new", "old"]);
+    });
+
+    it("falls back to localStorage when IndexedDB is empty", async () => {
+      const record = makeRecord({ id: "fallback" });
+      seedLocalStorage(JSON.stringify([record]));
+
+      const restored = await getAllGameRecordsAsync();
+      expect(restored).toHaveLength(1);
+      expect(restored[0].id).toBe("fallback");
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // 2. Version / schema mismatch
+  //
+  // The module has NO version field and NO schema validation: it does
+  // `JSON.parse(stored) as GameRecord[]` and returns it verbatim (QA §3.9).
+  // We pin that real behavior so a future safe-parse/ migrate change is a
+  // deliberate, visible diff rather than a silent semantics shift.
+  // ---------------------------------------------------------------------
+  describe("version / schema handling (no validation — pins QA-3.9)", () => {
+    it("returns a persisted object verbatim even when it is not a GameRecord[]", () => {
+      // A "versioned" envelope that is clearly not the documented shape.
+      seedLocalStorage(JSON.stringify({ version: 99, payload: "stale" }));
+
+      const restored = getAllGameRecords();
+      // Real behavior: silent cast, the whole object is returned as-is.
+      expect(restored).toEqual({ version: 99, payload: "stale" } as never);
+    });
+
+    it("does not migrate or reject older-shape data — it passes it through", () => {
+      const legacy = [{ who: "knows", not: "a-record" }];
+      seedLocalStorage(JSON.stringify(legacy));
+      expect(getAllGameRecords()).toEqual(legacy as never);
+    });
+
+    it("getPlayerStats throws when storage holds a non-iterable shape", () => {
+      // Downstream consumer assumes an array; the loader does not guarantee
+      // one. This pins the blast radius of the un-validated cast.
+      seedLocalStorage(JSON.stringify({ not: "an array" }));
+      expect(() => getPlayerStats()).toThrow();
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // 3. Adversarial / malformed JSON
+  // ---------------------------------------------------------------------
+  describe("adversarial JSON (sync loader fails safe)", () => {
+    it("returns [] and logs when localStorage holds malformed JSON", () => {
+      const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+      seedLocalStorage("{ not valid json,,, ");
+
+      expect(getAllGameRecords()).toEqual([]);
+      expect(errSpy).toHaveBeenCalled();
+    });
+
+    it("returns [] when the slot is empty", () => {
+      localStorage.removeItem(STORAGE_KEY);
+      expect(getAllGameRecords()).toEqual([]);
+    });
+
+    it("treats JSON `null` as a non-array value (silent cast, not [])", () => {
+      // `null` parses successfully so the try/catch does NOT fire; the loader
+      // returns `null as GameRecord[]`. Pinning real behavior.
+      seedLocalStorage("null");
+      expect(getAllGameRecords()).toBeNull();
+    });
+
+    it("does not pollute Object.prototype via a __proto__ key", () => {
+      // JSON.parse handles `__proto__` without mutating the global prototype
+      // (it uses property definition semantics). The security-relevant
+      // guarantee is that unrelated objects stay clean.
+      seedLocalStorage(
+        JSON.stringify({ __proto__: { polluted: "yes" }, id: "x" }),
+      );
+
+      getAllGameRecords(); // returns the parsed object; never throws here
+      expect(({} as { polluted?: unknown }).polluted).toBeUndefined();
+      // A pristine object's prototype must be untouched.
+      expect(Object.getPrototypeOf({})).toBe(Object.prototype);
+    });
+
+    it("survives a large payload (no length-based crash)", () => {
+      const big: GameRecord[] = Array.from({ length: 500 }, (_, i) =>
+        makeRecord({ id: `big-${i}`, notes: "x".repeat(500) }),
+      );
+      seedLocalStorage(JSON.stringify(big));
+
+      const restored = getAllGameRecords();
+      expect(restored).toHaveLength(500);
+    });
+  });
+
+  describe("adversarial JSON (async loader fails safe with fallback)", () => {
+    it("returns [] and falls back when IndexedDB read throws", async () => {
+      const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+      // Force the async path to throw by poisoning localStorage fallback too,
+      // then exercise the outer catch (which logs and retries localStorage).
+      seedLocalStorage("not json");
+
+      // IndexedDB is empty here so it will hit the localStorage fallback, which
+      // throws (malformed JSON); the inner catch swallows and returns [].
+      const restored = await getAllGameRecordsAsync();
+      expect(restored).toEqual([]);
+      expect(errSpy).toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // createGameRecord factory + getPlayerStats aggregation
+  // ---------------------------------------------------------------------
+  describe("createGameRecord", () => {
+    it("produces a record with a generated id, date and all provided fields", () => {
+      const before = Date.now();
+      const record = createGameRecord({
+        mode: "self_play",
+        result: "draw",
+        playerDeck: "d",
+        turns: 7,
+        playerLifeAtEnd: 5,
+        mulligans: 0,
+      });
+      const after = Date.now();
+
+      expect(record.id).toMatch(/^game-/);
+      expect(record.mode).toBe("self_play");
+      expect(record.result).toBe("draw");
+      expect(record.date).toBeGreaterThanOrEqual(before);
+      expect(record.date).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe("getPlayerStats aggregation", () => {
+    type ModeResult = {
+      mode: GameMode;
+      result: GameResult;
+      difficulty?: string;
+    };
+
+    function seedStats(rows: ModeResult[]): void {
+      const records: GameRecord[] = rows.map((r, i) =>
+        makeRecord({
+          id: `s-${i}`,
+          mode: r.mode,
+          result: r.result,
+          difficulty: r.difficulty,
+          turns: 10,
+          playerLifeAtEnd: 20,
+        }),
+      );
+      seedLocalStorage(JSON.stringify(records));
+    }
+
+    it("aggregates overall + per-mode + per-difficulty win rates", () => {
+      seedStats([
+        { mode: "vs_ai", result: "win", difficulty: "hard" },
+        { mode: "vs_ai", result: "loss", difficulty: "hard" },
+        { mode: "vs_ai", result: "win", difficulty: "easy" },
+        { mode: "self_play", result: "draw" },
+      ]);
+
       const stats = getPlayerStats();
-      expect(stats).toBeDefined();
-    });
-  });
+      expect(stats.totalGames).toBe(4);
+      expect(stats.wins).toBe(2);
+      expect(stats.losses).toBe(1);
+      expect(stats.draws).toBe(1);
+      expect(stats.winRate).toBe(50);
 
-  describe('getRecentGames', () => {
-    it('should return games with default limit', () => {
-      const games = getRecentGames();
-      expect(Array.isArray(games)).toBe(true);
+      expect(stats.vsAiStats.games).toBe(3);
+      expect(stats.vsAiStats.wins).toBe(2);
+      expect(stats.vsAiStats.winRate).toBe(67);
+
+      expect(stats.selfPlayStats.games).toBe(1);
+      expect(stats.selfPlayStats.draws).toBe(1);
+
+      expect(stats.difficultyStats.hard.games).toBe(2);
+      expect(stats.difficultyStats.hard.winRate).toBe(50);
+      expect(stats.difficultyStats.easy.winRate).toBe(100);
+
+      // recentForm reflects storage order (most-recent-first).
+      expect(stats.recentForm).toEqual(["win", "loss", "win", "draw"]);
     });
 
-    it('should respect limit parameter', () => {
-      const games = getRecentGames(5);
-      expect(games.length).toBeLessThanOrEqual(5);
+    it("returns zeroed stats for empty history", () => {
+      const stats = getPlayerStats();
+      expect(stats.totalGames).toBe(0);
+      expect(stats.winRate).toBe(0);
+      expect(stats.recentForm).toEqual([]);
     });
-  });
 
-  describe('clearGameHistory', () => {
-    it('should not throw', () => {
-      expect(() => clearGameHistory()).not.toThrow();
+    it("ignores the playerId argument (currently unused)", () => {
+      seedStats([{ mode: "vs_ai", result: "win", difficulty: "easy" }]);
+      expect(getPlayerStats("anyone")).toEqual(getPlayerStats(undefined));
     });
   });
 });

--- a/src/lib/__tests__/replay-buffer.test.ts
+++ b/src/lib/__tests__/replay-buffer.test.ts
@@ -1,0 +1,491 @@
+/**
+ * @fileoverview ReplayBuffer tests (issue #1432).
+ *
+ * `src/lib/replay-buffer.ts` is an in-memory action buffer (no persistence),
+ * so the issue's three axes map onto its real public contract:
+ *   1. Round-trip / integrity — `addAction` → `getBufferedActions` preserves
+ *      the action payload and metadata (receivedAt, applied) faithfully;
+ *      `addActions` de-duplicates by action id; trimming evicts oldest-first
+ *      while keeping currentIndex in range.
+ *   2. Version / boundary handling — `validateJoin` enforces the game-age
+ *      boundary and warns on advanced games; `seekTo` bounds-checks its
+ *      index; the singleton factory caches its instance.
+ *   3. Adversarial input — `addAction` performs NO validation; we pin that
+ *      empty/oddly-shaped actions are accepted verbatim (so a future
+ *      schema guard is a deliberate diff).
+ *
+ * Playback uses `jest.useFakeTimers()` because the playback loop is driven
+ * by `setInterval` (delay = 100ms / speed).
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+import {
+  ReplayBuffer,
+  BufferedAction,
+  ReplayState,
+  getReplayBuffer,
+  resetReplayBuffer,
+} from "../replay-buffer";
+import type { GameAction } from "../action-broadcast";
+
+function makeAction(overrides: Partial<GameAction> = {}): GameAction {
+  return {
+    id: `act-${Math.random().toString(36).slice(2)}`,
+    type: "cast-spell",
+    playerId: "p1",
+    timestamp: 1_700_000_000_000,
+    payload: { cardId: "c1" },
+    ...overrides,
+  };
+}
+
+describe("replay-buffer", () => {
+  let buffer: ReplayBuffer;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(1_700_000_000_000));
+    resetReplayBuffer();
+    buffer = new ReplayBuffer();
+  });
+
+  afterEach(() => {
+    buffer.clear();
+    resetReplayBuffer();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------
+  // Constructor / defaults
+  // -------------------------------------------------------------------
+  describe("constructor", () => {
+    it("applies default size and age limits", () => {
+      const b = new ReplayBuffer();
+      // Defaults are exercised via trim + validateJoin below.
+      expect(b.getActionCount()).toBe(0);
+      expect(b.getState()).toBe("idle" as ReplayState);
+    });
+
+    it("honours custom options", () => {
+      const b = new ReplayBuffer({
+        maxBufferSize: 3,
+        maxGameAge: 1000,
+        gameStartTime: 100,
+      });
+      // Indirectly observable: validateJoin uses maxGameAge=1000ms.
+      // now=1_700_000_000_000 (set above), gameStartTime=100 → very old.
+      const result = b.validateJoin();
+      expect(result.canJoin).toBe(false);
+      expect(result.reason).toBe("Game is too old to join");
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // 1. Round-trip / integrity
+  // -------------------------------------------------------------------
+  describe("add → read round-trip", () => {
+    it("preserves the action payload and stamps receivedAt/applied=false", () => {
+      const action = makeAction({ id: "a1" });
+      buffer.addAction(action);
+
+      const buffered = buffer.getBufferedActions();
+      expect(buffered).toHaveLength(1);
+      expect(buffered[0].action).toEqual(action);
+      expect(buffered[0].receivedAt).toBe(1_700_000_000_000);
+      expect(buffered[0].applied).toBe(false);
+      expect(buffered[0].appliedAt).toBeUndefined();
+    });
+
+    it("increments getActionCount and emits progress", () => {
+      const progress: number[] = [];
+      buffer.setProgressHandler((p) => progress.push(p.percentage));
+
+      buffer.addAction(makeAction());
+      buffer.addAction(makeAction());
+
+      expect(buffer.getActionCount()).toBe(2);
+      expect(progress).toEqual([0, 0]); // nothing applied yet → 0%
+    });
+
+    it("addActions de-duplicates by action.id", () => {
+      const shared = makeAction({ id: "dup" });
+      buffer.addActions([shared, makeAction({ id: "b" }), shared]);
+
+      expect(buffer.getActionCount()).toBe(2);
+      expect(buffer.getBufferedActions().map((b) => b.action.id)).toEqual([
+        "dup",
+        "b",
+      ]);
+    });
+
+    it("addActions with an empty array is a no-op", () => {
+      buffer.addActions([]);
+      expect(buffer.getActionCount()).toBe(0);
+    });
+
+    it("trims to maxBufferSize evicting oldest-first and keeps currentIndex in range", () => {
+      const small = new ReplayBuffer({ maxBufferSize: 3 });
+      small.addAction(makeAction({ id: "1" }));
+      small.addAction(makeAction({ id: "2" }));
+      small.addAction(makeAction({ id: "3" }));
+
+      // Move currentIndex forward so the trim's clamp is exercised.
+      small.seekTo(1);
+      expect(small.getCurrentIndex()).toBe(1);
+
+      small.addAction(makeAction({ id: "4" })); // exceeds 3 → shift "1", clamp index
+
+      expect(small.getActionCount()).toBe(3);
+      expect(small.getBufferedActions().map((b) => b.action.id)).toEqual([
+        "2",
+        "3",
+        "4",
+      ]);
+      // currentIndex was 1; after shift it is clamped to max(0, 1-1)=0.
+      expect(small.getCurrentIndex()).toBe(0);
+    });
+
+    it("getUnappliedActions slices from currentIndex", () => {
+      buffer.addActions([
+        makeAction({ id: "1" }),
+        makeAction({ id: "2" }),
+        makeAction({ id: "3" }),
+      ]);
+      buffer.seekTo(1); // applies [0], currentIndex = 1
+      // slice(1) → actions at indices 1 and 2.
+      expect(buffer.getUnappliedActions().map((b) => b.action.id)).toEqual([
+        "2",
+        "3",
+      ]);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // 2. Boundary / validation behavior
+  // -------------------------------------------------------------------
+  describe("validateJoin", () => {
+    it("allows joining a fresh, small game", () => {
+      const fresh = new ReplayBuffer({ gameStartTime: Date.now() });
+      fresh.addAction(makeAction());
+      const result = fresh.validateJoin();
+      expect(result.canJoin).toBe(true);
+      expect(result.reason).toBeUndefined();
+      expect(result.actionCount).toBe(1);
+    });
+
+    it("rejects a game older than maxGameAge", () => {
+      const old = new ReplayBuffer({
+        gameStartTime: Date.now() - 3 * 60 * 60 * 1000, // 3h > 2h default
+      });
+      const result = old.validateJoin();
+      expect(result.canJoin).toBe(false);
+      expect(result.reason).toBe("Game is too old to join");
+      expect(result.gameAge).toBeGreaterThan(2 * 60 * 60 * 1000);
+    });
+
+    it("warns (but still allows) when the game has > 500 actions", () => {
+      const b = new ReplayBuffer({ gameStartTime: Date.now() });
+      for (let i = 0; i < 501; i++) b.addAction(makeAction({ id: `${i}` }));
+      const result = b.validateJoin();
+      expect(result.canJoin).toBe(true);
+      expect(result.reason).toBe("Warning: Late join to advanced game");
+      expect(result.actionCount).toBe(501);
+    });
+
+    it("reports oldestActionTimestamp from the first buffered action", () => {
+      const b = new ReplayBuffer({ gameStartTime: 5 });
+      b.addAction(makeAction());
+      const first = b.getBufferedActions()[0];
+      const result = b.validateJoin();
+      expect(result.oldestActionTimestamp).toBe(first.receivedAt);
+    });
+  });
+
+  describe("seekTo bounds checking", () => {
+    beforeEach(() => {
+      buffer.addActions([
+        makeAction({ id: "1" }),
+        makeAction({ id: "2" }),
+        makeAction({ id: "3" }),
+      ]);
+    });
+
+    it("ignores a negative index (with a console warning)", () => {
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+      buffer.seekTo(-1);
+      expect(buffer.getCurrentIndex()).toBe(0);
+      expect(warn).toHaveBeenCalledWith("Invalid seek index");
+    });
+
+    it("ignores an out-of-range high index", () => {
+      jest.spyOn(console, "warn").mockImplementation(() => {});
+      buffer.seekTo(99);
+      expect(buffer.getCurrentIndex()).toBe(0);
+    });
+
+    it("marks every action up to the index as applied and fires the handler", () => {
+      const applied: number[] = [];
+      buffer.setActionHandler((_a, i) => applied.push(i));
+      buffer.seekTo(2);
+      expect(applied).toEqual([0, 1, 2]);
+      expect(
+        buffer.getBufferedActions().every((b) => b.applied && b.appliedAt),
+      ).toBe(true);
+      expect(buffer.getCurrentIndex()).toBe(2);
+    });
+
+    it("does not re-apply already-applied actions on a subsequent seek", () => {
+      buffer.setActionHandler((_a, i) => {});
+      buffer.seekTo(2);
+      const appliedSpy = jest.fn();
+      buffer.setActionHandler(appliedSpy);
+      buffer.seekTo(2); // all already applied
+      expect(appliedSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // 3. Playback (fake timers)
+  // -------------------------------------------------------------------
+  describe("playback loop", () => {
+    function seed(n: number): void {
+      for (let i = 0; i < n; i++) buffer.addAction(makeAction({ id: `a${i}` }));
+    }
+
+    it("startReplay on an empty buffer is a no-op (warns)", () => {
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+      const states: ReplayState[] = [];
+      buffer.setStateChangeHandler((s) => states.push(s));
+      buffer.startReplay();
+      expect(warn).toHaveBeenCalledWith("No actions to replay");
+      expect(buffer.getState()).toBe("idle");
+      expect(states).toEqual([]); // no transition emitted
+    });
+
+    it("plays through all actions and reaches 'completed'", () => {
+      seed(2);
+      const applied: string[] = [];
+      buffer.setActionHandler((a) => applied.push(a.id));
+      const states: ReplayState[] = [];
+      buffer.setStateChangeHandler((s) => states.push(s));
+
+      buffer.startReplay(); // delay = 100ms (speed 1)
+      expect(buffer.getState()).toBe("playing");
+
+      // 2 actions → apply on tick 1 (100ms) and tick 2 (200ms);
+      // tick 3 (300ms) sees currentIndex>target → completes.
+      jest.advanceTimersByTime(100);
+      expect(applied).toEqual(["a0"]);
+      jest.advanceTimersByTime(100);
+      expect(applied).toEqual(["a0", "a1"]);
+      jest.advanceTimersByTime(100);
+      expect(buffer.getState()).toBe("completed");
+      expect(states[states.length - 1]).toBe("completed");
+    });
+
+    it("emits a replay-completed event and records it", () => {
+      seed(1);
+      buffer.startReplay();
+      jest.advanceTimersByTime(300); // apply + completion tick
+      const types = buffer.getEvents().map((e) => e.type);
+      expect(types).toContain("replay-started");
+      expect(types).toContain("replay-completed");
+    });
+
+    it("pauseReplay only acts when playing/fast-forwarding", () => {
+      seed(2);
+      // idle → no-op
+      buffer.pauseReplay();
+      expect(buffer.getState()).toBe("idle");
+
+      buffer.startReplay();
+      buffer.pauseReplay();
+      expect(buffer.getState()).toBe("paused");
+      // paused → pauseReplay is a no-op
+      buffer.pauseReplay();
+      expect(buffer.getState()).toBe("paused");
+    });
+
+    it("resumeReplay only acts when paused", () => {
+      seed(2);
+      buffer.startReplay();
+      // playing → resume is a no-op
+      buffer.resumeReplay();
+      expect(buffer.getState()).toBe("playing");
+
+      buffer.pauseReplay();
+      buffer.resumeReplay();
+      expect(buffer.getState()).toBe("playing");
+    });
+
+    it("setSpeed restarts the playback interval at the new rate", () => {
+      seed(4);
+      buffer.startReplay(); // 100ms/tick
+      jest.advanceTimersByTime(100); // a0 applied
+      buffer.setSpeed(4); // now 25ms/tick → 3 remaining actions
+      // 3 actions left → 4 ticks (25ms each) to finish.
+      jest.advanceTimersByTime(100);
+      expect(buffer.getState()).toBe("completed");
+    });
+
+    it("stopReplay returns to idle and halts playback", () => {
+      seed(3);
+      buffer.startReplay();
+      jest.advanceTimersByTime(100);
+      buffer.stopReplay();
+      expect(buffer.getState()).toBe("idle");
+      const appliedBefore = buffer
+        .getBufferedActions()
+        .filter((b) => b.applied).length;
+      jest.advanceTimersByTime(1000);
+      expect(buffer.getBufferedActions().filter((b) => b.applied).length).toBe(
+        appliedBefore,
+      ); // no further progress
+    });
+  });
+
+  describe("fast-forward", () => {
+    function seed(n: number): void {
+      for (let i = 0; i < n; i++) buffer.addAction(makeAction({ id: `a${i}` }));
+    }
+
+    it("is a no-op when already at or past the target", () => {
+      seed(3);
+      buffer.seekTo(2);
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+      buffer.startFastForward(); // target = length-1 = 2, currentIndex = 2 → warn
+      expect(warn).toHaveBeenCalledWith("Already at or before target index");
+      expect(buffer.getState()).toBe("idle");
+    });
+
+    it("fast-forwards to a target index at maximum speed", () => {
+      seed(4);
+      const applied: string[] = [];
+      buffer.setActionHandler((a) => applied.push(a.id));
+      buffer.startFastForward(3); // currentIndex is 0 → proceeds; speed 16
+      expect(buffer.getState()).toBe("fast-forwarding");
+      // speed 16 → delay ≈ 6.25ms; advance enough to cover apply + completion.
+      // The playback loop applies every index unconditionally (including 0),
+      // so all four actions are emitted before the completion tick.
+      jest.advanceTimersByTime(200);
+      expect(buffer.getState()).toBe("completed");
+      expect(applied).toEqual(["a0", "a1", "a2", "a3"]);
+    });
+  });
+
+  describe("jumpToEnd / progress", () => {
+    it("jumpToEnd marks everything applied and moves to completed", () => {
+      buffer.addActions([makeAction({ id: "1" }), makeAction({ id: "2" })]);
+      buffer.jumpToEnd();
+      expect(buffer.getState()).toBe("completed");
+      expect(buffer.getProgress().percentage).toBe(100);
+    });
+
+    it("getProgress reports 0% on an empty buffer", () => {
+      expect(buffer.getProgress()).toEqual({
+        totalActions: 0,
+        appliedActions: 0,
+        percentage: 0,
+        estimatedTimeRemaining: 0,
+      });
+    });
+
+    it("getProgress estimates remaining time from applied-action spacing", () => {
+      buffer.addActions([
+        makeAction({ id: "1" }),
+        makeAction({ id: "2" }),
+        makeAction({ id: "3" }),
+      ]);
+      // Apply two actions with a known time gap.
+      buffer.seekTo(0);
+      jest.advanceTimersByTime(50);
+      buffer.getBufferedActions()[1].applied = true;
+      buffer.getBufferedActions()[1].appliedAt = Date.now();
+      const progress = buffer.getProgress();
+      expect(progress.totalActions).toBe(3);
+      expect(progress.appliedActions).toBe(2);
+      expect(progress.estimatedTimeRemaining).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // 4. Adversarial input (no validation — pins the gap)
+  // -------------------------------------------------------------------
+  describe("adversarial input (addAction accepts anything)", () => {
+    it("accepts an action missing optional fields verbatim", () => {
+      const minimal = {
+        id: "x",
+        type: "take-action",
+        playerId: "p",
+        timestamp: 1,
+        payload: {},
+      } as GameAction;
+      buffer.addAction(minimal);
+      expect(buffer.getBufferedActions()[0].action).toEqual(minimal);
+    });
+
+    it("accepts duplicate ids via addAction (only addActions dedupes)", () => {
+      // addAction itself has no dedupe — only addActions checks ids.
+      const a = makeAction({ id: "same" });
+      buffer.addAction(a);
+      buffer.addAction(a);
+      expect(buffer.getActionCount()).toBe(2);
+    });
+
+    it("handles a very large batch without throwing", () => {
+      const actions: GameAction[] = Array.from({ length: 1000 }, (_, i) =>
+        makeAction({ id: `m${i}` }),
+      );
+      expect(() => buffer.addActions(actions)).not.toThrow();
+      expect(buffer.getActionCount()).toBe(1000);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // 5. clear + events cap + singleton factory
+  // -------------------------------------------------------------------
+  describe("clear / events / singleton", () => {
+    it("clear resets state, actions, index and events", () => {
+      buffer.addActions([makeAction(), makeAction()]);
+      buffer.startReplay();
+      jest.advanceTimersByTime(50);
+
+      buffer.clear();
+      expect(buffer.getActionCount()).toBe(0);
+      expect(buffer.getCurrentIndex()).toBe(0);
+      expect(buffer.getState()).toBe("idle");
+      expect(buffer.getEvents()).toEqual([]);
+    });
+
+    it("keeps only the last 100 events", () => {
+      buffer.addActions(
+        Array.from({ length: 60 }, (_, i) => makeAction({ id: `a${i}` })),
+      );
+      buffer.startReplay();
+      // Each startReplay emits one event; cap is exercised by many seeks.
+      buffer.stopReplay();
+      for (let i = 0; i < 120; i++) {
+        // jumpToEnd emits a replay-completed event each call.
+        buffer.jumpToEnd();
+      }
+      expect(buffer.getEvents().length).toBeLessThanOrEqual(100);
+    });
+
+    it("getReplayBuffer returns a cached singleton until reset", () => {
+      const a = getReplayBuffer();
+      const b = getReplayBuffer();
+      expect(b).toBe(a);
+      resetReplayBuffer();
+      const c = getReplayBuffer();
+      expect(c).not.toBe(a);
+    });
+  });
+});

--- a/src/lib/__tests__/replay-sharing.test.ts
+++ b/src/lib/__tests__/replay-sharing.test.ts
@@ -1,0 +1,731 @@
+/**
+ * @fileoverview Replay sharing tests (issue #1432).
+ *
+ * Pins the real encode/decode behavior of `src/lib/replay-sharing.ts`:
+ *   1. Round-trip is intentionally LOSSY — `minifyReplay` collapses each
+ *      action's `resultingState` to counts and `expandGameState` rebuilds a
+ *      simplified placeholder state. We assert deep equality on every field
+ *      that IS preserved, and separately assert the reconstructed state is a
+ *      well-formed GameState.
+ *   2. Version/Phase coercion — `expandGameState` does
+ *      `(minified.t?.cp || Phase.UNTAP) as Phase` with NO enum validation
+ *      (QA report §2.8). We pin that unknown strings pass through verbatim
+ *      and that a missing phase defaults to UNTAP.
+ *   3. Adversarial JSON — `decodeReplayFromURL` catches every error path and
+ *      returns null; we feed it malformed base64, malformed JSON, null,
+ *      wrong-shape objects and prototype-pollution-ish keys.
+ *
+ * `fetch`, `navigator.clipboard` and `URL.createObjectURL` are mocked per
+ * test because jsdom does not implement them.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+import type {
+  GameState,
+  Player,
+  Zone,
+  Combat,
+  LinkedEffectRegistry,
+} from "../game-state/types";
+import { Phase, ZoneType } from "../game-state/types";
+import { ReplacementEffectManager } from "../game-state/replacement-effects";
+import { LayerSystem } from "../game-state/layer-system";
+import type { Replay } from "../game-state/replay";
+import {
+  encodeReplayToURL,
+  decodeReplayFromURL,
+  generateShareableURL,
+  generateServerShareableLink,
+  getReplayFromCurrentURL,
+  copyShareableLink,
+  exportReplayToFile,
+  importReplayFromFile,
+  importReplayFromURL,
+  canShareViaURL,
+  getEstimatedURLLength,
+} from "../replay-sharing";
+
+const FIXED_NOW = 1_700_000_000_000;
+
+/** Build a minimal-but-valid GameState mirroring expandGameState's output. */
+function makeGameState(): GameState {
+  const playerId = "p1";
+  return {
+    gameId: "g1",
+    players: new Map<string, Player>([
+      [
+        playerId,
+        {
+          id: playerId,
+          name: "Alex",
+          life: 20,
+        } as Player,
+      ],
+    ]),
+    cards: new Map(),
+    zones: new Map<string, Zone>([
+      [
+        `hand-${playerId}`,
+        {
+          type: ZoneType.HAND,
+          playerId,
+          cardIds: ["c1", "c2"],
+          isRevealed: false,
+          visibleTo: [playerId],
+        } as Zone,
+      ],
+      [
+        "battlefield",
+        {
+          type: ZoneType.BATTLEFIELD,
+          playerId: null,
+          cardIds: ["c3", "c4"],
+          isRevealed: true,
+          visibleTo: [],
+        } as Zone,
+      ],
+      [
+        `library-${playerId}`,
+        {
+          type: ZoneType.LIBRARY,
+          playerId,
+          cardIds: Array(40).fill("x"),
+          isRevealed: false,
+          visibleTo: [playerId],
+        } as Zone,
+      ],
+      [
+        `graveyard-${playerId}`,
+        {
+          type: ZoneType.GRAVEYARD,
+          playerId,
+          cardIds: [],
+          isRevealed: true,
+          visibleTo: [],
+        } as Zone,
+      ],
+    ]),
+    stack: [],
+    turn: {
+      activePlayerId: playerId,
+      currentPhase: Phase.PRECOMBAT_MAIN,
+      turnNumber: 3,
+      extraTurns: 0,
+      isFirstTurn: false,
+      startedAt: FIXED_NOW,
+    },
+    combat: {
+      inCombatPhase: false,
+      attackers: [],
+      blockers: new Map(),
+      remainingCombatPhases: 0,
+    } as Combat,
+    waitingChoice: null,
+    priorityPlayerId: playerId,
+    consecutivePasses: 0,
+    status: "in_progress",
+    winners: [],
+    endReason: null,
+    format: "modern",
+    createdAt: FIXED_NOW,
+    lastModifiedAt: FIXED_NOW,
+    replacementEffectManager: new ReplacementEffectManager(),
+    layerSystem: new LayerSystem(),
+    linkedEffectRegistry: {
+      effects: [],
+      bySourceCard: new Map(),
+    } as LinkedEffectRegistry,
+  };
+}
+
+function makeReplay(overrides: Partial<Replay> = {}): Replay {
+  return {
+    id: "replay-1",
+    metadata: {
+      format: "modern",
+      playerNames: ["Alex", "Sam"],
+      startingLife: 20,
+      isCommander: false,
+      winners: ["Alex"],
+      gameStartDate: FIXED_NOW,
+      gameEndDate: FIXED_NOW + 1000,
+      endReason: "concession",
+    },
+    actions: [
+      {
+        sequenceNumber: 0,
+        action: {
+          type: "cast_spell",
+          playerId: "p1",
+          timestamp: FIXED_NOW,
+          data: { cardId: "c1" },
+        },
+        resultingState: makeGameState(),
+        description: "Alex cast Lightning Bolt",
+        recordedAt: FIXED_NOW,
+      },
+    ],
+    currentPosition: 0,
+    totalActions: 1,
+    createdAt: FIXED_NOW,
+    lastModifiedAt: FIXED_NOW,
+    ...overrides,
+  };
+}
+
+/** Encode a raw JS value the same way encodeReplayToURL does. */
+function encodeValue(value: unknown): string {
+  return btoa(encodeURIComponent(JSON.stringify(value)));
+}
+
+describe("replay-sharing", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------
+  // 1. Round-trip (lossy)
+  // -------------------------------------------------------------------
+  describe("encode/decode round-trip", () => {
+    it("preserves id, metadata and top-level scalar fields", () => {
+      const replay = makeReplay();
+      const encoded = encodeReplayToURL(replay);
+      const decoded = decodeReplayFromURL(encoded)!;
+
+      expect(decoded.id).toBe(replay.id);
+      expect(decoded.metadata).toEqual(replay.metadata);
+      expect(decoded.currentPosition).toBe(replay.currentPosition);
+      expect(decoded.totalActions).toBe(replay.totalActions);
+      expect(decoded.createdAt).toBe(replay.createdAt);
+      expect(decoded.lastModifiedAt).toBe(replay.lastModifiedAt);
+    });
+
+    it("preserves per-action type/playerId/data/description/timestamps", () => {
+      const replay = makeReplay();
+      const decoded = decodeReplayFromURL(encodeReplayToURL(replay))!;
+
+      expect(decoded.actions).toHaveLength(1);
+      const a = decoded.actions[0];
+      const r = replay.actions[0];
+      expect(a.sequenceNumber).toBe(r.sequenceNumber);
+      expect(a.action.type).toBe(r.action.type);
+      expect(a.action.playerId).toBe(r.action.playerId);
+      expect(a.action.data).toEqual(r.action.data);
+      expect(a.action.timestamp).toBe(r.action.timestamp);
+      expect(a.description).toBe(r.description);
+      expect(a.recordedAt).toBe(r.recordedAt);
+    });
+
+    it("reconstructs a well-formed resultingState (lossy but valid)", () => {
+      const decoded = decodeReplayFromURL(encodeReplayToURL(makeReplay()))!;
+      const state = decoded.actions[0].resultingState;
+
+      // Players and zones survive as Maps with the right cardinalities.
+      expect(state.players).toBeInstanceOf(Map);
+      expect(state.players.size).toBe(1);
+      expect(state.zones).toBeInstanceOf(Map);
+      expect(state.zones.size).toBeGreaterThan(0);
+      // Battlefield count (2 cards) is preserved as placeholder ids.
+      const bf = state.zones.get("battlefield");
+      expect(bf?.cardIds).toHaveLength(2);
+      // Hand size for the single player is preserved.
+      const hand = state.zones.get("hand-p1");
+      expect(hand?.cardIds).toHaveLength(2);
+      // Manager instances are present (not undefined).
+      expect(state.replacementEffectManager).toBeDefined();
+      expect(state.layerSystem).toBeDefined();
+    });
+
+    it("round-trips a multi-action replay with no winners/end", () => {
+      const base = makeReplay();
+      const replay = makeReplay({
+        id: "replay-2",
+        metadata: {
+          format: "commander",
+          playerNames: ["A", "B", "C", "D"],
+          startingLife: 40,
+          isCommander: true,
+          gameStartDate: FIXED_NOW,
+        },
+        actions: [
+          base.actions[0],
+          {
+            ...base.actions[0],
+            sequenceNumber: 1,
+            action: {
+              type: "pass_priority",
+              playerId: "p2",
+              timestamp: FIXED_NOW + 5,
+              data: {},
+            },
+            description: "Sam passed",
+          },
+        ],
+        totalActions: 2,
+        currentPosition: 1,
+      });
+
+      const decoded = decodeReplayFromURL(encodeReplayToURL(replay))!;
+      expect(decoded.actions).toHaveLength(2);
+      expect(decoded.metadata.isCommander).toBe(true);
+      expect(decoded.metadata.startingLife).toBe(40);
+      expect(decoded.metadata.winners).toBeUndefined();
+      expect(decoded.metadata.gameEndDate).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // 2. Version / Phase coercion  (pins QA-2.8)
+  // -------------------------------------------------------------------
+  describe("Phase / status coercion (no enum validation — pins QA-2.8)", () => {
+    it("passes an unknown phase string through verbatim (silent cast)", () => {
+      const minified = {
+        i: "r",
+        m: {
+          f: "modern",
+          p: ["A"],
+          s: 20,
+          c: false,
+        },
+        a: [
+          {
+            s: 0,
+            t: "cast_spell",
+            pid: "p1",
+            rs: {
+              t: { cp: "NOT_A_REAL_PHASE", tn: 5 },
+              p: [{ id: "p1", n: "A", l: 17, h: 3 }],
+              z: { bf: 1, g: 0, l: 30 },
+            },
+            desc: "x",
+            ra: FIXED_NOW,
+          },
+        ],
+        cp: 0,
+        ta: 1,
+        ca: FIXED_NOW,
+        lma: FIXED_NOW,
+      };
+
+      const decoded = decodeReplayFromURL(encodeValue(minified))!;
+      expect(decoded.actions[0].resultingState.turn.currentPhase).toBe(
+        "NOT_A_REAL_PHASE",
+      );
+    });
+
+    it("defaults a missing phase to UNTAP", () => {
+      const minified = {
+        i: "r",
+        m: { f: "modern", p: ["A"], s: 20, c: false },
+        a: [
+          {
+            s: 0,
+            t: "cast_spell",
+            pid: "p1",
+            rs: {
+              t: { tn: 2 }, // no cp
+              p: [{ id: "p1", n: "A", l: 20, h: 7 }],
+              z: { bf: 0, g: 0, l: 40 },
+            },
+            desc: "x",
+            ra: FIXED_NOW,
+          },
+        ],
+        cp: 0,
+        ta: 1,
+        ca: FIXED_NOW,
+        lma: FIXED_NOW,
+      };
+
+      const decoded = decodeReplayFromURL(encodeValue(minified))!;
+      expect(decoded.actions[0].resultingState.turn.currentPhase).toBe(
+        Phase.UNTAP,
+      );
+    });
+
+    it("passes an unknown status string through verbatim", () => {
+      const minified = {
+        i: "r",
+        m: { f: "modern", p: ["A"], s: 20, c: false },
+        a: [
+          {
+            s: 0,
+            t: "cast_spell",
+            pid: "p1",
+            rs: {
+              p: [{ id: "p1", n: "A", l: 20, h: 7 }],
+              z: { bf: 0, g: 0, l: 40 },
+              s: "frozen", // not a real GameStatus
+            },
+            desc: "x",
+            ra: FIXED_NOW,
+          },
+        ],
+        cp: 0,
+        ta: 1,
+        ca: FIXED_NOW,
+        lma: FIXED_NOW,
+      };
+
+      const decoded = decodeReplayFromURL(encodeValue(minified))!;
+      expect(decoded.actions[0].resultingState.status).toBe("frozen");
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // 3. Adversarial JSON
+  // -------------------------------------------------------------------
+  describe("adversarial decodeReplayFromURL (fails safe → null)", () => {
+    it("returns null for malformed base64", () => {
+      const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      expect(decodeReplayFromURL("!!!not-base64!!!")).toBeNull();
+      expect(errSpy).toHaveBeenCalled();
+    });
+
+    it("returns null when the decoded payload is not valid JSON", () => {
+      jest.spyOn(console, "error").mockImplementation(() => {});
+      // btoa("not json") decodes to a non-JSON string.
+      expect(decodeReplayFromURL(btoa("not json at all"))).toBeNull();
+    });
+
+    it("returns null for an empty string", () => {
+      jest.spyOn(console, "error").mockImplementation(() => {});
+      expect(decodeReplayFromURL("")).toBeNull();
+    });
+
+    it("returns null when the payload is JSON null", () => {
+      jest.spyOn(console, "error").mockImplementation(() => {});
+      expect(decodeReplayFromURL(encodeValue(null))).toBeNull();
+    });
+
+    it("returns null when required fields are missing (empty object)", () => {
+      jest.spyOn(console, "error").mockImplementation(() => {});
+      // expandReplay touches minified.a.map → throws on undefined.
+      expect(decodeReplayFromURL(encodeValue({}))).toBeNull();
+    });
+
+    it("does not pollute Object.prototype via a __proto__ key", () => {
+      jest.spyOn(console, "error").mockImplementation(() => {});
+      const payload = { __proto__: { polluted: "yes" } };
+      // Decoding throws (wrong shape) → returns null; prototype stays clean.
+      expect(decodeReplayFromURL(encodeValue(payload))).toBeNull();
+      expect(({} as { polluted?: unknown }).polluted).toBeUndefined();
+    });
+  });
+
+  describe("encodeReplayToURL failure", () => {
+    it("re-throws a descriptive error when minify/encode fails", () => {
+      // A circular reference inside action.data is copied verbatim into the
+      // minified envelope, so JSON.stringify then throws inside encode.
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      const bad = makeReplay();
+      bad.actions[0].action.data = circular as never;
+      jest.spyOn(console, "error").mockImplementation(() => {});
+
+      expect(() => encodeReplayToURL(bad)).toThrow(
+        "Failed to encode replay for sharing",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // 4. URL length guards
+  // -------------------------------------------------------------------
+  describe("URL length guards", () => {
+    it("generateShareableURL returns a replay URL for a small replay", () => {
+      const url = generateShareableURL(makeReplay())!;
+      expect(url).toContain("/replay?replay=");
+      expect(url.startsWith("http") || url.startsWith("localhost")).toBe(true);
+    });
+
+    it("generateShareableURL returns null when the replay exceeds 8000 chars", () => {
+      const huge = makeReplay({
+        actions: Array.from({ length: 400 }, (_, i) => ({
+          sequenceNumber: i,
+          action: {
+            type: "cast_spell",
+            playerId: "p1",
+            timestamp: FIXED_NOW + i,
+            data: { cardId: `c${i}`, padding: "x".repeat(40) },
+          },
+          resultingState: makeGameState(),
+          description: `action ${i} `.repeat(20),
+          recordedAt: FIXED_NOW + i,
+        })),
+        totalActions: 400,
+      });
+      jest.spyOn(console, "warn").mockImplementation(() => {});
+      expect(generateShareableURL(huge)).toBeNull();
+    });
+
+    it("canShareViaURL mirrors the length guard", () => {
+      expect(canShareViaURL(makeReplay())).toBe(true);
+    });
+
+    it("getEstimatedURLLength is positive for a shareable replay", () => {
+      expect(getEstimatedURLLength(makeReplay())).toBeGreaterThan(0);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // 5. Current-URL extraction
+  // -------------------------------------------------------------------
+  describe("getReplayFromCurrentURL", () => {
+    it("returns null when the URL has no replay param", () => {
+      expect(getReplayFromCurrentURL()).toBeNull();
+    });
+
+    it("decodes the replay param when present", () => {
+      const encoded = encodeReplayToURL(makeReplay());
+      // jsdom supports history.replaceState for updating location.search.
+      window.history.replaceState({}, "", `/replay?replay=${encoded}`);
+
+      try {
+        const replay = getReplayFromCurrentURL();
+        expect(replay).not.toBeNull();
+        expect(replay!.id).toBe("replay-1");
+      } finally {
+        window.history.replaceState({}, "", "/");
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // 6. File / server / clipboard I/O
+  // -------------------------------------------------------------------
+  describe("file import/export", () => {
+    it("importReplayFromFile round-trips a JSON file", async () => {
+      const replay = makeReplay();
+      // jsdom's File does not implement .text(); stub it directly.
+      const file = {
+        text: async () => JSON.stringify(replay),
+      } as unknown as File;
+      const imported = await importReplayFromFile(file);
+      expect(imported).not.toBeNull();
+      expect(imported!.id).toBe(replay.id);
+      expect(imported!.metadata).toEqual(replay.metadata);
+    });
+
+    it("importReplayFromFile returns null on malformed text", async () => {
+      jest.spyOn(console, "error").mockImplementation(() => {});
+      const file = { text: async () => "{ broken" } as unknown as File;
+      expect(await importReplayFromFile(file)).toBeNull();
+    });
+
+    /** jsdom does not implement URL.createObjectURL/revokeObjectURL. */
+    function installURLMocks(): {
+      createObjectURL: ReturnType<typeof jest.fn>;
+      revokeObjectURL: ReturnType<typeof jest.fn>;
+      restore: () => void;
+    } {
+      const url = URL as unknown as {
+        createObjectURL?: unknown;
+        revokeObjectURL?: unknown;
+      };
+      const prevCreate = url.createObjectURL;
+      const prevRevoke = url.revokeObjectURL;
+      const createObjectURL = jest.fn().mockReturnValue("blob:fake");
+      const revokeObjectURL = jest.fn();
+      url.createObjectURL = createObjectURL;
+      url.revokeObjectURL = revokeObjectURL;
+      return {
+        createObjectURL,
+        revokeObjectURL,
+        restore: () => {
+          url.createObjectURL = prevCreate;
+          url.revokeObjectURL = prevRevoke;
+        },
+      };
+    }
+
+    function captureAnchor(): {
+      capture: () => HTMLAnchorElement | null;
+      install: () => void;
+      restore: () => void;
+    } {
+      const realCreate = document.createElement.bind(document);
+      let captured: HTMLAnchorElement | null = null;
+      return {
+        install: () => {
+          jest
+            .spyOn(document, "createElement")
+            .mockImplementation((tag: string) => {
+              const el = realCreate(tag);
+              if (tag.toLowerCase() === "a") {
+                captured = el as HTMLAnchorElement;
+                el.click = jest.fn(); // jsdom click() is otherwise a no-op
+              }
+              return el;
+            });
+        },
+        capture: () => captured,
+        restore: () => {
+          // restored via jest.restoreAllMocks() in afterEach
+        },
+      };
+    }
+
+    it("exportReplayToFile triggers an anchor download with the filename", () => {
+      const urlMocks = installURLMocks();
+      const anchor = captureAnchor();
+      anchor.install();
+      try {
+        exportReplayToFile(makeReplay(), "my-replay.json");
+        expect(urlMocks.createObjectURL).toHaveBeenCalledTimes(1);
+        expect(urlMocks.revokeObjectURL).toHaveBeenCalledTimes(1);
+        expect(anchor.capture()!.download).toBe("my-replay.json");
+        expect(anchor.capture()!.href).toBe("blob:fake");
+      } finally {
+        urlMocks.restore();
+      }
+    });
+
+    it("exportReplayToFile uses a default filename derived from replay id", () => {
+      const urlMocks = installURLMocks();
+      const anchor = captureAnchor();
+      anchor.install();
+      try {
+        exportReplayToFile(makeReplay({ id: "abc-123" }));
+        expect(anchor.capture()!.download).toBe("replay-abc-123.json");
+      } finally {
+        urlMocks.restore();
+      }
+    });
+  });
+
+  describe("server shareable link", () => {
+    /** Install a fetch mock; the global Response from jest.setup lacks .ok/.json. */
+    function installFetch(response: unknown): {
+      mock: ReturnType<typeof jest.fn>;
+      restore: () => void;
+    } {
+      const g = globalThis as { fetch?: unknown };
+      const prev = g.fetch;
+      const mock = jest
+        .fn<(input: string, init?: unknown) => Promise<unknown>>()
+        .mockResolvedValue(response);
+      g.fetch = mock;
+      return {
+        mock,
+        restore: () => {
+          g.fetch = prev;
+        },
+      };
+    }
+
+    it("POSTs the replay and returns the share URL on success", async () => {
+      const { mock, restore } = installFetch({
+        ok: true,
+        status: 201,
+        json: async () => ({ id: "srv-1" }),
+      });
+      try {
+        const url = await generateServerShareableLink(
+          makeReplay(),
+          "https://srv.example",
+        );
+        expect(url).toBe("https://srv.example/replay/srv-1");
+        expect(mock).toHaveBeenCalledWith(
+          "https://srv.example/api/replays",
+          expect.objectContaining({ method: "POST" }),
+        );
+      } finally {
+        restore();
+      }
+    });
+
+    it("returns null when the server responds with an error", async () => {
+      jest.spyOn(console, "error").mockImplementation(() => {});
+      const { restore } = installFetch({ ok: false, status: 500 });
+      try {
+        expect(
+          await generateServerShareableLink(
+            makeReplay(),
+            "https://srv.example",
+          ),
+        ).toBeNull();
+      } finally {
+        restore();
+      }
+    });
+
+    it("importReplayFromURL GETs and returns the replay on success", async () => {
+      const replay = makeReplay();
+      const { restore } = installFetch({
+        ok: true,
+        status: 200,
+        json: async () => replay,
+      });
+      try {
+        const imported = await importReplayFromURL(
+          "srv-1",
+          "https://srv.example",
+        );
+        expect(imported).not.toBeNull();
+        expect(imported!.id).toBe("replay-1");
+      } finally {
+        restore();
+      }
+    });
+
+    it("importReplayFromURL returns null on a non-ok response", async () => {
+      jest.spyOn(console, "error").mockImplementation(() => {});
+      const { restore } = installFetch({ ok: false, status: 404 });
+      try {
+        expect(
+          await importReplayFromURL("srv-1", "https://srv.example"),
+        ).toBeNull();
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe("copyShareableLink", () => {
+    it("returns true and writes the URL when clipboard is available", async () => {
+      const writeText = jest
+        .fn<(text: string) => Promise<void>>()
+        .mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText },
+        configurable: true,
+      });
+
+      const ok = await copyShareableLink(makeReplay());
+      expect(ok).toBe(true);
+      expect(writeText).toHaveBeenCalledTimes(1);
+      expect(writeText.mock.calls[0][0]).toContain("/replay?replay=");
+    });
+
+    it("returns false when the replay cannot be shared", async () => {
+      const huge = makeReplay({
+        actions: Array.from({ length: 400 }, (_, i) => ({
+          sequenceNumber: i,
+          action: {
+            type: "cast_spell",
+            playerId: "p1",
+            timestamp: FIXED_NOW + i,
+            data: { cardId: `c${i}`, padding: "x".repeat(40) },
+          },
+          resultingState: makeGameState(),
+          description: `action ${i} `.repeat(20),
+          recordedAt: FIXED_NOW + i,
+        })),
+        totalActions: 400,
+      });
+      expect(await copyShareableLink(huge)).toBe(false);
+    });
+  });
+});

--- a/src/lib/__tests__/trading.test.ts
+++ b/src/lib/__tests__/trading.test.ts
@@ -1,0 +1,427 @@
+/**
+ * @fileoverview Card trading persistence tests (issue #1432).
+ *
+ * Pins the real behavior of `src/lib/trading.ts` (`tradeManager` singleton
+ * + `calculateTradeFairness`) across the three issue axes:
+ *   1. Save/restore round-trip of TradeOffer through localStorage.
+ *   2. Lifecycle / state-machine transitions (draft → pending → accepted →
+ *      history) including the both-parties-accepted branch.
+ *   3. Adversarial JSON — note `getAllTrades()` performs a bare
+ *      `JSON.parse(stored)` with NO try/catch (QA report §4.7 / §2.13), so
+ *      malformed storage *propagates* the parse error. We pin that real
+ *      behavior so a future safe-load migration is a deliberate diff.
+ *
+ * Additionally reproduces the non-atomic read-modify-write hazard flagged in
+ * QA §4.7 (two concurrent tabs) by interleaving two writers against the same
+ * storage slot and asserting the lost update.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+import type { ScryfallCard } from "@/app/actions";
+import {
+  tradeManager,
+  calculateTradeFairness,
+  TradeOffer,
+  TradeCardItem,
+} from "../trading";
+
+const STORAGE_KEY = "planar_nexus_trades";
+const HISTORY_KEY = "planar_nexus_trade_history";
+
+function makeCard(overrides: Partial<ScryfallCard> = {}): ScryfallCard {
+  return {
+    id: `card-${Math.random().toString(36).slice(2)}`,
+    name: "Lightning Bolt",
+    cmc: 1,
+    type_line: "Instant",
+    colors: ["R"],
+    color_identity: ["R"],
+    legalities: {},
+    ...overrides,
+  };
+}
+
+function makeCardItem(overrides: Partial<TradeCardItem> = {}): TradeCardItem {
+  return {
+    card: makeCard(),
+    quantity: 1,
+    ...overrides,
+  };
+}
+
+/** Read the raw trades slot the way `tradeManager.getAllTrades()` does. */
+function readRawTrades(): unknown {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return stored ? JSON.parse(stored) : [];
+}
+
+/**
+ * Faithful simulation of one "tab" performing `saveTrade`'s read-modify-write
+ * against a PRE-CAPTURED snapshot. The hazard (QA §4.7) is that a tab writes
+ * based on a stale read taken before another tab's write landed. Using a
+ * snapshot — instead of re-reading live storage — reproduces that exactly
+ * without modifying the source.
+ */
+function tabWriteFromSnapshot(snapshot: TradeOffer[], offer: TradeOffer): void {
+  const trades = [...snapshot];
+  const index = trades.findIndex((t) => t.id === offer.id);
+  if (index >= 0) trades[index] = offer;
+  else trades.push(offer);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(trades));
+}
+
+describe("trading — tradeManager", () => {
+  beforeEach(() => {
+    tradeManager.clearAllTrades();
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    tradeManager.clearAllTrades();
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------
+  // 1. Save / restore round-trip
+  // -------------------------------------------------------------------
+  describe("save/restore round-trip", () => {
+    it("round-trips a freshly-created offer through getTradeOffer", () => {
+      const created = tradeManager.createTradeOffer("p1", "Alice", "p2", "Bob");
+
+      const restored = tradeManager.getTradeOffer(created.id);
+      expect(restored).toEqual(created);
+    });
+
+    it("persists across a simulated reload by reading the same storage slot", () => {
+      const created = tradeManager.createTradeOffer("p1", "A", "p2", "B");
+
+      // Snapshot + restore the raw storage to emulate a fresh page load.
+      const snapshot = localStorage.getItem(STORAGE_KEY);
+      tradeManager.clearAllTrades();
+      localStorage.setItem(STORAGE_KEY, snapshot!);
+
+      expect(tradeManager.getTradeOffer(created.id)).toEqual(created);
+    });
+
+    it("persists added cards and want-lists across reload", () => {
+      const created = tradeManager.createTradeOffer("p1", "A", "p2", "B");
+      const item = makeCardItem({ quantity: 3 });
+      tradeManager.addCardsToOffer(created.id, "p1", [item]);
+      tradeManager.addWantedCards(created.id, "p2", [
+        makeCardItem({ quantity: 2 }),
+      ]);
+
+      const snapshot = localStorage.getItem(STORAGE_KEY);
+      tradeManager.clearAllTrades();
+      localStorage.setItem(STORAGE_KEY, snapshot!);
+
+      const restored = tradeManager.getTradeOffer(created.id)!;
+      expect(restored.parties[0].offeredCards).toHaveLength(1);
+      expect(restored.parties[0].offeredCards[0].quantity).toBe(3);
+      expect(restored.parties[1].wantedCards).toHaveLength(1);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // 2. Lifecycle / state machine
+  // -------------------------------------------------------------------
+  describe("lifecycle", () => {
+    it("creates an offer in the draft state with two pending parties", () => {
+      const offer = tradeManager.createTradeOffer("p1", "A", "p2", "B");
+
+      expect(offer.status).toBe("draft");
+      expect(offer.parties).toHaveLength(2);
+      expect(offer.parties.map((p) => p.status)).toEqual([
+        "pending",
+        "pending",
+      ]);
+      expect(offer.createdAt).toBe(offer.updatedAt);
+    });
+
+    it("submitTradeOffer moves draft → pending and notifies subscribers", () => {
+      const offer = tradeManager.createTradeOffer("p1", "A", "p2", "B");
+      const events: string[] = [];
+      const unsub = tradeManager.subscribe((n) => events.push(n.type));
+
+      const submitted = tradeManager.submitTradeOffer(offer.id, "p1");
+      unsub();
+
+      expect(submitted!.status).toBe("pending");
+      expect(events).toContain("new_offer");
+    });
+
+    it("acceptTrade by one party keeps the trade open; both parties close it", () => {
+      const offer = tradeManager.createTradeOffer("p1", "A", "p2", "B");
+
+      const first = tradeManager.acceptTrade(offer.id, "p1");
+      expect(first!.status).not.toBe("accepted");
+      expect(first!.parties[0].status).toBe("accepted");
+      expect(first!.parties[0].respondedAt).toBeDefined();
+
+      const second = tradeManager.acceptTrade(offer.id, "p2");
+      expect(second!.status).toBe("accepted");
+      expect(second!.completedAt).toBeDefined();
+    });
+
+    it("writes a TradeHistoryEntry for both parties once fully accepted", () => {
+      const offer = tradeManager.createTradeOffer("p1", "A", "p2", "B");
+      tradeManager.addCardsToOffer(offer.id, "p1", [
+        makeCardItem({ card: makeCard({ id: "given" }), quantity: 1 }),
+      ]);
+      tradeManager.addCardsToOffer(offer.id, "p2", [
+        makeCardItem({ card: makeCard({ id: "received" }), quantity: 1 }),
+      ]);
+
+      tradeManager.acceptTrade(offer.id, "p1");
+      tradeManager.acceptTrade(offer.id, "p2"); // p2 accepts last → bothAccepted
+
+      // Two history entries are written, one from each party's perspective.
+      const history = tradeManager.getTradeHistory("p1");
+      expect(history).toHaveLength(2);
+      const givenIds = history.map((h) => h.cardsGiven[0].card.id).sort();
+      const receivedIds = history.map((h) => h.cardsReceived[0].card.id).sort();
+      // Each party's "given" is their own offered card; "received" is the other's.
+      expect(givenIds).toEqual(["given", "received"]);
+      expect(receivedIds).toEqual(["given", "received"]);
+    });
+
+    it("rejectTrade marks the trade rejected", () => {
+      const offer = tradeManager.createTradeOffer("p1", "A", "p2", "B");
+      const rejected = tradeManager.rejectTrade(offer.id, "p2");
+      expect(rejected!.status).toBe("rejected");
+      expect(rejected!.parties[1].status).toBe("rejected");
+    });
+
+    it("counterOffer resets both parties to pending and moves to countered", () => {
+      const offer = tradeManager.createTradeOffer("p1", "A", "p2", "B");
+      tradeManager.acceptTrade(offer.id, "p1");
+
+      const countered = tradeManager.counterOffer(offer.id, "p2");
+      expect(countered!.status).toBe("countered");
+      expect(countered!.parties.every((p) => p.status === "pending")).toBe(
+        true,
+      );
+    });
+
+    it("cancelTrade succeeds for the initiator but not the recipient", () => {
+      const offer = tradeManager.createTradeOffer("p1", "A", "p2", "B");
+
+      expect(tradeManager.cancelTrade(offer.id, "p2")).toBeNull();
+      expect(tradeManager.getTradeOffer(offer.id)!.status).not.toBe(
+        "cancelled",
+      );
+
+      const cancelled = tradeManager.cancelTrade(offer.id, "p1");
+      expect(cancelled!.status).toBe("cancelled");
+    });
+
+    it("addTradeNotes appends party-attributed lines", () => {
+      const offer = tradeManager.createTradeOffer("p1", "Alice", "p2", "Bob");
+      tradeManager.addTradeNotes(offer.id, "p1", "hello");
+      tradeManager.addTradeNotes(offer.id, "p2", "deal");
+
+      const restored = tradeManager.getTradeOffer(offer.id)!;
+      expect(restored.notes).toContain("Alice: hello");
+      expect(restored.notes).toContain("Bob: deal");
+    });
+  });
+
+  describe("queries", () => {
+    it("getTradesForPlayer / getPendingTrades filter by party and status", () => {
+      const o1 = tradeManager.createTradeOffer("p1", "A", "p2", "B");
+      const o2 = tradeManager.createTradeOffer("p1", "A", "p3", "C");
+      tradeManager.submitTradeOffer(o1.id, "p1");
+      tradeManager.acceptTrade(o2.id, "p1");
+      tradeManager.acceptTrade(o2.id, "p3"); // o2 fully accepted → not pending
+
+      expect(tradeManager.getTradesForPlayer("p1")).toHaveLength(2);
+      expect(tradeManager.getPendingTrades("p1").map((t) => t.id)).toEqual([
+        o1.id,
+      ]);
+      // getTradeHistory does not currently filter by playerId.
+      expect(tradeManager.getTradeHistory("p1")).toHaveLength(2);
+    });
+
+    it("returns null for an unknown trade id", () => {
+      expect(tradeManager.getTradeOffer("does-not-exist")).toBeNull();
+    });
+
+    it("returns null when mutating an unknown trade / unknown party", () => {
+      expect(tradeManager.addCardsToOffer("nope", "p1", [])).toBeNull();
+      const offer = tradeManager.createTradeOffer("p1", "A", "p2", "B");
+      expect(tradeManager.addCardsToOffer(offer.id, "ghost", [])).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // 3. Adversarial JSON  (pins QA §2.13 / §4.7 — bare JSON.parse)
+  // -------------------------------------------------------------------
+  describe("adversarial storage (bare JSON.parse, no try/catch)", () => {
+    it("propagates a SyntaxError when the trades slot holds malformed JSON", () => {
+      localStorage.setItem(STORAGE_KEY, "{ totally not json");
+
+      // Real behavior: getAllTrades() has no try/catch, so the error escapes.
+      expect(() => tradeManager.getTradeOffer("any")).toThrow(SyntaxError);
+    });
+
+    it("throws a TypeError when the slot holds a non-array JSON value", () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ not: "an array" }));
+
+      // trades.find is called on a plain object → TypeError propagates.
+      expect(() => tradeManager.getTradeOffer("any")).toThrow(TypeError);
+    });
+
+    it("does not pollute Object.prototype via a __proto__ key", () => {
+      // The bare JSON.parse keeps __proto__ without touching the global
+      // prototype, but getAllTrades still returns a non-array which makes
+      // downstream `find` throw — that's the pinned unsafe behavior above.
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ __proto__: { polluted: "yes" } }),
+      );
+
+      // The non-array storage makes getTradeOffer throw (TypeError); pin it.
+      expect(() => tradeManager.getTradeOffer("any")).toThrow(TypeError);
+      // Global prototype is not polluted regardless.
+      expect(({} as { polluted?: unknown }).polluted).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // 4. Non-atomic read-modify-write (QA §4.7 — two concurrent tabs)
+  // -------------------------------------------------------------------
+  describe("two-tab write race (pins QA-4.7 lost update)", () => {
+    /** Build a minimal but valid TradeOffer for direct storage manipulation. */
+    function offer(id: string): TradeOffer {
+      return {
+        id,
+        parties: [
+          {
+            id: "pA",
+            name: "A",
+            offeredCards: [],
+            wantedCards: [],
+            status: "pending",
+          },
+          {
+            id: "pB",
+            name: "B",
+            offeredCards: [],
+            wantedCards: [],
+            status: "pending",
+          },
+        ],
+        status: "draft",
+        createdAt: 1,
+        updatedAt: 1,
+      };
+    }
+
+    it("a later-writing tab with a stale snapshot silently overwrites the first", () => {
+      expect(readRawTrades()).toEqual([]);
+
+      // Both tabs read BEFORE either writes → both hold an empty snapshot.
+      const snapA = readRawTrades() as TradeOffer[];
+      const snapB = readRawTrades() as TradeOffer[];
+
+      const offerA = offer("trade-A");
+      const offerB = offer("trade-B");
+
+      // Interleaving: A writes from snapA ([] + A → [A]), then B writes from
+      // its STALE snapB ([] + B → [B]) — overwriting A entirely.
+      tabWriteFromSnapshot(snapA, offerA);
+      tabWriteFromSnapshot(snapB, offerB);
+
+      // Pin the real (unsafe) behavior: offerA is GONE (lost update). A future
+      // atomic / compare-and-swap migration must flip this to .not.toBeNull().
+      expect(tradeManager.getTradeOffer("trade-A")).toBeNull();
+      expect(tradeManager.getTradeOffer("trade-B")).not.toBeNull();
+    });
+
+    it("records two setItem calls — the last write wins (lost update)", () => {
+      const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+
+      const snap: TradeOffer[] = []; // both tabs capture the same empty state
+      tabWriteFromSnapshot(snap, offer("trade-A"));
+      tabWriteFromSnapshot(snap, offer("trade-B")); // stale snapshot
+
+      const final = readRawTrades() as TradeOffer[];
+      expect(final.map((t) => t.id)).toEqual(["trade-B"]);
+      // Two writes occurred; the second one (trade-B) is the survivor.
+      expect(setItemSpy).toHaveBeenCalled();
+    });
+
+    it("contrast: sequential non-overlapping writes do NOT lose data", () => {
+      // When tab B reads AFTER tab A's write lands, its snapshot includes A,
+      // so both offers survive. This is the behavior a fix would guarantee
+      // unconditionally.
+      const snapA = readRawTrades() as TradeOffer[]; // []
+      tabWriteFromSnapshot(snapA, offer("trade-A")); // [A]
+
+      const snapBAfter = readRawTrades() as TradeOffer[]; // [A] — fresh
+      tabWriteFromSnapshot(snapBAfter, offer("trade-B")); // [A, B]
+
+      const final = readRawTrades() as TradeOffer[];
+      expect(final.map((t) => t.id).sort()).toEqual(["trade-A", "trade-B"]);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // 5. calculateTradeFairness (pure function)
+  // -------------------------------------------------------------------
+  describe("calculateTradeFairness", () => {
+    it("returns 'Incomplete trade' when either side has zero quantity", () => {
+      expect(calculateTradeFairness([], [makeCardItem()])).toEqual({
+        score: 0,
+        assessment: "Incomplete trade",
+      });
+      expect(calculateTradeFairness([makeCardItem()], [])).toEqual({
+        score: 0,
+        assessment: "Incomplete trade",
+      });
+    });
+
+    it("rates an equal-quantity trade as fair (score 1)", () => {
+      const res = calculateTradeFairness(
+        [makeCardItem({ quantity: 3 })],
+        [makeCardItem({ quantity: 3 })],
+      );
+      expect(res.score).toBe(1);
+      expect(res.assessment).toBe("Fair trade");
+    });
+
+    it("rates a ~0.8 ratio as slightly imbalanced", () => {
+      const res = calculateTradeFairness(
+        [makeCardItem({ quantity: 8 })],
+        [makeCardItem({ quantity: 10 })],
+      );
+      expect(res.score).toBeCloseTo(0.8, 5);
+      expect(res.assessment).toBe("Slightly imbalanced");
+    });
+
+    it("rates a ~0.6 ratio as imbalanced", () => {
+      const res = calculateTradeFairness(
+        [makeCardItem({ quantity: 6 })],
+        [makeCardItem({ quantity: 10 })],
+      );
+      expect(res.assessment).toBe("Imbalanced trade");
+    });
+
+    it("rates a <0.5 ratio as highly imbalanced", () => {
+      const res = calculateTradeFairness(
+        [makeCardItem({ quantity: 3 })],
+        [makeCardItem({ quantity: 10 })],
+      );
+      expect(res.assessment).toBe("Highly imbalanced");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds Jest suites for the four `src/lib/` modules flagged at 0% coverage by the linked issue, covering the three required axes (save/restore round-trips, version-mismatch handling, adversarial JSON) for each. Tests assert the **real** behavior of each module — they pin existing unsafe patterns (bare `JSON.parse`, non-atomic writes, enum coercion) so any future hardening is a deliberate, visible diff rather than a silent semantics shift.

## Per-module coverage

| File | Stmts before → after | Branches | Functions |
|------|----------------------|----------|-----------|
| `game-history.ts` | 29.24% → **89.62%** | 75.47% | 100% |
| `replay-buffer.ts` | 0% → **98%** | 89.72% | 97.14% |
| `replay-sharing.ts` | 0% → **94.69%** | 82.94% | 100% |
| `trading.ts` | 0% → **84.83%** | 70.37% | 93.02% |

All four clear the issue's >70% statements bar.

## What each suite covers

### `src/lib/__tests__/game-history.test.ts` (extended)
- **Round-trips**: sync (`getAllGameRecords`) + async (`getAllGameRecordsAsync` via IndexedDB, with localStorage fallback), 1000-entry cap semantics, optional-field preservation.
- **Version/schema**: pins QA-§3.9 — `JSON.parse(stored) as GameRecord[]` performs **no** validation; a non-array/object value is returned verbatim and downstream `getPlayerStats` then throws.
- **Adversarial**: malformed JSON (→ `[]` + logged error), `null`, oversized payload, and `__proto__` key (global prototype stays unpolluted). Plus `createGameRecord` + full `getPlayerStats` aggregation (per-mode/difficulty win rates, recent form).

### `src/lib/__tests__/trading.test.ts` (new)
- **Round-trips**: `createTradeOffer` → `getTradeOffer` deep-equal; persistence across a simulated reload (incl. added/offered/wanted cards).
- **Lifecycle**: draft → pending → accepted (both parties) → history entries; reject, counter, cancel (initiator-only), notes append, subscriber notifications, queries.
- **Version/schema / adversarial**: pins QA-§2.13/§4.7 — `getAllTrades()` does a bare `JSON.parse` with **no** try/catch, so malformed JSON propagates `SyntaxError` and non-array storage propagates `TypeError`. `__proto__` does not pollute the global prototype.
- **Two-tab race** (QA-§4.7): a faithful snapshot-based simulation of `saveTrade`'s non-atomic read-modify-write demonstrates the lost update (second writer with a stale snapshot silently overwrites the first), plus a contrast test showing sequential non-overlapping writes do not lose data.

### `src/lib/__tests__/replay-sharing.test.ts` (new)
- **Round-trips**: encode→decode is intentionally lossy (`minifyReplay` collapses `resultingState` to counts); asserts deep equality on every **preserved** field and that the reconstructed `resultingState` is a well-formed `GameState`. Covers single + multi-action replays.
- **Phase/status coercion** (QA-§2.8): pins that `(minified.t?.cp || Phase.UNTAP) as Phase` passes unknown phase strings through verbatim, and that a missing phase defaults to `UNTAP`.
- **Adversarial**: malformed base64 / invalid JSON / JSON `null` / missing-field object / `__proto__` all → `null`; `encodeReplayToURL` re-throws a descriptive error on a circular `action.data`.
- **URL guards**: `generateShareableURL` returns `null` past 8000 chars; `canShareViaURL` / `getEstimatedURLLength` mirrors it. Plus `getReplayFromCurrentURL`, file import/export (with jsdom `URL.createObjectURL`/`File.text` stubs), server share/import (fetch mocked with a `.ok`/`.json`-shaped response), and `copyShareableLink` (clipboard mocked).

### `src/lib/__tests__/replay-buffer.test.ts` (new)
- **Round-trip/integrity**: `addAction` → `getBufferedActions` preserves payload + `receivedAt`/`applied`; `addActions` de-duplicates by `action.id`; `maxBufferSize` trim evicts oldest-first while clamping `currentIndex`.
- **Boundaries**: `validateJoin` enforces `maxGameAge` (→ "Game is too old") and warns at >500 actions; `seekTo` bounds-checks and marks applied actions (no double-apply); `jumpToEnd` completes.
- **Playback** (fake timers): empty-buffer no-op, full playthrough → `completed`, event log, pause/resume idempotency, `setSpeed` restart, `stopReplay` halts, fast-forward at speed 16.
- **Adversarial**: pins that `addAction` performs **no** validation (accepts minimal/duplicate-id actions); 1000-action batch does not throw.
- Singleton: `getReplayBuffer` caches until `resetReplayBuffer`.

## Gaps pinned (no source changes — tests document real behavior)

These suites deliberately assert the **current** behavior rather than inventing safety that doesn't exist, so a hardening PR shows up as a clear diff:

1. **`game-history.ts:95,122,130`** — bare `JSON.parse(...) as GameRecord[]`, no schema validation (QA §3.9).
2. **`trading.ts` `getAllTrades`** — bare `JSON.parse` with no try/catch (QA §2.13); `saveTrade` is a non-atomic read-modify-write (QA §4.7).
3. **`replay-sharing.ts:477`** — `(minified.t?.cp || Phase.UNTAP) as Phase` coerces without enum validation (QA §2.8).
4. **`replay-buffer.ts`** — `addAction`/`addActions` accept arbitrary action shapes with no validation.

No source modules were modified.

## Validation

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (warnings only, per repo gate)
- `npm test -- --testPathPatterns="(trading|replay-sharing|replay-buffer|game-history)"` — **116/116 pass** (5 suites)
- Full suite: **8425 pass**, only the pre-existing `backup-compression.test.ts` failures on `main` (5 checksum/corruption tests, unrelated to these modules).

Closes #1432