### PR TITLE
fix(a11y): add region/list semantics and live region to DraftPoolView

### DIFF
--- a/src/components/__tests__/draft-pool-view.test.tsx
+++ b/src/components/__tests__/draft-pool-view.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * DraftPoolView accessibility tests — issue #1421.
+ *
+ * Covers the three WCAG gaps called out in the issue:
+ *   - 1.3.1 (Info and Relationships): pool rendered as a real list with a
+ *     named region landmark wrapping the whole view.
+ *   - 1.4.1 (Use of Color): the "ready" state is conveyed by a visible
+ *     text + icon badge, not by the green count color alone.
+ *   - 4.1.3 (Status Messages): a polite `role="status"` live region announces
+ *     deck-readiness transitions, and the progress bar exposes
+ *     `aria-valuetext` mirroring the announced counts.
+ *
+ * The component calls `useRouter()` from `next/navigation`, so we mock that
+ * module. Radix `Card` / `ScrollArea` reach for `ResizeObserver`, which jsdom
+ * does not implement, so we install the same stub used by sibling tests.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import { DraftPoolView } from "../draft-pool-view";
+import type { PoolCard } from "@/lib/limited/types";
+
+// next/navigation is consumed by the component via useRouter().
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    refresh: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    prefetch: jest.fn(),
+  }),
+}));
+
+// Radix primitives (Card, ScrollArea) read ResizeObserver during layout.
+class RO {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (typeof globalThis.ResizeObserver === "undefined") {
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = RO;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MINIMUM_DECK_SIZE = 40;
+
+function makeCard(overrides: Partial<PoolCard> = {}): PoolCard {
+  return {
+    id: "card-1",
+    oracle_id: "oracle-1",
+    name: "Llanowar Elves",
+    set: "znr",
+    collector_number: "1",
+    cmc: 1,
+    type_line: "Creature — Elf Druid",
+    oracle_text: "{T}: Add {G}.",
+    colors: ["G"],
+    color_identity: ["G"],
+    rarity: "common",
+    legalities: {},
+    name_lower: "llanowar elves",
+    packId: 0,
+    packSlot: 0,
+    addedAt: "2024-01-01T00:00:00.000Z",
+    ...overrides,
+  } as PoolCard;
+}
+
+/** Build a pool of N distinct cards so the row count matches the pool size. */
+function makePool(count: number): PoolCard[] {
+  return Array.from({ length: count }, (_, i) =>
+    makeCard({ id: `card-${i}`, name: `Card ${i}` }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Region + list semantics (WCAG 1.3.1)
+// ---------------------------------------------------------------------------
+
+describe("DraftPoolView — structural semantics (#1421, WCAG 1.3.1)", () => {
+  it("wraps the view in a named region landmark", () => {
+    render(<DraftPoolView pool={makePool(2)} />);
+    expect(
+      screen.getByRole("region", { name: /draft card pool/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the pool as a list with an accessible name including the count", () => {
+    render(<DraftPoolView pool={makePool(3)} />);
+    const list = screen.getByRole("list", { name: /draft pool: 3 cards/i });
+    expect(list).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  it("renders no list when the pool is empty", () => {
+    render(<DraftPoolView pool={[]} />);
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/pick cards to build your pool/i),
+    ).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Progress bar exposes aria-valuetext (WCAG 1.3.1 / 4.1.3)
+// ---------------------------------------------------------------------------
+
+describe("DraftPoolView — progress bar aria-valuetext (#1421)", () => {
+  it("exposes aria-valuetext in the 'X of Y cards, Z to go' form while incomplete", () => {
+    render(<DraftPoolView pool={makePool(23)} sessionId="s1" />);
+    const bar = screen.getByRole("progressbar", { name: /deck completion/i });
+    expect(bar).toHaveAttribute("aria-valuetext", "23 of 40 cards, 17 to go");
+  });
+
+  it("drops the 'to go' suffix from aria-valuetext when the deck is ready", () => {
+    render(<DraftPoolView pool={makePool(40)} sessionId="s1" />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuetext", "40 of 40 cards");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Color not alone (WCAG 1.4.1)
+// ---------------------------------------------------------------------------
+
+describe("DraftPoolView — ready state is not conveyed by color alone (#1421, WCAG 1.4.1)", () => {
+  it("renders a 'Ready to build' badge with text + icon when the deck is ready", () => {
+    render(<DraftPoolView pool={makePool(40)} sessionId="s1" />);
+    // Visible text conveys readiness independently of the green color.
+    expect(screen.getByText(/ready to build/i)).toBeInTheDocument();
+    // The check icon is present and marked decorative (text carries meaning).
+    const badge = screen
+      .getByText(/ready to build/i)
+      .closest("[class*='border']");
+    expect(badge).not.toBeNull();
+  });
+
+  it("conveys the not-ready state with visible text rather than color", () => {
+    render(<DraftPoolView pool={makePool(38)} sessionId="s1" />);
+    expect(screen.queryByText(/ready to build/i)).not.toBeInTheDocument();
+    // The footer hint is textual, not color-only.
+    expect(
+      screen.getByText(`Pick ${MINIMUM_DECK_SIZE - 38} more cards`),
+    ).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ARIA live region for status messages (WCAG 4.1.3)
+// ---------------------------------------------------------------------------
+
+describe("DraftPoolView — live region announces readiness transitions (#1421, WCAG 4.1.3)", () => {
+  it("mounts a polite role=status live region with aria-atomic", () => {
+    render(<DraftPoolView pool={makePool(2)} />);
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveAttribute("aria-atomic", "true");
+  });
+
+  it("does not announce on the initial mount", () => {
+    render(<DraftPoolView pool={makePool(2)} />);
+    expect(screen.getByRole("status")).toHaveTextContent("");
+  });
+
+  it("announces 'Draft deck ready' when the pool crosses the minimum size", () => {
+    const { rerender } = render(<DraftPoolView pool={makePool(39)} />);
+    expect(screen.getByRole("status")).toHaveTextContent("");
+
+    rerender(<DraftPoolView pool={makePool(40)} />);
+    expect(screen.getByRole("status")).toHaveTextContent(
+      /draft deck ready — 40 of 40 cards/i,
+    );
+  });
+
+  it("announces 'Still need N cards' when a card is removed while incomplete", async () => {
+    const onRemoveCard = jest.fn((id: string) => {
+      // The parent normally mutates state; we simulate by rerendering below.
+      void id;
+    });
+    const pool = makePool(25);
+    const { rerender } = render(
+      <DraftPoolView pool={pool} onRemoveCard={onRemoveCard} />,
+    );
+
+    // Click the first remove button, then rerender with the card gone.
+    const removeButton = screen.getByRole("button", {
+      name: /remove card 0 from pool/i,
+    });
+    await userEvent.click(removeButton);
+    expect(onRemoveCard).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <DraftPoolView pool={pool.slice(1)} onRemoveCard={onRemoveCard} />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(
+      /still need 16 cards — 24 of 40 cards/i,
+    );
+  });
+
+  it("does not re-announce when neither readiness nor total changes", () => {
+    const { rerender } = render(<DraftPoolView pool={makePool(10)} />);
+    rerender(<DraftPoolView pool={makePool(10)} />);
+    expect(screen.getByRole("status")).toHaveTextContent("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pool row controls expose accessible names (WCAG 4.1.2 / #1101 consistency)
+// ---------------------------------------------------------------------------
+
+describe("DraftPoolView — pool row accessible names", () => {
+  it("names each remove button with the card it removes", () => {
+    render(<DraftPoolView pool={makePool(2)} onRemoveCard={jest.fn()} />);
+    expect(
+      screen.getByRole("button", { name: /remove card 0 from pool/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /remove card 1 from pool/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/draft-pool-view.tsx
+++ b/src/components/draft-pool-view.tsx
@@ -7,7 +7,7 @@
  * Phase 15: Draft Core
  */
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -15,7 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Progress } from "@/components/ui/progress";
-import { Package, Layers, Trash2 } from "lucide-react";
+import { Package, Layers, Trash2, CheckCircle2 } from "lucide-react";
 import type { PoolCard } from "@/lib/limited/types";
 
 // ============================================================================
@@ -95,6 +95,32 @@ export function DraftPoolView({
     return { uniqueCards, totalCards, progress, isDeckReady, colorCounts };
   }, [pool, groupedPool]);
 
+  // ARIA live region: announce deck-readiness transitions only (not every
+  // render). WCAG 4.1.3 (Status Messages). The ref pair tracks the previous
+  // readiness/total so the announcement fires on change, and the initial
+  // mount seeds the refs without announcing.
+  const [announcement, setAnnouncement] = useState("");
+  const prevReadyRef = useRef<boolean | null>(null);
+  const prevTotalRef = useRef<number>(stats.totalCards);
+  useEffect(() => {
+    if (prevReadyRef.current === null) {
+      prevReadyRef.current = stats.isDeckReady;
+      prevTotalRef.current = stats.totalCards;
+      return;
+    }
+    const readinessChanged = stats.isDeckReady !== prevReadyRef.current;
+    const totalChanged = stats.totalCards !== prevTotalRef.current;
+    prevReadyRef.current = stats.isDeckReady;
+    prevTotalRef.current = stats.totalCards;
+    if (!readinessChanged && !totalChanged) return;
+
+    setAnnouncement(
+      stats.isDeckReady
+        ? `Draft deck ready — ${stats.totalCards} of ${MINIMUM_DECK_SIZE} cards`
+        : `Still need ${MINIMUM_DECK_SIZE - stats.totalCards} cards — ${stats.totalCards} of ${MINIMUM_DECK_SIZE} cards`,
+    );
+  }, [stats.isDeckReady, stats.totalCards]);
+
   // Navigate to deck builder
   const handleBuildDeck = () => {
     if (sessionId) {
@@ -104,6 +130,8 @@ export function DraftPoolView({
 
   return (
     <Card
+      role="region"
+      aria-label="Draft card pool"
       className={cn(
         "flex flex-col h-full border-l-4 border-l-primary",
         className,
@@ -113,7 +141,7 @@ export function DraftPoolView({
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between">
           <CardTitle className="text-lg flex items-center gap-2">
-            <Package className="h-5 w-5" />
+            <Package className="h-5 w-5" aria-hidden="true" />
             Draft Pool
           </CardTitle>
           <Badge variant="secondary">{stats.totalCards} cards</Badge>
@@ -123,16 +151,39 @@ export function DraftPoolView({
         <div className="mt-2 space-y-1">
           <div className="flex items-center justify-between text-sm">
             <span className="text-muted-foreground">Progress</span>
-            <span
-              className={cn(
-                "font-medium",
-                stats.isDeckReady && "text-green-500",
+            <div className="flex items-center gap-2">
+              {/* Count text. Color reinforces ready state but is NOT the only
+                  signal — the "Ready to build" badge (text + icon) and the
+                  aria-live region below also convey it (WCAG 1.4.1). */}
+              <span
+                className={cn(
+                  "font-medium",
+                  stats.isDeckReady && "text-green-500",
+                )}
+              >
+                {stats.totalCards} / {MINIMUM_DECK_SIZE}
+              </span>
+              {stats.isDeckReady && (
+                <Badge
+                  variant="outline"
+                  className="gap-1 text-green-600 border-green-600"
+                >
+                  <CheckCircle2 className="h-3 w-3" aria-hidden="true" />
+                  Ready to build
+                </Badge>
               )}
-            >
-              {stats.totalCards} / {MINIMUM_DECK_SIZE}
-            </span>
+            </div>
           </div>
-          <Progress value={stats.progress} className="h-2" />
+          <Progress
+            value={stats.progress}
+            className="h-2"
+            aria-label="Deck completion"
+            aria-valuetext={`${stats.totalCards} of ${MINIMUM_DECK_SIZE} cards${
+              stats.isDeckReady
+                ? ""
+                : `, ${MINIMUM_DECK_SIZE - stats.totalCards} to go`
+            }`}
+          />
         </div>
       </CardHeader>
 
@@ -142,7 +193,10 @@ export function DraftPoolView({
           {groupedPool.length === 0 ? (
             <EmptyState />
           ) : (
-            <div className="space-y-1">
+            <ul
+              className="space-y-1 list-none p-0 m-0"
+              aria-label={`Draft pool: ${stats.totalCards} cards`}
+            >
               {groupedPool.map(([name, cards]) => (
                 <PoolCardRow
                   key={name}
@@ -153,7 +207,7 @@ export function DraftPoolView({
                   }
                 />
               ))}
-            </div>
+            </ul>
           )}
 
           {/* Show indicator if truncated */}
@@ -172,7 +226,7 @@ export function DraftPoolView({
           disabled={!sessionId || !stats.isDeckReady}
           className="w-full"
         >
-          <Layers className="h-4 w-4 mr-2" />
+          <Layers className="h-4 w-4 mr-2" aria-hidden="true" />
           Build Deck
         </Button>
         {!stats.isDeckReady && sessionId && (
@@ -180,6 +234,18 @@ export function DraftPoolView({
             Pick {MINIMUM_DECK_SIZE - stats.totalCards} more cards
           </p>
         )}
+      </div>
+
+      {/* Visually-hidden polite live region for deck-readiness transitions.
+          Announces only when readiness or total card count changes
+          (WCAG 4.1.3 Status Messages). */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {announcement}
       </div>
     </Card>
   );
@@ -200,7 +266,7 @@ function PoolCardRow({ card, quantity, onRemove }: PoolCardRowProps) {
   const imageUrl = card.image_uris?.small;
 
   return (
-    <div className="flex items-center gap-2 p-2 rounded-md hover:bg-muted/50 group">
+    <li className="flex items-center gap-2 p-2 rounded-md hover:bg-muted/50 group">
       {/* Card Thumbnail */}
       <div className="w-8 h-11 rounded overflow-hidden bg-muted shrink-0">
         {imageUrl ? (
@@ -229,6 +295,7 @@ function PoolCardRow({ card, quantity, onRemove }: PoolCardRowProps) {
         <Badge
           variant="secondary"
           className="h-5 w-5 p-0 flex items-center justify-center"
+          aria-label={`${quantity} copies`}
         >
           {quantity}
         </Badge>
@@ -239,14 +306,14 @@ function PoolCardRow({ card, quantity, onRemove }: PoolCardRowProps) {
         <Button
           variant="ghost"
           size="icon"
-          className="h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity"
+          className="h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity focus-visible:opacity-100"
           onClick={onRemove}
-          aria-label="Remove card"
+          aria-label={`Remove ${card.name} from pool`}
         >
-          <Trash2 className="h-3 w-3" />
+          <Trash2 className="h-3 w-3" aria-hidden="true" />
         </Button>
       )}
-    </div>
+    </li>
   );
 }
 
@@ -257,7 +324,10 @@ function PoolCardRow({ card, quantity, onRemove }: PoolCardRowProps) {
 function EmptyState() {
   return (
     <div className="flex flex-col items-center justify-center py-8 text-center">
-      <Package className="h-12 w-12 text-muted-foreground/50 mb-3" />
+      <Package
+        className="h-12 w-12 text-muted-foreground/50 mb-3"
+        aria-hidden="true"
+      />
       <p className="text-sm text-muted-foreground">
         Pick cards to build your pool
       </p>


### PR DESCRIPTION
## Summary

`DraftPoolView` (used on `/draft` and `/limited-deck-builder`) had three accessibility gaps. This PR is an a11y-only overlay — the visual design is preserved; status is now conveyed by structure, text, and announcements rather than color alone.

## Changes (`src/components/draft-pool-view.tsx`)

**Structural semantics (WCAG 1.3.1)**
- The whole view is wrapped in a named landmark: `role="region"` + `aria-label="Draft card pool"` on the root `Card`.
- The pool container changed from a bare `<div className="space-y-1">` to `<ul className="space-y-1 list-none p-0 m-0" aria-label="Draft pool: N cards">`, and each `PoolCardRow` now renders an `<li>` instead of a `<div>`. Screen-reader list navigation now works.

**Color not alone (WCAG 1.4.1)**
- The ready state was previously signaled **only** by `text-green-500` on the same `"40 / 40"` count text. Now, when the deck is ready, an explicit visible badge renders next to the count: `Ready to build` with a `CheckCircle2` lucide icon. The green count color is kept as reinforcement, but text + icon now carry the meaning independently of color. The not-ready state was already textual (`Pick N more cards`) and is unchanged.

**Status messages (WCAG 4.1.3)**
- Added a visually-hidden (`sr-only`) polite live region: `role="status"` + `aria-live="polite"` + `aria-atomic="true"`.
- Guarded by a ref pair so it announces **only on transition**, not on every render / initial mount. It fires when `isDeckReady` flips or when the total card count changes:
  - ready transition → `Draft deck ready — 40 of 40 cards`
  - still incomplete → `Still need N cards — M of 40 cards`
- This covers both the production pick flow (the `pool` prop changes externally) and the optional `onRemoveCard` flow.

**Progress bar**
- `<Progress>` now exposes `aria-label="Deck completion"` and `aria-valuetext="X of 40 cards"` (plus `, Z to go` while incomplete), so the bar conveys the same information as the live region.

**Minor a11y hygiene**
- Each row's remove button is now named with the card it acts on (`Remove <card name> from pool`) instead of the generic `"Remove card"`, and decorative icons (`Package`, `Layers`, `Trash2`, `CheckCircle2`) are marked `aria-hidden="true"`. The quantity badge exposes an `aria-label` for multi-copy rows.

## Tests (`src/components/__tests__/draft-pool-view.test.tsx`, new — 13 tests)

- region landmark resolves by name (`Draft card pool`)
- list resolves with accessible name including the count (`Draft pool: 3 cards`) and correct `listitem` count
- empty pool renders no list
- progressbar `aria-valuetext` is `23 of 40 cards, 17 to go` while incomplete and `40 of 40 cards` when ready
- ready state renders a `Ready to build` badge (text + icon), not color alone
- not-ready state conveys status via visible text (`Pick N more cards`)
- live region is `role=status` / `aria-live=polite` / `aria-atomic=true`
- no announcement on initial mount
- announces `Draft deck ready` on crossing the 40-card threshold
- announces `Still need N cards` when a card is removed while incomplete
- no re-announcement when neither readiness nor total changes
- remove buttons expose per-card accessible names

## WCAG criteria addressed
- **1.3.1 (Info and Relationships, A)** — list structure + region landmark are programmatically determinable.
- **1.4.1 (Use of Color, A)** — ready state has text + icon in addition to color.
- **4.1.3 (Status Messages, AA)** — deck-readiness transitions are announced via a polite live region.
- 4.1.2 / 1.3.1 — per-card control naming.

## Validation
- `npm run typecheck` — pass
- `npm run lint` — 0 errors (warnings pre-existing, under cap)
- `npm run a11y:contrast` — all 19 pairs pass
- `npm test -- --testPathPatterns=draft-pool-view` — 13/13 pass
- `npm test` (full suite) — 417 suites / 8537 tests pass, 0 failures (green on main, no new failures)

Closes #1421