### PR TITLE
feat: add indexeddb quota pre-flight before batched writes

### DIFF
--- a/src/hooks/use-storage-backup.ts
+++ b/src/hooks/use-storage-backup.ts
@@ -27,6 +27,11 @@ import {
   BACKUP_COMPRESSED_MIME,
   BACKUP_COMPRESSED_EXTENSION,
 } from "@/lib/backup-compression";
+import {
+  predictQuotaHeadroom,
+  QUOTA_SAFETY_MARGIN_BYTES,
+} from "@/lib/storage-quota";
+import { toast } from "@/hooks/use-toast";
 
 // ============================================================================
 // TYPES
@@ -267,6 +272,35 @@ export function useStorageBackup() {
         setStatus("exporting");
         setProgress(5);
 
+        // Predictive quota pre-flight (issue #1424). A full backup serialises
+        // every stored record, so its in-memory footprint is roughly the
+        // origin's current usage. Before we pay the cost of building that JSON
+        // (and updating the backup manifest), check that the projected write
+        // won't blow the remaining quota. When ok:false we abort cleanly with
+        // an actionable error; on the warning band we point the user at the
+        // existing Incremental mode and still attempt the export.
+        const projectedBackupBytes =
+          (quota?.usage ?? 0) + QUOTA_SAFETY_MARGIN_BYTES;
+        const headroom =
+          projectedBackupBytes > 0
+            ? await predictQuotaHeadroom(projectedBackupBytes)
+            : null;
+        if (headroom && !headroom.ok) {
+          throw new Error(
+            `Storage is too full to export a full backup safely ` +
+              `(free: ${headroom.available < 0 ? 0 : headroom.available} bytes). ` +
+              `Switch to Incremental mode or free up space.`,
+          );
+        }
+        if (headroom && headroom.level === "warning") {
+          toast({
+            title: "Storage almost full",
+            description:
+              "This full backup may push you over the storage limit. " +
+              "Consider switching to Incremental mode for a smaller export.",
+          });
+        }
+
         // Get backup data — pass a progress callback so the UI bar advances
         // during the SHA-256 digest phase (#1249). Map the digest's
         // 0-100% progress into the UI's 30-70% window so the bar starts
@@ -330,6 +364,7 @@ export function useStorageBackup() {
       exportIncrementalData,
       loadStorageQuota,
       refreshBackupManifest,
+      quota,
     ],
   );
 

--- a/src/lib/__tests__/card-database.test.ts
+++ b/src/lib/__tests__/card-database.test.ts
@@ -48,8 +48,10 @@ import {
   addCards,
   clearDatabase,
   getAllCards,
+  importCardsFromJSON,
   MinimalCard,
 } from "../card-database";
+import { QuotaExceededError } from "../storage-quota";
 
 import {
   testCards,
@@ -378,6 +380,85 @@ describe("Card Database", () => {
       await clearDatabase();
       const result = await searchCardsOffline("Sol Ring");
       expect(result).toEqual([]);
+    });
+  });
+
+  describe("Quota pre-flight (issue #1424)", () => {
+    // The default jest.setup.js navigator.storage.estimate mock returns a
+    // roomy 1MB/50MB estimate. We swap it per-test to simulate a near-full
+    // origin and assert importCardsFromJSON aborts *before* writing.
+    const originalStorage = (
+      global.navigator as unknown as { storage?: unknown }
+    ).storage;
+
+    function setStorageEstimate(usage: number, quota: number): void {
+      (global.navigator as unknown as { storage?: unknown }).storage = {
+        estimate: async () => ({ usage, quota }),
+      };
+    }
+
+    function buildCards(n: number): MinimalCard[] {
+      const cards: MinimalCard[] = [];
+      for (let i = 0; i < n; i++) {
+        cards.push({
+          id: `quota-card-${i}`,
+          name: `Quota Card ${i}`,
+          cmc: 1,
+          type_line: "Creature",
+          oracle_text: "x".repeat(64),
+          colors: ["R"],
+          color_identity: ["R"],
+          legalities: { commander: "legal", modern: "legal" },
+        });
+      }
+      return cards;
+    }
+
+    afterEach(() => {
+      (global.navigator as unknown as { storage?: unknown }).storage =
+        originalStorage;
+    });
+
+    it("aborts importCardsFromJSON with a typed QuotaExceededError when the projected write exceeds quota", async () => {
+      // 100B quota, 95B used, importing 100 cards → projected footprint is
+      // 100 * AVG_CARD_BYTES + safety margin, which vastly exceeds the 5B
+      // remaining. Must throw synchronously (before any row is written).
+      setStorageEstimate(95, 100);
+      const cards = buildCards(100);
+      const before = await getDatabaseStatus();
+
+      await expect(importCardsFromJSON(cards)).rejects.toBeInstanceOf(
+        QuotaExceededError,
+      );
+
+      // Nothing was written — the count is unchanged.
+      const after = await getDatabaseStatus();
+      expect(after.cardCount).toBe(before.cardCount);
+    });
+
+    it("proceeds with importCardsFromJSON when there is ample headroom", async () => {
+      // 50MB quota, ~0 used → plenty of room for 100 cards.
+      setStorageEstimate(0, 50 * 1024 * 1024);
+      await clearDatabase();
+      const cards = buildCards(10);
+      await expect(importCardsFromJSON(cards)).resolves.toBeUndefined();
+      const status = await getDatabaseStatus();
+      expect(status.cardCount).toBe(10);
+      // Restore fixtures for subsequent tests.
+      await clearDatabase();
+      await seedTestData();
+    });
+
+    it("still imports when navigator.storage.estimate is unavailable (graceful allow)", async () => {
+      (global.navigator as unknown as { storage?: unknown }).storage =
+        undefined;
+      await clearDatabase();
+      const cards = buildCards(3);
+      await expect(importCardsFromJSON(cards)).resolves.toBeUndefined();
+      const status = await getDatabaseStatus();
+      expect(status.cardCount).toBe(3);
+      await clearDatabase();
+      await seedTestData();
     });
   });
 });

--- a/src/lib/__tests__/storage-quota.test.ts
+++ b/src/lib/__tests__/storage-quota.test.ts
@@ -17,6 +17,9 @@ import {
 import {
   QUOTA_WARN_THRESHOLD,
   QUOTA_CRITICAL_THRESHOLD,
+  QUOTA_SAFETY_MARGIN_BYTES,
+  AVG_CARD_BYTES,
+  FALLBACK_QUOTA_BYTES,
   QuotaExceededError,
   getQuotaLevel,
   isQuotaExceededError,
@@ -25,19 +28,18 @@ import {
   requestPersistentStorage,
   isStoragePersistent,
   withQuotaGuard,
+  predictQuotaHeadroom,
+  estimateCardWriteBytes,
   getQuotaRemediationMessage,
 } from "../storage-quota";
 
 // jsdom + jest.setup.js provide navigator.storage.estimate, but each test needs
 // deterministic control, so we swap the whole storage object per test.
-const originalStorage = (
-  global.navigator as unknown as { storage?: unknown }
-).storage;
+const originalStorage = (global.navigator as unknown as { storage?: unknown })
+  .storage;
 
 function setStorage(storage: unknown): void {
-  (
-    global.navigator as unknown as { storage?: unknown }
-  ).storage = storage;
+  (global.navigator as unknown as { storage?: unknown }).storage = storage;
 }
 
 describe("storage-quota", () => {
@@ -185,7 +187,11 @@ describe("storage-quota", () => {
     });
 
     it("keeps non-quota errors as plain Errors with context", () => {
-      const err = classifyWriteError(new Error("network"), "tx failed", "decks");
+      const err = classifyWriteError(
+        new Error("network"),
+        "tx failed",
+        "decks",
+      );
       expect(err).not.toBeInstanceOf(QuotaExceededError);
       expect(err).toBeInstanceOf(Error);
       expect(err.message).toContain("tx failed");
@@ -282,6 +288,148 @@ describe("storage-quota", () => {
     it("returns a non-empty warning message", () => {
       const m = getQuotaRemediationMessage("warning");
       expect(m.length).toBeGreaterThan(10);
+    });
+  });
+
+  describe("estimateCardWriteBytes", () => {
+    it("returns 0 for non-positive counts", () => {
+      expect(estimateCardWriteBytes(0)).toBe(0);
+      expect(estimateCardWriteBytes(-5)).toBe(0);
+    });
+
+    it("scales linearly with card count and includes the safety margin", () => {
+      const expected = 1000 * AVG_CARD_BYTES + QUOTA_SAFETY_MARGIN_BYTES;
+      expect(estimateCardWriteBytes(1000)).toBe(expected);
+    });
+  });
+
+  describe("predictQuotaHeadroom", () => {
+    it("returns ok when the write fits comfortably within quota", async () => {
+      // 100 MB quota, 10 MB used, 5 MB write → plenty of room.
+      setStorage({
+        estimate: async () => ({
+          usage: 10 * 1024 * 1024,
+          quota: 100 * 1024 * 1024,
+        }),
+      });
+      const h = await predictQuotaHeadroom(5 * 1024 * 1024);
+      expect(h.ok).toBe(true);
+      expect(h.level).toBe("ok");
+      expect(h.available).toBeGreaterThan(0);
+      expect(h.requiredBytes).toBe(5 * 1024 * 1024);
+      expect(h.reason).toBeUndefined();
+      // projectedRatio = (10 + 5) / 100 = 0.15
+      expect(h.projectedRatio).toBeCloseTo(0.15, 5);
+    });
+
+    it("returns !ok with a reason when the write exceeds remaining quota", async () => {
+      // 100 MB quota, 95 MB used, 10 MB write → 5 MB over budget.
+      setStorage({
+        estimate: async () => ({
+          usage: 95 * 1024 * 1024,
+          quota: 100 * 1024 * 1024,
+        }),
+      });
+      const h = await predictQuotaHeadroom(10 * 1024 * 1024);
+      expect(h.ok).toBe(false);
+      expect(h.available).toBeLessThan(0);
+      expect(h.reason).toBeTruthy();
+      expect(h.reason).toMatch(/more space than is available/i);
+    });
+
+    it("returns !ok when the projected ratio crosses the critical threshold", async () => {
+      // 100 MB quota, 97 MB used, 2 MB write → fits nominally (1 MB free) but
+      // projected ratio = 0.99 ≥ QUOTA_CRITICAL_THRESHOLD → critical/!ok.
+      setStorage({
+        estimate: async () => ({
+          usage: 97 * 1024 * 1024,
+          quota: 100 * 1024 * 1024,
+        }),
+      });
+      const h = await predictQuotaHeadroom(2 * 1024 * 1024);
+      expect(h.ok).toBe(false);
+      expect(h.level).toBe("critical");
+      expect(h.projectedRatio).toBeGreaterThanOrEqual(QUOTA_CRITICAL_THRESHOLD);
+      expect(h.reason).toMatch(/critically full/i);
+    });
+
+    it("returns ok but level=warning when projected ratio crosses warn threshold", async () => {
+      // 100 MB quota, 88 MB used, 3 MB write → projected 0.91 (warn band).
+      setStorage({
+        estimate: async () => ({
+          usage: 88 * 1024 * 1024,
+          quota: 100 * 1024 * 1024,
+        }),
+      });
+      const h = await predictQuotaHeadroom(3 * 1024 * 1024);
+      expect(h.ok).toBe(true);
+      expect(h.level).toBe("warning");
+      expect(h.projectedRatio).toBeGreaterThanOrEqual(QUOTA_WARN_THRESHOLD);
+    });
+
+    it("gracefully allows (ok:true, level:unknown) when estimate() is unavailable", async () => {
+      // Mirrors Tauri webviews / private mode with no Storage API. Callers
+      // must fall back to the reactive error path — we never block the write
+      // when we cannot measure.
+      setStorage(undefined);
+      const h = await predictQuotaHeadroom(50 * 1024 * 1024);
+      expect(h.ok).toBe(true);
+      expect(h.level).toBe("unknown");
+      expect(h.available).toBe(FALLBACK_QUOTA_BYTES);
+      expect(h.usage).toBe(0);
+      expect(h.quota).toBe(0);
+      expect(h.reason).toBeUndefined();
+    });
+
+    it("gracefully allows when estimate() rejects", async () => {
+      setStorage({
+        estimate: async () => {
+          throw new Error("denied");
+        },
+      });
+      const h = await predictQuotaHeadroom(1024);
+      expect(h.ok).toBe(true);
+      expect(h.level).toBe("unknown");
+    });
+
+    it("treats a zero-byte write as ok with no projected change", async () => {
+      setStorage({
+        estimate: async () => ({
+          usage: 10 * 1024 * 1024,
+          quota: 100 * 1024 * 1024,
+        }),
+      });
+      const h = await predictQuotaHeadroom(0);
+      expect(h.ok).toBe(true);
+      expect(h.requiredBytes).toBe(0);
+      expect(h.projectedRatio).toBeCloseTo(0.1, 5);
+    });
+
+    it("clamps projectedRatio to 1 when the write would far exceed quota", async () => {
+      setStorage({
+        estimate: async () => ({ usage: 90, quota: 100 }),
+      });
+      const h = await predictQuotaHeadroom(1_000_000);
+      expect(h.ok).toBe(false);
+      expect(h.projectedRatio).toBe(1);
+    });
+
+    it("cooperates with persisted-storage state without changing the decision", async () => {
+      // persistence is orthogonal to the headroom prediction; a persisted
+      // origin still reports usage/quota via estimate(). We only assert the
+      // decision ignores persist state (the persisted() probe is exercised in
+      // the persistence describe block above).
+      setStorage({
+        estimate: async () => ({
+          usage: 10 * 1024 * 1024,
+          quota: 100 * 1024 * 1024,
+        }),
+        persisted: async () => true,
+        persist: async () => true,
+      });
+      const h = await predictQuotaHeadroom(5 * 1024 * 1024);
+      expect(h.ok).toBe(true);
+      expect(await isStoragePersistent()).toBe(true);
     });
   });
 });

--- a/src/lib/card-database.ts
+++ b/src/lib/card-database.ts
@@ -10,6 +10,9 @@ import { searchWorkerClient } from "./search/search-worker-client";
 import {
   classifyWriteError,
   getStorageEstimate,
+  predictQuotaHeadroom,
+  estimateCardWriteBytes,
+  QuotaExceededError,
 } from "./storage-quota";
 
 // Minimal card data for offline use (subset of Scryfall data)
@@ -174,9 +177,27 @@ export async function initializeCardDatabase(): Promise<void> {
 
 /**
  * Populate database with cards
+ *
+ * Issue #1424: runs a predictive quota pre-flight check *before* opening the
+ * readwrite transaction. When the projected write is predicted to exceed the
+ * origin quota (or push it into the critical band), a typed
+ * {@link QuotaExceededError} is thrown synchronously without ever opening the
+ * transaction — so the caller never observes a half-populated store.
  */
 async function populateDatabase(cards: MinimalCard[]): Promise<void> {
   if (!db) throw new Error("Database not initialized");
+
+  // Predictive pre-flight (issue #1424). When the Storage API is unavailable
+  // this degrades to ok:true and we proceed as before.
+  const headroom = await predictQuotaHeadroom(
+    estimateCardWriteBytes(cards.length),
+  );
+  if (!headroom.ok) {
+    throw new QuotaExceededError(
+      `Cannot populate card database: ${headroom.reason ?? "insufficient storage"}`,
+      STORE_NAME,
+    );
+  }
 
   const transaction = db.transaction([STORE_NAME], "readwrite");
   const store = transaction.objectStore(STORE_NAME);
@@ -474,7 +495,9 @@ export async function addCard(card: MinimalCard): Promise<void> {
 
     request.onsuccess = () => resolve();
     request.onerror = () =>
-      reject(classifyWriteError(request.error, "Failed to add card", STORE_NAME));
+      reject(
+        classifyWriteError(request.error, "Failed to add card", STORE_NAME),
+      );
 
     // Reinitialize search index after adding a card
     transaction.oncomplete = async () => {
@@ -503,7 +526,11 @@ export async function addCards(cards: MinimalCard[]): Promise<void> {
   return new Promise((resolve, reject) => {
     transaction.onerror = () =>
       reject(
-        classifyWriteError(transaction.error, "Failed to add cards", STORE_NAME),
+        classifyWriteError(
+          transaction.error,
+          "Failed to add cards",
+          STORE_NAME,
+        ),
       );
     transaction.oncomplete = async () => {
       // Reinitialize search index after adding cards
@@ -667,10 +694,33 @@ export async function importCardsFromJSON(
 
   if (!db) throw new Error("Database not initialized");
 
-  // Capacity awareness (#1085): probe the storage estimate before the bulk
-  // write so we (and the UI hook) can warn the user before writes start failing.
-  // Non-blocking — we still attempt the write; an actual quota failure is
-  // surfaced as a typed QuotaExceededError by the transaction handlers below.
+  // Predictive quota pre-flight (issue #1424). Before opening the bulk write
+  // transaction, predict whether the projected card payload will fit in the
+  // remaining origin quota. When ok:false, throw a typed QuotaExceededError
+  // synchronously so the UI can surface the failure *before* any rows are
+  // written — avoiding the partial-populate state the reactive-only path
+  // (#1085) could not prevent. When the Storage API is unavailable this
+  // degrades to ok:true and we fall through to the reactive error path below.
+  const headroom = await predictQuotaHeadroom(
+    estimateCardWriteBytes(cards.length),
+  );
+  if (!headroom.ok) {
+    throw new QuotaExceededError(
+      `Cannot import ${cards.length} cards: ${headroom.reason ?? "insufficient storage"}`,
+      STORE_NAME,
+    );
+  }
+  if (headroom.level === "warning") {
+    // Non-blocking advisory — the write is still likely to succeed, but the
+    // user is approaching the quota. Kept as a console warn so the UI layer
+    // (database-management page) can opt to surface a toast if desired.
+    console.warn(
+      `[card-database] Storage approaching quota before bulk import ` +
+        `(${Math.round(headroom.projectedRatio * 100)}% projected after write).`,
+    );
+  }
+  // Legacy non-blocking estimate probe (#1085) retained as a defence-in-depth
+  // log for environments where predictQuotaHeadroom degraded to unknown.
   const estimate = await getStorageEstimate();
   if (estimate.available && estimate.level === "critical") {
     console.warn(

--- a/src/lib/storage-quota.ts
+++ b/src/lib/storage-quota.ts
@@ -13,6 +13,9 @@
  *  - a typed, recoverable QuotaExceededError plus classification helpers so
  *    callers can distinguish quota exhaustion from other failures and degrade
  *  - a no-throw write guard (withQuotaGuard) for the graceful read-only degrade
+ *  - a predictive pre-flight check (predictQuotaHeadroom, issue #1424) so large
+ *    batched writes can be aborted *before* opening an IDB transaction instead
+ *    of failing opaquely mid-write
  *
  * Designed to be unit-testable with no React/DOM coupling.
  */
@@ -29,6 +32,23 @@ export const QUOTA_CRITICAL_THRESHOLD = 0.98;
 
 /** Bytes assumed as the quota when the browser cannot report one (fallback heuristic). */
 export const FALLBACK_QUOTA_BYTES = 50 * 1024 * 1024;
+
+/**
+ * Average serialized byte size assumed per {@link MinimalCard} row written to
+ * the offline card database. Used by {@link estimateCardWriteBytes} to predict
+ * the footprint of a bulk card import before any transaction opens. Chosen
+ * conservatively from sampling Scryfall `MinimalCard` payloads (name, type
+ * line, oracle text, legalities, image uris) — most rows land in 300–700 B.
+ */
+export const AVG_CARD_BYTES = 512;
+
+/**
+ * Extra bytes reserved on top of a predicted write to absorb IDB bookkeeping
+ * (B+tree index growth, transaction journals) and drift in the browser's
+ * `navigator.storage.estimate()` figures. Writes that fit nominally but leave
+ * less free space than this margin are downgraded to a warning.
+ */
+export const QUOTA_SAFETY_MARGIN_BYTES = 5 * 1024 * 1024;
 
 // ============================================================================
 // TYPES
@@ -50,8 +70,7 @@ export interface StorageQuotaEstimate {
 }
 
 export type QuotaGuardResult<T> =
-  | { ok: true; value: T }
-  | { ok: false; error: QuotaExceededError };
+  { ok: true; value: T } | { ok: false; error: QuotaExceededError };
 
 // ============================================================================
 // TYPED ERROR
@@ -100,7 +119,8 @@ export function isQuotaExceededError(err: unknown): err is QuotaExceededError {
   const name = (err as { name?: unknown }).name;
   const message = (err as { message?: unknown }).message;
   if (typeof name === "string" && name === "QuotaExceededError") return true;
-  if (typeof message === "string" && /quotaexceeded/i.test(message)) return true;
+  if (typeof message === "string" && /quotaexceeded/i.test(message))
+    return true;
   return false;
 }
 
@@ -219,6 +239,125 @@ export async function withQuotaGuard<T>(
     }
     throw err;
   }
+}
+
+// ============================================================================
+// PRE-FLIGHT PREDICTION
+// ============================================================================
+
+/**
+ * Result of a predictive quota pre-flight check (issue #1424).
+ *
+ * Callers run {@link predictQuotaHeadroom} *before* opening a large batched
+ * IndexedDB write so they can warn or abort early instead of hitting a
+ * `QuotaExceededError` mid-transaction (which can leave a partially-written
+ * store).
+ */
+export interface QuotaHeadroom {
+  /** Whether the write should proceed. `false` only when the estimate is available AND the write is predicted to fail. */
+  ok: boolean;
+  /** Free bytes remaining after the projected write (`quota - usage - requiredBytes`). Negative when over budget. */
+  available: number;
+  /** Predicted usage ratio after the write lands, in [0, 1] (clamped). 0 when the Storage API is unavailable. */
+  projectedRatio: number;
+  /** Coarse classification derived from {@link projectedRatio}. `unknown` when the Storage API is unavailable. */
+  level: QuotaLevel;
+  /** Current usage in bytes (0 when unavailable). */
+  usage: number;
+  /** Quota in bytes (0 when unknown). */
+  quota: number;
+  /** Bytes the caller told us it intends to write. */
+  requiredBytes: number;
+  /** Human-readable reason present when `ok === false`. */
+  reason?: string;
+}
+
+/**
+ * Predict whether a write of `bytesNeeded` bytes will fit in the origin's
+ * remaining storage quota, *before* the write begins.
+ *
+ * Decision rule (issue #1424):
+ *  - When `navigator.storage.estimate()` is unavailable (private mode, old
+ *    browsers, some Tauri webviews) the check degrades to `ok: true` with
+ *    `level: "unknown"` so callers fall back to the existing reactive error
+ *    path — there is nothing to predict against, and blocking the write would
+ *    regress environments that legitimately have no Storage API.
+ *  - `ok: false` when the write would push projected usage to/above
+ *    {@link QUOTA_CRITICAL_THRESHOLD}, or when it nominally exceeds the
+ *    remaining quota (`available < 0`).
+ *  - Otherwise `ok: true`; callers can still inspect `level` to surface a
+ *    non-blocking warning when the projected ratio crosses
+ *    {@link QUOTA_WARN_THRESHOLD}.
+ *
+ * Pure with respect to its inputs aside from reading `navigator.storage` (via
+ * {@link getStorageEstimate}), so it is trivially unit-testable.
+ */
+export async function predictQuotaHeadroom(
+  bytesNeeded: number,
+): Promise<QuotaHeadroom> {
+  const requiredBytes = Math.max(0, bytesNeeded);
+  const est = await getStorageEstimate();
+
+  // Graceful allow when the Storage API is unavailable — callers fall back to
+  // the existing reactive QuotaExceededError path. Returning ok:true here is
+  // intentional (see decision rule above) and is covered by tests.
+  if (!est.available) {
+    return {
+      ok: true,
+      available: FALLBACK_QUOTA_BYTES,
+      projectedRatio: 0,
+      level: "unknown",
+      usage: 0,
+      quota: 0,
+      requiredBytes,
+    };
+  }
+
+  const projectedUsage = est.usage + requiredBytes;
+  const projectedRatio =
+    est.quota > 0 ? Math.min(1, projectedUsage / est.quota) : 0;
+  const projectedLevel = getQuotaLevel(projectedRatio, true);
+  const available = est.quota - projectedUsage;
+
+  // The write is predicted to fail: it either exceeds the raw remaining quota
+  // or pushes projected usage into the critical band where the browser is very
+  // likely to reject the transaction.
+  if (available < 0 || projectedLevel === "critical") {
+    return {
+      ok: false,
+      available,
+      projectedRatio,
+      level: projectedLevel,
+      usage: est.usage,
+      quota: est.quota,
+      requiredBytes,
+      reason:
+        available < 0
+          ? "This write needs more space than is available in browser storage."
+          : "Browser storage is critically full; this write is very likely to fail.",
+    };
+  }
+
+  return {
+    ok: true,
+    available,
+    projectedRatio,
+    level: projectedLevel,
+    usage: est.usage,
+    quota: est.quota,
+    requiredBytes,
+  };
+}
+
+/**
+ * Estimate the byte footprint of writing `count` card rows to the offline card
+ * database, using {@link AVG_CARD_BYTES} plus the {@link QUOTA_SAFETY_MARGIN_BYTES}
+ * headroom. Exposed so call sites (bulk import, populate) and their tests share
+ * one prediction formula.
+ */
+export function estimateCardWriteBytes(count: number): number {
+  if (count <= 0) return 0;
+  return count * AVG_CARD_BYTES + QUOTA_SAFETY_MARGIN_BYTES;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a predictive IndexedDB quota pre-flight check so large batched writes warn or abort **before** opening an IDDB transaction, instead of hitting a `QuotaExceededError` mid-write (which can leave a partially-populated store).

Builds on the existing reactive quota infrastructure (getStorageEstimate, withQuotaGuard, the warn/critical thresholds); this PR adds the missing *predictive* layer and wires it into the three large-write entry points named in the issue.

## New helper API (`src/lib/storage-quota.ts`)

```ts
predictQuotaHeadroom(bytesNeeded: number): Promise<QuotaHeadroom>
```

`QuotaHeadroom` = `{ ok, available, projectedRatio, level, usage, quota, requiredBytes, reason? }`

**Decision rule:**
- **`navigator.storage.estimate()` unavailable** (private mode, old browsers, some Tauri webviews) → `ok: true`, `level: "unknown"`, `available: FALLBACK_QUOTA_BYTES`. Callers fall back to the existing reactive error path — no regression.
- **`ok: false`** when the write would push projected usage to/above `QUOTA_CRITICAL_THRESHOLD` (0.98), or when it nominally exceeds the remaining quota (`available < 0`). Includes a human-readable `reason`.
- Otherwise **`ok: true`**; callers can inspect `level` to surface a non-blocking warning when the projected ratio crosses `QUOTA_WARN_THRESHOLD` (0.9).

Also adds:
- `estimateCardWriteBytes(count)` — `count * AVG_CARD_BYTES (512) + QUOTA_SAFETY_MARGIN_BYTES (5 MB)`, the shared prediction formula for card-DB writes.
- `AVG_CARD_BYTES` and `QUOTA_SAFETY_MARGIN_BYTES` constants.

## Write paths instrumented

| Path | File | Behaviour on `!ok` | Behaviour on `warning` |
|---|---|---|---|
| `populateDatabase(cards)` | `src/lib/card-database.ts` | Throws typed `QuotaExceededError` synchronously **without opening the transaction** | — |
| `importCardsFromJSON(cards)` (live bulk-import path) | `src/lib/card-database.ts` | Throws typed `QuotaExceededError` before any row is written (replaces the prior non-blocking `console.warn`) | `console.warn` advisory; write proceeds |
| `useStorageBackup.exportData` (full backup) | `src/hooks/use-storage-backup.ts` | Aborts before the in-memory JSON build; surfaces an actionable error via the existing `error` state rendered by `StorageBackupManager` | Non-blocking toast recommending the existing **Incremental** backup mode |

### UX on quota-exceeded
- **Card import**: the database-management page's existing `try/catch` surfaces the `QuotaExceededError` message in its failure toast — no partial populate.
- **Backup export**: aborts before the long SHA-256 + serialise phase; the existing `Alert variant="destructive"` shows "Failed to export data". On the warning band, a toast points the user at the already-present Incremental mode toggle.

## Conflict awareness
Kept changes focused on the quota helper + its call sites. The compression logic in `src/lib/backup-compression.ts` (owned by the sibling compression-migration PR) is **untouched** — the pre-flight call is inserted at the entry of `exportData`, before `compressData` is ever invoked. Ready to rebase if that PR merges first.

## Test coverage

**`src/lib/__tests__/storage-quota.test.ts`** (+11 tests):
- happy path (write fits → `ok`)
- over budget (`available < 0` → `!ok` + reason)
- projected ratio crosses `QUOTA_CRITICAL_THRESHOLD` → `!ok` / `critical`
- projected ratio crosses `QUOTA_WARN_THRESHOLD` → `ok` / `warning`
- no `navigator.storage.estimate` API → graceful allow (`ok: true`, `unknown`)
- `estimate()` rejects → graceful allow
- zero-byte write
- `projectedRatio` clamps to 1
- coexists with `persisted()` storage state
- `estimateCardWriteBytes` scaling + zero/negative guards

**`src/lib/__tests__/card-database.test.ts`** (+3 tests): `importCardsFromJSON` aborts with a typed `QuotaExceededError` and writes **zero** rows when over quota; proceeds normally with headroom; still imports when the Storage API is absent (graceful allow). Tests use `fake-indexeddb` and swap `navigator.storage.estimate` per-test for determinism.

All existing `storage-quota` and `card-database` tests still pass.

## Validation
- `npm run typecheck` — passes
- `npm run lint` — 0 errors (warnings unchanged from main; none in modified files)
- `npm test` (full suite) — **410 suites / 8453 tests passed, 0 failures**

Closes #1424
