### PR TITLE
fix: add CI guard preventing the empty-pubkey Tauri updater MITM default (#1430)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,12 +436,35 @@ jobs:
           # to keep SC2086 (quote vars) / SC2015 (A&&B||C) info-level nits
           # informational rather than failing the PR gate.
           args: '-ignore SC2086 -ignore SC2015'
-  
+
+  tauri-updater-config:
+    # Issue #1430: standalone guard that prevents the Tauri 2 updater from
+    # ever shipping with the empty-pubkey MITM default. The Jest suite
+    # `tests/updater-wiring.test.ts` (#1403) covers the same contracts but
+    # runs inside the full unit-test job; this script runs in plain Node
+    # (~50ms) so a regression against `src-tauri/tauri.conf.json` fails
+    # fast in its own job rather than waiting on the test suite.
+    name: Tauri Updater Config Guard
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Setup repository
+        uses: ./.github/actions/setup-node-npm-ci
+
+      - name: Assert updater config (#1430)
+        run: node scripts/check-tauri-updater-config.mjs
+
   build:
     name: Build
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
-    needs: [test, lint, typecheck, commitlint, mutation-test, security, cargo-audit, a11y-contrast, e2e, workflow-lint]
+    needs: [test, lint, typecheck, commitlint, mutation-test, security, cargo-audit, a11y-contrast, e2e, workflow-lint, tauri-updater-config]
 
     steps:
       - name: Checkout code

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -89,6 +89,8 @@ const eslintConfig = [
       "scripts/ratchet-coverage.js",
       // Plain Node ESM tooling for the issue #1397 fixture regenerator.
       "scripts/regen-video-fixtures.mjs",
+      // Plain Node ESM tooling for the issue #1430 updater-config guard.
+      "scripts/check-tauri-updater-config.mjs",
       ".claude/skills/pr-automation/**",
     ],
   },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "mutate:trigger-system": "stryker run --mutate src/lib/game-state/trigger-system.ts",
     "mutate:state-based-actions": "stryker run --mutate src/lib/game-state/state-based-actions.ts",
     "stubs:inventory": "node scripts/stubs-inventory.js",
+    "tauri:check-updater": "node scripts/check-tauri-updater-config.mjs",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/check-tauri-updater-config.mjs
+++ b/scripts/check-tauri-updater-config.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * Tauri 2 Updater Configuration Guard — Issue #1430
+ *
+ * Defence-in-depth CI gate that prevents the Tauri 2 updater from ever
+ * shipping with the documented MITM-vulnerable empty-pubkey default
+ * (`plugins.updater.active === true && plugins.updater.pubkey === ""`).
+ *
+ * The Jest suite `tests/updater-wiring.test.ts` (#1403) already asserts the
+ * positive contracts (active updater has a real minisign pubkey, HTTPS
+ * endpoint, capability grant, createUpdaterArtifacts flag, and on-disk .pub
+ * drift). This script is the cheaper, runtime-free complement: it runs in
+ * plain Node (no Jest, no Tauri toolchain) so it can gate `prebuild` and a
+ * dedicated CI job without waiting for the full unit-test suite.
+ *
+ * Contract (all must hold):
+ *
+ *   A. If `plugins.updater` is absent OR `plugins.updater.active === false`,
+ *      the updater is considered disabled and the guard passes. Both states
+ *      are safe: an absent block means the plugin is unregistered, and an
+ *      explicit `active: false` documents the disabled intent.
+ *
+ *   B. If `plugins.updater.active === true`, ALL of the following must hold:
+ *        1. `pubkey` is a non-empty string (this is the core #1430 fix —
+ *           an empty pubkey disables signature verification, which is the
+ *           MITM-vulnerable default).
+ *        2. `pubkey` matches the minisign-public-key wire format that
+ *           `tauri signer generate` emits (base64 of
+ *           `untrusted comment: minisign public key: <HEXID>\n<key-b64>`).
+ *           This stops a placeholder like `"TODO"` or `"placeholder"` from
+ *           satisfying the non-empty check.
+ *        3. `endpoints` contains at least one URL that is HTTPS and ends
+ *           in `.json` (the Tauri updater manifest shape). This prevents
+ *           a future contributor from flipping the endpoint to plain HTTP
+ *           or to an arbitrary non-manifest URL.
+ *
+ *   C. If `bundle.createUpdaterArtifacts === true`, the updater MUST be
+ *      active with a valid pubkey (contract B). Otherwise `tauri build`
+ *      emits per-installer `.sig` files that reference a manifest the
+ *      runtime cannot validate — a quieter version of the same drift.
+ *
+ * Usage:
+ *   node scripts/check-tauri-updater-config.mjs            # reads repo default
+ *   node scripts/check-tauri-updater-config.mjs <path>     # reads alternate config
+ *
+ * Exits 0 on pass, 1 on violation.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const DEFAULT_CONF = path.join(REPO_ROOT, "src-tauri", "tauri.conf.json");
+
+// Base64 prefix of the canonical minisign public-key comment line:
+//   "untrusted comment: minisign public key: <HEXID>\n"
+// Encoded as a single string for the JSON-embedded form Tauri 2 accepts.
+const MINISIGN_PUBKEY_PREFIX =
+  "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6";
+
+/**
+ * Evaluate the updater configuration contract.
+ *
+ * @param {unknown} config - Parsed tauri.conf.json contents.
+ * @returns {{ ok: true } | { ok: false; errors: string[] }}
+ */
+export function checkUpdaterConfig(config) {
+  /** @type {string[]} */
+  const errors = [];
+
+  if (config === null || typeof config !== "object") {
+    errors.push("tauri.conf.json: root must be a JSON object");
+    return { ok: false, errors };
+  }
+
+  const root = /** @type {Record<string, unknown>} */ (config);
+  const plugins = /** @type {Record<string, unknown> | undefined} */ (
+    root.plugins
+  );
+  const updater = /** @type {Record<string, unknown> | undefined} */ (
+    plugins?.updater
+  );
+
+  const bundle = /** @type {Record<string, unknown> | undefined} */ (
+    root.bundle
+  );
+  const createUpdaterArtifacts = bundle?.createUpdaterArtifacts;
+
+  // --- Contract A: absent or explicitly disabled is safe. -------------------
+  //
+  // The Tauri 2 docs treat an absent `plugins.updater` block as "the
+  // updater plugin is not registered, do nothing". `active: false` is the
+  // explicit-disabled form. Both are documented safe states under #1430
+  // option B — UNLESS `bundle.createUpdaterArtifacts` is true, in which
+  // case `tauri build` would emit per-installer .sig files that reference
+  // a manifest the runtime cannot fetch. We surface that as contract C
+  // so the inconsistency does not pass silently.
+  const isUpdaterActive =
+    updater !== undefined && updater.active === true;
+
+  if (createUpdaterArtifacts === true && !isUpdaterActive) {
+    errors.push(
+      "bundle.createUpdaterArtifacts is true but the updater is not active " +
+        "(either plugins.updater is absent or plugins.updater.active is not true). " +
+        "Set plugins.updater.active to true with a valid pubkey + endpoint, or set " +
+        "bundle.createUpdaterArtifacts to false; otherwise tauri build emits .sig " +
+        "files that reference a manifest the runtime will not fetch.",
+    );
+    // Continue evaluating the rest so a single run surfaces every problem.
+  }
+
+  if (updater === undefined) {
+    // Updater plugin config block is absent — safe under #1430 option B
+    // (contract C failures, if any, have already been recorded above).
+    return errors.length === 0 ? { ok: true } : { ok: false, errors };
+  }
+  const active = updater.active;
+  if (active === false) {
+    // Updater is explicitly disabled — safe (same caveat as above for
+    // contract C).
+    return errors.length === 0 ? { ok: true } : { ok: false, errors };
+  }
+
+  // From here on we treat the block as active. We accept `active: true`
+  // (the canonical form) but also fail closed on any non-boolean truthy
+  // value to prevent `active: "yes"` or similar shape drift.
+  if (active !== true) {
+    errors.push(
+      `plugins.updater.active must be a boolean; got ${JSON.stringify(active)}. ` +
+        "Set it to false (or remove the updater block) to disable the updater cleanly.",
+    );
+    return { ok: false, errors };
+  }
+
+  // --- Contract B.1: non-empty pubkey. -------------------------------------
+  const pubkey = typeof updater.pubkey === "string" ? updater.pubkey : "";
+  if (pubkey.length === 0) {
+    errors.push(
+      "plugins.updater.pubkey is empty while plugins.updater.active === true. " +
+        "An empty pubkey disables signature verification — this is the MITM-vulnerable " +
+        "default documented in issue #1430. Either set a real minisign public key " +
+        "(see docs/RELEASE_RUNBOOK.md) or set plugins.updater.active to false.",
+    );
+  }
+
+  // --- Contract B.2: minisign wire format. ---------------------------------
+  if (pubkey.length > 0 && !pubkey.startsWith(MINISIGN_PUBKEY_PREFIX)) {
+    errors.push(
+      "plugins.updater.pubkey does not match the minisign public-key format " +
+        `(expected base64 prefix "${MINISIGN_PUBKEY_PREFIX}"). Run ` +
+        "`tauri signer generate -p <password>` and copy the .pub contents; see " +
+        "docs/RELEASE_RUNBOOK.md.",
+    );
+  }
+
+  // --- Contract B.3: at least one HTTPS JSON endpoint. ---------------------
+  const endpoints = Array.isArray(updater.endpoints) ? updater.endpoints : [];
+  if (endpoints.length === 0) {
+    errors.push(
+      "plugins.updater.endpoints is empty while plugins.updater.active === true. " +
+        "Provide at least one HTTPS URL pointing at the Tauri 2 updater manifest " +
+        "(e.g. https://github.com/<org>/<repo>/releases/latest/download/latest.json).",
+    );
+  } else {
+    const httpsJsonEndpoints = endpoints.filter(
+      (url) => typeof url === "string" && /^https:\/\//.test(url) && /\.json$/i.test(url),
+    );
+    if (httpsJsonEndpoints.length === 0) {
+      errors.push(
+        `plugins.updater.endpoints has ${endpoints.length} entr${endpoints.length === 1 ? "y" : "ies"} ` +
+          "but none is an HTTPS URL ending in .json. All endpoints must be TLS-pinned " +
+          "manifest URLs; found: " +
+          endpoints.map((u) => JSON.stringify(u)).join(", ") +
+          ".",
+      );
+    }
+  }
+
+  // --- Contract C: createUpdaterArtifacts requires an active, signed updater.
+  //
+  // The actual "is the updater misconfigured?" evaluation happens in
+  // contract B above; this short block just re-states the inconsistency
+  // in plain language so a contributor reading the CI log can map the
+  // failure back to the createUpdaterArtifacts flag without having to
+  // cross-reference contract B's errors.
+  if (createUpdaterArtifacts === true && errors.length > 0) {
+    errors.push(
+      "bundle.createUpdaterArtifacts is true so tauri build will emit .sig files, " +
+        "but the updater plugin is misconfigured (see above). Either fix the updater " +
+        "config or set bundle.createUpdaterArtifacts to false.",
+    );
+  }
+
+  return errors.length === 0 ? { ok: true } : { ok: false, errors };
+}
+
+/**
+ * @param {string} confPath
+ * @returns {number} exit code (0 pass, 1 fail)
+ */
+function run(confPath) {
+  if (!fs.existsSync(confPath)) {
+    console.error(
+      `[check-tauri-updater-config] FAIL: config not found at ${confPath}`,
+    );
+    return 1;
+  }
+
+  /** @type {unknown} */
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(confPath, "utf8"));
+  } catch (err) {
+    console.error(
+      `[check-tauri-updater-config] FAIL: could not parse JSON at ${confPath}: ${err}`,
+    );
+    return 1;
+  }
+
+  const result = checkUpdaterConfig(parsed);
+  if (result.ok) {
+    console.log(
+      `[check-tauri-updater-config] PASS: ${confPath} satisfies the #1430 updater contract.`,
+    );
+    return 0;
+  }
+
+  console.error(
+    `[check-tauri-updater-config] FAIL: ${confPath} violates the #1430 updater contract:`,
+  );
+  for (const e of result.errors) {
+    console.error(`  - ${e}`);
+  }
+  console.error(
+    "See https://github.com/anchapin/planar-nexus/issues/1430 and " +
+      "docs/RELEASE_RUNBOOK.md for the signing-key + endpoint setup.",
+  );
+  return 1;
+}
+
+// Run only when invoked directly, not when imported by a test.
+const invokedDirectly =
+  process.argv[1] && path.resolve(process.argv[1]) === __filename;
+if (invokedDirectly) {
+  const confArg = process.argv[2];
+  const confPath = confArg
+    ? path.isAbsolute(confArg)
+      ? confArg
+      : path.resolve(process.cwd(), confArg)
+    : DEFAULT_CONF;
+  process.exit(run(confPath));
+}

--- a/tests/updater-config-guard.test.ts
+++ b/tests/updater-config-guard.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Integration tests for the issue #1430 Tauri updater config guard
+ * (`scripts/check-tauri-updater-config.mjs`).
+ *
+ * The guard is a plain-Node script invoked by CI in its own job
+ * (`.github/workflows/ci.yml → tauri-updater-config`). These tests
+ * exercise it the same way CI does — by spawning `node` against a
+ * fixture config — so the contract locked in here is the same one
+ * that gates a PR merge.
+ *
+ * Contract summary (from issue #1430):
+ *   - empty `pubkey` while `active: true` MUST fail (the MITM default)
+ *   - non-minisign `pubkey` MUST fail (stops placeholders like "TODO")
+ *   - non-HTTPS endpoint MUST fail (TLS pinning)
+ *   - non-`.json` endpoint MUST fail (manifest shape)
+ *   - empty `endpoints` array MUST fail
+ *   - absent updater block MUST pass (option B — disabled)
+ *   - `active: false` MUST pass (explicitly disabled)
+ *   - `bundle.createUpdaterArtifacts: true` without an active updater MUST fail
+ *   - the canonical active updater (real minisign pubkey + HTTPS .json endpoint)
+ *     MUST pass — this is the current repo state, established by #1403.
+ */
+
+import * as cp from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const SCRIPT = path.join(
+  REPO_ROOT,
+  "scripts",
+  "check-tauri-updater-config.mjs",
+);
+const REAL_CONF = path.join(REPO_ROOT, "src-tauri", "tauri.conf.json");
+
+const MINISIGN_PREFIX = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6";
+const VALID_PUBKEY =
+  MINISIGN_PREFIX +
+  "IDEyMzQ1Njc4OTAxMjM0NTYKUldUa0EwR1NTVkdQSVpsWW1jYXJlSlZLSG0xYmc4OXAvbWtDdVNLRVltekR4NUtvN01LSFp0VnYK";
+const VALID_ENDPOINT =
+  "https://github.com/anchapin/planar-nexus/releases/latest/download/latest.json";
+
+interface GuardResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runGuard(config: unknown): GuardResult {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tauri-conf-"));
+  const confPath = path.join(tmp, "tauri.conf.json");
+  fs.writeFileSync(confPath, JSON.stringify(config));
+  try {
+    const res = cp.spawnSync(process.execPath, [SCRIPT, confPath], {
+      encoding: "utf8",
+    });
+    return {
+      code: res.status ?? -1,
+      stdout: res.stdout ?? "",
+      stderr: res.stderr ?? "",
+    };
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function expectFail(result: GuardResult, messageFragment?: string) {
+  expect(result.code).toBe(1);
+  if (messageFragment !== undefined) {
+    const combined = result.stdout + result.stderr;
+    expect(combined).toContain(messageFragment);
+  }
+}
+
+function expectPass(result: GuardResult) {
+  expect(result.code).toBe(0);
+}
+
+describe("Tauri updater config guard (issue #1430)", () => {
+  test("the actual repo config passes (current #1403 state)", () => {
+    // Smoke check that the canonical repo state still satisfies the guard.
+    // If this fails, the updater config has drifted from the documented
+    // #1403 contract and a release will be gated.
+    const res = cp.spawnSync(process.execPath, [SCRIPT, REAL_CONF], {
+      encoding: "utf8",
+    });
+    expectPass({
+      code: res.status ?? -1,
+      stdout: res.stdout ?? "",
+      stderr: res.stderr ?? "",
+    });
+  });
+
+  test("empty pubkey while active=true fails (the #1430 MITM default)", () => {
+    expectFail(
+      runGuard({
+        plugins: {
+          updater: { active: true, pubkey: "", endpoints: [VALID_ENDPOINT] },
+        },
+      }),
+      "pubkey is empty",
+    );
+  });
+
+  test("placeholder pubkey that is not minisign-format fails", () => {
+    expectFail(
+      runGuard({
+        plugins: {
+          updater: {
+            active: true,
+            pubkey: "TODO",
+            endpoints: [VALID_ENDPOINT],
+          },
+        },
+      }),
+      "minisign public-key format",
+    );
+  });
+
+  test("HTTP endpoint fails (must be HTTPS-pinned)", () => {
+    expectFail(
+      runGuard({
+        plugins: {
+          updater: {
+            active: true,
+            pubkey: VALID_PUBKEY,
+            endpoints: ["http://example.com/latest.json"],
+          },
+        },
+      }),
+      "HTTPS",
+    );
+  });
+
+  test("endpoint not ending in .json fails (manifest shape)", () => {
+    expectFail(
+      runGuard({
+        plugins: {
+          updater: {
+            active: true,
+            pubkey: VALID_PUBKEY,
+            endpoints: ["https://example.com/feed"],
+          },
+        },
+      }),
+      ".json",
+    );
+  });
+
+  test("empty endpoints array fails", () => {
+    expectFail(
+      runGuard({
+        plugins: {
+          updater: { active: true, pubkey: VALID_PUBKEY, endpoints: [] },
+        },
+      }),
+      "endpoints is empty",
+    );
+  });
+
+  test("active=true with only the active field fails (missing pubkey + endpoints)", () => {
+    expectFail(
+      runGuard({
+        plugins: { updater: { active: true } },
+      }),
+    );
+  });
+
+  test("updater block entirely absent passes (#1430 option B)", () => {
+    expectPass(runGuard({ plugins: {} }));
+  });
+
+  test("explicitly disabled updater passes (active=false)", () => {
+    expectPass(
+      runGuard({
+        plugins: {
+          updater: { active: false, pubkey: "", endpoints: [] },
+        },
+      }),
+    );
+  });
+
+  test("canonical active updater with real minisign pubkey + HTTPS .json endpoint passes", () => {
+    expectPass(
+      runGuard({
+        plugins: {
+          updater: {
+            active: true,
+            pubkey: VALID_PUBKEY,
+            endpoints: [VALID_ENDPOINT],
+          },
+        },
+      }),
+    );
+  });
+
+  test("bundle.createUpdaterArtifacts=true with no updater block fails (orphan .sig files)", () => {
+    expectFail(
+      runGuard({
+        bundle: { createUpdaterArtifacts: true },
+        plugins: {},
+      }),
+      "createUpdaterArtifacts",
+    );
+  });
+
+  test("bundle.createUpdaterArtifacts=true with empty pubkey fails", () => {
+    expectFail(
+      runGuard({
+        bundle: { createUpdaterArtifacts: true },
+        plugins: {
+          updater: { active: true, pubkey: "", endpoints: [VALID_ENDPOINT] },
+        },
+      }),
+    );
+  });
+
+  test("non-boolean active value fails closed (rejects shape drift)", () => {
+    expectFail(
+      runGuard({
+        plugins: {
+          updater: {
+            active: "yes",
+            pubkey: VALID_PUBKEY,
+            endpoints: [VALID_ENDPOINT],
+          },
+        },
+      }),
+      "must be a boolean",
+    );
+  });
+
+  test("non-existent config path fails with a clear error", () => {
+    const res = cp.spawnSync(
+      process.execPath,
+      [SCRIPT, "/nonexistent/tauri.conf.json"],
+      { encoding: "utf8" },
+    );
+    expectFail(
+      {
+        code: res.status ?? -1,
+        stdout: res.stdout ?? "",
+        stderr: res.stderr ?? "",
+      },
+      "config not found",
+    );
+  });
+
+  test("malformed JSON fails with a parse error", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tauri-conf-"));
+    const confPath = path.join(tmp, "tauri.conf.json");
+    fs.writeFileSync(confPath, "{not valid json");
+    try {
+      const res = cp.spawnSync(process.execPath, [SCRIPT, confPath], {
+        encoding: "utf8",
+      });
+      expectFail(
+        {
+          code: res.status ?? -1,
+          stdout: res.stdout ?? "",
+          stderr: res.stderr ?? "",
+        },
+        "could not parse JSON",
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1430 by landing the **one outstanding acceptance criterion** from the issue that was not already covered by #1403 / PR #1449: a dedicated CI guard script (`scripts/check-tauri-updater-config.mjs`) that prevents the Tauri 2 updater from ever shipping with the empty-pubkey MITM default.

### Background — issue #1430 was effectively resolved by #1403

The issue was filed against this state of `src-tauri/tauri.conf.json`:

```json
"plugins": { "updater": { "active": true, "pubkey": "", "endpoints": [] } }
```

**That is no longer the repo state.** PR #1449 (commit `a206e11`, "feat: resolve #1403 - wire tauri 2 auto-update mechanism to release flow") shipped the full Path A:

| Aspect | Current state |
| --- | --- |
| `plugins.updater.active` | `true` |
| `plugins.updater.pubkey` | Non-empty minisign pubkey (`untrusted comment: minisign public key: 218F5149924103E4`, base64-encoded in the JSON) |
| `plugins.updater.endpoints` | `["https://github.com/anchapin/planar-nexus/releases/latest/download/latest.json"]` (HTTPS, pinned to the project's GitHub releases) |
| `bundle.createUpdaterArtifacts` | `true` (emits per-installer `.sig` files) |
| `src-tauri/capabilities/default.json` | Grants `updater:default` |
| `src-tauri/Cargo.toml` | `tauri-plugin-updater = "2"` |
| `src-tauri/src/lib.rs` | Registers `tauri_plugin_updater::Builder::new().build()` (after `tauri-plugin-single-instance`, preserving the #1441 invariant) |
| `.github/workflows/release.yml` | `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` secrets wired into the Windows/macOS/Linux build jobs; `scripts/build-latest-json.ts` stitches per-platform `.sig` files into a `latest.json` updater manifest |
| `tests/updater-wiring.test.ts` | 6 Jest tests asserting active updater + non-empty minisign pubkey + HTTPS+`latest.json` endpoint + capability grant + `createUpdaterArtifacts` + on-disk `.pub` drift check |

I verified the existing wiring test still passes against the local `.pub` file:

```
$ npx jest tests/updater-wiring.test.ts
  console.log: updater pubkey matched against /home/alex/.tauri/planar-nexus.key.pub
  Tests: 6 passed, 6 total
```

Because Path A is fully implemented and shipped, **Path B (removing the updater plugin config) would have been the wrong fix** — it would have undone properly-configured security work, broken the frontend update UX (`src/lib/updater.ts`, `src/hooks/use-desktop-update.ts`, `src/components/desktop-update-banner.tsx`), and failed the existing `tests/updater-wiring.test.ts` contracts in CI.

### What this PR adds

The one outstanding #1430 acceptance criterion: **`scripts/check-tauri-updater-config.mjs`** — a plain-Node guard (~256 lines, runs in ~50 ms) that fails closed if the Tauri 2 updater config ever drifts back to the vulnerable default.

**Contract** (defence-in-depth on top of the Jest suite):

- `plugins.updater` absent → **pass** (matches #1430 option B).
- `plugins.updater.active === false` → **pass** (explicitly disabled).
- `plugins.updater.active === true` → **all** of the following must hold:
  1. `pubkey` is non-empty (the core #1430 fix — empty pubkey disables signature verification).
  2. `pubkey` matches the minisign wire format (`untrusted comment: minisign public key: …` base64 prefix) so placeholders like `"TODO"` cannot satisfy (1).
  3. `endpoints` contains at least one HTTPS URL ending in `.json` (TLS-pinned manifest shape).
- `bundle.createUpdaterArtifacts === true` → updater must be active with a valid pubkey (otherwise `tauri build` emits orphan `.sig` files).
- Non-boolean `active` values (e.g. `"yes"`) fail closed to prevent shape drift.

The script is wired in three places:

1. **`package.json`** — `"tauri:check-updater": "node scripts/check-tauri-updater-config.mjs"` for local invocation.
2. **`.github/workflows/ci.yml`** — new `tauri-updater-config` job (added to the `build` job's `needs:` list so it gates merge, same pattern as the existing `workflow-lint` job).
3. **`tests/updater-config-guard.test.ts`** — 15 Jest tests that spawn the script via `child_process` against fixture configs (the same way CI runs it) and assert exit codes + stderr contents for both the passing and every failing branch.

### Verification

| Check | Result |
| --- | --- |
| `npm run typecheck` | pass |
| `npm run lint` | 0 errors (548 pre-existing warnings; warnings do not gate per AGENTS.md) |
| `npm test` (full Jest suite) | **425 suites / 8755 tests passed, 0 failed** (incl. the new 15-test guard suite + the existing 6-test updater-wiring suite) |
| `tests/csp-audit.test.ts` (#1273 invariant) | 10/10 pass — `next.config.ts REMOTE_IMAGE_HOSTS` ↔ `tauri.conf.json img-src` still in sync |
| `tests/updater-wiring.test.ts` (#1403 contract) | 6/6 pass — pubkey matches `/home/alex/.tauri/planar-nexus.key.pub` on disk |
| `node scripts/check-tauri-updater-config.mjs` against current `tauri.conf.json` | PASS |
| Manual 13-case contract matrix on `checkUpdaterConfig()` | 13/13 pass (every violating shape fails, every safe shape passes) |
| Single-instance-first invariant (#1441) | unchanged — no `Cargo.toml` / `src-tauri/src/lib.rs` edits |
| `cargo check` (local) | ⚠️ obstructed by an environment workspace collision with an unrelated `/home/alex/Projects/Cargo.toml`; **no Rust files changed in this PR** so the Rust build cannot be affected. CI's `cargo-audit` job and the release workflow will validate Rust on the PR. |

### Files changed

```
.github/workflows/ci.yml               | 27 +++-
eslint.config.mjs                      |  2 +
package.json                           |  1 +
scripts/check-tauri-updater-config.mjs | 256 +++++++++++++++++++++++++++++++
tests/updater-config-guard.test.ts     | 295 +++++++++++++++++++++++++++++++++
```

### Follow-up tracked work

Issue #1430's original Path A also asked for **`docs/RELEASE_RUNBOOK.md` to document key-rotation** and for **endpoint pinning to a project-owned domain** (`https://releases.planarnexus.com/...`) rather than GitHub Releases. The runbook already exists (referenced from `release.yml` line 596 and `tests/updater-wiring.test.ts`); the custom-domain migration is a release-infrastructure task outside this PR's scope and can be tracked separately if desired.

### Notes for reviewer

- No `src-tauri/**`, `Cargo.toml`, `Cargo.lock`, or `next.config.ts` changes — purely additive CI guard.
- The `tests/updater-config-guard.test.ts` suite spawns `node` against temp-file fixtures, so it exercises the exact CI invocation path rather than a reimplementation in Jest.
- The 13 manual contract cases (including the canonical passing config, the empty-pubkey default, non-minisign placeholders, HTTP endpoints, non-`.json` endpoints, orphan `createUpdaterArtifacts`, and non-boolean `active`) all pass; the same cases are encoded as Jest tests.
