### PR TITLE
refactor: migrate P2P console.warn/error calls to p2pLogger

### DIFF
--- a/src/lib/__tests__/mesh-game-connection.test.ts
+++ b/src/lib/__tests__/mesh-game-connection.test.ts
@@ -17,6 +17,7 @@ import {
   type MeshGameConnectionEvents,
 } from "../mesh-game-connection";
 import type { GameMessage } from "../p2p-game-connection";
+import { p2pLogger } from "../p2p-logger";
 
 /** The event handle: each callback is a jest.Mock so call sites can assert. */
 interface MockEvents {
@@ -1073,5 +1074,47 @@ describe("MeshGameConnection chat cap + sanitize (#1428)", () => {
       // Non-string senderName coerced to "" by the inbound guard.
       expect(events.onChat).toHaveBeenCalledWith("p1", "", "hi");
     });
+  });
+});
+
+/**
+ * Issue #1426 — the mesh warn/error paths must route through the shared
+ * `p2pLogger` (not raw `console.*`) so P2P logging stays leveled and
+ * prod-strippable. Covers a representative `.warn` and `.error` path.
+ */
+describe("MeshGameConnection logs through p2pLogger (#1426)", () => {
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(p2pLogger, "warn").mockImplementation(() => {});
+    errorSpy = jest.spyOn(p2pLogger, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("routes a malformed peer message to p2pLogger.error (not console)", () => {
+    const { mesh, events } = newMesh();
+    mesh.addPeerLink(new MockLink("p1"));
+    mesh.handleIncoming("{ not json", "p1");
+    expect(events.onMessage).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[MeshGameConnection] Rejected malformed peer message",
+      expect.anything(),
+    );
+  });
+
+  it("routes a duplicate/replay to p2pLogger.warn (not console)", () => {
+    const { mesh } = newMesh();
+    mesh.addPeerLink(new MockLink("p1"));
+    mesh.handleIncoming(inbound("p1", 5), "p1");
+    mesh.handleIncoming(inbound("p1", 5), "p1"); // duplicate seq
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[MeshGameConnection] Dropping duplicate/replay message",
+      expect.anything(),
+    );
   });
 });

--- a/src/lib/__tests__/p2p-game-connection.test.ts
+++ b/src/lib/__tests__/p2p-game-connection.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../p2p-game-connection";
 import { signMessageEnvelope } from "../p2p-json-validation";
 import { ValidationService } from "../game-state/validation-service";
+import { p2pLogger } from "../p2p-logger";
 
 describe("P2P Game Connection Types", () => {
   describe("GameMessageType", () => {
@@ -2446,5 +2447,69 @@ describe("P2PGameConnection chat cap + sanitize (#1428)", () => {
       expect(payload.senderName).not.toMatch(/[<>\u202E]/);
       expect(payload.senderName).toBe("Evilb");
     });
+  });
+});
+
+/**
+ * Issue #1426 — the data-channel warn/error paths must route through the
+ * shared `p2pLogger` (not raw `console.*`) so P2P logging stays leveled and
+ * prod-strippable. These cover a representative `.warn` and `.error` path.
+ */
+describe("P2PGameConnection logs through p2pLogger (#1426)", () => {
+  let connection: P2PGameConnection;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(p2pLogger, "warn").mockImplementation(() => {});
+    errorSpy = jest.spyOn(p2pLogger, "error").mockImplementation(() => {});
+    connection = createP2PGameConnection({
+      playerId: "player-1",
+      playerName: "Host",
+      role: "host",
+      events: {
+        onConnectionStateChange: () => {},
+        onSignalingStateChange: () => {},
+        onMessage: () => {},
+        onGameStateSync: () => {},
+        onChat: () => {},
+        onError: () => {},
+        onPlayerJoined: () => {},
+        onPlayerLeft: () => {},
+      },
+    });
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  const handleMessage = (raw: string) =>
+    (
+      connection as unknown as { handleMessage: (d: string) => void }
+    ).handleMessage(raw);
+
+  it("routes a malformed peer message to p2pLogger.error (not console)", () => {
+    handleMessage("{ not json");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[P2PGameConnection] Rejected malformed peer message",
+    );
+  });
+
+  it("routes a duplicate/replay to p2pLogger.warn (not console)", () => {
+    const raw = JSON.stringify({
+      type: "game-action",
+      senderId: "player-2",
+      timestamp: Date.now(),
+      seq: 4,
+      data: { action: "pass" },
+    });
+    handleMessage(raw);
+    handleMessage(raw); // same seq → dropped as a replay
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[P2PGameConnection] Dropping duplicate/replay message",
+      expect.anything(),
+    );
   });
 });

--- a/src/lib/mesh-game-connection.ts
+++ b/src/lib/mesh-game-connection.ts
@@ -72,6 +72,7 @@ import {
 import { safeParseJson } from "./p2p-json-validation";
 import { P2PRateLimiter, type P2PRateLimitOptions } from "./p2p-rate-limiter";
 import { redactSensitive } from "./p2p-log-redact";
+import { p2pLogger } from "./p2p-logger";
 import { AntiReplayTracker } from "./anti-replay-tracker";
 import {
   type PeerRole,
@@ -333,7 +334,7 @@ export class MeshGameConnection {
       return;
     }
     if (typeof key !== "string" || key.length === 0) {
-      console.warn(
+      p2pLogger.warn(
         "[MeshGameConnection] Ignoring invalid sessionKey (must be a non-empty hex string)",
       );
       return;
@@ -600,7 +601,7 @@ export class MeshGameConnection {
       return link.send(raw);
     } catch (error) {
       // #982: redact — transport errors may reference the payload/SDP.
-      console.error(
+      p2pLogger.error(
         "[MeshGameConnection] Failed to send to peer:",
         redactSensitive(error),
       );
@@ -706,7 +707,7 @@ export class MeshGameConnection {
       // 1. Per-link rate limit first — never do parse/validation work for a
       //    flooding peer.
       if (!this.ensureLimiter(fromPeerId).tryAcquire()) {
-        console.warn(
+        p2pLogger.warn(
           "[MeshGameConnection] Rate limit exceeded; dropping peer message",
           redactSensitive({ fromPeerId }),
         );
@@ -716,7 +717,7 @@ export class MeshGameConnection {
       // 2 + 3. Safe parse + structural limits + shape validation.
       const message = safeParseJson<GameMessage>(raw, isGameMessage);
       if (!message) {
-        console.error(
+        p2pLogger.error(
           "[MeshGameConnection] Rejected malformed peer message",
           redactSensitive({ fromPeerId }),
         );
@@ -725,7 +726,7 @@ export class MeshGameConnection {
 
       // 4. Anti-replay (per senderId, scales to N senders). Issue #1091.
       if (this.antiReplay.isReplay(message.senderId, message.seq)) {
-        console.warn(
+        p2pLogger.warn(
           "[MeshGameConnection] Dropping duplicate/replay message",
           redactSensitive({ senderId: message.senderId, seq: message.seq }),
         );
@@ -742,7 +743,7 @@ export class MeshGameConnection {
       //    counted once (the anti-replay check rejects it first).
       if (!isMessageAllowedForRole(this.localRoleFlag, message.type)) {
         this.spectatorDrops += 1;
-        console.warn(
+        p2pLogger.warn(
           "[MeshGameConnection] Dropped message disallowed for local role",
           redactSensitive({
             fromPeerId,
@@ -773,7 +774,7 @@ export class MeshGameConnection {
       this.dispatch(message, fromPeerId);
     } catch (error) {
       // Defensive: a handler bug must not tear down the mesh.
-      console.error(
+      p2pLogger.error(
         "[MeshGameConnection] Failed to handle message:",
         redactSensitive(error),
       );
@@ -972,7 +973,7 @@ export class MeshGameConnection {
       try {
         link.close();
       } catch (error) {
-        console.error(
+        p2pLogger.error(
           "[MeshGameConnection] Error closing peer link:",
           redactSensitive(error),
         );

--- a/src/lib/p2p-game-connection.ts
+++ b/src/lib/p2p-game-connection.ts
@@ -56,6 +56,7 @@ import {
   type ConnectionFailureDiagnostic,
 } from "./p2p-failure-diagnostics";
 import { redactSensitive } from "./p2p-log-redact";
+import { p2pLogger } from "./p2p-logger";
 import {
   type PeerRole,
   DEFAULT_PEER_ROLE,
@@ -809,7 +810,7 @@ export class P2PGameConnection {
       await this.signalingClient.addRemoteIceCandidates(candidates);
     } catch (error) {
       // #982: redact — candidate errors may embed ICE candidate blobs.
-      console.error(
+      p2pLogger.error(
         "[P2PGameConnection] Failed to process ICE candidates:",
         redactSensitive(error),
       );
@@ -849,7 +850,7 @@ export class P2PGameConnection {
     // local role is not allowed to originate.
     if (!isRoleAllowedToSend(this.localRoleFlag, message.type)) {
       const reason = rejectionReasonForSend(this.localRoleFlag, message.type);
-      console.warn(
+      p2pLogger.warn(
         "[P2PGameConnection] Refusing outbound message: local role disallows it",
         redactSensitive({
           type: message.type,
@@ -865,7 +866,7 @@ export class P2PGameConnection {
     // Remote role gate. If the remote is a non-player, suppress the
     // types the remote is not allowed to RECEIVE (currently `game-action`).
     if (!isMessageAllowedForRole(this.remoteRoleFlag, message.type)) {
-      console.warn(
+      p2pLogger.warn(
         "[P2PGameConnection] Refusing outbound message: remote role disallows it",
         redactSensitive({
           type: message.type,
@@ -875,7 +876,7 @@ export class P2PGameConnection {
       return false;
     }
     if (!this.dataChannel || this.dataChannel.readyState !== "open") {
-      console.warn("[P2PGameConnection] Data channel not ready");
+      p2pLogger.warn("[P2PGameConnection] Data channel not ready");
       return false;
     }
 
@@ -911,7 +912,7 @@ export class P2PGameConnection {
       inFlight,
     );
     if (!accepted) {
-      console.error(
+      p2pLogger.error(
         "[P2PGameConnection] Send queue rejected outbound message",
         redactSensitive({
           type: message.type,
@@ -946,7 +947,7 @@ export class P2PGameConnection {
         return true;
       } catch (error) {
         // #982: redact — send errors may reference the payload.
-        console.error(
+        p2pLogger.error(
           "[P2PGameConnection] Failed to send queued message:",
           redactSensitive(error),
         );
@@ -1043,7 +1044,7 @@ export class P2PGameConnection {
         this.localRoleFlag === "spectator"
           ? REJECT_SENT_AS_SPECTATOR
           : "Moderator peers may not originate game actions";
-      console.warn(
+      p2pLogger.warn(
         "[P2PGameConnection] Refusing game-action: local role is read-only",
         redactSensitive({ localRole: this.localRoleFlag, action }),
       );
@@ -1143,7 +1144,7 @@ export class P2PGameConnection {
       return;
     }
     if (typeof key !== "string" || key.length === 0) {
-      console.warn(
+      p2pLogger.warn(
         "[P2PGameConnection] Ignoring invalid sessionKey (must be a non-empty hex string)",
       );
       return;
@@ -1270,7 +1271,7 @@ export class P2PGameConnection {
 
     this.dataChannel.onerror = (event) => {
       // #982: redact — data channel error events may embed diagnostic info.
-      console.error(
+      p2pLogger.error(
         "[P2PGameConnection] Data channel error:",
         redactSensitive(event),
       );
@@ -1281,7 +1282,7 @@ export class P2PGameConnection {
 
     this.dataChannel.onmessage = (event) => {
       if (typeof event.data !== "string") {
-        console.warn("[P2PGameConnection] Received non-string message");
+        p2pLogger.warn("[P2PGameConnection] Received non-string message");
         return;
       }
       this.handleMessage(event.data);
@@ -1327,7 +1328,7 @@ export class P2PGameConnection {
     try {
       // Rate-limit first: never do parse/validation work for a flooding peer.
       if (!this.rateLimiter.tryAcquire()) {
-        console.warn(
+        p2pLogger.warn(
           "[P2PGameConnection] Rate limit exceeded; dropping peer message",
         );
         return;
@@ -1347,12 +1348,12 @@ export class P2PGameConnection {
         );
         if (!envelope) {
           this.envelopeRejections += 1;
-          console.warn("[P2PGameConnection] Rejected malformed envelope");
+          p2pLogger.warn("[P2PGameConnection] Rejected malformed envelope");
           return;
         }
         if (!verifyMessageEnvelope(envelope, this.sessionKeyHex)) {
           this.envelopeRejections += 1;
-          console.warn(
+          p2pLogger.warn(
             "[P2PGameConnection] envelope-sender-mismatch; dropping forged envelope",
             redactSensitive({
               declaredSender: envelope.payload?.senderId,
@@ -1368,7 +1369,9 @@ export class P2PGameConnection {
         const legacy = safeParseJson<GameMessage>(data, isGameMessage);
         if (!legacy) {
           // Malformed JSON or wrong shape — reject without breaking the channel.
-          console.error("[P2PGameConnection] Rejected malformed peer message");
+          p2pLogger.error(
+            "[P2PGameConnection] Rejected malformed peer message",
+          );
           return;
         }
         message = legacy;
@@ -1378,7 +1381,7 @@ export class P2PGameConnection {
       // message can touch game state. This runs after shape validation so
       // `message.seq` is guaranteed to be a non-negative integer.
       if (this.isReplay(message)) {
-        console.warn(
+        p2pLogger.warn(
           "[P2PGameConnection] Dropping duplicate/replay message",
           redactSensitive({ senderId: message.senderId, seq: message.seq }),
         );
@@ -1395,7 +1398,7 @@ export class P2PGameConnection {
       // counted once (the anti-replay check rejects it first).
       if (!isMessageAllowedForRole(this.localRoleFlag, message.type)) {
         this.spectatorDrops += 1;
-        console.warn(
+        p2pLogger.warn(
           "[P2PGameConnection] Dropped message disallowed for local role",
           redactSensitive({
             type: message.type,
@@ -1482,7 +1485,7 @@ export class P2PGameConnection {
       this.events.onMessage(message);
     } catch (error) {
       // #982: redact — handler errors may reference the peer message payload.
-      console.error(
+      p2pLogger.error(
         "[P2PGameConnection] Failed to handle message:",
         redactSensitive(error),
       );
@@ -1682,7 +1685,7 @@ export class P2PGameConnection {
       state = this.onStateSyncRequest();
     } catch (error) {
       // #982: redact — a throwing host callback may reference game state.
-      console.error(
+      p2pLogger.error(
         "[P2PGameConnection] onStateSyncRequest threw:",
         redactSensitive(error),
       );
@@ -1703,7 +1706,7 @@ export class P2PGameConnection {
   private handleLobbyControl(message: GameMessage): void {
     const payload = message.data;
     if (typeof payload !== "object" || payload === null) {
-      console.warn(
+      p2pLogger.warn(
         "[P2PGameConnection] Rejected malformed lobby-control payload",
       );
       return;
@@ -1716,7 +1719,7 @@ export class P2PGameConnection {
       kind !== "pause" &&
       kind !== "resume"
     ) {
-      console.warn(
+      p2pLogger.warn(
         "[P2PGameConnection] Rejected lobby-control with invalid kind",
         redactSensitive({ kind }),
       );
@@ -1871,7 +1874,7 @@ export class P2PGameConnection {
   private handleError(error: Error): void {
     // #982: redact — error.message may embed session metadata propagated up
     // from lower layers.
-    console.error("[P2PGameConnection] Error:", redactSensitive(error));
+    p2pLogger.error("[P2PGameConnection] Error:", redactSensitive(error));
     if (!this.lastFailureDiagnostic) {
       this.lastFailureDiagnostic = classifyConnectionFailure({
         rtcConfig: this.getRTCConfig(),
@@ -2031,7 +2034,7 @@ export class P2PGameConnection {
       return await this.peerConnection.getStats();
     } catch (error) {
       // #982: redact — getStats errors may reference ICE candidates.
-      console.error(
+      p2pLogger.error(
         "[P2PGameConnection] Failed to get stats:",
         redactSensitive(error),
       );


### PR DESCRIPTION
## Summary

Migrates the remaining raw `console.warn` / `console.error` calls in the two largest P2P connection files to the shared `p2pLogger` singleton introduced by the leveled P2P logging work, so P2P logging is consistent, leveled, and prod-strippable like the rest of the WebRTC/signaling layer (`webrtc-p2p.ts`, `p2p-signaling-client.ts`, `ice-config.ts`).

Closes #1426

## Changes

- **`src/lib/p2p-game-connection.ts`** — migrated **22** calls (**13** `warn` + **9** `error`) to `p2pLogger.warn` / `p2pLogger.error`.
- **`src/lib/mesh-game-connection.ts`** — migrated **8** calls (**4** `warn` + **4** `error`). The issue text listed 7, but the file has since grown to 8; all were migrated.
- Added `import { p2pLogger } from "./p2p-logger";` to both files (placed next to the existing `redactSensitive` import).

### Migration shape
- Pure mechanical 1:1 replacement: `console.warn(` → `p2pLogger.warn(`, `console.error(` → `p2pLogger.error(`. No control-flow or behavior change beyond the logging call.
- Every existing `redactSensitive(...)` wrapper is preserved verbatim — the logger forwards args unchanged and intentionally does **not** re-redact.
- The logger signature is `(message: string, ...args: unknown[])`; all migrated call sites already passed a `[Component] message` string as the first arg, so message content/shape is unchanged.

## Verification

- `grep -nE "console\\.(warn|error|log|info|debug)"` on both target files returns **zero matches**.
- `npm run typecheck` — clean.
- `npm run lint` — 0 errors (warning count unchanged from baseline).
- `npm test` (full suite) — **418 suites / 8551 tests passed, 0 failures**.
- Added 4 representative regression tests (spy on `p2pLogger.warn` / `p2pLogger.error` rather than `console`):
  - `p2p-game-connection.test.ts`: malformed peer message → `p2pLogger.error`; duplicate/replay → `p2pLogger.warn`.
  - `mesh-game-connection.test.ts`: malformed peer message → `p2pLogger.error`; duplicate/replay → `p2pLogger.warn`.

## Scope

Touches only the logging calls in the two target files plus minimal tests, to minimize overlap with the parallel chat-sanitize PR.
