### PR TITLE
fix: add idle/LRU eviction to WebRTCConnectionPool.acquire() (#1427)

### DIFF
--- a/src/lib/__tests__/webrtc-connection-pool.test.ts
+++ b/src/lib/__tests__/webrtc-connection-pool.test.ts
@@ -67,13 +67,19 @@ class MockPooledConnection {
 type MockConnection = MockPooledConnection;
 
 /** Build a pool whose factory hands back controllable mock connections. */
-function makePool(options: {
-  maxConnections?: number;
-  pingIntervalMs?: number;
-  cacheTtlMs?: number;
-  createConnection?: (peerId: string) => MockConnection;
-  events?: ConstructorParameters<typeof WebRTCConnectionPool>[0]["events"];
-} = {}) {
+function makePool(
+  options: {
+    maxConnections?: number;
+    pingIntervalMs?: number;
+    cacheTtlMs?: number;
+    idleFailureMs?: number;
+    idleConnectedMs?: number;
+    activeMs?: number;
+    now?: () => number;
+    createConnection?: (peerId: string) => MockConnection;
+    events?: ConstructorParameters<typeof WebRTCConnectionPool>[0]["events"];
+  } = {},
+) {
   const created: Record<string, MockConnection> = {};
   const factory =
     options.createConnection ??
@@ -86,10 +92,25 @@ function makePool(options: {
     maxConnections: options.maxConnections,
     pingIntervalMs: options.pingIntervalMs,
     cacheTtlMs: options.cacheTtlMs,
+    idleFailureMs: options.idleFailureMs,
+    idleConnectedMs: options.idleConnectedMs,
+    activeMs: options.activeMs,
+    now: options.now,
     events: options.events,
-    createConnection: factory as unknown as (peerId: string) => WebRTCConnection,
+    createConnection: factory as unknown as (
+      peerId: string,
+    ) => WebRTCConnection,
   });
   return { pool, created, factory };
+}
+
+/**
+ * Mutable clock for deterministic eviction tests. Advance `clock.value` to
+ * move the pool's notion of "now".
+ */
+function makeClock(initial = 1_000_000) {
+  const clock = { value: initial };
+  return { clock, now: () => clock.value };
 }
 
 describe("WebRTCConnectionPool", () => {
@@ -146,15 +167,22 @@ describe("WebRTCConnectionPool", () => {
   describe("capacity limit", () => {
     it("refuses new connections once maxConnections is reached", () => {
       const onPoolFull = jest.fn();
-      const { pool } = makePool({ maxConnections: 2, events: { onPoolFull } });
+      const onEvict = jest.fn();
+      const { pool } = makePool({
+        maxConnections: 2,
+        events: { onPoolFull, onEvict },
+      });
 
       expect(pool.acquire("p1")).not.toBeNull();
       expect(pool.acquire("p2")).not.toBeNull();
-      // Third peer exceeds the cap of 2.
+      // Third peer exceeds the cap of 2; both slots are freshly used (active),
+      // so nothing is evictable and the pool refuses.
       expect(pool.acquire("p3")).toBeNull();
       expect(pool.size).toBe(2);
       expect(pool.capacity).toBe(2);
-      expect(onPoolFull).toHaveBeenCalledWith("p3");
+      expect(onPoolFull).toHaveBeenCalledTimes(1);
+      expect(onPoolFull).toHaveBeenCalledWith("p3", { evictedPeerIds: [] });
+      expect(onEvict).not.toHaveBeenCalled();
     });
 
     it("allows new connections once a slot is released", () => {
@@ -164,6 +192,363 @@ describe("WebRTCConnectionPool", () => {
       expect(pool.acquire("p2")).toBeNull();
       pool.release("p1");
       expect(pool.acquire("p2")).not.toBeNull();
+    });
+  });
+
+  describe("idle / LRU eviction (issue #1427)", () => {
+    // Each test injects a mutable clock so eviction thresholds are evaluated
+    // deterministically without jest fake timers.
+    it("acquire succeeds when the pool has room (no eviction)", () => {
+      const { clock, now } = makeClock();
+      const onEvict = jest.fn();
+      const { pool } = makePool({
+        maxConnections: 4,
+        now,
+        events: { onEvict },
+      });
+
+      clock.value = 0;
+      expect(pool.acquire("p1")).not.toBeNull();
+      expect(pool.size).toBe(1);
+      expect(onEvict).not.toHaveBeenCalled();
+    });
+
+    it("refuses when full and every peer is actively in use (last-used < activeMs)", () => {
+      const { clock, now } = makeClock();
+      const onPoolFull = jest.fn();
+      const onEvict = jest.fn();
+      const { pool } = makePool({
+        maxConnections: 2,
+        activeMs: 30_000,
+        now,
+        events: { onPoolFull, onEvict },
+      });
+
+      clock.value = 0;
+      pool.acquire("p1");
+      pool.acquire("p2");
+      // Only 5s elapse — both peers are still "active".
+      clock.value = 5_000;
+      expect(pool.acquire("p3")).toBeNull();
+      expect(pool.size).toBe(2);
+      expect(onEvict).not.toHaveBeenCalled();
+      expect(onPoolFull).toHaveBeenCalledWith("p3", { evictedPeerIds: [] });
+    });
+
+    it("evicts a dead (disconnected) connection past idleFailureMs to admit a new peer", () => {
+      const { clock, now } = makeClock();
+      const onEvict = jest.fn();
+      const onPoolFull = jest.fn();
+      const { pool, created } = makePool({
+        maxConnections: 2,
+        idleFailureMs: 60_000,
+        now,
+        events: { onEvict, onPoolFull },
+      });
+
+      clock.value = 0;
+      pool.acquire("p1");
+      pool.acquire("p2");
+      // p1 drops and stays gone past the failure grace period.
+      created.p1.connected = false;
+      clock.value = 61_000;
+      // Pool is full, but p1 is a dead, expired candidate.
+      const conn = pool.acquire("p3");
+
+      expect(conn).not.toBeNull();
+      expect(pool.has("p1")).toBe(false);
+      expect(pool.has("p3")).toBe(true);
+      expect(pool.size).toBe(2);
+      expect(created.p1.closed).toBe(true);
+      expect(onEvict).toHaveBeenCalledTimes(1);
+      expect(onEvict).toHaveBeenCalledWith("p1");
+      expect(onPoolFull).not.toHaveBeenCalled();
+    });
+
+    it("does NOT evict a freshly-disconnected peer within the idleFailureMs grace period", () => {
+      const { clock, now } = makeClock();
+      const { pool, created } = makePool({
+        maxConnections: 2,
+        idleFailureMs: 60_000,
+        now,
+      });
+
+      clock.value = 0;
+      pool.acquire("p1");
+      pool.acquire("p2");
+      created.p1.connected = false;
+      // Only 10s since last use — within the grace window.
+      clock.value = 10_000;
+      expect(pool.acquire("p3")).toBeNull();
+      expect(pool.has("p1")).toBe(true);
+      expect(pool.size).toBe(2);
+    });
+
+    it("evicts the LEAST-recently-used candidate (not an arbitrary one)", () => {
+      const { clock, now } = makeClock();
+      const { pool, created } = makePool({
+        maxConnections: 3,
+        idleFailureMs: 60_000,
+        now,
+      });
+
+      // Stagger last-used timestamps: p1 oldest, p3 newest.
+      clock.value = 0;
+      pool.acquire("p1");
+      clock.value = 1_000;
+      pool.acquire("p2");
+      clock.value = 2_000;
+      pool.acquire("p3");
+      // All three drop and age past the failure grace period.
+      created.p1.connected = false;
+      created.p2.connected = false;
+      created.p3.connected = false;
+      clock.value = 70_000; // age(p1)=70s, age(p2)=69s, age(p3)=68s — all > 60s
+
+      const conn = pool.acquire("p4");
+      expect(conn).not.toBeNull();
+      // p1 has the oldest lastUsedAt → it must be the one evicted.
+      expect(pool.has("p1")).toBe(false);
+      expect(pool.has("p2")).toBe(true);
+      expect(pool.has("p3")).toBe(true);
+      expect(pool.has("p4")).toBe(true);
+      expect(created.p1.closed).toBe(true);
+      expect(created.p2.closed).toBe(false);
+    });
+
+    it("prefers a dead link over an idle-but-connected peer when both are evictable", () => {
+      const { clock, now } = makeClock();
+      const { pool, created } = makePool({
+        maxConnections: 2,
+        idleFailureMs: 60_000,
+        idleConnectedMs: 600_000,
+        now,
+      });
+
+      clock.value = 0;
+      pool.acquire("p1");
+      pool.acquire("p2");
+      // p1 dies; p2 stays connected but idle long enough to be evictable too.
+      created.p1.connected = false;
+      clock.value = 700_000; // > idleConnectedMs (10min) AND > idleFailureMs
+      const conn = pool.acquire("p3");
+
+      expect(conn).not.toBeNull();
+      // The dead link (p1) is reclaimed even though p2 is also evictable.
+      expect(pool.has("p1")).toBe(false);
+      expect(pool.has("p2")).toBe(true);
+    });
+
+    it("evicts a connected-but-idle peer past idleConnectedMs when no dead links exist", () => {
+      const { clock, now } = makeClock();
+      const { pool, created } = makePool({
+        maxConnections: 2,
+        idleConnectedMs: 600_000,
+        now,
+      });
+
+      clock.value = 0;
+      pool.acquire("p1");
+      pool.acquire("p2");
+      // Both stay connected and idle past the idle-connected threshold.
+      clock.value = 601_000;
+      const conn = pool.acquire("p3");
+
+      expect(conn).not.toBeNull();
+      expect(pool.size).toBe(2);
+      // Exactly one slot was reclaimed; the LRU (p1) was chosen.
+      expect(pool.has("p1")).toBe(false);
+      expect(pool.has("p2")).toBe(true);
+      expect(pool.has("p3")).toBe(true);
+      expect(created.p1.closed).toBe(true);
+    });
+
+    it("never evicts an actively-trafficked peer even when eviction occurs", () => {
+      const { clock, now } = makeClock();
+      const onEvict = jest.fn();
+      const { pool, created } = makePool({
+        maxConnections: 2,
+        activeMs: 30_000,
+        idleFailureMs: 60_000,
+        now,
+        events: { onEvict },
+      });
+
+      clock.value = 0;
+      pool.acquire("active");
+      pool.acquire("zombie");
+      // "active" was just used (within activeMs); "zombie" is dead and old.
+      created.zombie.connected = false;
+      clock.value = 70_000;
+      // Re-mark "active" as freshly used right before the contested acquire.
+      pool.markConnectionUsed("active");
+      const conn = pool.acquire("p3");
+
+      expect(conn).not.toBeNull();
+      // The active peer is retained; the zombie is reclaimed instead.
+      expect(pool.has("active")).toBe(true);
+      expect(pool.has("zombie")).toBe(false);
+      expect(created.active.closed).toBe(false);
+      expect(onEvict).toHaveBeenCalledWith("zombie");
+    });
+
+    it("eviction tears down cleanly: caches state, closes, removes, fires onCache + onEvict", () => {
+      const { clock, now } = makeClock();
+      const onCache = jest.fn();
+      const onEvict = jest.fn();
+      const { pool, created } = makePool({
+        maxConnections: 1,
+        idleFailureMs: 60_000,
+        now,
+        events: { onCache, onEvict },
+      });
+
+      clock.value = 0;
+      pool.acquire("p1");
+      created.p1.connected = false;
+      clock.value = 61_000;
+      pool.acquire("p2");
+
+      expect(created.p1.closed).toBe(true);
+      expect(pool.has("p1")).toBe(false);
+      // State cached so reconnect can reuse identity.
+      expect(pool.hasCachedState("p1")).toBe(true);
+      expect(pool.getCachedState("p1")?.peerId).toBe("p1");
+      expect(onCache).toHaveBeenCalledWith("p1", expect.any(Object));
+      expect(onEvict).toHaveBeenCalledWith("p1");
+    });
+
+    it("regression: a stale occupant does not block a later fresh peer", () => {
+      const { clock, now } = makeClock();
+      const { pool, created } = makePool({
+        maxConnections: 8,
+        idleFailureMs: 60_000,
+        now,
+      });
+
+      // Fill the 8-slot pool.
+      clock.value = 0;
+      for (let i = 1; i <= 8; i++) pool.acquire(`p${i}`);
+      // One occupant (p1) goes stale: dropped and gone past the grace period.
+      created.p1.connected = false;
+      clock.value = 120_000;
+      // A later fresh peer must be admitted by reclaiming the stale slot,
+      // instead of being refused because the pool reads as "full".
+      const conn = pool.acquire("fresh");
+
+      expect(conn).not.toBeNull();
+      expect(pool.has("fresh")).toBe(true);
+      expect(pool.has("p1")).toBe(false);
+      expect(pool.size).toBe(8);
+    });
+
+    describe("lastUsedAt tracking", () => {
+      it("is stamped on acquire and re-stamped on reuse", () => {
+        const { clock, now } = makeClock();
+        const { pool } = makePool({ now });
+
+        clock.value = 100;
+        pool.acquire("p1");
+        expect(pool.getLastUsedAt("p1")).toBe(100);
+
+        clock.value = 500;
+        pool.acquire("p1"); // reuse
+        expect(pool.getLastUsedAt("p1")).toBe(500);
+        expect(pool.getLastUsedAt("unknown")).toBeNull();
+      });
+
+      it("is bumped on every broadcast send to a connected peer", () => {
+        const { clock, now } = makeClock();
+        const { pool } = makePool({ now });
+
+        clock.value = 0;
+        pool.acquire("p1");
+        expect(pool.getLastUsedAt("p1")).toBe(0);
+
+        clock.value = 1_000;
+        pool.broadcast({
+          type: "game-action",
+          senderId: "local",
+          timestamp: 1_000,
+          payload: null,
+        });
+        expect(pool.getLastUsedAt("p1")).toBe(1_000);
+      });
+
+      it("is bumped on every successful pooled ping", () => {
+        // Uses fake timers so the consolidated sweep advances Date.now.
+        jest.useFakeTimers();
+        const { pool, created } = makePool({ pingIntervalMs: 1_000 });
+        try {
+          pool.acquire("p1");
+          const before = pool.getLastUsedAt("p1");
+          created.p1.connected = true;
+
+          pool.start();
+          jest.advanceTimersByTime(1_000);
+
+          expect(created.p1.pingCount).toBe(1);
+          expect(pool.getLastUsedAt("p1")).toBeGreaterThan(before as number);
+        } finally {
+          jest.useRealTimers();
+        }
+      });
+
+      it("markConnectionUsed lets external traffic keep a peer fresh", () => {
+        const { clock, now } = makeClock();
+        const { pool } = makePool({ now });
+
+        clock.value = 0;
+        pool.acquire("p1");
+        clock.value = 5_000;
+        pool.markConnectionUsed("p1");
+        expect(pool.getLastUsedAt("p1")).toBe(5_000);
+        // No-op for unknown peers.
+        pool.markConnectionUsed("ghost");
+        expect(pool.getLastUsedAt("ghost")).toBeNull();
+      });
+    });
+
+    describe("evictIdle (proactive)", () => {
+      it("evicts all currently-evictable connections and returns their ids", () => {
+        const { clock, now } = makeClock();
+        const onEvict = jest.fn();
+        const { pool, created } = makePool({
+          maxConnections: 4,
+          idleFailureMs: 60_000,
+          now,
+          events: { onEvict },
+        });
+
+        clock.value = 0;
+        pool.acquire("dead1");
+        pool.acquire("dead2");
+        pool.acquire("live");
+        created.dead1.connected = false;
+        created.dead2.connected = false;
+        clock.value = 61_000;
+        // "live" is re-used right before the sweep so it is retained.
+        pool.markConnectionUsed("live");
+
+        const evicted = pool.evictIdle();
+
+        expect(evicted.sort()).toEqual(["dead1", "dead2"]);
+        expect(pool.has("dead1")).toBe(false);
+        expect(pool.has("dead2")).toBe(false);
+        expect(pool.has("live")).toBe(true);
+        expect(onEvict).toHaveBeenCalledTimes(2);
+      });
+
+      it("is a no-op (returns []) when nothing is evictable", () => {
+        const { clock, now } = makeClock();
+        const { pool } = makePool({ now });
+
+        clock.value = 0;
+        pool.acquire("p1");
+        clock.value = 1_000;
+        expect(pool.evictIdle()).toEqual([]);
+        expect(pool.size).toBe(1);
+      });
     });
   });
 

--- a/src/lib/webrtc-connection-pool.ts
+++ b/src/lib/webrtc-connection-pool.ts
@@ -13,6 +13,17 @@
  *    multi-player game and shares data channels via the pool.
  * 3. A single consolidated ping sweep that drives health checks for every
  *    pooled connection from one interval instead of N independent timers.
+ * 4. <b>Idle/LRU eviction</b> (issue #1427): when the pool is full,
+ *    {@link WebRTCConnectionPool.acquire} no longer refuses new peers out of
+ *    hand. It first looks for an <i>evictable</i> connection — a dead link
+ *    (not {@link WebRTCConnection.isConnected} for longer than
+ *    {@link ConnectionPoolOptions.idleFailureMs}) or a connected-but-idle peer
+ *    (no traffic for longer than {@link ConnectionPoolOptions.idleConnectedMs})
+ *    — and removes the least-recently-used one to make room. A connection
+ *    used within {@link ConnectionPoolOptions.activeMs} is never evicted.
+ *    {@link ConnectionPoolEvents.onPoolFull} therefore fires only on true
+ *    capacity exhaustion; per-eviction visibility is delivered via
+ *    {@link ConnectionPoolEvents.onEvict}.
  */
 
 import {
@@ -29,6 +40,24 @@ const DEFAULT_MAX_CONNECTIONS = 8;
 const DEFAULT_PING_INTERVAL_MS = 5000;
 /** Default time-to-live (ms) for cached dropped-peer state. */
 const DEFAULT_CACHE_TTL_MS = 60_000;
+/**
+ * Default grace period (ms) before a non-connected (disconnected / failed /
+ * connecting / reconnecting) pooled connection becomes evictable. Gives a
+ * dropped peer time to reconnect before its slot is reclaimed.
+ */
+const DEFAULT_IDLE_FAILURE_MS = 60_000;
+/**
+ * Default threshold (ms) after which a connected-but-silent pooled connection
+ * becomes evictable. Pings keep the link up but do not reset this; only real
+ * traffic (or an explicit {@link WebRTCConnectionPool.markConnectionUsed})
+ * keeps a peer "fresh".
+ */
+const DEFAULT_IDLE_CONNECTED_MS = 600_000;
+/**
+ * Default window (ms) within which a connection is considered actively in use
+ * and is therefore never an eviction candidate.
+ */
+const DEFAULT_ACTIVE_MS = 30_000;
 
 /**
  * Snapshot of a peer's connection state captured when its connection dropped,
@@ -43,6 +72,21 @@ export interface CachedConnectionState {
 }
 
 /**
+ * Supplementary payload for {@link ConnectionPoolEvents.onPoolFull}.
+ *
+ * `evictedPeerIds` is always empty when `onPoolFull` fires: `acquire` only
+ * fires `onPoolFull` after determining that <i>no</i> pooled connection is
+ * evictable (real capacity exhaustion). When an eviction does make room,
+ * `acquire` succeeds instead, and each evicted peer is reported via
+ * {@link ConnectionPoolEvents.onEvict}. The field is retained on the payload
+ * so the host layer can assert the "nothing was evicted" contract explicitly.
+ */
+export interface PoolFullInfo {
+  /** Always `[]` when `onPoolFull` fires (see type doc). */
+  evictedPeerIds: string[];
+}
+
+/**
  * Event hooks fired by the connection pool. All are optional.
  */
 export interface ConnectionPoolEvents {
@@ -50,8 +94,20 @@ export interface ConnectionPoolEvents {
   onReuse?: (peerId: string) => void;
   /** Fired when state is cached for a dropped peer. */
   onCache?: (peerId: string, cached: CachedConnectionState) => void;
-  /** Fired when a connection is refused because the pool is at capacity. */
-  onPoolFull?: (peerId: string) => void;
+  /**
+   * Fired when a connection is refused because the pool is at capacity AND no
+   * pooled connection was evictable. When an idle/LRU connection WAS evicted
+   * to make room, {@link acquire} succeeds and this event does not fire;
+   * instead {@link onEvict} reports the eviction.
+   */
+  onPoolFull?: (peerId: string, info: PoolFullInfo) => void;
+  /**
+   * Fired for each connection evicted by the idle/LRU policy (either
+   * proactively via {@link WebRTCConnectionPool.evictIdle} or reactively inside
+   * {@link acquire}). The peer's state is cached first (so
+   * {@link onCache} also fires), enabling a fast reconnect.
+   */
+  onEvict?: (peerId: string) => void;
 }
 
 /**
@@ -66,6 +122,27 @@ export interface ConnectionPoolOptions {
   pingIntervalMs?: number;
   /** How long (ms) cached dropped-peer state stays valid. */
   cacheTtlMs?: number;
+  /**
+   * Grace period (ms) before a non-connected pooled connection becomes
+   * evictable. Defaults to {@link DEFAULT_IDLE_FAILURE_MS} (60s).
+   */
+  idleFailureMs?: number;
+  /**
+   * Threshold (ms) after which a connected-but-idle pooled connection becomes
+   * evictable. Defaults to {@link DEFAULT_IDLE_CONNECTED_MS} (10 min).
+   */
+  idleConnectedMs?: number;
+  /**
+   * Window (ms) within which a connection is considered actively in use and is
+   * never evicted. Defaults to {@link DEFAULT_ACTIVE_MS} (30s).
+   */
+  activeMs?: number;
+  /**
+   * Clock injected for deterministic eviction behaviour. Defaults to
+   * `Date.now`. All internal time reads go through this, so eviction tests can
+   * advance time without `jest.useFakeTimers`.
+   */
+  now?: () => number;
   /** Pool lifecycle events. */
   events?: ConnectionPoolEvents;
   /**
@@ -118,12 +195,28 @@ export function defaultConnectionFactory(
  *   timers.
  * - <b>State caching:</b> when a connection is released or drops, its peer
  *   identity is cached so a near-term reconnect skips re-discovery.
+ * - <b>Idle/LRU eviction:</b> {@link acquire} on a full pool first tries to
+ *   reclaim a slot by evicting the least-recently-used evictable connection
+ *   (dead links first, then connected-but-idle peers). A peer used within
+ *   {@link ConnectionPoolOptions.activeMs} is always retained. See
+ *   {@link selectEvictionCandidate} for the exact order.
+ *
+ * Each pooled connection has a `lastUsedAt` timestamp (readable via
+ * {@link getLastUsedAt}), bumped on acquire-reuse, on every successful
+ * broadcast {@link send}, on every successful healthy {@link ping}, and on an
+ * explicit {@link markConnectionUsed}. Callers that send over a pooled
+ * connection without going through {@link broadcast} should call
+ * {@link markConnectionUsed} so the LRU order stays accurate.
  */
 export class WebRTCConnectionPool {
   private readonly localPlayerId: string;
   private readonly maxConnections: number;
   private readonly pingIntervalMs: number;
   private readonly cacheTtlMs: number;
+  private readonly idleFailureMs: number;
+  private readonly idleConnectedMs: number;
+  private readonly activeMs: number;
+  private readonly now: () => number;
   private readonly events: ConnectionPoolEvents;
   private readonly createConnection: (peerId: string) => WebRTCConnection;
 
@@ -131,6 +224,11 @@ export class WebRTCConnectionPool {
   private readonly connections: Map<string, WebRTCConnection> = new Map();
   /** Cached state for dropped peers. */
   private readonly cache: Map<string, CachedConnectionState> = new Map();
+  /**
+   * Last-used timestamp (epoch ms) per pooled peer, driving the LRU order.
+   * Bumped by {@link markUsed}.
+   */
+  private readonly lastUsedAt: Map<string, number> = new Map();
   /** Single consolidated ping timer sweeping all pooled connections. */
   private pingTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -142,6 +240,10 @@ export class WebRTCConnectionPool {
     this.maxConnections = options.maxConnections ?? DEFAULT_MAX_CONNECTIONS;
     this.pingIntervalMs = options.pingIntervalMs ?? DEFAULT_PING_INTERVAL_MS;
     this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    this.idleFailureMs = options.idleFailureMs ?? DEFAULT_IDLE_FAILURE_MS;
+    this.idleConnectedMs = options.idleConnectedMs ?? DEFAULT_IDLE_CONNECTED_MS;
+    this.activeMs = options.activeMs ?? DEFAULT_ACTIVE_MS;
+    this.now = options.now ?? (() => Date.now());
     this.events = options.events ?? {};
     this.createConnection =
       options.createConnection ??
@@ -169,8 +271,14 @@ export class WebRTCConnectionPool {
 
   /**
    * Return the existing connection for a peer (reuse), or create a new one if
-   * the peer is unknown and the pool is under capacity. Returns null — and
-   * fires {@link ConnectionPoolEvents.onPoolFull} — when at capacity.
+   * the peer is unknown and the pool is under capacity.
+   *
+   * When the pool is full, this first tries to evict an idle/LRU connection
+   * (see {@link selectEvictionCandidate}) to make room. Only if NO connection
+   * is evictable does it return `null` and fire
+   * {@link ConnectionPoolEvents.onPoolFull}. Each successful eviction is
+   * reported via {@link ConnectionPoolEvents.onEvict} (and the peer's state is
+   * cached first via {@link cacheState} so reconnect is fast).
    */
   acquire(peerId: string): WebRTCConnection | null {
     if (!peerId) {
@@ -178,17 +286,25 @@ export class WebRTCConnectionPool {
     }
     const existing = this.connections.get(peerId);
     if (existing) {
+      this.markUsed(peerId);
       this.events.onReuse?.(peerId);
       return existing;
     }
 
     if (this.connections.size >= this.maxConnections) {
-      this.events.onPoolFull?.(peerId);
-      return null;
+      // Pool full: reclaim a slot from the least-recently-used evictable
+      // connection before refusing. Falls through to creation on success.
+      const evictable = this.selectEvictionCandidate(this.now());
+      if (!evictable) {
+        this.events.onPoolFull?.(peerId, { evictedPeerIds: [] });
+        return null;
+      }
+      this.evictPeer(evictable);
     }
 
     const connection = this.createConnection(peerId);
     this.connections.set(peerId, connection);
+    this.markUsed(peerId);
     return connection;
   }
 
@@ -231,6 +347,33 @@ export class WebRTCConnectionPool {
   }
 
   /**
+   * Last-used timestamp (epoch ms) for a pooled peer, or `null` if the peer is
+   * unknown. Drives the LRU eviction order.
+   */
+  getLastUsedAt(peerId: string): number | null {
+    return this.lastUsedAt.has(peerId)
+      ? (this.lastUsedAt.get(peerId) as number)
+      : null;
+  }
+
+  /**
+   * Stamp a pooled connection as freshly used without going through
+   * {@link broadcast} (e.g. a caller sending over a connection obtained via
+   * {@link acquire}). No-op for unknown peers. Required to keep the LRU order
+   * accurate when traffic bypasses the pool.
+   */
+  markConnectionUsed(peerId: string): void {
+    if (this.connections.has(peerId)) {
+      this.markUsed(peerId);
+    }
+  }
+
+  /** Bump a peer's last-used timestamp to the current pool time. */
+  private markUsed(peerId: string): void {
+    this.lastUsedAt.set(peerId, this.now());
+  }
+
+  /**
    * Remove and close a peer's connection, caching its state so a near-term
    * reconnect can reuse it. No-op if the peer is unknown.
    */
@@ -240,6 +383,83 @@ export class WebRTCConnectionPool {
     this.cacheState(peerId, connection);
     connection.close();
     this.connections.delete(peerId);
+    this.lastUsedAt.delete(peerId);
+  }
+
+  /**
+   * Proactively evict every currently-evictable pooled connection (dead links
+   * past {@link ConnectionPoolOptions.idleFailureMs} first, then connected-
+   * but-idle peers past {@link ConnectionPoolOptions.idleConnectedMs}). Returns
+   * the evicted peer ids. {@link acquire} does NOT call this — it evicts at
+   * most one connection via {@link selectEvictionCandidate}; this method is
+   * for periodic maintenance sweeps.
+   */
+  evictIdle(now: number = this.now()): string[] {
+    const evicted: string[] = [];
+    let candidate = this.selectEvictionCandidate(now);
+    while (candidate) {
+      this.evictPeer(candidate);
+      evicted.push(candidate);
+      candidate = this.selectEvictionCandidate(now);
+    }
+    return evicted;
+  }
+
+  /**
+   * Pick the single best eviction candidate at `now`, or `null` if nothing is
+   * evictable.
+   *
+   * Eviction order:
+   * 1. <b>Dead links first</b> — connections whose {@link WebRTCConnection.isConnected}
+   *    is `false` AND whose last-used age exceeds
+   *    {@link ConnectionPoolOptions.idleFailureMs}. Among these, the
+   *    least-recently-used (oldest `lastUsedAt`) is chosen.
+   * 2. <b>Connected-but-idle</b> — `isConnected === true` AND last-used age
+   *    exceeds {@link ConnectionPoolOptions.idleConnectedMs}. Again the LRU
+   *    peer is chosen.
+   *
+   * A connection used within {@link ConnectionPoolOptions.activeMs} is never
+   * returned (it is actively in use).
+   */
+  private selectEvictionCandidate(now: number): string | null {
+    let zombieLRU: string | null = null;
+    let zombieLRUAt = Infinity;
+    let idleLRU: string | null = null;
+    let idleLRUAt = Infinity;
+    for (const [peerId, connection] of this.connections) {
+      const lastUsed = this.lastUsedAt.get(peerId) ?? now;
+      const age = now - lastUsed;
+      // Actively in use — never evict, regardless of connected state.
+      if (age <= this.activeMs) continue;
+      if (connection.isConnected()) {
+        if (age > this.idleConnectedMs && lastUsed < idleLRUAt) {
+          idleLRU = peerId;
+          idleLRUAt = lastUsed;
+        }
+      } else if (age > this.idleFailureMs && lastUsed < zombieLRUAt) {
+        zombieLRU = peerId;
+        zombieLRUAt = lastUsed;
+      }
+    }
+    // Prefer reclaiming a dead/zombie slot over dropping a live-but-idle peer.
+    return zombieLRU ?? idleLRU;
+  }
+
+  /**
+   * Tear down a single pooled connection: cache its state (so
+   * {@link ConnectionPoolEvents.onCache} fires and reconnect is fast), close
+   * it, remove it from the pool, drop its last-used stamp, and fire
+   * {@link ConnectionPoolEvents.onEvict}. Mirrors {@link release} but signals
+   * eviction.
+   */
+  private evictPeer(peerId: string): void {
+    const connection = this.connections.get(peerId);
+    if (!connection) return;
+    this.cacheState(peerId, connection);
+    connection.close();
+    this.connections.delete(peerId);
+    this.lastUsedAt.delete(peerId);
+    this.events.onEvict?.(peerId);
   }
 
   /**
@@ -249,21 +469,20 @@ export class WebRTCConnectionPool {
    */
   cacheState(peerId: string, connection: WebRTCConnection): void {
     const peers = connection.getPeers();
-    const peerInfo: PeerInfo =
-      peers.find((p) => p.peerId === peerId) ??
+    const peerInfo: PeerInfo = peers.find((p) => p.peerId === peerId) ??
       peers[0] ?? {
         peerId,
         playerId: peerId,
         playerName: `Peer-${peerId}`,
         connectionState: connection.getConnectionState(),
-        connectedAt: Date.now(),
+        connectedAt: this.now(),
       };
     const cached: CachedConnectionState = {
       peerId,
       peerInfo,
       state: connection.getConnectionState(),
-      lastConnectedAt: Date.now(),
-      lastDroppedAt: Date.now(),
+      lastConnectedAt: this.now(),
+      lastDroppedAt: this.now(),
     };
     this.cache.set(peerId, cached);
     this.events.onCache?.(peerId, cached);
@@ -275,7 +494,7 @@ export class WebRTCConnectionPool {
   getCachedState(peerId: string): CachedConnectionState | null {
     const cached = this.cache.get(peerId);
     if (!cached) return null;
-    if (Date.now() - cached.lastDroppedAt > this.cacheTtlMs) {
+    if (this.now() - cached.lastDroppedAt > this.cacheTtlMs) {
       this.cache.delete(peerId);
       return null;
     }
@@ -295,12 +514,15 @@ export class WebRTCConnectionPool {
   /**
    * Broadcast a message across the pool by reusing each pooled connection's
    * open data channel. Returns the number of peers the message was sent to.
+   * Each successful send bumps the peer's `lastUsedAt` so active peers are
+   * retained by the LRU policy.
    */
   broadcast(message: P2PMessage): number {
     let sent = 0;
-    for (const connection of this.connections.values()) {
+    for (const [peerId, connection] of this.connections) {
       if (connection.isConnected()) {
         connection.send(message);
+        this.markUsed(peerId);
         sent++;
       }
     }
@@ -316,17 +538,22 @@ export class WebRTCConnectionPool {
       connection.close();
     }
     this.connections.clear();
+    this.lastUsedAt.clear();
     this.cache.clear();
   }
 
   /**
    * Single sweep that pings every connected pooled connection. Replaces the
-   * N independent per-connection ping intervals from webrtc-p2p.ts.
+   * N independent per-connection ping intervals from webrtc-p2p.ts. A
+   * successful healthy ping bumps the peer's `lastUsedAt` so live links are
+   * retained by the LRU policy (disconnected peers are skipped, freezing
+   * their stamp so they age into eviction candidates).
    */
   private pingAll(): void {
-    for (const connection of this.connections.values()) {
+    for (const [peerId, connection] of this.connections) {
       if (connection.isConnected()) {
         connection.ping();
+        this.markUsed(peerId);
       }
     }
   }


### PR DESCRIPTION
## What

Adds an idle/LRU eviction policy to `WebRTCConnectionPool.acquire()` so a full pool no longer refuses new peers when an idle/expirable slot can be reclaimed. Previously `acquire()` returned `null` and fired `onPoolFull` the moment `connections.size >= maxConnections`, even if some pooled connections were dead (`disconnected`/`failed`) or had been idle for minutes. In long-running commander/spectator sessions this permanently blocked fresh joins behind zombie handles.

Closes #1427

## Idle / LRU definition

Each pooled connection now carries a `lastUsedAt` timestamp (epoch ms), exposed via `pool.getLastUsedAt(peerId)` and bumped on:
- `acquire()` reuse,
- every successful `broadcast()` send,
- every successful healthy `ping()` in the consolidated sweep,
- an explicit `pool.markConnectionUsed(peerId)` (for callers that send over an `acquire()`d connection without going through `broadcast`).

An **evictable** connection is one that is **not** actively in use and meets one of:
1. **Dead link** — `connection.isConnected() === false` AND `now - lastUsedAt > idleFailureMs` (default 60s grace period so a freshly-dropped peer can reconnect).
2. **Connected-but-idle** — `isConnected() === true` AND `now - lastUsedAt > idleConnectedMs` (default 10 min).

A connection used within `activeMs` (default 30s) is **never** evicted.

## acquire() decision flow

```
acquire(peerId):
  if peer known -> bump lastUsedAt, onReuse, return existing
  if size < maxConnections -> create, set, stamp lastUsedAt, return
  // pool is full — try to reclaim a slot before refusing
  candidate = selectEvictionCandidate(now)   // dead links first, LRU tiebreak
  if candidate:
      evictPeer(candidate)                    // cacheState + close + remove + onEvict
      create new connection, return it        // SUCCESS
  // nothing evictable — true capacity exhaustion
  onPoolFull(peerId, { evictedPeerIds: [] })
  return null
```

`selectEvictionCandidate` prefers dead links over connected-but-idle peers; within either bucket it picks the **least-recently-used** (oldest `lastUsedAt`).

`onPoolFull` now fires **only** on genuine capacity exhaustion (no eviction candidate existed). Each eviction is surfaced via a new `onEvict(peerId)` event (the peer's state is cached first via `cacheState`, so `onCache` also fires and reconnect stays fast). The `onPoolFull` payload is now `(peerId, info: PoolFullInfo)` where `info.evictedPeerIds` is always `[]` when it fires — this lets the host layer assert the "nothing was evicted" contract explicitly while keeping eviction visibility on `onEvict`.

## New public surface

- `ConnectionPoolOptions.idleFailureMs` / `idleConnectedMs` / `activeMs` (configurable thresholds)
- `ConnectionPoolOptions.now` (injectable clock for deterministic tests; defaults to `Date.now`)
- `pool.getLastUsedAt(peerId)`, `pool.markConnectionUsed(peerId)`, `pool.evictIdle(now?)`
- Events: `onEvict`, and `onPoolFull` second arg `PoolFullInfo`

No wire-protocol change. All thresholds default to current/unchanged behavior for the steady-state happy path. The `now` injection also made `cacheState`/`getCachedState` clock-consistent (they previously hardcoded `Date.now()`).

## Test coverage (`src/lib/__tests__/webrtc-connection-pool.test.ts`)

New `idle / LRU eviction (issue #1427)` suite, fully deterministic via an injected mutable clock:
- acquire succeeds when there is room (no eviction)
- refuses when full and every peer is active (`lastUsedAt < activeMs`) — `onPoolFull` fires, `onEvict` does not
- evicts a dead (`disconnected`) connection past `idleFailureMs` to admit a new peer
- does NOT evict a freshly-disconnected peer within the `idleFailureMs` grace period
- **LRU correctness**: with three stale candidates, the least-recently-used is evicted (not an arbitrary one)
- prefers a dead link over a connected-but-idle peer when both are evictable
- evicts a connected-but-idle peer past `idleConnectedMs` when no dead links exist
- never evicts an actively-trafficked peer even when eviction occurs
- eviction tears down cleanly: caches state, closes, removes, fires `onCache` + `onEvict`
- **regression**: a stale occupant of a full 8-slot pool does not block a later fresh peer
- `lastUsedAt` tracking: stamped on acquire/reuse, bumped on every broadcast send, bumped on every successful pooled ping, and via `markConnectionUsed`
- `evictIdle()` proactive sweep: evicts all currently-evictable peers (retaining active ones) and returns their ids; no-op when nothing is evictable

The pre-existing capacity test was updated for the new `onPoolFull` payload shape and now also asserts no eviction occurred.

## Validation

- `npm run typecheck` — pass
- `npm run lint` — 0 errors (546 pre-existing warnings, unchanged)
- `npm test` — 418 suites / 8563 tests pass (11 skipped, 48 todo), 0 failures
- `npm test webrtc-connection-pool` — 47/47 pass

## Scope

Changes are confined to `src/lib/webrtc-connection-pool.ts` and its co-located test. No sibling multiplayer files (mesh game-connection, chat) were touched, to avoid overlap with parallel PRs.