### PR TITLE
fix(a11y): add progressbar role and sr-only score to format health gauge

### DIFF
--- a/src/components/meta/FormatHealthGauge.tsx
+++ b/src/components/meta/FormatHealthGauge.tsx
@@ -1,6 +1,6 @@
-'use client';
+"use client";
 
-import { cn } from '@/lib/utils';
+import { cn } from "@/lib/utils";
 
 interface FormatHealthGaugeProps {
   score: number;
@@ -8,21 +8,21 @@ interface FormatHealthGaugeProps {
 
 export default function FormatHealthGauge({ score }: FormatHealthGaugeProps) {
   const getScoreColor = (score: number) => {
-    if (score >= 70) return 'text-green-500';
-    if (score >= 40) return 'text-yellow-500';
-    return 'text-red-500';
+    if (score >= 70) return "text-green-500";
+    if (score >= 40) return "text-yellow-500";
+    return "text-red-500";
   };
 
   const getArcColor = (score: number) => {
-    if (score >= 70) return '#22c55e';
-    if (score >= 40) return '#eab308';
-    return '#ef4444';
+    if (score >= 70) return "#22c55e";
+    if (score >= 40) return "#eab308";
+    return "#ef4444";
   };
 
   const getHealthLabel = (score: number) => {
-    if (score >= 70) return 'Healthy';
-    if (score >= 40) return 'Moderate';
-    return 'Unhealthy';
+    if (score >= 70) return "Healthy";
+    if (score >= 40) return "Moderate";
+    return "Unhealthy";
   };
 
   const radius = 40;
@@ -35,11 +35,16 @@ export default function FormatHealthGauge({ score }: FormatHealthGaugeProps) {
   return (
     <div
       className="flex flex-col items-center"
-      role="img"
-      aria-label={`Format health gauge: ${score} out of 100, ${healthLabel.toLowerCase()}`}
+      role="progressbar"
+      aria-label="Format health score"
+      aria-valuenow={score}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuetext={`${healthLabel}, ${score} out of 100`}
     >
       <p className="sr-only">
-        Format health score is {score} out of 100, rated {healthLabel.toLowerCase()}.
+        Format health score: {score} out of 100, rated{" "}
+        {healthLabel.toLowerCase()}.
       </p>
       <div className="relative size-32" aria-hidden="true">
         <svg className="size-full -rotate-90" viewBox="0 0 100 100">
@@ -69,14 +74,14 @@ export default function FormatHealthGauge({ score }: FormatHealthGaugeProps) {
         </svg>
         {/* Score text in center */}
         <div className="absolute inset-0 flex flex-col items-center justify-center">
-          <span className={cn('text-3xl font-bold', getScoreColor(score))}>
+          <span className={cn("text-3xl font-bold", getScoreColor(score))}>
             {score}
           </span>
           <span className="text-xs text-muted-foreground">/ 100</span>
         </div>
       </div>
       <div className="mt-2 text-center">
-        <span className={cn('font-medium', getScoreColor(score))}>
+        <span className={cn("font-medium", getScoreColor(score))}>
           {healthLabel}
         </span>
         <p className="text-xs text-muted-foreground">Format Health Score</p>

--- a/src/components/meta/__tests__/meta-charts-a11y.test.tsx
+++ b/src/components/meta/__tests__/meta-charts-a11y.test.tsx
@@ -21,11 +21,17 @@ jest.mock("recharts", () => ({
   ResponsiveContainer: ({ children }: any) => (
     <div data-testid="responsive-container">{children}</div>
   ),
-  LineChart: ({ children }: any) => <div data-testid="line-chart">{children}</div>,
+  LineChart: ({ children }: any) => (
+    <div data-testid="line-chart">{children}</div>
+  ),
   Line: () => <div data-testid="line" />,
-  BarChart: ({ children }: any) => <div data-testid="bar-chart">{children}</div>,
+  BarChart: ({ children }: any) => (
+    <div data-testid="bar-chart">{children}</div>
+  ),
   Bar: () => <div data-testid="bar" />,
-  PieChart: ({ children }: any) => <div data-testid="pie-chart">{children}</div>,
+  PieChart: ({ children }: any) => (
+    <div data-testid="pie-chart">{children}</div>
+  ),
   Pie: () => <div data-testid="pie" />,
   XAxis: () => null,
   YAxis: () => null,
@@ -158,20 +164,51 @@ describe("ColorDistributionChart — screen-reader alternative", () => {
 });
 
 describe("FormatHealthGauge — screen-reader alternative", () => {
-  it("exposes a role=img with an accessible name describing the score", () => {
+  it("exposes a role=progressbar with name, value, and value-range attributes", () => {
     const { container } = render(<FormatHealthGauge score={82} />);
 
-    const img = container.querySelector('[role="img"]');
-    expect(img).not.toBeNull();
-    expect(img).toHaveAttribute(
+    const gauge = container.querySelector('[role="progressbar"]');
+    expect(gauge).not.toBeNull();
+    expect(gauge).toHaveAttribute(
       "aria-label",
-      expect.stringMatching(/format health gauge/i),
+      expect.stringMatching(/format health score/i),
     );
-    expect(img).toHaveAttribute("aria-label", expect.stringContaining("82"));
-    expect(img).toHaveAttribute(
-      "aria-label",
-      expect.stringContaining("healthy"),
+    expect(gauge).toHaveAttribute("aria-valuenow", "82");
+    expect(gauge).toHaveAttribute("aria-valuemin", "0");
+    expect(gauge).toHaveAttribute("aria-valuemax", "100");
+    // aria-valuetext conveys the tier + score so SRs speak
+    // "Healthy, 82 out of 100" rather than just "82".
+    expect(gauge).toHaveAttribute(
+      "aria-valuetext",
+      expect.stringMatching(/healthy, 82 out of 100/i),
     );
+  });
+
+  it("is queryable via getByRole('progressbar') with a descriptive name", () => {
+    const { getByRole } = render(<FormatHealthGauge score={55} />);
+
+    const gauge = getByRole("progressbar", {
+      name: /format health score/i,
+    });
+    expect(gauge).toHaveAttribute("aria-valuenow", "55");
+    expect(gauge).toHaveAttribute(
+      "aria-valuetext",
+      expect.stringMatching(/moderate, 55 out of 100/i),
+    );
+  });
+
+  it("clamps the value-range semantics to the 0-100 bounds", () => {
+    const { container } = render(<FormatHealthGauge score={20} />);
+
+    const gauge = container.querySelector('[role="progressbar"]');
+    expect(gauge).not.toBeNull();
+    const now = Number(gauge?.getAttribute("aria-valuenow"));
+    const min = Number(gauge?.getAttribute("aria-valuemin"));
+    const max = Number(gauge?.getAttribute("aria-valuemax"));
+    expect(min).toBe(0);
+    expect(max).toBe(100);
+    expect(now).toBeGreaterThanOrEqual(min);
+    expect(now).toBeLessThanOrEqual(max);
   });
 
   it("renders an sr-only description of the score", () => {
@@ -179,7 +216,7 @@ describe("FormatHealthGauge — screen-reader alternative", () => {
 
     const desc = container.querySelector(".sr-only");
     expect(desc).not.toBeNull();
-    expect(desc).toHaveTextContent(/format health score is 50/i);
+    expect(desc).toHaveTextContent(/format health score: 50/i);
     expect(desc).toHaveTextContent(/moderate/i);
   });
 


### PR DESCRIPTION
## Summary

Makes the `FormatHealthGauge` on the `/meta` dashboard perceivable to non-visual users by converting it from a presentational `role="img"` block into a proper ARIA range widget with a screen-reader-only description. The visible gauge (arc, score number, tier label) is unchanged.

Closes #1422

## What changed

`src/components/meta/FormatHealthGauge.tsx` — the wrapping container element now exposes:

- `role="progressbar"` (replaces the previous `role="img"`) so the gauge is announced as a range widget and is reachable via landmark/role navigation.
- `aria-label="Format health score"` — a concise, directly-exposed accessible name (not tooltip-only).
- `aria-valuenow={score}`, `aria-valuemin={0}`, `aria-valuemax={100}` — the numeric value and bounds.
- `aria-valuetext={`${tier}, ${score} out of 100`}` (e.g. `"Healthy, 82 out of 100"`) so screen readers speak the tier + value instead of just the number.
- An `sr-only` `<p>` element — `Format health score: {score} out of 100, rated {tier}.` — as an explicit text fallback for assistive tech that ignores `aria-valuetext`.

The decorative SVG arc continues to live inside an `aria-hidden="true"` wrapper, consistent with the convention used by the sibling meta charts, so the visual graphic is not double-announced.

## WCAG criteria addressed

- **1.1.1 Non-text Content (A)** — the SVG gauge has an explicit text alternative (accessible name + sr-only description).
- **4.1.2 Name, Role, Value (A)** — the widget exposes a programmatic role (`progressbar`), an accessible name (`aria-label`), and its value/range (`aria-valuenow` / `aria-valuemin` / `aria-valuemax` / `aria-valuetext`).

## Test coverage

Extended the existing `FormatHealthGauge` suite in `src/components/meta/__tests__/meta-charts-a11y.test.tsx`:

- Asserts `role="progressbar"` with `aria-label` matching `/format health score/i` and correct `aria-valuenow` / `aria-valuemin` / `aria-valuemax` / `aria-valuetext`.
- Asserts the gauge is queryable via `getByRole("progressbar", { name: /format health score/i })`.
- Asserts `aria-valuenow` is within the `[aria-valuemin, aria-valuemax]` bounds.
- Asserts the `sr-only` description is present and contains the score + tier.
- Asserts the decorative SVG remains hidden from AT (`aria-hidden`).

## Validation

- `npm run typecheck` — pass
- `npm run lint` — 0 errors (warnings only)
- `npm run a11y:contrast` — all 19 pairs pass
- `npm test` — full suite green (416 suites, 8526 tests)

## Scope note

This PR touches only `FormatHealthGauge` and its test, per the task boundary. Broader items from the issue that require editing other components (icon-based tier indicator swap, and the `aria-live` announcement on format/date-range change) are intentionally left for follow-up since they belong to other files.
