### PR TITLE
fix: cap and sanitize P2P chat messages against injection and overflow (#1428)

### DIFF
--- a/src/components/__tests__/game-chat.test.tsx
+++ b/src/components/__tests__/game-chat.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Render-layer safety test for the game chat panel (issue #1428).
+ *
+ * The transport layer (P2PGameConnection / MeshGameConnection) now caps and
+ * sanitizes chat on both send and receive. This test pins the ADDITIONAL
+ * render-time defense in `game-chat.tsx` — the layer a future change could
+ * accidentally weaken. It asserts that a malicious message (raw HTML,
+ * javascript: link, control chars, an oversized blob) reaches the DOM only
+ * as safe, escaped plain text, with no executable element materialised and
+ * no renderer overflow.
+ *
+ * `game-chat.tsx` renders message content via JSX interpolation of
+ * `sanitizeCardText(message.content, 1_000)` (no `dangerouslySetInnerHTML`,
+ * no `react-markdown`), so React auto-escapes the residual HTML chars. These
+ * tests verify that contract end-to-end through the real component.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { GameChat, type ChatMessage } from "../game-chat";
+
+// Radix ScrollArea reads ResizeObserver during layout; jsdom lacks it.
+class RO {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (typeof globalThis.ResizeObserver === "undefined") {
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = RO;
+}
+
+const baseProps = {
+  currentPlayerId: "me",
+  currentPlayerName: "Me",
+  onSendMessage: jest.fn(),
+};
+
+function message(overrides: Partial<ChatMessage>): ChatMessage {
+  return {
+    id: "m1",
+    playerId: "other",
+    playerName: "Peer",
+    content: "hello",
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
+describe("GameChat render-layer sanitization (#1428)", () => {
+  it("renders an HTML-injection payload as escaped text, not as an element", () => {
+    const payload = "<script>alert(1)</script><img src=x onerror=alert(1)>";
+    render(
+      <GameChat {...baseProps} messages={[message({ content: payload })]} />,
+    );
+
+    // No executable element is materialised in the DOM.
+    expect(document.querySelector("script")).toBeNull();
+    expect(document.querySelector("img")).toBeNull();
+    // The payload is visible only as escaped text (the literal tag chars).
+    const log = screen.getByRole("log");
+    expect(log.textContent).toContain("script");
+    expect(log.textContent).toContain("alert(1)");
+  });
+
+  it("renders a javascript: URL / event-handler payload as inert text", () => {
+    const payload = '<a href="javascript:alert(1)">click</a>';
+    render(
+      <GameChat {...baseProps} messages={[message({ content: payload })]} />,
+    );
+
+    // No anchor element is materialised from the peer-controlled string.
+    expect(document.querySelector("a")).toBeNull();
+    expect(screen.getByRole("log").textContent).toContain("javascript");
+  });
+
+  it("renders a control-character payload without the control bytes", () => {
+    const payload = "hi\x00\x07\x1Bworld";
+    render(
+      <GameChat {...baseProps} messages={[message({ content: payload })]} />,
+    );
+
+    const text = screen.getByRole("log").textContent ?? "";
+    // sanitizeCardText strips control chars at render; the visible text has
+    // the printable remainder.
+    expect(text).not.toContain("\x00");
+    expect(text).not.toContain("\x07");
+    expect(text).toContain("hi");
+    expect(text).toContain("world");
+  });
+
+  it("caps an oversized render payload so the renderer does not overflow", () => {
+    // The render layer caps at 1_000 chars via sanitizeCardText(content, 1_000).
+    const oversized = "A".repeat(5_000);
+    render(
+      <GameChat {...baseProps} messages={[message({ content: oversized })]} />,
+    );
+
+    const text = screen.getByRole("log").textContent ?? "";
+    // Truncated well below the 5_000-char input and flagged as truncated.
+    expect(text.length).toBeLessThan(5_000);
+    expect(text).toContain("truncated");
+  });
+
+  it("renders a normal chat message unchanged", () => {
+    render(
+      <GameChat
+        {...baseProps}
+        messages={[message({ content: "gg, nice play!" })]}
+      />,
+    );
+    expect(screen.getByRole("log").textContent).toContain("gg, nice play!");
+  });
+});

--- a/src/lib/__tests__/mesh-game-connection.test.ts
+++ b/src/lib/__tests__/mesh-game-connection.test.ts
@@ -928,3 +928,150 @@ describe("MeshGameConnection — session-key rotation API (#1391)", () => {
     expect(mesh.getSessionKey()).toBe(existing);
   });
 });
+
+/**
+ * Chat message cap + sanitization (issue #1428).
+ *
+ * Spectator + player chat flows through `broadcastChat` (outbound) and the
+ * inbound `case "chat"` (receive). These tests pin both directions:
+ * send-side refuse-over-length + sanitize, and receive-side defense-in-depth
+ * sanitize + cap (so a non-conforming peer cannot slip a payload past onChat).
+ */
+describe("MeshGameConnection chat cap + sanitize (#1428)", () => {
+  describe("broadcastChat — sanitize + refuse over-length", () => {
+    it("broadcasts a sanitized normal message unchanged", () => {
+      const { mesh } = newMesh({
+        localPlayerId: "me",
+        localPlayerName: "Me",
+        hostId: "me",
+      });
+      const a = new MockLink("a");
+      mesh.addPeerLink(a);
+
+      expect(mesh.broadcastChat("hello world")).toBe(1); // 1 peer reached
+      expect(a.messages()[0]).toEqual(
+        expect.objectContaining({
+          type: "chat",
+          data: { senderName: "Me", text: "hello world" },
+        }),
+      );
+    });
+
+    it("REFUSES an over-length message: returns 0 + warns, no wire bytes", () => {
+      const { mesh } = newMesh({
+        localPlayerId: "me",
+        localPlayerName: "Me",
+        hostId: "me",
+      });
+      const a = new MockLink("a");
+      mesh.addPeerLink(a);
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+      expect(mesh.broadcastChat("x".repeat(501))).toBe(0);
+      expect(a.sent).toHaveLength(0);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("broadcastChat refused"),
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it("strips control + markup chars before broadcasting", () => {
+      const { mesh } = newMesh({
+        localPlayerId: "me",
+        localPlayerName: "Me",
+        hostId: "me",
+      });
+      const a = new MockLink("a");
+      mesh.addPeerLink(a);
+
+      mesh.broadcastChat("hi\x00<img>");
+      expect(a.messages()[0]).toEqual(
+        expect.objectContaining({
+          data: { senderName: "Me", text: "hiimg" },
+        }),
+      );
+    });
+
+    it("respects a custom maxChatMessageLength option", () => {
+      const { mesh } = newMesh({
+        localPlayerId: "me",
+        localPlayerName: "Me",
+        hostId: "me",
+        maxChatMessageLength: 8,
+      });
+      const a = new MockLink("a");
+      mesh.addPeerLink(a);
+
+      expect(mesh.broadcastChat("01234567")).toBe(1); // exactly 8, ok
+      expect(mesh.broadcastChat("012345678")).toBe(0); // 9, refused
+      expect(a.sent).toHaveLength(1);
+    });
+  });
+
+  describe("inbound chat — sanitize + cap BEFORE onChat fires", () => {
+    it("strips a raw control char injected at the wire layer", () => {
+      const { mesh, events } = newMesh();
+      mesh.addPeerLink(new MockLink("p1"));
+
+      mesh.handleIncoming(
+        inbound("p1", 0, {
+          type: "chat",
+          data: { senderName: "P1", text: "abc\x00def" },
+        }),
+        "p1",
+      );
+
+      expect(events.onChat).toHaveBeenCalledWith("p1", "P1", "abcdef");
+    });
+
+    it("strips raw < > / backtick from peer markup", () => {
+      const { mesh, events } = newMesh();
+      mesh.addPeerLink(new MockLink("p1"));
+
+      mesh.handleIncoming(
+        inbound("p1", 0, {
+          type: "chat",
+          data: { senderName: "P1", text: "<b>bold</b>" },
+        }),
+        "p1",
+      );
+
+      const text = events.onChat.mock.calls[0]![2] as string;
+      expect(text).not.toMatch(/[<>`]/);
+    });
+
+    it("TRUNCATES an oversized inbound blob before onChat", () => {
+      const { mesh, events } = newMesh();
+      mesh.addPeerLink(new MockLink("p1"));
+
+      mesh.handleIncoming(
+        inbound("p1", 0, {
+          type: "chat",
+          data: { senderName: "P1", text: "q".repeat(5000) },
+        }),
+        "p1",
+      );
+
+      const text = events.onChat.mock.calls[0]![2] as string;
+      expect(text.length).toBeLessThanOrEqual(500);
+      expect(text.endsWith("…")).toBe(true);
+    });
+
+    it("sanitizes a non-string senderName safely (coerced then stripped)", () => {
+      const { mesh, events } = newMesh();
+      mesh.addPeerLink(new MockLink("p1"));
+
+      mesh.handleIncoming(
+        inbound("p1", 0, {
+          type: "chat",
+          data: { senderName: 42, text: "hi" },
+        }),
+        "p1",
+      );
+
+      // Non-string senderName coerced to "" by the inbound guard.
+      expect(events.onChat).toHaveBeenCalledWith("p1", "", "hi");
+    });
+  });
+});

--- a/src/lib/__tests__/p2p-game-connection.test.ts
+++ b/src/lib/__tests__/p2p-game-connection.test.ts
@@ -1018,8 +1018,7 @@ describe("P2PGameConnection host action validation (#1089)", () => {
       expect(validator).not.toHaveBeenCalled();
       // Peer is still notified of the rejection.
       const sent = sendSpy.mock.calls[sendSpy.mock.calls.length - 1]?.[0] as
-        | GameMessage
-        | undefined;
+        GameMessage | undefined;
       expect(sent?.type).toBe("error");
     });
 
@@ -1215,9 +1214,9 @@ describe("P2PGameConnection reconnect reconciliation (issue #1086)", () => {
   };
 
   const handleMessage = (conn: P2PGameConnection, raw: string): void => {
-    (
-      conn as unknown as { handleMessage: (d: string) => void }
-    ).handleMessage(raw);
+    (conn as unknown as { handleMessage: (d: string) => void }).handleMessage(
+      raw,
+    );
   };
 
   const msg = (
@@ -1530,16 +1529,12 @@ describe("P2PGameConnection reconnect reconciliation (issue #1086)", () => {
  */
 describe("P2PGameConnection lobby-control message (issue #1257)", () => {
   const handleMessage = (conn: P2PGameConnection, raw: string): void => {
-    (
-      conn as unknown as { handleMessage: (d: string) => void }
-    ).handleMessage(raw);
+    (conn as unknown as { handleMessage: (d: string) => void }).handleMessage(
+      raw,
+    );
   };
 
-  const msg = (
-    senderId: string,
-    seq: number,
-    data: unknown,
-  ): GameMessage => ({
+  const msg = (senderId: string, seq: number, data: unknown): GameMessage => ({
     type: "lobby-control",
     senderId,
     timestamp: Date.now(),
@@ -1871,9 +1866,9 @@ describe("P2PGameConnection HMAC envelope signing/verification (issue #1252)", (
   const POST_MIGRATION_KEY = "c".repeat(64);
 
   const handleMessage = (conn: P2PGameConnection, raw: string): void => {
-    (
-      conn as unknown as { handleMessage: (d: string) => void }
-    ).handleMessage(raw);
+    (conn as unknown as { handleMessage: (d: string) => void }).handleMessage(
+      raw,
+    );
   };
 
   /** Build a `game-action` message with a fresh seq. */
@@ -2081,10 +2076,7 @@ describe("P2PGameConnection HMAC envelope signing/verification (issue #1252)", (
         events: { onMessage },
       });
       // No `hmac` field — the envelope shape guard rejects it.
-      handleMessage(
-        conn,
-        JSON.stringify({ payload: actionMsg("peer", 0) }),
-      );
+      handleMessage(conn, JSON.stringify({ payload: actionMsg("peer", 0) }));
       expect(onMessage).not.toHaveBeenCalled();
       expect(conn.getEnvelopeRejections()).toBe(1);
     });
@@ -2116,9 +2108,18 @@ describe("P2PGameConnection HMAC envelope signing/verification (issue #1252)", (
     it("increments the rejection counter on each failed verification", () => {
       const conn = makeConn({ sessionKeyHex: SESSION_KEY });
       expect(conn.getEnvelopeRejections()).toBe(0);
-      handleMessage(conn, JSON.stringify(envelope(actionMsg("attacker", 0), OTHER_KEY)));
-      handleMessage(conn, JSON.stringify(envelope(actionMsg("attacker", 1), OTHER_KEY)));
-      handleMessage(conn, JSON.stringify(envelope(actionMsg("attacker", 2), OTHER_KEY)));
+      handleMessage(
+        conn,
+        JSON.stringify(envelope(actionMsg("attacker", 0), OTHER_KEY)),
+      );
+      handleMessage(
+        conn,
+        JSON.stringify(envelope(actionMsg("attacker", 1), OTHER_KEY)),
+      );
+      handleMessage(
+        conn,
+        JSON.stringify(envelope(actionMsg("attacker", 2), OTHER_KEY)),
+      );
       expect(conn.getEnvelopeRejections()).toBe(3);
     });
   });
@@ -2233,7 +2234,10 @@ describe("P2PGameConnection HMAC envelope signing/verification (issue #1252)", (
   describe("close() resets the rejection counter", () => {
     it("resets envelopeRejections to zero on close()", () => {
       const conn = makeConn({ sessionKeyHex: SESSION_KEY });
-      handleMessage(conn, JSON.stringify(envelope(actionMsg("attacker", 0), OTHER_KEY)));
+      handleMessage(
+        conn,
+        JSON.stringify(envelope(actionMsg("attacker", 0), OTHER_KEY)),
+      );
       expect(conn.getEnvelopeRejections()).toBe(1);
       conn.close();
       expect(conn.getEnvelopeRejections()).toBe(0);
@@ -2279,6 +2283,168 @@ describe("P2PGameConnection HMAC envelope signing/verification (issue #1252)", (
       // Higher seq — accepted.
       handleMessage(conn, JSON.stringify(envelope(actionMsg("peer", 1))));
       expect(onMessage).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+/**
+ * Chat message cap + sanitization (issue #1428).
+ *
+ * P2P chat is the only message type with arbitrary peer-controlled content
+ * rendered to other peers. These tests pin the send-side reject-over-length
+ * + sanitize behavior and the receive-side defense-in-depth sanitize + cap.
+ */
+describe("P2PGameConnection chat cap + sanitize (#1428)", () => {
+  const makeConn = (
+    overrides: Partial<P2PGameConnectionOptions> = {},
+  ): { conn: P2PGameConnection; onChat: jest.Mock } => {
+    const onChat = jest.fn();
+    const conn = createP2PGameConnection({
+      playerId: "player-1",
+      playerName: "Host",
+      role: "host",
+      events: {
+        onConnectionStateChange: () => {},
+        onSignalingStateChange: () => {},
+        onMessage: () => {},
+        onGameStateSync: () => {},
+        onChat,
+        onError: () => {},
+        onPlayerJoined: () => {},
+        onPlayerLeft: () => {},
+      },
+      ...overrides,
+    });
+    return { conn, onChat };
+  };
+
+  const handleMessage = (conn: P2PGameConnection, raw: string): void =>
+    (conn as unknown as { handleMessage: (d: string) => void }).handleMessage(
+      raw,
+    );
+
+  describe("sendChat — sanitize + reject over-length", () => {
+    it("REFUSES an over-length message: returns false + warns, no send", () => {
+      const { conn } = makeConn();
+      const sendSpy = jest.spyOn(conn, "send").mockReturnValue(true);
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+      // 501 chars — one over the 500 default cap.
+      const over = "x".repeat(501);
+      expect(conn.sendChat(over)).toBe(false);
+      expect(sendSpy).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("sendChat refused"),
+      );
+
+      sendSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("respects a custom maxChatMessageLength option", () => {
+      const { conn } = makeConn({ maxChatMessageLength: 10 });
+      const sendSpy = jest.spyOn(conn, "send").mockReturnValue(true);
+
+      expect(conn.sendChat("short")).toBe(true); // 5 chars, under 10
+      expect(conn.sendChat("0123456789")).toBe(true); // exactly 10, allowed
+      expect(conn.sendChat("0123456789A")).toBe(false); // 11, refused
+      expect(sendSpy).toHaveBeenCalledTimes(2);
+
+      sendSpy.mockRestore();
+    });
+
+    it("strips control chars and sends the sanitized text", () => {
+      const { conn } = makeConn();
+      const sendSpy = jest.spyOn(conn, "send").mockReturnValue(true);
+
+      expect(conn.sendChat("hello\x00world")).toBe(true);
+      expect(sendSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "chat",
+          data: expect.objectContaining({ text: "helloworld" }),
+        }),
+      );
+
+      sendSpy.mockRestore();
+    });
+
+    it("strips raw < > / backtick so the wire payload has no markup chars", () => {
+      const { conn } = makeConn();
+      const sendSpy = jest.spyOn(conn, "send").mockReturnValue(true);
+
+      expect(conn.sendChat("<img src=x>")).toBe(true);
+      const sent = sendSpy.mock.calls[0]![0] as GameMessage;
+      const text = (sent.data as { text: string }).text;
+      expect(text).not.toMatch(/[<>`]/);
+      expect(text).toBe("img src=x");
+
+      sendSpy.mockRestore();
+    });
+
+    it("passes a normal message through sanitized but uncapped", () => {
+      const { conn } = makeConn();
+      const sendSpy = jest.spyOn(conn, "send").mockReturnValue(true);
+
+      expect(conn.sendChat("gg, nice play!")).toBe(true);
+      expect(sendSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "chat",
+          data: expect.objectContaining({ text: "gg, nice play!" }),
+        }),
+      );
+
+      sendSpy.mockRestore();
+    });
+  });
+
+  describe("handleChat — receive-side defense in depth", () => {
+    const chatWire = (
+      text: unknown,
+      senderName: unknown = "Peer",
+      seq = 0,
+    ): string =>
+      JSON.stringify({
+        type: "chat",
+        senderId: "player-2",
+        timestamp: Date.now(),
+        seq,
+        data: { senderName, text },
+      });
+
+    it("sanitizes control chars before onChat fires", () => {
+      const { conn, onChat } = makeConn();
+      handleMessage(conn, chatWire("hello\x00world"));
+
+      expect(onChat).toHaveBeenCalledTimes(1);
+      const payload = onChat.mock.calls[0]![0] as ChatMessage;
+      expect(payload.text).toBe("helloworld");
+    });
+
+    it("strips raw < > from peer-supplied markup before onChat", () => {
+      const { conn, onChat } = makeConn();
+      handleMessage(conn, chatWire("<script>alert(1)</script>"));
+
+      const payload = onChat.mock.calls[0]![0] as ChatMessage;
+      expect(payload.text).not.toMatch(/[<>]/);
+    });
+
+    it("TRUNCATES an oversized inbound blob to the cap (never trust peer input)", () => {
+      const { conn, onChat } = makeConn();
+      // A legacy/hostile peer bypasses the send guard and ships 5000 chars.
+      handleMessage(conn, chatWire("z".repeat(5000), "Peer", 1));
+
+      const payload = onChat.mock.calls[0]![0] as ChatMessage;
+      expect(payload.text.length).toBeLessThanOrEqual(500);
+      expect(payload.text.endsWith("…")).toBe(true);
+    });
+
+    it("sanitizes the peer-supplied senderName too", () => {
+      const { conn, onChat } = makeConn();
+      handleMessage(conn, chatWire("hi", "Evil\u202E<b>", 2));
+
+      const payload = onChat.mock.calls[0]![0] as ChatMessage;
+      expect(payload.senderName).not.toMatch(/[<>\u202E]/);
+      expect(payload.senderName).toBe("Evilb");
     });
   });
 });

--- a/src/lib/mesh-game-connection.ts
+++ b/src/lib/mesh-game-connection.ts
@@ -80,6 +80,11 @@ import {
   isRoleAllowedToSend,
   rejectionReasonForSend,
 } from "./peer-role";
+import {
+  sanitizeChatMessage,
+  capMessageLength,
+  MAX_CHAT_MESSAGE_LENGTH,
+} from "./security/chat-sanitize";
 
 /**
  * A handle the mesh uses to push bytes to one remote peer and query its
@@ -167,6 +172,14 @@ export interface MeshGameConnectionOptions {
   validatePeerAction?: PeerActionValidator;
   /** Per-link rate limit for inbound messages (one counter per peer, #1111). */
   rateLimit?: Partial<P2PRateLimitOptions>;
+  /**
+   * Maximum length (chars) of a single chat message (issue #1428). Outbound
+   * chat whose sanitized length exceeds this is refused
+   * ({@link MeshGameConnection.broadcastChat} returns 0); inbound chat is
+   * truncated at this value before `onChat` fires. Defaults to
+   * {@link MAX_CHAT_MESSAGE_LENGTH} (500).
+   */
+  maxChatMessageLength?: number;
 }
 
 /** Default reason stamped on a host rejection when the validator omits one. */
@@ -223,6 +236,13 @@ export class MeshGameConnection {
   private readonly validatePeerActions: boolean;
   private readonly validatePeerAction: PeerActionValidator | null;
   private readonly events: MeshGameConnectionEvents;
+  /**
+   * Maximum length (chars) of a single chat message (issue #1428). Outbound
+   * chat whose sanitized length exceeds this is refused; inbound chat is
+   * truncated at this value before `onChat` fires. Defaults to
+   * {@link MAX_CHAT_MESSAGE_LENGTH}.
+   */
+  private readonly maxChatMessageLength: number;
 
   /**
    * Per-session HMAC key (issue #1391). Mirrors
@@ -250,7 +270,14 @@ export class MeshGameConnection {
     this.rateLimitOptions = options.rateLimit ?? {};
     this.validatePeerActions = options.validatePeerActions === true;
     this.validatePeerAction = options.validatePeerAction ?? null;
- 
+    // Chat message length cap (issue #1428). Sanitize + refuse-over-length on
+    // send; sanitize + truncate on receive (defense in depth).
+    this.maxChatMessageLength =
+      typeof options.maxChatMessageLength === "number" &&
+      options.maxChatMessageLength > 0
+        ? Math.floor(options.maxChatMessageLength)
+        : MAX_CHAT_MESSAGE_LENGTH;
+
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     const noop = (): void => {};
     const defaults: MeshGameConnectionEvents = {
@@ -351,10 +378,7 @@ export class MeshGameConnection {
     );
     // Record the link's declared role. `setPeerRole` can override this
     // post-registration (e.g. once the spectator handshake completes).
-    this.peerRoles.set(
-      link.peerId,
-      link.role ?? DEFAULT_PEER_ROLE,
-    );
+    this.peerRoles.set(link.peerId, link.role ?? DEFAULT_PEER_ROLE);
     if (!isReplace) {
       this.events.onPeerJoined(link.peerId);
     }
@@ -510,10 +534,7 @@ export class MeshGameConnection {
     // so the caller's `sendGameAction` is a clean no-op (no wire bytes,
     // no seq stamped).
     if (!isRoleAllowedToSend(this.localRoleFlag, payload.type)) {
-      const reason = rejectionReasonForSend(
-        this.localRoleFlag,
-        payload.type,
-      );
+      const reason = rejectionReasonForSend(this.localRoleFlag, payload.type);
       this.events.onError(
         new Error(reason ?? "Local role does not allow this send"),
         this.localPlayerId,
@@ -537,17 +558,18 @@ export class MeshGameConnection {
     const link = this.links.get(peerId);
     if (!link) return false;
     if (!isRoleAllowedToSend(this.localRoleFlag, payload.type)) {
-      const reason = rejectionReasonForSend(
-        this.localRoleFlag,
-        payload.type,
-      );
+      const reason = rejectionReasonForSend(this.localRoleFlag, payload.type);
       this.events.onError(
         new Error(reason ?? "Local role does not allow this send"),
         this.localPlayerId,
       );
       return false;
     }
-    return this.sendRawOnLink(link, this.serializeOutgoing(payload), payload.type);
+    return this.sendRawOnLink(
+      link,
+      this.serializeOutgoing(payload),
+      payload.type,
+    );
   }
 
   /**
@@ -564,7 +586,10 @@ export class MeshGameConnection {
     type?: GameMessageType,
   ): boolean {
     if (!link.isOpen()) return false;
-    if (type && !isMessageAllowedForRole(link.role ?? DEFAULT_PEER_ROLE, type)) {
+    if (
+      type &&
+      !isMessageAllowedForRole(link.role ?? DEFAULT_PEER_ROLE, type)
+    ) {
       // Per-peer inbound allowlist rejected this message type for the
       // link's role. Silent drop — the spectator never sees the wire
       // bytes, so a host pushing `game-action` to a 4-peer pod with
@@ -588,11 +613,26 @@ export class MeshGameConnection {
     return this.broadcast({ type: "game-action", data: { action, data } });
   }
 
-  /** Broadcast a `chat` message to all peers. */
+  /**
+   * Broadcast a `chat` message to all peers.
+   *
+   * Issue #1428: the text is sanitized (control / bidi / zero-width / raw
+   * markup chars stripped) and length-capped BEFORE transmission. An
+   * over-length message is refused: returns 0 and emits a warning, and no
+   * wire bytes are written. Spectator-authored chat (#1253) flows through
+   * here too, so the guard covers the full chat surface.
+   */
   broadcastChat(text: string): number {
+    const sanitized = sanitizeChatMessage(text);
+    if (sanitized.length > this.maxChatMessageLength) {
+      console.warn(
+        `[MeshGameConnection] broadcastChat refused: length=${sanitized.length} (max=${this.maxChatMessageLength})`,
+      );
+      return 0;
+    }
     return this.broadcast({
       type: "chat",
-      data: { senderName: this.localPlayerName, text },
+      data: { senderName: this.localPlayerName, text: sanitized },
     });
   }
 
@@ -770,11 +810,20 @@ export class MeshGameConnection {
           senderName?: unknown;
           text?: unknown;
         };
+        // Issue #1428 — defense in depth: sanitize + cap peer-supplied chat
+        // BEFORE `onChat` fires so a buggy/legacy/hostile sender cannot slip
+        // markup, control chars, or an oversized blob past the receiver.
+        // Only forward when the peer actually supplied a string `text`.
         if (typeof payload.text === "string") {
+          const senderName =
+            typeof payload.senderName === "string" ? payload.senderName : "";
           this.events.onChat(
             message.senderId,
-            typeof payload.senderName === "string" ? payload.senderName : "",
-            payload.text,
+            sanitizeChatMessage(senderName),
+            capMessageLength(
+              sanitizeChatMessage(payload.text),
+              this.maxChatMessageLength,
+            ),
           );
         }
         break;

--- a/src/lib/p2p-game-connection.ts
+++ b/src/lib/p2p-game-connection.ts
@@ -70,6 +70,11 @@ import {
   type PeerQueueStats,
   type SendPriority,
 } from "./peer-send-queue";
+import {
+  sanitizeChatMessage,
+  capMessageLength,
+  MAX_CHAT_MESSAGE_LENGTH,
+} from "./security/chat-sanitize";
 
 /**
  * P2P connection events
@@ -403,6 +408,14 @@ export interface P2PGameConnectionOptions {
    * Per-peer send queue hard message cap (issue #1251). Defaults to 1000.
    */
   sendQueueMaxMessages?: number;
+  /**
+   * Maximum length (chars) of a single outbound chat message (issue #1428).
+   * Messages whose sanitized length EXCEEDS this are REFUSED on send
+   * ({@link P2PGameConnection.sendChat} returns false). Inbound chat is
+   * truncated at the same value before `onChat` fires, as defense in depth.
+   * Defaults to {@link MAX_CHAT_MESSAGE_LENGTH} (500).
+   */
+  maxChatMessageLength?: number;
 }
 
 /**
@@ -471,7 +484,15 @@ export class P2PGameConnection {
    * Host callback returning the authoritative state to push when a peer
    * requests a state sync (issue #1086). Null on non-hosts / when unwired.
    */
-  private readonly onStateSyncRequest: (() => GameState | null | undefined) | null;
+  private readonly onStateSyncRequest:
+    (() => GameState | null | undefined) | null;
+  /**
+   * Maximum length (chars) of a single chat message (issue #1428). Outbound
+   * chat whose sanitized length exceeds this is refused on send; inbound
+   * chat is truncated at this value before `onChat` fires. Defaults to
+   * {@link MAX_CHAT_MESSAGE_LENGTH}.
+   */
+  private readonly maxChatMessageLength: number;
   /**
    * True once the connection has reached "connected" at least once. Used to
    * distinguish a RECONNECT (recovery after a drop) from the initial connect
@@ -577,6 +598,13 @@ export class P2PGameConnection {
     // Host-side state-sync request handler (issue #1086). Null on non-hosts
     // or when unwired; the transport never owns game state.
     this.onStateSyncRequest = options.onStateSyncRequest ?? null;
+    // Chat message length cap (issue #1428). Sanitize + reject-over-length on
+    // send; sanitize + truncate on receive (defense in depth).
+    this.maxChatMessageLength =
+      typeof options.maxChatMessageLength === "number" &&
+      options.maxChatMessageLength > 0
+        ? Math.floor(options.maxChatMessageLength)
+        : MAX_CHAT_MESSAGE_LENGTH;
 
     // Initialize ICE manager
     if (options.iceConfig) {
@@ -820,10 +848,7 @@ export class P2PGameConnection {
     // Local role gate (issue #1253). Refuse to send any message type the
     // local role is not allowed to originate.
     if (!isRoleAllowedToSend(this.localRoleFlag, message.type)) {
-      const reason = rejectionReasonForSend(
-        this.localRoleFlag,
-        message.type,
-      );
+      const reason = rejectionReasonForSend(this.localRoleFlag, message.type);
       console.warn(
         "[P2PGameConnection] Refusing outbound message: local role disallows it",
         redactSensitive({
@@ -1148,9 +1173,23 @@ export class P2PGameConnection {
   }
 
   /**
-   * Send a chat message
+   * Send a chat message.
+   *
+   * Issue #1428: the text is sanitized (control / bidi / zero-width / raw
+   * markup chars stripped) and length-capped BEFORE transmission. An
+   * over-length message is refused: the method returns false and emits a
+   * warning, and no wire bytes are written. Chat is the only P2P message
+   * type with arbitrary peer-controlled content, so it is the highest-
+   * leverage injection vector and is defended at the source.
    */
   sendChat(text: string): boolean {
+    const sanitized = sanitizeChatMessage(text);
+    if (sanitized.length > this.maxChatMessageLength) {
+      console.warn(
+        `[P2PGameConnection] sendChat refused: length=${sanitized.length} (max=${this.maxChatMessageLength})`,
+      );
+      return false;
+    }
     return this.send({
       type: "chat",
       senderId: this.playerId,
@@ -1158,7 +1197,7 @@ export class P2PGameConnection {
       seq: this.nextOutgoingSeq(),
       data: {
         senderName: this.playerName,
-        text,
+        text: sanitized,
       },
     });
   }
@@ -1302,12 +1341,13 @@ export class P2PGameConnection {
       // (back-compat with single-player / AI / pre-#1252 peers).
       let message: GameMessage;
       if (this.sessionKeyHex) {
-        const envelope = safeParseJson<MessageEnvelope>(data, isMessageEnvelope);
+        const envelope = safeParseJson<MessageEnvelope>(
+          data,
+          isMessageEnvelope,
+        );
         if (!envelope) {
           this.envelopeRejections += 1;
-          console.warn(
-            "[P2PGameConnection] Rejected malformed envelope",
-          );
+          console.warn("[P2PGameConnection] Rejected malformed envelope");
           return;
         }
         if (!verifyMessageEnvelope(envelope, this.sessionKeyHex)) {
@@ -1670,7 +1710,12 @@ export class P2PGameConnection {
     }
     const raw = payload as Record<string, unknown>;
     const kind = raw.kind;
-    if (kind !== "kick" && kind !== "ban" && kind !== "pause" && kind !== "resume") {
+    if (
+      kind !== "kick" &&
+      kind !== "ban" &&
+      kind !== "pause" &&
+      kind !== "resume"
+    ) {
       console.warn(
         "[P2PGameConnection] Rejected lobby-control with invalid kind",
         redactSensitive({ kind }),
@@ -1728,14 +1773,23 @@ export class P2PGameConnection {
   }
 
   /**
-   * Handle chat message
+   * Handle chat message.
+   *
+   * Issue #1428: defense in depth — re-sanitize and cap the peer-supplied
+   * `senderName` / `text` BEFORE `onChat` fires, so a buggy, legacy, or
+   * hostile sender cannot slip markup, control chars, or an oversized blob
+   * past the receiver even if the send-side guard was bypassed. Never trust
+   * peer input.
    */
   private handleChat(message: GameMessage): void {
-    const data = message.data as { senderName: string; text: string };
+    const data = message.data as { senderName?: unknown; text?: unknown };
     const chatMessage: ChatMessage = {
       senderId: message.senderId,
-      senderName: data.senderName,
-      text: data.text,
+      senderName: sanitizeChatMessage(data?.senderName),
+      text: capMessageLength(
+        sanitizeChatMessage(data?.text),
+        this.maxChatMessageLength,
+      ),
       timestamp: message.timestamp,
     };
     this.events.onChat(chatMessage);

--- a/src/lib/security/__tests__/chat-sanitize.test.ts
+++ b/src/lib/security/__tests__/chat-sanitize.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for src/lib/security/chat-sanitize.ts (issue #1428)
+ *
+ * The chat sanitizer is the application-layer defense for the only P2P
+ * message type with arbitrary peer-controlled content. These tests pin its
+ * contract: control-char / bidi / zero-width stripping, raw-markup removal,
+ * whitespace collapse, NFC normalization, length capping, idempotence, and
+ * safe coercion of non-string input.
+ */
+
+import {
+  sanitizeChatMessage,
+  capMessageLength,
+  MAX_CHAT_MESSAGE_LENGTH,
+} from "../chat-sanitize";
+
+describe("security/chat-sanitize — MAX_CHAT_MESSAGE_LENGTH", () => {
+  it("defaults to 500 (sensible UI line count, below wire-size thresholds)", () => {
+    expect(MAX_CHAT_MESSAGE_LENGTH).toBe(500);
+  });
+});
+
+describe("security/chat-sanitize — sanitizeChatMessage", () => {
+  it("passes normal text through unchanged", () => {
+    expect(sanitizeChatMessage("hello world")).toBe("hello world");
+    expect(sanitizeChatMessage("gg, nice play!")).toBe("gg, nice play!");
+  });
+
+  it("is idempotent (sanitize twice === sanitize once)", () => {
+    const payloads = [
+      "hello\x00world<script>",
+      "a   b\u202E<c>",
+      "\uFEFF\u200Bclean\u0007",
+    ];
+    for (const p of payloads) {
+      const once = sanitizeChatMessage(p);
+      const twice = sanitizeChatMessage(once);
+      expect(twice).toBe(once);
+    }
+  });
+
+  it("strips C0 control chars except tab/newline/cr", () => {
+    // NUL, BEL, ESC, GS stripped...
+    expect(sanitizeChatMessage("hello\x00world")).toBe("helloworld");
+    expect(sanitizeChatMessage("a\x07b\x1Bc")).toBe("abc");
+    // ...while \n \r \t are preserved (chat is line-oriented).
+    expect(sanitizeChatMessage("line1\nline2")).toBe("line1\nline2");
+    expect(sanitizeChatMessage("a\tb")).toBe("a\tb");
+    expect(sanitizeChatMessage("a\rb")).toBe("a\rb");
+  });
+
+  it("strips DEL and the C1 (0x80-0x9F) 8-bit control range", () => {
+    expect(sanitizeChatMessage("a\x7Fb")).toBe("ab");
+    expect(sanitizeChatMessage("a\x80b")).toBe("ab");
+    expect(sanitizeChatMessage("a\x9Fb")).toBe("ab");
+  });
+
+  it("strips bidi override / embedding controls (Trojan-source defense)", () => {
+    // U+202E RLO, U+202D LRO, U+2066 LRI ... U+2069 PDI
+    expect(sanitizeChatMessage("a\u202Eb")).toBe("ab");
+    expect(sanitizeChatMessage("a\u202Db")).toBe("ab");
+    expect(sanitizeChatMessage("a\u2066b\u2069")).toBe("ab");
+  });
+
+  it("strips zero-width and BOM characters", () => {
+    // U+200B ZWSP, U+200C ZWNJ, U+200D ZWJ, U+FEFF BOM
+    expect(sanitizeChatMessage("a\u200Bb")).toBe("ab");
+    expect(sanitizeChatMessage("a\u200Cb\u200Dc")).toBe("abc");
+    expect(sanitizeChatMessage("\uFEFFhi")).toBe("hi");
+  });
+
+  it("strips raw HTML/markup-significant chars (<, >, backtick)", () => {
+    expect(sanitizeChatMessage("<img src=x>")).toBe("img src=x");
+    expect(sanitizeChatMessage("<script>alert(1)</script>")).toBe(
+      "scriptalert(1)/script",
+    );
+    expect(sanitizeChatMessage("a`b`c")).toBe("abc");
+  });
+
+  it("collapses runs of 2+ horizontal whitespace into a single space", () => {
+    expect(sanitizeChatMessage("a    b")).toBe("a b");
+    expect(sanitizeChatMessage("a\t\t\tb")).toBe("a b"); // tabs collapse too
+    expect(sanitizeChatMessage("a b")).toBe("a b"); // single space preserved
+  });
+
+  it("preserves newlines through whitespace collapsing", () => {
+    expect(sanitizeChatMessage("line1\nline2\n\nline4")).toBe(
+      "line1\nline2\n\nline4",
+    );
+  });
+
+  it("normalizes to NFC so decomposed forms cannot smuggle confusables", () => {
+    // é as decomposed (e + U+0301 combining acute) vs precomposed (U+00E9).
+    const decomposed = "e\u0301";
+    const precomposed = "\u00E9";
+    expect(sanitizeChatMessage(decomposed)).toBe(precomposed);
+  });
+
+  it("coerces non-string input safely to an empty (or stringified) result", () => {
+    expect(sanitizeChatMessage(undefined)).toBe("");
+    expect(sanitizeChatMessage(null)).toBe("");
+    expect(sanitizeChatMessage(42)).toBe("42");
+    expect(sanitizeChatMessage({ x: 1 })).toBe("[object Object]");
+  });
+
+  it("strips a combined malicious payload down to safe text", () => {
+    // control char + HTML tag + bidi override + zero-width, all in one.
+    const payload = "hi\x00<svg/onload=alert(1)>\u202E\u200Bboom";
+    expect(sanitizeChatMessage(payload)).toBe("hisvg/onload=alert(1)boom");
+  });
+});
+
+describe("security/chat-sanitize — capMessageLength", () => {
+  it("leaves messages at or under the limit untouched", () => {
+    expect(capMessageLength("short")).toBe("short");
+    expect(capMessageLength("x".repeat(500), 500)).toBe("x".repeat(500));
+  });
+
+  it("truncates over-length messages and stays within the budget", () => {
+    const out = capMessageLength("x".repeat(501), 500);
+    expect(out.length).toBe(500);
+    expect(out.endsWith("…")).toBe(true);
+    expect(out.startsWith("x")).toBe(true);
+  });
+
+  it("defaults to MAX_CHAT_MESSAGE_LENGTH when no max given", () => {
+    const out = capMessageLength("y".repeat(600));
+    expect(out.length).toBe(MAX_CHAT_MESSAGE_LENGTH);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("returns empty string for a non-positive max length", () => {
+    expect(capMessageLength("abc", 0)).toBe("");
+    expect(capMessageLength("abc", -5)).toBe("");
+  });
+
+  it("coerces non-string input", () => {
+    expect(capMessageLength(123, 500)).toBe("123");
+    expect(capMessageLength(null, 500)).toBe("");
+  });
+
+  it("composes with sanitizeChatMessage on the receive path", () => {
+    // Mirrors the receiver: sanitize first, then cap.
+    const malicious = "a".repeat(495) + "<x>\x00" + "b".repeat(100);
+    const sanitized = sanitizeChatMessage(malicious);
+    const capped = capMessageLength(sanitized, 500);
+    expect(capped.length).toBeLessThanOrEqual(500);
+    expect(capped).not.toMatch(/[<>]/);
+    expect(capped).not.toContain("\x00");
+    expect(capped.endsWith("…")).toBe(true);
+  });
+});

--- a/src/lib/security/chat-sanitize.ts
+++ b/src/lib/security/chat-sanitize.ts
@@ -1,0 +1,127 @@
+/**
+ * @fileOverview P2P chat-message sanitization (issue #1428)
+ *
+ * Chat is the only P2P message type whose `data.text` is arbitrary,
+ * peer-controlled content rendered to other peers — players AND spectators
+ * (per #1253, `DEFAULT_SPECTATOR_PERMISSIONS.canChat = true`). The
+ * transport-level guards from #1111 cap wire SIZE and RATE but NOT
+ * single-message length, and #1276 only sanitizes card/coach text at
+ * RENDER time. This module is the application-layer cap + sanitize for
+ * chat on BOTH the send and receive paths — defense in depth:
+ *
+ *   SEND path  → {@link sanitizeChatMessage} + REJECT over-length
+ *                (P2PGameConnection.sendChat / MeshGameConnection.broadcastChat)
+ *   RECV path  → {@link sanitizeChatMessage} + {@link capMessageLength}
+ *                (handleChat / mesh inbound) so a buggy or hostile sender can
+ *                never slip an oversized or markup-laden payload past the
+ *                receiver, even if the render layer is later changed.
+ *
+ * Design notes:
+ *   - {@link sanitizeChatMessage} is a deny-list STRIP of characters that have
+ *     no legitimate place in chat and that could inject markup (raw `<`/`>`/
+ *     backtick) or smuggle payloads (C0/C1 controls, bidi overrides,
+ *     zero-width). It does NOT HTML-escape: escaping belongs to the render
+ *     layer (`game-chat.tsx` already runs `sanitizeCardText` from #1276, and
+ *     React's JSX interpolation auto-escapes). Escaping here would
+ *     double-escape at render (`<` → `&lt;` → `&amp;lt;`). Stripping the
+ *     chars at the source is the intentional transport-layer defense so they
+ *     never reach a renderer even if a future change bypasses sanitizeCardText.
+ *   - {@link capMessageLength} truncates with a single ellipsis. The send
+ *     path REJECTS over-length (returns false); the receive path TRUNCATES
+ *     (never trust peer input — a legacy/malformed peer may emit a huge blob).
+ *   - NFC normalization defeats homoglyph/confusable abuse that relies on
+ *     decomposed forms and makes byte-length comparisons stable.
+ */
+
+/**
+ * Default maximum length (chars) of a single P2P chat message. Chosen to fit
+ * a sensible UI line count and well below any plausible wire-size threshold
+ * (#1111). Overridable per-connection via
+ * `P2PGameConnectionOptions.maxChatMessageLength` /
+ * `MeshGameConnectionOptions.maxChatMessageLength`.
+ */
+export const MAX_CHAT_MESSAGE_LENGTH = 500;
+
+/**
+ * C0 control chars (`\u0000`-`\u001F`) EXCEPT tab (`\u0009`), newline
+ * (`\u000A`), and carriage return (`\u000D`); plus DEL (`\u007F`) and the
+ * C1 8-bit control range (`\u0080`-`\u009F`). Chat is line-oriented so
+ * `\n` / `\r` / `\t` are intentionally preserved.
+ */
+// eslint-disable-next-line no-control-regex -- intentionally targets control chars
+const CHAT_CONTROL_CHARS =
+  /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/g;
+
+/**
+ * Bidi override / embedding controls and zero-width / BOM characters used to
+ * spoof text direction or hide payloads (Trojan-source attacks). These have
+ * no place in chat. Mirrors the `SMUGGLE_CHARS` set in `sanitize-text.ts`
+ * (#1276) so the two layers agree on what is smuggle-grade.
+ */
+const CHAT_BIDI_ZW_CHARS = /[\u202A-\u202E\u2066-\u2069\u200B-\u200D\uFEFF]/g;
+
+/**
+ * Raw HTML / markdown-significant characters stripped at the transport
+ * layer. Removing `<`, `>`, and the backtick prevents a future or buggy
+ * renderer from ever materialising tags or inline-code spans from peer
+ * chat. The render layer (`sanitizeCardText`) would escape these; stripping
+ * here is the redundant defense so the characters are absent on the wire
+ * entirely (and survives any code path that bypasses the render sanitizer).
+ */
+const CHAT_MARKUP_CHARS = /[<>`]/g;
+
+/**
+ * Runs of 2+ horizontal whitespace (spaces / tabs / other horizontal
+ * spaces, but NOT newlines) collapsed to a single space. Defeats
+ * spacing-based log-spam and normalizes rendering across peers. Newlines
+ * are preserved because chat is line-oriented.
+ */
+const CHAT_WHITESPACE_RUNS = /[^\S\r\n]{2,}/g;
+
+/**
+ * Normalize and strip control / bidi / zero-width / markup characters from
+ * a raw chat string. Pure and idempotent: applying it twice yields the same
+ * string. Does NOT cap length and does NOT HTML-escape (the render layer's
+ * job). Safe for non-string input — coerces to `""`.
+ *
+ * @param raw - the untrusted chat text (any type; non-strings coerced)
+ * @returns the sanitized string (never null/undefined; may be empty)
+ */
+export function sanitizeChatMessage(raw: unknown): string {
+  const text = typeof raw === "string" ? raw : raw == null ? "" : String(raw);
+  return (
+    text
+      // NFC first so subsequent strips see the canonical form.
+      .normalize("NFC")
+      .replace(CHAT_CONTROL_CHARS, "")
+      .replace(CHAT_BIDI_ZW_CHARS, "")
+      .replace(CHAT_MARKUP_CHARS, "")
+      .replace(CHAT_WHITESPACE_RUNS, " ")
+  );
+}
+
+/**
+ * Truncate a chat message to `maxLength` chars, appending a single ellipsis
+ * (`…`) when truncation occurs so the receiver can tell the message was
+ * capped. Used on the RECEIVE path (defense in depth — never trust peer
+ * input even after sanitization). The SEND path rejects over-length instead
+ * of truncating so the sender gets feedback to shorten the message.
+ *
+ * The returned string is guaranteed `<= maxLength` chars (the ellipsis is
+ * counted within the budget).
+ *
+ * @param message - the (ideally already-sanitized) chat text
+ * @param maxLength - inclusive max length of the RETURNED string including
+ *   the ellipsis marker; defaults to {@link MAX_CHAT_MESSAGE_LENGTH}
+ */
+export function capMessageLength(
+  message: unknown,
+  maxLength: number = MAX_CHAT_MESSAGE_LENGTH,
+): string {
+  const text = typeof message === "string" ? message : String(message ?? "");
+  if (maxLength <= 0) return "";
+  if (text.length <= maxLength) return text;
+  // Reserve room for the ellipsis so the result never exceeds maxLength.
+  const marker = "…";
+  return text.slice(0, Math.max(0, maxLength - marker.length)) + marker;
+}

--- a/src/lib/security/chat-sanitize.ts
+++ b/src/lib/security/chat-sanitize.ts
@@ -48,9 +48,10 @@ export const MAX_CHAT_MESSAGE_LENGTH = 500;
  * C1 8-bit control range (`\u0080`-`\u009F`). Chat is line-oriented so
  * `\n` / `\r` / `\t` are intentionally preserved.
  */
-// eslint-disable-next-line no-control-regex -- intentionally targets control chars
+/* eslint-disable no-control-regex -- intentionally matches C0/C1 control chars */
 const CHAT_CONTROL_CHARS =
   /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/g;
+/* eslint-enable no-control-regex */
 
 /**
  * Bidi override / embedding controls and zero-width / BOM characters used to


### PR DESCRIPTION
## Summary

Closes #1428

P2P chat (spectator + player) is the only message type whose `data.text` is arbitrary peer-controlled content rendered to other peers. It had **no per-message length cap and no markdown / control-char sanitization** at the application layer (the existing wire-level guards only enforce byte-rate/total-size, and the existing render sanitizer only covers card/coach text). This PR adds an application-layer cap + sanitize on **both** the send and receive paths — defense in depth.

## Changes

### New pure helper — `src/lib/security/chat-sanitize.ts`
- **`MAX_CHAT_MESSAGE_LENGTH = 500`** — exported, sensible UI line count, well below any wire-size threshold.
- **`sanitizeChatMessage(raw)`** — pure, idempotent. NFC-normalizes, then strips:
  - C0 control chars (`\u0000-\u001F`) except tab/newline/cr; DEL (`\u007F`) and the C1 range (`\u0080-\u009F`)
  - bidi override / embedding controls (`U+202A-U+202E`, `U+2066-U+2069`) — Trojan-source defense
  - zero-width / BOM (`U+200B-U+200D`, `U+FEFF`)
  - raw HTML/markup-significant chars (`<`, `>`, backtick) so a future/buggy renderer can never materialise tags or inline-code from peer chat
  - collapses runs of 2+ horizontal whitespace into a single space (newlines preserved; chat is line-oriented)
  - does **not** HTML-escape (escaping belongs to the render layer; escaping here would double-escape). Strips at the source so the chars never reach a renderer even if the render sanitizer is bypassed.
- **`capMessageLength(msg, max)`** — truncates to `max` with a single `…`, result guaranteed `<= max`. Used on the receive path.

### `P2PGameConnection` (`src/lib/p2p-game-connection.ts`)
- New `maxChatMessageLength?` option (default `500`, overridable).
- **Send (`sendChat`)**: sanitize, then **reject** over-length → returns `false` + `console.warn`, no wire bytes. Sanitized text is what's transmitted.
- **Receive (`handleChat`)**: defense in depth — re-sanitize + cap both `senderName` and `text` **before** `onChat` fires.

### `MeshGameConnection` (`src/lib/mesh-game-connection.ts`)
- New `maxChatMessageLength?` option (default `500`, overridable).
- **Send (`broadcastChat`)**: sanitize, then **refuse** over-length → returns `0` + warning, no wire bytes.
- **Inbound (`case "chat"`)**: sanitize + cap before `onChat` — covers spectator-authored chat too.

### Render layer
`game-chat.tsx` already rendered content via `sanitizeCardText(content, 1_000)` JSX interpolation (no `dangerouslySetInnerHTML`, no `react-markdown`) — already safe. Left unchanged; a new test pins this contract so a future change can't silently weaken it.

## Defense-in-depth model

| Layer | Send | Receive/Render |
|---|---|---|
| Transport (this PR) | sanitize + **reject** over-length (returns false/0) | sanitize + **truncate** (never trust peer input) |
| Render (`sanitizeCardText`) | — | HTML-escape + cap |

A peer that bypasses the send-side guard (legacy / hostile) is still stopped at the receiver's inbound path, and again at render.

## Test coverage

- **`chat-sanitize.test.ts`** (19 tests): over-length truncation, C0/C1 control stripping, bidi/zero-width neutralization, raw-markup stripping, whitespace collapse + newline preservation, NFC normalization, idempotence, non-string coercion, cap edge cases (0/negative), malicious-payload composition.
- **`p2p-game-connection.test.ts`** (+9): `sendChat` over-length refusal + warning + no-send; custom cap; control-char strip; raw `<>` strip (`<img src=x>` → `img src=x`); normal passthrough; receive-side sanitize/cap of text **and** senderName; oversized inbound blob truncated.
- **`mesh-game-connection.test.ts`** (+8): `broadcastChat` sanitize + refuse-over-length (returns 0, no wire bytes) + custom cap; inbound control-char/markup strip before `onChat`; oversized inbound truncation; non-string senderName coercion.
- **`game-chat.test.tsx`** (5, new): malicious-payload render test — `<script>`/`<img onerror>`/`javascript:` link / control chars / 5 000-char blob all render as safe escaped plain text, no executable element materialised, render-layer cap prevents overflow.

## Validation

- `npm run typecheck` — pass
- `npm run lint` — 0 errors (546 warnings, under the 1000 gate)
- `npm run a11y:contrast` — pass (no rendered chat styling touched)
- `npm test` — **420 suites / 8588 tests passed, 0 failures** (no regression in `connection-fallback.test.ts` or existing chat tests)

## Acceptance criteria

- [x] `sendChat("".padEnd(501, "x"))` → `false` + warning
- [x] `sendChat("hello\x00world")` → `true`, receiver `text === "helloworld"`
- [x] `sendChat("<img src=x>")` → `true`, receiver text has no `<`/`>`
- [x] Mesh inbound chat sanitized before `onChat`
- [x] `MAX_CHAT_MESSAGE_LENGTH` exported + overridable via options
- [x] No regression in existing chat tests
- [ ] `use-game-chat.ts` shows an error when `sendChat` returns false — **deferred**: P2P `sendChat`/`broadcastChat` are not yet wired into any multiplayer chat UI (the game-board `GameChat` is bound to the AI-coach hook, not P2P). The transport now correctly returns `false`/`0` on rejection and `useP2PConnection.sendChat` already propagates that boolean, so surfacing it in a banner is a trivial follow-up once a multiplayer chat panel exists. The referenced `use-game-chat.ts` is the AI-coach hook, not the P2P path.

## Notes

- Logging uses `console.warn`, matching the surrounding code in both files. The sibling logger-migration PR owns the `p2pLogger` migration; this PR is scoped to chat message handling to avoid overlap and rebases cleanly.
- No wire-protocol change: receivers without the sanitizer still receive the same string envelope (sanitization is symmetric; worst case is a no-op on already-clean text).
