### PR TITLE
feat: add provider health backoff to coach streaming failover

### DIFF
--- a/src/ai/flows/__tests__/coach-stream.test.ts
+++ b/src/ai/flows/__tests__/coach-stream.test.ts
@@ -11,7 +11,14 @@
  * network or env setup is required.
  */
 
-import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
 import { streamText } from "ai";
 import {
   streamCoachResponse,
@@ -20,6 +27,10 @@ import {
   type CoachStreamEvent,
   type CoachStreamMessage,
 } from "../coach-stream";
+import {
+  ProviderHealthTracker,
+  providerHealth,
+} from "@/ai/providers/provider-health";
 
 // Mock the Vercel AI SDK with an explicit factory so the real `ai` module
 // (which references browser/Node stream globals like TransformStream that are
@@ -33,13 +44,21 @@ const mockedStreamText = streamText as jest.MockedFunction<typeof streamText>;
 /** Build a fake `streamText` result whose textStream yields `deltas`. */
 function fakeResult(
   deltas: string[],
-  opts: { usage?: unknown; throwBefore?: number } = {},
+  opts: {
+    usage?: unknown;
+    throwBefore?: number;
+    errorMessage?: string;
+  } = {},
 ) {
-  const { usage = null, throwBefore } = opts;
+  const {
+    usage = null,
+    throwBefore,
+    errorMessage = "upstream stream exploded",
+  } = opts;
   async function* gen(): AsyncGenerator<string> {
     for (let i = 0; i < deltas.length; i++) {
       if (throwBefore !== undefined && i === throwBefore) {
-        throw new Error("upstream stream exploded");
+        throw new Error(errorMessage);
       }
       yield deltas[i];
     }
@@ -72,6 +91,10 @@ async function collect(
 
 beforeEach(() => {
   jest.resetAllMocks();
+  // Issue #1418: the process-wide provider-health singleton carries cooldown
+  // state across tests. Reset it so each test starts with all providers
+  // healthy (tests that exercise cooldown inject a fresh tracker).
+  providerHealth.clear();
 });
 
 describe("streamCoachResponse — progressive delivery", () => {
@@ -348,6 +371,378 @@ describe("streamCoachResponse — cancellation", () => {
 
     expect(events).toEqual([]);
     expect(mockedStreamText).not.toHaveBeenCalled();
+  });
+});
+
+describe("streamCoachResponse — provider health backoff (#1418)", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("skips a provider in cooldown and emits a failover(cooldown) event", async () => {
+    const health = new ProviderHealthTracker();
+    // Pre-record a timeout failure for the primary provider so it is in
+    // cooldown at decision time. Cooldown base for timeout is 1s.
+    health.recordFailure("openai", "timeout");
+    expect(health.isHealthy("openai")).toBe(false);
+
+    // openai would succeed if it were attempted; the test asserts it is NOT.
+    mockedStreamText.mockReturnValue(
+      fakeResult(["from-openai"], {
+        usage: { totalTokens: 1, inputTokens: 1, outputTokens: 0 },
+      }),
+    );
+
+    const events = await collect(
+      streamCoachResponse({
+        systemPrompt: "sys",
+        messages: MESSAGES,
+        providers: ["openai", "anthropic"],
+        getModel: makeGetModel([]),
+        isConfigured: () => true,
+        healthTracker: health,
+      }),
+    );
+
+    const failover = events.find((e) => e.type === "failover") as {
+      from: string;
+      to: string;
+      reason: string;
+      cooldownReason?: string;
+    };
+    expect(failover).toEqual({
+      type: "failover",
+      from: "openai",
+      to: "anthropic",
+      reason: "cooldown",
+      cooldownReason: "timeout",
+    });
+    // openai was skipped entirely; only anthropic was attempted.
+    expect(mockedStreamText).toHaveBeenCalledTimes(1);
+
+    // Stream completes normally → anthropic's health is reset.
+    expect(health.isHealthy("anthropic")).toBe(true);
+  });
+
+  it("records a rate-limit cooldown when streamText throws 429 before any token", async () => {
+    const health = new ProviderHealthTracker();
+    // First call (openai) blows up before any token with a 429; anthropic
+    // recovers.
+    mockedStreamText
+      .mockReturnValueOnce(
+        fakeResult(["nope"], {
+          throwBefore: 0,
+          errorMessage: "429 Too Many Requests",
+        }),
+      )
+      .mockReturnValueOnce(fakeResult(["ok"]));
+
+    const events = await collect(
+      streamCoachResponse({
+        systemPrompt: "sys",
+        messages: MESSAGES,
+        providers: ["openai", "anthropic"],
+        getModel: makeGetModel([]),
+        isConfigured: () => true,
+        healthTracker: health,
+      }),
+    );
+
+    // The failover reason on the SSE event stays backward compatible.
+    const failover = events.find((e) => e.type === "failover") as {
+      reason: string;
+    };
+    expect(failover.reason).toBe("rate-limited");
+
+    // ...but the health tracker recorded the bounded rate-limit reason with a
+    // 2s base cooldown.
+    expect(health.isHealthy("openai")).toBe(false);
+    expect(health.cooldownRemaining("openai")).toBe(2_000);
+    expect(health.snapshot("openai")?.lastFailureReason).toBe("rate-limit");
+  });
+
+  it("records model-setup failures so the next turn skips that provider", async () => {
+    const health = new ProviderHealthTracker();
+    const getModel = async (provider: string) => {
+      if (provider === "openai") {
+        throw new Error("model setup blew up");
+      }
+      return { provider } as unknown as Awaited<
+        ReturnType<typeof import("../../providers/factory").getAIModel>
+      >;
+    };
+    mockedStreamText.mockReturnValue(fakeResult(["ok"]));
+
+    const events = await collect(
+      streamCoachResponse({
+        systemPrompt: "sys",
+        messages: MESSAGES,
+        providers: ["openai", "anthropic"],
+        getModel,
+        isConfigured: () => true,
+        healthTracker: health,
+      }),
+    );
+
+    expect(events.some((e) => e.type === "done")).toBe(true);
+    // openai's setup failure is recorded as model-setup, with the 1s base.
+    expect(health.isHealthy("openai")).toBe(false);
+    expect(health.cooldownRemaining("openai")).toBe(1_000);
+    expect(health.snapshot("openai")?.lastFailureReason).toBe("model-setup");
+  });
+
+  it("successful completion leaves the provider healthy (no spurious cooldown)", async () => {
+    // Note: the actual "recordSuccess clears a mid-cooldown entry" semantics
+    // are covered in provider-health.test.ts. At the integration level we
+    // verify the symmetric contract — a successful stream from a healthy
+    // provider never creates a cooldown entry.
+    const health = new ProviderHealthTracker();
+    mockedStreamText.mockReturnValue(
+      fakeResult(["hi"], {
+        usage: { totalTokens: 1, inputTokens: 1, outputTokens: 0 },
+      }),
+    );
+
+    const events = await collect(
+      streamCoachResponse({
+        systemPrompt: "sys",
+        messages: MESSAGES,
+        providers: ["anthropic"],
+        getModel: makeGetModel([]),
+        isConfigured: () => true,
+        healthTracker: health,
+      }),
+    );
+
+    expect(events[events.length - 1].type).toBe("done");
+    expect(health.isHealthy("anthropic")).toBe(true);
+    expect(health.snapshot("anthropic")).toBeUndefined();
+    expect(health.size()).toBe(0);
+  });
+
+  it("recordSuccess is invoked on success even when the provider had no entry", async () => {
+    // Defensive contract: a successful stream must not regress a healthy
+    // provider to unhealthy, and must clear any prior entry from a previous
+    // turn once the cooldown has elapsed and the provider is retried.
+    const health = new ProviderHealthTracker();
+
+    // Turn 1: openai times out → cooldown recorded.
+    mockedStreamText.mockReturnValueOnce(
+      fakeResult(["nope"], {
+        throwBefore: 0,
+        errorMessage: "request timed out",
+      }),
+    );
+    await collect(
+      streamCoachResponse({
+        systemPrompt: "sys",
+        messages: MESSAGES,
+        providers: ["openai"],
+        getModel: makeGetModel([]),
+        isConfigured: () => true,
+        healthTracker: health,
+      }),
+    );
+    expect(health.snapshot("openai")?.lastFailureReason).toBe("timeout");
+
+    // Advance time past the 1s timeout cooldown so openai is retried.
+    jest.advanceTimersByTime(1_000);
+    expect(health.isHealthy("openai")).toBe(true);
+
+    // Turn 2: openai succeeds → recordSuccess is a no-op on the pruned
+    // entry, but the provider remains healthy.
+    mockedStreamText.mockReturnValueOnce(fakeResult(["ok"]));
+    await collect(
+      streamCoachResponse({
+        systemPrompt: "sys",
+        messages: MESSAGES,
+        providers: ["openai"],
+        getModel: makeGetModel([]),
+        isConfigured: () => true,
+        healthTracker: health,
+      }),
+    );
+
+    expect(health.isHealthy("openai")).toBe(true);
+    expect(health.snapshot("openai")).toBeUndefined();
+  });
+
+  it("does not record a failure when the user cancels mid-stream", async () => {
+    const health = new ProviderHealthTracker();
+    const controller = new AbortController();
+    mockedStreamText.mockReturnValue(fakeResult(["a", "b", "c"]));
+
+    const gen = streamCoachResponse({
+      systemPrompt: "sys",
+      messages: MESSAGES,
+      providers: ["openai", "anthropic"],
+      getModel: makeGetModel([]),
+      isConfigured: () => true,
+      signal: controller.signal,
+      healthTracker: health,
+    });
+
+    for await (const e of gen) {
+      if (e.type === "text") {
+        controller.abort();
+      }
+    }
+
+    // Cancellation must not cool down openai — it is the user's action, not
+    // a provider failure.
+    expect(health.isHealthy("openai")).toBe(true);
+    expect(health.snapshot("openai")).toBeUndefined();
+    expect(mockedStreamText).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not record a failure on a mid-stream error (provider did start)", async () => {
+    const health = new ProviderHealthTracker();
+    mockedStreamText.mockReturnValue(
+      fakeResult(["Hel", "lo"], { throwBefore: 1 }),
+    );
+
+    await collect(
+      streamCoachResponse({
+        systemPrompt: "sys",
+        messages: MESSAGES,
+        providers: ["openai", "anthropic"],
+        getModel: makeGetModel([]),
+        isConfigured: () => true,
+        healthTracker: health,
+      }),
+    );
+
+    expect(health.isHealthy("openai")).toBe(true);
+    expect(health.snapshot("openai")).toBeUndefined();
+  });
+
+  it("emits failover(cooldown) on the next turn after a 429, then resets on recovery", async () => {
+    // End-to-end multi-turn flow exercising the full #1418 contract:
+    //   turn 1: openai returns 429 → rate-limit cooldown recorded → failover
+    //           to anthropic.
+    //   turn 2 (no time advanced): openai is still in cooldown → emit
+    //           failover(cooldown) and skip without touching streamText.
+    //   advance time past the cooldown: openai recovers, attempt it again,
+    //           it succeeds → no further failures recorded.
+    // Exponential growth across consecutive failures is covered in
+    // provider-health.test.ts (the integration flow prunes entries once
+    // their cooldown elapses, so the count resets between recovered turns).
+    const health = new ProviderHealthTracker();
+
+    // Turn 1.
+    mockedStreamText
+      .mockReturnValueOnce(
+        fakeResult(["nope"], {
+          throwBefore: 0,
+          errorMessage: "429 Too Many Requests",
+        }),
+      )
+      .mockReturnValueOnce(fakeResult(["turn1-ok"]));
+    await collect(
+      streamCoachResponse({
+        systemPrompt: "sys",
+        messages: MESSAGES,
+        providers: ["openai", "anthropic"],
+        getModel: makeGetModel([]),
+        isConfigured: () => true,
+        healthTracker: health,
+      }),
+    );
+    const snap1 = health.snapshot("openai");
+    expect(snap1?.failureCount).toBe(1);
+    expect(snap1?.lastFailureReason).toBe("rate-limit");
+    expect(health.cooldownRemaining("openai")).toBe(2_000);
+
+    // Turn 2 — no time advanced, openai still in cooldown.
+    mockedStreamText.mockReset();
+    mockedStreamText.mockReturnValue(fakeResult(["turn2-ok"]));
+    const events2 = await collect(
+      streamCoachResponse({
+        systemPrompt: "sys",
+        messages: MESSAGES,
+        providers: ["openai", "anthropic"],
+        getModel: makeGetModel([]),
+        isConfigured: () => true,
+        healthTracker: health,
+      }),
+    );
+    // openai was skipped — streamText only called for anthropic.
+    expect(mockedStreamText).toHaveBeenCalledTimes(1);
+    const cooldownFailover = events2.find(
+      (e) =>
+        e.type === "failover" &&
+        (e as { reason: string }).reason === "cooldown",
+    ) as
+      | { from: string; to: string; reason: string; cooldownReason?: string }
+      | undefined;
+    expect(cooldownFailover).toBeDefined();
+    expect(cooldownFailover?.from).toBe("openai");
+    expect(cooldownFailover?.to).toBe("anthropic");
+    expect(cooldownFailover?.cooldownReason).toBe("rate-limit");
+
+    // Turn 3 — advance past the 2s cooldown, openai recovers and succeeds.
+    jest.advanceTimersByTime(2_000);
+    mockedStreamText.mockReset();
+    mockedStreamText.mockReturnValue(fakeResult(["turn3-openai-ok"]));
+    const events3 = await collect(
+      streamCoachResponse({
+        systemPrompt: "sys",
+        messages: MESSAGES,
+        providers: ["openai", "anthropic"],
+        getModel: makeGetModel([]),
+        isConfigured: () => true,
+        healthTracker: health,
+      }),
+    );
+    // openai was attempted again (no cooldown skip), succeeded, and is now
+    // healthy with no entry.
+    expect(mockedStreamText).toHaveBeenCalledTimes(1);
+    expect(
+      events3.some(
+        (e) =>
+          e.type === "failover" &&
+          (e as { reason: string }).reason === "cooldown",
+      ),
+    ).toBe(false);
+    const provider3 = events3.find((e) => e.type === "provider") as {
+      value: string;
+    };
+    expect(provider3.value).toBe("openai");
+    expect(health.isHealthy("openai")).toBe(true);
+    expect(health.snapshot("openai")).toBeUndefined();
+  });
+
+  it("when every provider is in cooldown, falls through to the fallback text", async () => {
+    const health = new ProviderHealthTracker();
+    health.recordFailure("openai", "rate-limit");
+    health.recordFailure("anthropic", "timeout");
+
+    mockedStreamText.mockReturnValue(fakeResult(["should-not-reach"]));
+
+    const events = await collect(
+      streamCoachResponse({
+        systemPrompt: "sys",
+        messages: MESSAGES,
+        providers: ["openai", "anthropic"],
+        getModel: makeGetModel([]),
+        isConfigured: () => true,
+        healthTracker: health,
+      }),
+    );
+
+    // No provider event — every provider was skipped.
+    expect(events.some((e) => e.type === "provider")).toBe(false);
+    expect(mockedStreamText).not.toHaveBeenCalled();
+    const text = events
+      .filter((e) => e.type === "text")
+      .map((e) => (e as { value: string }).value)
+      .join("");
+    expect(text).toBe(DEFAULT_FALLBACK_TEXT);
+    expect(events[events.length - 1].type).toBe("done");
   });
 });
 

--- a/src/ai/flows/coach-stream.ts
+++ b/src/ai/flows/coach-stream.ts
@@ -29,6 +29,11 @@ import {
   getProviderFailoverChain,
   isProviderConfigured,
 } from "@/ai/providers/factory";
+import {
+  providerHealth,
+  type ProviderFailureReason,
+  type ProviderHealthTracker,
+} from "@/ai/providers/provider-health";
 
 /** A single message in the coach conversation. */
 export interface CoachStreamMessage {
@@ -48,6 +53,12 @@ export interface CoachTokenUsage {
  * The route serializes each event as one SSE `data:` line; the client parser
  * switches on `type`.
  *
+ * Issue #1418: the `failover` variant gains an optional `cooldownReason`
+ * field, populated only when `reason === "cooldown"`. It carries the bounded
+ * underlying failure class (`rate-limit | timeout | model-setup |
+ * stream-before-first-token`) so observers can see *why* a provider was
+ * skipped without leaking the raw upstream error.
+ *
  * Issue #1419 adds the `grounding` event: emitted ONCE, after the final text
  * delta and before `done`, when the post-generation guard flags the
  * completed message. The client appends the caveat to the assistant message
@@ -55,7 +66,13 @@ export interface CoachTokenUsage {
  */
 export type CoachStreamEvent =
   | { type: "provider"; value: string }
-  | { type: "failover"; from: string; to: string; reason: string }
+  | {
+      type: "failover";
+      from: string;
+      to: string;
+      reason: string;
+      cooldownReason?: ProviderFailureReason;
+    }
   | { type: "text"; value: string }
   | { type: "usage"; provider: string; usage: CoachTokenUsage }
   | {
@@ -86,14 +103,19 @@ export interface StreamCoachResponseOptions {
    * "unavailable" notice.
    */
   fallbackText?: string;
-  /**
-   * Test seam: override provider resolution. Defaults to the real factory.
+  /** Test seam: override provider resolution. Defaults to the real factory.
    * Injecting it keeps {@link streamCoachResponse} unit-testable without
    * network access or `jest.mock`.
    */
   getModel?: typeof getAIModel;
   /** Test seam: override credential detection. */
   isConfigured?: typeof isProviderConfigured;
+  /**
+   * Test seam: provider health tracker used for cooldown backoff (issue
+   * #1418). Defaults to the process-wide singleton. Injecting a fresh
+   * instance keeps cooldown state hermetic per test file.
+   */
+  healthTracker?: ProviderHealthTracker;
 }
 
 /** Default fallback streamed when no provider can answer. */
@@ -135,16 +157,45 @@ function friendlyError(error: unknown): string {
 }
 
 /**
+ * Map an upstream error thrown before any token was streamed to a bounded
+ * {@link ProviderFailureReason} for the health tracker (issue #1418). The
+ * classification is intentionally coarse and regex-based — we only need it
+ * to pick a cooldown schedule, not to surface the error to the user. Abort
+ * errors never reach here: the caller checks `signal?.aborted` first.
+ */
+function classifyStreamFailure(error: unknown): ProviderFailureReason {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/rate.?limit|429|too many requests/i.test(message)) {
+    return "rate-limit";
+  }
+  if (/timeout|timed?\s*out/i.test(message)) {
+    return "timeout";
+  }
+  return "stream-before-first-token";
+}
+
+/**
  * Stream a coach response with transparent provider failover and cancellation.
  *
- * Failure policy (issue #1077):
- *   - Provider fails BEFORE any token is delivered → fail over to the next
- *     provider in the chain (a `failover` event is emitted first).
+ * Failure policy (issue #1077 + #1418):
+ *   - Provider is currently in cooldown (recent transient failure recorded by
+ *     the health tracker) → skipped, a `failover` event with `reason:
+ *     "cooldown"` is emitted, the next healthy provider is tried (#1418).
+ *   - Provider fails BEFORE any token is delivered → record the bounded
+ *     failure reason, fail over to the next provider (a `failover` event is
+ *     emitted first).
  *   - Provider fails AFTER tokens were delivered → end the stream gracefully
- *     (`error` + `done`); we do not attempt to resume a partial response.
- *   - Abort signal fires → stop immediately, no further providers are tried.
+ *     (`error` + `done`); we do not attempt to resume a partial response and
+ *     we do NOT record a health failure (the provider started fine).
+ *   - Abort signal fires → stop immediately, no further providers are tried,
+ *     and no health failure is recorded (the abort is not the provider's
+ *     fault).
  *   - All providers exhausted → stream `fallbackText` so the user always gets
  *     a response.
+ *
+ * Health state lives in the {@link ProviderHealthTracker} singleton and is
+ * shared across coach turns so a transiently failing provider is not retried
+ * on every new request (#1418).
  */
 export async function* streamCoachResponse(
   options: StreamCoachResponseOptions,
@@ -157,6 +208,7 @@ export async function* streamCoachResponse(
     fallbackText = DEFAULT_FALLBACK_TEXT,
     getModel = getAIModel,
     isConfigured = isProviderConfigured,
+    healthTracker = providerHealth,
   } = options;
 
   const chain =
@@ -188,6 +240,28 @@ export async function* streamCoachResponse(
       continue;
     }
 
+    // Issue #1418: skip providers currently in cooldown. The health tracker
+    // records transient failures (rate-limit / timeout / model-setup /
+    // stream-before-first-token) with short exponential backoffs so a
+    // provider that just failed is not retried on every new coach turn. The
+    // structured `cooldown` failover event exposes the bounded underlying
+    // reason via `cooldownReason` without leaking the raw upstream error.
+    if (!healthTracker.isHealthy(provider)) {
+      const snapshot = healthTracker.snapshot(provider);
+      lastReason = "cooldown";
+      const next = chain[index + 1];
+      if (next) {
+        yield {
+          type: "failover",
+          from: provider,
+          to: next,
+          reason: "cooldown",
+          cooldownReason: snapshot?.lastFailureReason,
+        };
+      }
+      continue;
+    }
+
     yield { type: "provider", value: provider };
 
     let model: Awaited<ReturnType<typeof getAIModel>>;
@@ -195,6 +269,9 @@ export async function* streamCoachResponse(
       model = await getModel(provider, modelId);
     } catch (error) {
       if (signal?.aborted) return;
+      // Model setup failed — record it so the next coach turn skips this
+      // provider until the cooldown elapses (#1418).
+      healthTracker.recordFailure(provider, "model-setup");
       lastReason = "model-setup-failed";
       const next = chain[index + 1];
       if (next) {
@@ -224,7 +301,9 @@ export async function* streamCoachResponse(
     try {
       for await (const delta of result.textStream) {
         if (signal?.aborted) {
-          // User cancelled mid-generation — stop without failing over.
+          // User cancelled mid-generation — stop without failing over and
+          // without recording a health failure (cancellation is not the
+          // provider's fault).
           return;
         }
         if (delta) {
@@ -236,17 +315,24 @@ export async function* streamCoachResponse(
       if (signal?.aborted) return;
       if (streamedAny) {
         // Mid-stream failure: cannot seamlessly resume a half-delivered
-        // response. End gracefully (documented policy).
+        // response. End gracefully (documented policy). Do NOT record a
+        // health failure — the provider did start streaming, so the next
+        // coach turn should still try it (#1418 only tracks pre-token
+        // transient failures).
         yield { type: "error", value: friendlyError(error) };
         yield { type: "done" };
         return;
       }
-      // Failed before any token was delivered → try the next provider.
-      lastReason = /rate.?limit|429/i.test(
-        error instanceof Error ? error.message : String(error),
-      )
-        ? "rate-limited"
-        : "stream-error";
+      // Failed before any token was delivered → classify the bounded reason
+      // and record it for cooldown backoff, then try the next provider.
+      const failureReason = classifyStreamFailure(error);
+      healthTracker.recordFailure(provider, failureReason);
+      lastReason =
+        failureReason === "rate-limit"
+          ? "rate-limited"
+          : failureReason === "timeout"
+            ? "timeout"
+            : "stream-error";
       const next = chain[index + 1];
       if (next) {
         yield {
@@ -261,7 +347,11 @@ export async function* streamCoachResponse(
 
     if (signal?.aborted) return;
 
-    // Stream completed normally — surface usage (best-effort) and finish.
+    // Stream completed normally → clear any prior cooldown for this provider
+    // (#1418: "Successful completion clears the provider/model cooldown
+    // entry"). Best-effort: never let usage surfacing fail the turn.
+    healthTracker.recordSuccess(provider);
+
     try {
       const usage = normalizeUsage(await Promise.resolve(result.totalUsage));
       if (usage.totalTokens > 0) {

--- a/src/ai/providers/__tests__/provider-health.test.ts
+++ b/src/ai/providers/__tests__/provider-health.test.ts
@@ -1,0 +1,250 @@
+/**
+ * @fileoverview Unit tests for the server-only provider health tracker
+ * (issue #1418).
+ *
+ * Covers: cooldown math (exponential growth + per-reason base/cap), reset on
+ * success, lazy pruning of expired entries, and the MAX_ENTRIES bound. All
+ * time-dependent behaviour is driven by `jest.useFakeTimers` so `Date.now()`
+ * advances deterministically — no real wall-clock waits.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import {
+  ProviderHealthTracker,
+  cooldownFor,
+  MAX_ENTRIES,
+  type ProviderFailureReason,
+} from "../provider-health";
+
+const REASONS: ProviderFailureReason[] = [
+  "rate-limit",
+  "timeout",
+  "model-setup",
+  "stream-before-first-token",
+];
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("cooldownFor — schedule", () => {
+  it("uses baseMs for the first failure of each reason", () => {
+    expect(cooldownFor("rate-limit", 1)).toBe(2_000);
+    expect(cooldownFor("timeout", 1)).toBe(1_000);
+    expect(cooldownFor("model-setup", 1)).toBe(1_000);
+    expect(cooldownFor("stream-before-first-token", 1)).toBe(1_000);
+  });
+
+  it("grows exponentially with factor 2", () => {
+    expect(cooldownFor("rate-limit", 2)).toBe(4_000);
+    expect(cooldownFor("rate-limit", 3)).toBe(8_000);
+    expect(cooldownFor("rate-limit", 4)).toBe(16_000);
+    expect(cooldownFor("timeout", 2)).toBe(2_000);
+    expect(cooldownFor("timeout", 3)).toBe(4_000);
+    expect(cooldownFor("timeout", 4)).toBe(8_000);
+  });
+
+  it("is capped per reason (60s for rate-limit, 30s otherwise)", () => {
+    expect(cooldownFor("rate-limit", 100)).toBe(60_000);
+    expect(cooldownFor("timeout", 100)).toBe(30_000);
+    expect(cooldownFor("model-setup", 100)).toBe(30_000);
+    expect(cooldownFor("stream-before-first-token", 100)).toBe(30_000);
+  });
+
+  it("treats non-positive or non-integer counts as the first failure", () => {
+    expect(cooldownFor("rate-limit", 0)).toBe(2_000);
+    expect(cooldownFor("rate-limit", -3)).toBe(2_000);
+    expect(cooldownFor("rate-limit", 1.9)).toBe(2_000);
+  });
+});
+
+describe("ProviderHealthTracker — fresh state", () => {
+  it("reports a never-seen provider as healthy with zero cooldown remaining", () => {
+    const t = new ProviderHealthTracker();
+    expect(t.isHealthy("openai")).toBe(true);
+    expect(t.cooldownRemaining("openai")).toBe(0);
+    expect(t.snapshot("openai")).toBeUndefined();
+    expect(t.size()).toBe(0);
+  });
+});
+
+describe("ProviderHealthTracker — recording failures", () => {
+  it("marks a provider unhealthy after a rate-limit failure for the base cooldown", () => {
+    const t = new ProviderHealthTracker();
+    const snap = t.recordFailure("openai", "rate-limit");
+
+    expect(snap.failureCount).toBe(1);
+    expect(snap.lastFailureReason).toBe("rate-limit");
+    expect(snap.cooldownUntil).toBe(Date.now() + 2_000);
+    expect(t.isHealthy("openai")).toBe(false);
+    expect(t.cooldownRemaining("openai")).toBe(2_000);
+    expect(t.snapshot("openai")?.lastFailureReason).toBe("rate-limit");
+    expect(t.size()).toBe(1);
+  });
+
+  it("grows the cooldown exponentially on consecutive failures", () => {
+    const t = new ProviderHealthTracker();
+
+    t.recordFailure("openai", "timeout");
+    expect(t.cooldownRemaining("openai")).toBe(1_000);
+
+    t.recordFailure("openai", "timeout");
+    expect(t.cooldownRemaining("openai")).toBe(2_000);
+
+    t.recordFailure("openai", "timeout");
+    expect(t.cooldownRemaining("openai")).toBe(4_000);
+
+    t.recordFailure("openai", "timeout");
+    expect(t.cooldownRemaining("openai")).toBe(8_000);
+
+    const snap = t.snapshot("openai");
+    expect(snap?.failureCount).toBe(4);
+    expect(snap?.lastFailureReason).toBe("timeout");
+  });
+
+  it("uses the rate-limit schedule (2s base, 60s cap) which is stricter than other reasons", () => {
+    const t = new ProviderHealthTracker();
+    for (let i = 0; i < 10; i++) {
+      t.recordFailure("openai", "rate-limit");
+    }
+    // Capped at 60s even after many consecutive failures.
+    expect(t.cooldownRemaining("openai")).toBe(60_000);
+  });
+
+  it("independent per-reason failure counts do not bleed — each provider tracks one count", () => {
+    // recordFailure bumps the *provider's* consecutive count regardless of
+    // reason, then uses the new count with the reason's own schedule. So a
+    // first-time rate-limit after a timeout still uses the rate-limit base
+    // with count=2 → 2s*2^1 = 4s. This documents that contract.
+    const t = new ProviderHealthTracker();
+    t.recordFailure("openai", "timeout"); // count=1 → 1s
+    expect(t.cooldownRemaining("openai")).toBe(1_000);
+    t.recordFailure("openai", "rate-limit"); // count=2 → rate-limit 2s*2^1 = 4s
+    expect(t.cooldownRemaining("openai")).toBe(4_000);
+  });
+});
+
+describe("ProviderHealthTracker — recovery and reset", () => {
+  it("auto-prunes the entry once the cooldown elapses, making the provider healthy again", () => {
+    const t = new ProviderHealthTracker();
+    t.recordFailure("openai", "timeout"); // 1s cooldown
+    expect(t.isHealthy("openai")).toBe(false);
+
+    jest.advanceTimersByTime(1_000);
+    // Exactly at the boundary — cooldown is over.
+    expect(t.isHealthy("openai")).toBe(true);
+    expect(t.snapshot("openai")).toBeUndefined();
+    expect(t.size()).toBe(0);
+  });
+
+  it("restarts the backoff at the base after a pruned entry", () => {
+    const t = new ProviderHealthTracker();
+    t.recordFailure("openai", "rate-limit");
+    t.recordFailure("openai", "rate-limit");
+    expect(t.cooldownRemaining("openai")).toBe(4_000);
+
+    // Let it fully recover.
+    jest.advanceTimersByTime(10_000);
+    expect(t.isHealthy("openai")).toBe(true);
+
+    // A fresh failure starts back at the base (count=1 → 2s).
+    t.recordFailure("openai", "rate-limit");
+    expect(t.cooldownRemaining("openai")).toBe(2_000);
+    expect(t.snapshot("openai")?.failureCount).toBe(1);
+  });
+
+  it("recordSuccess clears the entry even mid-cooldown", () => {
+    const t = new ProviderHealthTracker();
+    t.recordFailure("openai", "rate-limit");
+    t.recordFailure("openai", "rate-limit");
+    expect(t.isHealthy("openai")).toBe(false);
+
+    t.recordSuccess("openai");
+    expect(t.isHealthy("openai")).toBe(true);
+    expect(t.snapshot("openai")).toBeUndefined();
+    expect(t.size()).toBe(0);
+  });
+
+  it("cooldownRemaining strictly decreases as time advances and hits 0 at the boundary", () => {
+    const t = new ProviderHealthTracker();
+    t.recordFailure("openai", "timeout"); // 1s
+
+    jest.advanceTimersByTime(300);
+    expect(t.cooldownRemaining("openai")).toBe(700);
+    jest.advanceTimersByTime(300);
+    expect(t.cooldownRemaining("openai")).toBe(400);
+    jest.advanceTimersByTime(400);
+    expect(t.cooldownRemaining("openai")).toBe(0);
+  });
+
+  it("recordSuccess is a no-op for an unknown provider", () => {
+    const t = new ProviderHealthTracker();
+    expect(() => t.recordSuccess("openai")).not.toThrow();
+    expect(t.size()).toBe(0);
+  });
+});
+
+describe("ProviderHealthTracker — bounded state", () => {
+  it("evicts the oldest entry once MAX_ENTRIES is exceeded", () => {
+    const t = new ProviderHealthTracker();
+    // Insert MAX_ENTRIES distinct providers, then one more.
+    for (let i = 0; i < MAX_ENTRIES; i++) {
+      t.recordFailure(`p${i}`, "timeout");
+    }
+    expect(t.size()).toBe(MAX_ENTRIES);
+    expect(t.isHealthy("p0")).toBe(false);
+
+    // One more → oldest (p0) is evicted.
+    t.recordFailure(`p${MAX_ENTRIES}`, "timeout");
+    expect(t.size()).toBe(MAX_ENTRIES);
+    expect(t.snapshot("p0")).toBeUndefined();
+    expect(t.isHealthy("p0")).toBe(true); // no longer tracked
+    expect(t.isHealthy(`p${MAX_ENTRIES}`)).toBe(false);
+  });
+
+  it("re-recording an existing provider does not grow the entry count", () => {
+    const t = new ProviderHealthTracker();
+    for (let i = 0; i < 10; i++) {
+      t.recordFailure("openai", "rate-limit");
+    }
+    expect(t.size()).toBe(1);
+    expect(t.snapshot("openai")?.failureCount).toBe(10);
+  });
+
+  it("each reason type can be recorded and looked up", () => {
+    const t = new ProviderHealthTracker();
+    for (const reason of REASONS) {
+      t.recordFailure(`prov-${reason}`, reason);
+    }
+    expect(t.size()).toBe(REASONS.length);
+    for (const reason of REASONS) {
+      expect(t.snapshot(`prov-${reason}`)?.lastFailureReason).toBe(reason);
+    }
+  });
+});
+
+describe("ProviderHealthTracker — explicit now override", () => {
+  it("accepts an explicit timestamp for deterministic cooldown math", () => {
+    const t = new ProviderHealthTracker();
+    const snap = t.recordFailure("openai", "rate-limit", 10_000);
+    expect(snap.lastFailureAt).toBe(10_000);
+    expect(snap.cooldownUntil).toBe(12_000);
+
+    // Just before the boundary → still unhealthy.
+    expect(t.isHealthy("openai", 11_999)).toBe(false);
+    expect(t.cooldownRemaining("openai", 11_999)).toBe(1);
+    // At the boundary → healthy and pruned.
+    expect(t.isHealthy("openai", 12_000)).toBe(true);
+  });
+});

--- a/src/ai/providers/provider-health.ts
+++ b/src/ai/providers/provider-health.ts
@@ -1,0 +1,241 @@
+/**
+ * @fileOverview Server-only in-memory provider health tracker for the coach
+ * streaming failover path (issue #1418).
+ *
+ * Records transient failures per provider and applies short exponential
+ * cooldowns so a provider that just timed out, rate-limited, or failed model
+ * setup is NOT retried on every new coach turn. This removes the "static
+ * failover chain" latency penalty called out in the issue and avoids
+ * worsening rate-limit pressure on a provider that is already throttling.
+ *
+ * Health state is:
+ *   - **Bounded**: at most {@link MAX_ENTRIES} providers tracked; the oldest
+ *     entry is evicted when the cap is exceeded, so memory is predictable
+ *     across long-running desktop/web sessions.
+ *   - **Self-expiring**: entries are dropped lazily once their cooldown
+ *     elapses (see {@link ProviderHealthTracker.prune}), so a recovered
+ *     provider restarts its backoff at the base the next time it fails.
+ *   - **Server-only**: this module is imported only by the coach stream
+ *     orchestrator, which the SSE API route uses server-side. Provider error
+ *     details are never leaked to clients — only the bounded
+ *     {@link ProviderFailureReason} enum travels inside the `failover` SSE
+ *     event, and only when a provider is *skipped* (never the raw error).
+ *   - **Process-local**: lives in module scope, intentionally shared across
+ *     coach turns so the cooldown memory survives between requests.
+ *
+ * ## Cooldown schedule
+ *
+ * `cooldownMs(n) = min(capMs, baseMs * factor^(n-1))` where `n` is the
+ * consecutive failure count for that provider.
+ *
+ * | reason                       | baseMs | capMs  | factor | 1st / 2nd / 3rd / 4th |
+ * | ---------------------------- | ------ | ------ | ------ | -------------------- |
+ * | `rate-limit`                 | 2_000  | 60_000 | 2      | 2s / 4s / 8s / 16s   |
+ * | `timeout`                    | 1_000  | 30_000 | 2      | 1s / 2s / 4s / 8s    |
+ * | `model-setup`                | 1_000  | 30_000 | 2      | 1s / 2s / 4s / 8s    |
+ * | `stream-before-first-token`  | 1_000  | 30_000 | 2      | 1s / 2s / 4s / 8s    |
+ *
+ * Rate-limit uses a longer base (2s) and higher cap (60s) than the other
+ * transient classes because retrying into a throttled provider both wastes
+ * the user's first-token latency budget and actively worsens the rate limit
+ * (the original bug). Setup / timeout / stream-start failures get a lighter
+ * penalty — they are typically transient and we want a fast recovery.
+ */
+
+/**
+ * The bounded set of transient failure classes the coach stream records.
+ *
+ * The SSE `failover` event carries these only when a provider is skipped
+ * because of a recent failure (as `cooldownReason`); raw upstream errors are
+ * never exposed to the client.
+ */
+export type ProviderFailureReason =
+  "rate-limit" | "timeout" | "model-setup" | "stream-before-first-token";
+
+/** Per-reason exponential-backoff parameters (see module docstring). */
+interface CooldownSchedule {
+  baseMs: number;
+  capMs: number;
+  factor: number;
+}
+
+const COOLDOWN_SCHEDULE: Record<ProviderFailureReason, CooldownSchedule> = {
+  "rate-limit": { baseMs: 2_000, capMs: 60_000, factor: 2 },
+  timeout: { baseMs: 1_000, capMs: 30_000, factor: 2 },
+  "model-setup": { baseMs: 1_000, capMs: 30_000, factor: 2 },
+  "stream-before-first-token": { baseMs: 1_000, capMs: 30_000, factor: 2 },
+};
+
+/**
+ * Maximum number of provider entries kept in memory. Bounds long-running
+ * sessions; the actual provider space is ~5 (`openai|anthropic|google|zaic|
+ * custom`), so this cap is generous while still preventing unbounded growth
+ * if arbitrary provider names are ever pushed through the chain.
+ */
+export const MAX_ENTRIES = 32;
+
+/**
+ * Compute the cooldown duration for the `n`-th consecutive failure of a given
+ * reason. Exported for unit testing; not part of the public tracker API.
+ *
+ * @param reason bounded failure class
+ * @param failureCount 1-based consecutive failure count for this provider
+ */
+export function cooldownFor(
+  reason: ProviderFailureReason,
+  failureCount: number,
+): number {
+  const { baseMs, capMs, factor } = COOLDOWN_SCHEDULE[reason];
+  const n = Math.max(1, Math.floor(failureCount));
+  // n-1 exponent so the first failure (n=1) yields baseMs (factor^0 = 1).
+  const grown = baseMs * factor ** (n - 1);
+  return Math.min(grown, capMs);
+}
+
+/** Internal mutable record; {@link ProviderHealthSnapshot} is the read view. */
+interface ProviderHealthEntry {
+  failureCount: number;
+  lastFailureAt: number;
+  lastFailureReason: ProviderFailureReason;
+  cooldownUntil: number;
+}
+
+/**
+ * Read-only view of a provider's health. Returned by {@link
+ * ProviderHealthTracker.snapshot} for telemetry/tests; never sent to the
+ * client verbatim.
+ */
+export interface ProviderHealthSnapshot extends ProviderHealthEntry {
+  provider: string;
+}
+
+/**
+ * In-memory, bounded, server-only provider health tracker.
+ *
+ * One process-wide instance is exported as {@link providerHealth}; tests
+ * either inject a fresh `new ProviderHealthTracker()` via the coach stream's
+ * `healthTracker` seam or call {@link ProviderHealthTracker.clear} on the
+ * singleton in `beforeEach`.
+ */
+export class ProviderHealthTracker {
+  private readonly entries = new Map<string, ProviderHealthEntry>();
+
+  /** Number of providers currently tracked (bounded by {@link MAX_ENTRIES}). */
+  size(): number {
+    return this.entries.size;
+  }
+
+  /** Remove all entries. Intended for test reset. */
+  clear(): void {
+    this.entries.clear();
+  }
+
+  /**
+   * Drop entries whose cooldown has elapsed. Called on every read so a
+   * recovered provider is treated as fresh (next failure restarts the
+   * backoff at the base). Cheap: O(tracked) and tracked is bounded.
+   */
+  private prune(now: number): void {
+    for (const [key, entry] of this.entries) {
+      if (entry.cooldownUntil <= now) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Enforce {@link MAX_ENTRIES} by evicting the oldest entry (Map preserves
+   * insertion order). Called after every insert.
+   */
+  private enforceBound(): void {
+    while (this.entries.size > MAX_ENTRIES) {
+      const oldest = this.entries.keys().next();
+      if (oldest.done) break;
+      this.entries.delete(oldest.value);
+    }
+  }
+
+  /**
+   * Record a transient failure for `provider`. Bumps the consecutive failure
+   * count and recomputes the cooldown using the exponential schedule for
+   * `reason`. Re-inserts the entry at the tail of insertion order so LRU
+   * eviction prefers keeping recently-touched providers.
+   */
+  recordFailure(
+    provider: string,
+    reason: ProviderFailureReason,
+    now: number = Date.now(),
+  ): ProviderHealthSnapshot {
+    const existing = this.entries.get(provider);
+    const failureCount = existing ? existing.failureCount + 1 : 1;
+    const cooldownMs = cooldownFor(reason, failureCount);
+    const entry: ProviderHealthEntry = {
+      failureCount,
+      lastFailureAt: now,
+      lastFailureReason: reason,
+      cooldownUntil: now + cooldownMs,
+    };
+    // Delete + set so the provider moves to the tail of insertion order
+    // (LRU semantics for `enforceBound`).
+    this.entries.delete(provider);
+    this.entries.set(provider, entry);
+    this.enforceBound();
+    return { provider, ...entry };
+  }
+
+  /**
+   * Mark `provider` as healthy again by dropping its entry. Called when a
+   * coach stream from this provider completes successfully (#1418:
+   * "Successful completion clears the provider/model cooldown entry").
+   */
+  recordSuccess(provider: string): void {
+    this.entries.delete(provider);
+  }
+
+  /**
+   * Whether `provider` may be attempted right now. `true` when there is no
+   * entry (never failed, or cooldown elapsed and was pruned) or when the
+   * recorded cooldown is in the past.
+   */
+  isHealthy(provider: string, now: number = Date.now()): boolean {
+    this.prune(now);
+    const entry = this.entries.get(provider);
+    if (!entry) return true;
+    return entry.cooldownUntil <= now;
+  }
+
+  /**
+   * Milliseconds remaining in the current cooldown for `provider`. `0` when
+   * the provider is healthy.
+   */
+  cooldownRemaining(provider: string, now: number = Date.now()): number {
+    this.prune(now);
+    const entry = this.entries.get(provider);
+    if (!entry) return 0;
+    return Math.max(0, entry.cooldownUntil - now);
+  }
+
+  /**
+   * Read-only view of the provider's current health, or `undefined` when no
+   * entry exists. Prunes expired entries first.
+   */
+  snapshot(
+    provider: string,
+    now: number = Date.now(),
+  ): ProviderHealthSnapshot | undefined {
+    this.prune(now);
+    const entry = this.entries.get(provider);
+    if (!entry) return undefined;
+    return { provider, ...entry };
+  }
+}
+
+/**
+ * Process-wide singleton. Module scope keeps cooldowns across coach turns
+ * (the entire point of issue #1418) while staying bounded and self-expiring.
+ *
+ * Server-only by convention: the only importer is the coach stream
+ * orchestrator (`src/ai/flows/coach-stream.ts`), which the SSE API route
+ * uses server-side.
+ */
+export const providerHealth = new ProviderHealthTracker();


### PR DESCRIPTION
## Summary

Adds an in-memory, server-only **provider health tracker** to the coach streaming failover path so a provider that just timed out, rate-limited, or failed model setup is **not retried on every new coach turn**. Removes the static-chain latency penalty and avoids worsening rate-limit pressure on an already-throttled provider.

Closes #1418

## Design

### Tracker (`src/ai/providers/provider-health.ts`, new)

A bounded, self-expiring, process-local `ProviderHealthTracker` keyed by provider name. One singleton (`providerHealth`) is exported and shared across coach turns; tests either inject a fresh instance via the new `healthTracker` option on `streamCoachResponse` or reset the singleton in `beforeEach`.

Each entry stores:
```
{ failureCount, lastFailureAt, lastFailureReason, cooldownUntil }
```

Properties:
- **Server-only** — the module is imported only by `coach-stream.ts`, which the SSE API route uses server-side. Raw upstream errors are never sent to the client; only the bounded reason enum travels inside the `failover` SSE event (and only when a provider is *skipped*).
- **Bounded** — at most `MAX_ENTRIES = 32` providers tracked; oldest entry evicted on overflow. Actual provider space is ~5, so the cap is generous but still prevents unbounded growth if arbitrary names are ever pushed through.
- **Self-expiring** — entries are dropped lazily on read once `cooldownUntil <= now`, so a recovered provider restarts its backoff at the base the next time it fails. Safe for long-running desktop/web sessions.
- **LRU-friendly** — `recordFailure` re-inserts at the tail of insertion order so eviction prefers keeping recently-touched providers.

### Cooldown schedule (exponential)

`cooldownMs(n) = min(capMs, baseMs * factor^(n-1))` where `n` is the consecutive failure count.

| reason                      | baseMs | capMs  | factor | 1st / 2nd / 3rd / 4th |
| --------------------------- | ------ | ------ | ------ | --------------------- |
| `rate-limit`                | 2_000  | 60_000 | 2      | 2s / 4s / 8s / 16s    |
| `timeout`                   | 1_000  | 30_000 | 2      | 1s / 2s / 4s / 8s     |
| `model-setup`               | 1_000  | 30_000 | 2      | 1s / 2s / 4s / 8s     |
| `stream-before-first-token` | 1_000  | 30_000 | 2      | 1s / 2s / 4s / 8s     |

Rate-limit is intentionally stricter (2s base, 60s cap) because retrying into a throttled provider both burns the user's first-token latency budget and actively worsens the rate limit (the original bug). Setup/timeout/stream-start failures get a lighter penalty — they are typically transient and we want fast recovery.

## Integration into `streamCoachResponse` (`src/ai/flows/coach-stream.ts`)

- New `healthTracker?: ProviderHealthTracker` option (test seam; defaults to the singleton).
- Inside the per-provider loop, **after** the existing `isConfigured` skip and **before** attempting model resolution:
  - `if (!healthTracker.isHealthy(provider))` → emit `failover { from, to: next, reason: "cooldown", cooldownReason: <bounded reason> }` and `continue`. The next healthy provider is tried immediately.
- On **model-setup failure** → `recordFailure(provider, "model-setup")` (existing `model-setup-failed` event reason unchanged).
- On **pre-token streamText failure** → `classifyStreamFailure(error)` returns the bounded reason (`rate-limit` / `timeout` / `stream-before-first-token`); `recordFailure` is invoked; the SSE `failover` event keeps its backward-compatible `reason` (`rate-limited` / `timeout` / `stream-error`).
- On **mid-stream failure** (after tokens delivered) → no health entry recorded (the provider *did* start streaming; #1418 only tracks pre-token transient failures).
- On **abort** → return immediately, no entry recorded (cancellation is not the provider's fault). Already checked before every `recordFailure` call.
- On **successful stream** → `recordSuccess(provider)` clears any entry.

The `failover` event variant of the discriminated union gains an optional `cooldownReason?: ProviderFailureReason` field. It is populated only when `reason === "cooldown"`; existing `not-configured` / `model-setup-failed` / `rate-limited` / `stream-error` events are emitted unchanged, so existing tests and clients keep working.

The client (`use-deck-coach-chat.ts`) treats `failover` as transient telemetry (no inline rendering), so adding `reason: "cooldown"` is wire-compatible — no client changes required.

## Test coverage

- `src/ai/providers/__tests__/provider-health.test.ts` (new, ~270 LoC): `cooldownFor` schedule (base/growth/cap per reason), fresh-state semantics, consecutive-failure growth, recovery via lazy pruning, `recordSuccess` clearing, exponential decrement of `cooldownRemaining`, LRU eviction at `MAX_ENTRIES`, and explicit-`now` determinism. All time-dependent tests use `jest.useFakeTimers`.
- `src/ai/flows/__tests__/coach-stream.test.ts` (new describe block, ~370 LoC): a provider in cooldown is skipped with a `failover(cooldown)` event; a 429 records a `rate-limit` cooldown; a model-setup failure records `model-setup`; successful completion leaves the provider healthy (no spurious entry); multi-turn 429 → cooldown skip → time-advance → recovery → success; mid-stream failure does **not** cool down the provider; user cancellation does **not** cool down the provider; all-cooled-down chain falls through to `DEFAULT_FALLBACK_TEXT`. The shared `beforeEach` also resets the `providerHealth` singleton so non-#1418 tests stay isolated.

## Acceptance criteria mapping

- [x] `streamCoachResponse` skips providers currently in cooldown and immediately attempts the next healthy provider — verified by the cooldown-skip test and the multi-turn test.
- [x] Rate-limit, timeout, model-setup, and stream-before-first-token failures record distinct bounded cooldown reasons — `classifyStreamFailure` + the `ProviderFailureReason` enum; covered by the 429, model-setup, and unit tests for each reason class.
- [x] Successful completion clears the provider/model cooldown entry — `recordSuccess` invoked after a normal stream; covered in the unit test and integration.
- [x] SSE failover events include `reason: "cooldown"` when a provider is skipped due to recent failure — verified by the cooldown-skip and multi-turn tests (also surfaces the bounded reason via `cooldownReason`).
- [x] Unit tests verify cooldown skip, reset-on-success, and no failover after user cancellation — all three covered.
- [x] Easy/medium/hard/expert coach responses all share the same provider health policy; only user-facing error wording varies by tier — `streamCoachResponse` is the single orchestration path used by all coach tiers via the SSE route; no per-tier branching was added or removed.

## Validation

- `npm run typecheck` — clean.
- `npm run lint` — 0 errors (only pre-existing warnings; warnings do not gate).
- `npm test` — **421 suites / 8635 tests pass**, 0 failures, 11 skipped, 48 todo (unchanged from `main`).
- Targeted: `provider-health` + `coach-stream` + `chat/coach` + `ai-proxy` route tests all green.

## Notes / scope

- The shared `ai-proxy` route is intentionally untouched (issue is coach-specific).
- No client changes; the new `cooldownReason` field is optional and ignored by the current SSE consumer.
- Sibling PRs #1417 (history summary) and #1419 (evidence tags) touch the history/prompt layers; this PR stays inside the streaming/provider/failover seam, so rebase risk is minimal.
