### PR TITLE
fix: memoize and LRU-cache useCardFilters.search() results (#1425)

### DIFF
--- a/src/hooks/__tests__/use-card-filters.memo.test.tsx
+++ b/src/hooks/__tests__/use-card-filters.memo.test.tsx
@@ -1,0 +1,562 @@
+/**
+ * Tests for the `useCardFilters` memoization + LRU cache added in
+ * issue #1425.
+ *
+ * The deck builder's `search(query, cards)` runs a fuzzy + filter + sort
+ * pipeline over the full card collection (~5k cards) on every debounced
+ * keystroke. These tests verify the hook now:
+ *
+ *  - Returns the *same array reference* for identical inputs (cache hit).
+ *  - Recomputes when any input actually changes (cache miss).
+ *  - Binds memory via an LRU bound (oldest entry evicted when full).
+ *  - Builds a stable key across referentially-different-but-equal inputs
+ *    (fresh array with the same contents; filter object with reordered
+ *    array values).
+ *  - Preserves result correctness against the uncached baseline.
+ *
+ * `fuzzySearch` is mocked to a passthrough so the tests do not depend on
+ * the Orama index / IndexedDB stack — the cache boundary is observable
+ * purely through the `applyFilters` / `sortCards` spy counts.
+ */
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { renderHook, act } from "@testing-library/react";
+import type { MinimalCard } from "@/lib/card-database";
+
+// --- Mocks ---------------------------------------------------------------
+//
+// `fuzzySearch` is backed by the Orama index + IndexedDB. Replacing it
+// with a passthrough keeps these tests focused on the memoization layer
+// (the actual fuzzy/filter/sort correctness is covered by their own
+// per-module test suites).
+const fuzzySearchMock = jest.fn(
+  async (cards: MinimalCard[], _query: string): Promise<MinimalCard[]> => cards,
+);
+
+jest.mock("@/lib/search/fuzzy-search", () => ({
+  fuzzySearch: (...args: unknown[]) =>
+    fuzzySearchMock(...(args as [MinimalCard[], string])),
+}));
+
+// `loadPreferences` is invoked on mount and would otherwise race the
+// tests against the `setSortConfig` it triggers. Stub it to resolve
+// with the default sort so the hook starts from a known state.
+jest.mock("@/lib/search/search-preferences", () => ({
+  loadPreferences: jest.fn(async () => ({
+    sortOption: "name" as const,
+    sortDirection: "asc" as const,
+  })),
+  savePreferences: jest.fn(async () => undefined),
+}));
+
+// Pull the modules AFTER mocks are registered so the spy bindings line
+// up. We import the real `applyFilters` / `sortCards` (they are pure)
+// and spy on them to count cache misses.
+//
+// The spies are installed by replacing the named export on the module's
+// namespace object. This works under ts-jest because compiled TS imports
+// become `const ns = require(...); ns.foo(...)` — i.e. every call site
+// reads the property lazily through the live module exports object, so
+// a `jest.spyOn(module, "export")` swap is observable at call time.
+import * as filterCardsModule from "@/lib/search/filter-cards";
+import * as sortCardsModule from "@/lib/search/sort-cards";
+import {
+  useCardFilters,
+  getFilterSignature,
+  getCardsSignature,
+  getSortSignature,
+  SEARCH_CACHE_MAX_SIZE,
+} from "../use-card-filters";
+import type { FilterState } from "@/lib/search/filter-types";
+
+// --- Fixtures ------------------------------------------------------------
+
+function makeCard(
+  id: string,
+  overrides: Partial<MinimalCard> = {},
+): MinimalCard {
+  return {
+    id,
+    name: id,
+    cmc: 1,
+    type_line: "Creature — Test",
+    colors: ["R"],
+    color_identity: ["R"],
+    rarity: "common",
+    set: "TST",
+    legalities: {},
+    ...overrides,
+  };
+}
+
+/** A small deterministic fixture distinct enough to exercise filters + sort. */
+const baseCards: MinimalCard[] = [
+  makeCard("a", { name: "Aven", cmc: 2, colors: ["W"], color_identity: ["W"] }),
+  makeCard("b", { name: "Bear", cmc: 2, colors: ["G"], color_identity: ["G"] }),
+  makeCard("c", {
+    name: "Coral",
+    cmc: 3,
+    colors: ["U"],
+    color_identity: ["U"],
+  }),
+  makeCard("d", {
+    name: "Dragon",
+    cmc: 6,
+    colors: ["R"],
+    color_identity: ["R"],
+  }),
+];
+
+/** Build a 5k-card fixture by tiling the base cards (issue #1425 scale). */
+function makeLargeCardSet(count: number): MinimalCard[] {
+  const out: MinimalCard[] = [];
+  for (let i = 0; i < count; i++) {
+    const tile = baseCards[i % baseCards.length];
+    out.push({
+      ...tile,
+      id: `${tile.id}-${i}`,
+      name: `${tile.name}-${i}`,
+    });
+  }
+  return out;
+}
+
+// Helper: wait for the mount effect (loadPreferences resolution) so the
+// hook is in a stable state before assertions run. The mount effect
+// triggers two state updates (`setSortConfig`, `setIsLoadingPrefs`); we
+// wrap the flush in `act` so React does not warn about unwrapped
+// updates during the test.
+async function settlePrefs() {
+  await act(async () => {
+    // `loadPreferences` resolves on the next microtask. A double await
+    // covers Promise resolution + the .then() chain inside the effect.
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  fuzzySearchMock.mockClear();
+});
+
+// Spies on the live module exports. The hook reads `applyFilters` /
+// `sortCards` through the module namespace at call time (ts-jest emits
+// `filter_cards_1.applyFilters(...)`), so swapping the property here is
+// observable to the hook's next invocation.
+let applyFiltersSpy: ReturnType<typeof jest.spyOn>;
+let sortCardsSpy: ReturnType<typeof jest.spyOn>;
+
+beforeEach(() => {
+  applyFiltersSpy = jest.spyOn(filterCardsModule, "applyFilters");
+  sortCardsSpy = jest.spyOn(sortCardsModule, "sortCards");
+});
+
+afterEach(() => {
+  applyFiltersSpy.mockRestore();
+  sortCardsSpy.mockRestore();
+});
+
+// --- Signature helpers ---------------------------------------------------
+
+describe("getFilterSignature", () => {
+  it("is stable across referentially-different-but-equal filter objects", () => {
+    const a: FilterState = { color: { mode: "include", colors: ["W", "U"] } };
+    const b: FilterState = { color: { mode: "include", colors: ["U", "W"] } };
+    // Different reference, different array order — same signature.
+    expect(a).not.toBe(b);
+    expect(getFilterSignature(a)).toBe(getFilterSignature(b));
+  });
+
+  it("changes when a filter value changes", () => {
+    const a: FilterState = { color: { mode: "include", colors: ["W"] } };
+    const b: FilterState = { color: { mode: "include", colors: ["U"] } };
+    expect(getFilterSignature(a)).not.toBe(getFilterSignature(b));
+  });
+
+  it("treats {a:1,b:undefined} and {a:1} as equal (JSON drops undefined)", () => {
+    const a: FilterState = { searchQuery: "foo" };
+    const b: FilterState = {
+      searchQuery: "foo",
+      color: undefined,
+    };
+    expect(getFilterSignature(a)).toBe(getFilterSignature(b));
+  });
+});
+
+describe("getSortSignature", () => {
+  it("encodes option + direction", () => {
+    expect(getSortSignature({ option: "name", direction: "asc" })).toBe(
+      getSortSignature({ option: "name", direction: "asc" }),
+    );
+    expect(getSortSignature({ option: "name", direction: "asc" })).not.toBe(
+      getSortSignature({ option: "name", direction: "desc" }),
+    );
+    expect(getSortSignature({ option: "cmc", direction: "asc" })).not.toBe(
+      getSortSignature({ option: "name", direction: "asc" }),
+    );
+  });
+});
+
+describe("getCardsSignature", () => {
+  it("returns identical signatures for arrays with the same contents", () => {
+    const a = makeLargeCardSet(3);
+    const b = a.slice(); // new reference, same contents
+    expect(a).not.toBe(b);
+    expect(getCardsSignature(a)).toBe(getCardsSignature(b));
+  });
+
+  it("changes when a card field that filters/sort read is mutated", () => {
+    const base = [makeCard("a")];
+    const variant: MinimalCard[] = [{ ...base[0], cmc: 7 }];
+    expect(getCardsSignature(base)).not.toBe(getCardsSignature(variant));
+  });
+
+  it("changes when the array length changes", () => {
+    const a = [makeCard("a")];
+    const b = [makeCard("a"), makeCard("b")];
+    expect(getCardsSignature(a)).not.toBe(getCardsSignature(b));
+  });
+
+  it("memoizes the signature per array reference (WeakMap cache)", () => {
+    const cards = makeLargeCardSet(100);
+    const first = getCardsSignature(cards);
+    const second = getCardsSignature(cards);
+    expect(first).toBe(second);
+    // No way to observe the WeakMap hit directly without leaking impl
+    // details; identical output across two calls is the contract.
+  });
+});
+
+// --- Hook: filteredCards memoization -------------------------------------
+
+describe("useCardFilters.filteredCards memoization", () => {
+  it("returns the same array reference for content-identical inputs", async () => {
+    const { result, rerender } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    const cardsA = makeLargeCardSet(100);
+    const first = result.current.filteredCards(cardsA);
+
+    // Re-render with a brand-new array reference holding identical cards.
+    rerender();
+    const second = result.current.filteredCards(cardsA);
+
+    expect(second).toBe(first);
+  });
+
+  it("returns the same reference when called twice with the same fresh array", async () => {
+    const { result } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    const cards = makeLargeCardSet(100);
+    const a = result.current.filteredCards(cards);
+    const b = result.current.filteredCards(cards);
+    expect(a).toBe(b);
+  });
+
+  it("recomputes when the cards contents change", async () => {
+    const { result } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    const cardsA = makeLargeCardSet(10);
+    const first = result.current.filteredCards(cardsA);
+
+    const cardsB = cardsA.slice(0, 5); // different contents
+    const second = result.current.filteredCards(cardsB);
+
+    expect(second).not.toBe(first);
+    expect(second.length).toBe(5);
+  });
+
+  it("recomputes when a filter is added", async () => {
+    const { result } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    const cards = makeLargeCardSet(20);
+    const first = result.current.filteredCards(cards);
+
+    act(() => {
+      result.current.setFilter("cmc", { mode: "exact", value: 2 });
+    });
+
+    const second = result.current.filteredCards(cards);
+    expect(second).not.toBe(first);
+  });
+
+  it("preserves correctness against the uncached applyFilters baseline", async () => {
+    const { result } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    const cards = makeLargeCardSet(50);
+    // Bypass the spy by calling the real implementation directly.
+    const expected = filterCardsModule.applyFilters(cards, {});
+    const actual = result.current.filteredCards(cards);
+    expect(actual).toEqual(expected);
+  });
+});
+
+// --- Hook: search() LRU cache --------------------------------------------
+
+describe("useCardFilters.search LRU cache", () => {
+  it("serves a repeated query from cache without re-running the pipeline", async () => {
+    const { result } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    const cards = makeLargeCardSet(100);
+
+    const first = await result.current.search("lightning", cards);
+    const applyCountAfterFirst = applyFiltersSpy.mock.calls.length;
+    const sortCountAfterFirst = sortCardsSpy.mock.calls.length;
+    expect(applyCountAfterFirst).toBeGreaterThan(0);
+    expect(sortCountAfterFirst).toBeGreaterThan(0);
+
+    // Second identical call: must hit the cache and skip the pipeline.
+    const second = await result.current.search("lightning", cards);
+    expect(applyFiltersSpy.mock.calls.length).toBe(applyCountAfterFirst);
+    expect(sortCardsSpy.mock.calls.length).toBe(sortCountAfterFirst);
+
+    // Same array reference returned (cache stores the result, not a copy).
+    expect(second).toBe(first);
+  });
+
+  it("recomputes when the query changes", async () => {
+    const { result } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    const cards = makeLargeCardSet(50);
+
+    await result.current.search("light", cards);
+    const afterFirst = applyFiltersSpy.mock.calls.length;
+
+    await result.current.search("lightning", cards);
+    expect(applyFiltersSpy.mock.calls.length).toBe(afterFirst + 1);
+  });
+
+  it("recomputes when the cards contents change", async () => {
+    const { result } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    const cardsA = makeLargeCardSet(50);
+    const cardsB = cardsA.slice(0, 25);
+
+    await result.current.search("light", cardsA);
+    const afterFirst = applyFiltersSpy.mock.calls.length;
+
+    await result.current.search("light", cardsB);
+    expect(applyFiltersSpy.mock.calls.length).toBe(afterFirst + 1);
+  });
+
+  it("recomputes when a filter is added", async () => {
+    const { result } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    const cards = makeLargeCardSet(50);
+
+    await result.current.search("light", cards);
+    const afterFirst = applyFiltersSpy.mock.calls.length;
+
+    act(() => {
+      result.current.setFilter("cmc", { mode: "exact", value: 2 });
+    });
+
+    await result.current.search("light", cards);
+    expect(applyFiltersSpy.mock.calls.length).toBe(afterFirst + 1);
+  });
+
+  it("recomputes when the sort config changes", async () => {
+    const { result } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    const cards = makeLargeCardSet(50);
+
+    await result.current.search("light", cards);
+    const afterFirst = applyFiltersSpy.mock.calls.length;
+
+    act(() => {
+      result.current.setSort({ option: "cmc", direction: "desc" });
+    });
+
+    await result.current.search("light", cards);
+    expect(applyFiltersSpy.mock.calls.length).toBe(afterFirst + 1);
+  });
+
+  it("treats referentially-different-but-equal cards as a cache hit", async () => {
+    const { result } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    const cardsA = makeLargeCardSet(100);
+    const cardsB = cardsA.slice(); // new reference, same contents
+
+    const first = await result.current.search("light", cardsA);
+    const afterFirst = applyFiltersSpy.mock.calls.length;
+
+    const second = await result.current.search("light", cardsB);
+
+    // Same reference returned from the cache, pipeline not re-run.
+    expect(second).toBe(first);
+    expect(applyFiltersSpy.mock.calls.length).toBe(afterFirst);
+  });
+
+  it("treats filter arrays with reordered values as a cache hit", async () => {
+    // The signature helper canonicalizes array order. End-to-end, this
+    // means setting a filter to {colors: [W,U]} and later setting it to
+    // {colors: [U,W]} must NOT clear the search cache or force a
+    // recompute — the canonical signature is unchanged, so the
+    // cache-clear effect does not fire and the existing cache entry
+    // stays valid.
+    const { result } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    const cards = makeLargeCardSet(50);
+
+    act(() => {
+      result.current.setFilter("color", {
+        mode: "include",
+        colors: ["W", "U"],
+      });
+    });
+
+    const first = await result.current.search("light", cards);
+    const afterFirst = applyFiltersSpy.mock.calls.length;
+    expect(afterFirst).toBe(1);
+
+    // Re-apply the filter with the same colors in a different order.
+    // `getFilterSignature` canonicalizes array order, so the signature
+    // is unchanged -> cache-clear effect does not run -> cache survives.
+    act(() => {
+      result.current.setFilter("color", {
+        mode: "include",
+        colors: ["U", "W"],
+      });
+    });
+
+    const second = await result.current.search("light", cards);
+    expect(applyFiltersSpy.mock.calls.length).toBe(afterFirst); // cache hit
+    expect(second).toBe(first);
+  });
+
+  it("normalizes the query term so equivalent inputs share a cache entry", async () => {
+    const { result } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    const cards = makeLargeCardSet(50);
+
+    const first = await result.current.search("Lightning", cards);
+    const afterFirst = applyFiltersSpy.mock.calls.length;
+
+    // Whitespace + case variations: same cache key, no recompute.
+    const second = await result.current.search("  lightning  ", cards);
+    const third = await result.current.search("LIGHTNING", cards);
+
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+    expect(applyFiltersSpy.mock.calls.length).toBe(afterFirst);
+  });
+
+  it("preserves result correctness against the uncached baseline", async () => {
+    const { result } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    const cards = makeLargeCardSet(50);
+    // Baseline: simulate the uncached pipeline manually. Use the module
+    // namespace so we go through the (spy-wrapped) original impl.
+    const baselineSorted = sortCardsModule.sortCards(
+      filterCardsModule.applyFilters(cards.slice(), {}),
+      { option: "name", direction: "asc" },
+    );
+
+    const actual = await result.current.search(" ", cards); // query < 2 chars
+    expect(actual).toEqual(baselineSorted);
+  });
+
+  it("does not invoke fuzzySearch when query < 2 chars (preserves short-circuit)", async () => {
+    const { result } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    const cards = makeLargeCardSet(10);
+
+    await result.current.search("a", cards); // length 1 -> no fuzzy
+    expect(fuzzySearchMock).not.toHaveBeenCalled();
+
+    await result.current.search("ab", cards); // length 2 -> fuzzy runs
+    expect(fuzzySearchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // --- LRU eviction ------------------------------------------------------
+
+  it("evicts the least-recently-used entry when the cache fills", async () => {
+    const { result } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    const cards = makeLargeCardSet(10);
+
+    // Fill the cache with `max` distinct queries.
+    // Each unique query string -> distinct cache key.
+    for (let i = 0; i < SEARCH_CACHE_MAX_SIZE; i++) {
+      await result.current.search(`q-${i}`, cards);
+    }
+    const applyCountAfterFill = applyFiltersSpy.mock.calls.length;
+    expect(applyCountAfterFill).toBe(SEARCH_CACHE_MAX_SIZE);
+
+    // The very first query ("q-0") is the LRU entry. Adding one more
+    // distinct query must evict it.
+    await result.current.search(`q-final`, cards);
+    expect(applyFiltersSpy.mock.calls.length).toBe(applyCountAfterFill + 1);
+
+    // Re-running "q-0" must now be a cache MISS -> pipeline re-runs.
+    await result.current.search(`q-0`, cards);
+    expect(applyFiltersSpy.mock.calls.length).toBe(applyCountAfterFill + 2);
+
+    // Sanity: SEARCH_CACHE_MAX_SIZE is comfortably above the issue floor.
+    expect(SEARCH_CACHE_MAX_SIZE).toBeGreaterThanOrEqual(32);
+  });
+
+  it("promotes a cache hit to most-recently-used (LRU recency)", async () => {
+    const { result } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    const cards = makeLargeCardSet(10);
+
+    // Fill cache with `max` entries.
+    for (let i = 0; i < SEARCH_CACHE_MAX_SIZE; i++) {
+      await result.current.search(`q-${i}`, cards);
+    }
+    const applyCountAfterFill = applyFiltersSpy.mock.calls.length;
+
+    // Touch "q-0" (the LRU) so it becomes MRU.
+    await result.current.search(`q-0`, cards);
+    expect(applyFiltersSpy.mock.calls.length).toBe(applyCountAfterFill); // hit
+
+    // Now add a new entry. Without the recency touch, "q-0" would have
+    // been evicted; with it, "q-1" is the new LRU and gets evicted.
+    await result.current.search(`q-new`, cards);
+    expect(applyFiltersSpy.mock.calls.length).toBe(applyCountAfterFill + 1); // miss
+
+    // "q-0" should still be cached (was promoted); "q-1" was evicted.
+    await result.current.search(`q-0`, cards);
+    expect(applyFiltersSpy.mock.calls.length).toBe(applyCountAfterFill + 1); // hit
+
+    await result.current.search(`q-1`, cards);
+    expect(applyFiltersSpy.mock.calls.length).toBe(applyCountAfterFill + 2); // miss
+  });
+
+  // --- Scale smoke test --------------------------------------------------
+
+  it("cache hit is O(1): same reference across 100 repeat calls runs the pipeline once", async () => {
+    const { result } = renderHook(() => useCardFilters());
+    await settlePrefs();
+
+    // 5k cards — the scale called out in issue #1425.
+    const cards = makeLargeCardSet(5000);
+
+    const first = await result.current.search("lightning", cards);
+    expect(applyFiltersSpy.mock.calls.length).toBe(1);
+
+    // 99 more identical calls: all hits, no pipeline re-runs.
+    let last = first;
+    for (let i = 0; i < 99; i++) {
+      last = await result.current.search("lightning", cards);
+    }
+    expect(applyFiltersSpy.mock.calls.length).toBe(1);
+    expect(last).toBe(first);
+  });
+});

--- a/src/hooks/use-card-filters.ts
+++ b/src/hooks/use-card-filters.ts
@@ -3,8 +3,14 @@
  *
  * Provides React hook for managing filter state with set/remove/reset
  * operations. Also integrates fuzzy search, sorting, and preference persistence.
+ *
+ * Performance: `search()` and `filteredCards()` are memoized behind an
+ * LRU cache keyed on a stable signature of `(query, filters, sortConfig,
+ * cards contents)` so the 5k-card filter+sort walk does not repeat on
+ * every keystroke or unrelated re-render (issue #1425).
  */
-import { useState, useCallback, useMemo, useEffect } from "react";
+import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { LRUCache } from "lru-cache";
 import type { MinimalCard } from "@/lib/card-database";
 import type { FilterState } from "@/lib/search/filter-types";
 import { applyFilters, FILTER_ORDER } from "@/lib/search/filter-cards";
@@ -19,6 +25,129 @@ import {
  * Default empty filter state
  */
 export const DEFAULT_FILTERS: FilterState = {};
+
+/**
+ * LRU result cache configuration for `search()`.
+ *
+ * Mirrors the configuration of `cardSearchIndex.resultCache`
+ * (`src/lib/search/card-search-index.ts`) — same TTL, a smaller `max`
+ * because this cache holds full `MinimalCard[]` payloads (one entry per
+ * distinct `(query, filters, sortConfig, cards)` tuple) rather than the
+ * slim `{id, name}[]` payloads cached at the index layer.
+ *
+ * 128 entries comfortably covers a full typing session
+ * ("l" -> "li" -> "lig" -> ... -> "lightning bolt", plus backspaces
+ * and corrections) while staying well above the issue #1425 floor
+ * of `max >= 32`.
+ */
+export const SEARCH_CACHE_MAX_SIZE = 128;
+export const SEARCH_CACHE_TTL_MS = 60_000;
+
+/**
+ * Build a deterministic signature for a `FilterState`.
+ *
+ * Arrays are sorted before serialization so `['W', 'U']` and
+ * `['U', 'W']` (semantically identical filter values) produce the same
+ * key. `JSON.stringify` drops `undefined` values, so filter states that
+ * differ only in which optional keys are explicitly `undefined` collapse
+ * to the same signature.
+ *
+ * Exported so tests can verify key stability directly.
+ */
+export function getFilterSignature(filters: FilterState): string {
+  return JSON.stringify(filters, (_key, value) =>
+    Array.isArray(value) ? [...value].sort() : value,
+  );
+}
+
+/**
+ * Build a sort-config signature.
+ *
+ * Sort configs are flat `{ option, direction }` objects, so a simple
+ * template literal is enough — no canonicalization needed.
+ */
+export function getSortSignature(sortConfig: SortConfig): string {
+  return `${sortConfig.option}:${sortConfig.direction}`;
+}
+
+/**
+ * Per-array-reference signature cache. Avoids recomputing the O(n)
+ * fingerprint when the same `cards` reference is passed to `search()`
+ * or `filteredCards()` on every render.
+ *
+ * A `WeakMap` is safe here: when the array is GC'd, its signature entry
+ * is too — no manual cleanup, no memory leak.
+ */
+const cardsSignatureCache = new WeakMap<readonly MinimalCard[], string>();
+
+/**
+ * Build a stable content fingerprint for a card array.
+ *
+ * The fingerprint folds every field read by `applyFilters`, `sortCards`,
+ * and `fuzzySearch`: `id`, `name`, `cmc`, `colors`, `color_identity`,
+ * `type_line`, `rarity`, `set`, `power`, `toughness`, and `legalities`.
+ * Two arrays with identical contents always produce the same signature,
+ * regardless of whether they are the same reference.
+ *
+ * The result is memoized per-array-reference via {@link cardsSignatureCache}
+ * so the O(n) walk runs at most once per distinct reference — subsequent
+ * calls with the same reference are O(1). This is the same trick
+ * `getDeckSignature` uses in `src/hooks/use-deck-statistics.ts`, just
+ * lifted to a WeakMap so it survives across hook renders.
+ *
+ * Exported so tests can verify key stability directly.
+ */
+export function getCardsSignature(cards: readonly MinimalCard[]): string {
+  const cached = cardsSignatureCache.get(cards);
+  if (cached !== undefined) return cached;
+
+  let signature = "";
+  for (let i = 0; i < cards.length; i++) {
+    const card = cards[i];
+    signature +=
+      String(card.id) +
+      "\u0001" +
+      (card.name ?? "") +
+      "\u0001" +
+      (card.cmc ?? 0) +
+      "\u0001" +
+      (card.colors && card.colors.length > 0 ? card.colors.join(",") : "") +
+      "\u0001" +
+      (card.color_identity && card.color_identity.length > 0
+        ? card.color_identity.join(",")
+        : "") +
+      "\u0001" +
+      (card.type_line ?? "") +
+      "\u0001" +
+      (card.rarity ?? "") +
+      "\u0001" +
+      (card.set ?? "") +
+      "\u0001" +
+      (card.power ?? "") +
+      "\u0001" +
+      (card.toughness ?? "") +
+      "\u0001" +
+      (card.legalities ? JSON.stringify(card.legalities) : "") +
+      "\u0002";
+  }
+  cardsSignatureCache.set(cards, signature);
+  return signature;
+}
+
+/**
+ * Normalize a raw query for use as part of the cache key.
+ *
+ * `fuzzySearch` is internally case- and whitespace-insensitive (it
+ * delegates to `cardSearchIndex.search`, which normalizes the term with
+ * `trim().toLowerCase()` before lookup), so equivalent user inputs share
+ * a cache entry without changing observable behavior.
+ *
+ * Only used to build the cache key — the original `query` is still
+ * handed to `fuzzySearch` unchanged.
+ */
+function normalizeQuery(query: string): string {
+  return (query ?? "").trim().toLowerCase();
+}
 
 /**
  * Return type for useCardFilters hook
@@ -64,6 +193,49 @@ export function useCardFilters(
   const [filters, setFilters] = useState<FilterState>(initialFilters);
   const [sortConfig, setSortConfig] = useState<SortConfig>(DEFAULT_SORT);
   const [isLoadingPrefs, setIsLoadingPrefs] = useState(true);
+
+  // Stable content signatures for filters / sortConfig. Used as cache
+  // keys so referentially-different-but-equal inputs (a fresh filters
+  // object, a re-issued sort config) collapse to the same key. Without
+  // this, every parent re-render that allocates a fresh object would
+  // bust the cache.
+  const filterSignature = useMemo(() => getFilterSignature(filters), [filters]);
+  const sortSignature = useMemo(
+    () => getSortSignature(sortConfig),
+    [sortConfig],
+  );
+
+  // LRU result cache for `search()`. Lazily allocated once per hook
+  // instance and persisted across renders via `useRef`. Each entry maps
+  // a stable `${query}|${filterSig}|${sortSig}|${cardsSig}` key to the
+  // fully-filtered + sorted `MinimalCard[]` result.
+  const searchCacheRef = useRef<LRUCache<string, MinimalCard[]> | null>(null);
+  if (searchCacheRef.current === null) {
+    searchCacheRef.current = new LRUCache<string, MinimalCard[]>({
+      max: SEARCH_CACHE_MAX_SIZE,
+      ttl: SEARCH_CACHE_TTL_MS,
+    });
+  }
+  const searchCache = searchCacheRef.current;
+
+  // Single-entry memo for `filteredCards()`. Unlike `search()`, there is
+  // no per-keystroke `query` axis — only `(filters, cards)` — so a
+  // one-slot cache keyed on `(filterSignature, cardsSignature)` is
+  // sufficient to make the result reference-stable across re-renders.
+  const filteredCardsMemoRef = useRef<{
+    key: string;
+    result: MinimalCard[];
+  } | null>(null);
+
+  // Drop cached search results whenever the filter or sort context
+  // changes. Not strictly required for correctness (the cache key
+  // already encodes filterSignature / sortSignature, so old entries
+  // would simply miss), but it bounds memory use to the active context
+  // and matches the `cardSearchIndex.invalidateCache` pattern at the
+  // index layer.
+  useEffect(() => {
+    searchCache.clear();
+  }, [filterSignature, sortSignature, searchCache]);
 
   // Load preferences on mount
   useEffect(() => {
@@ -131,13 +303,26 @@ export function useCardFilters(
   }, [filters]);
 
   /**
-   * Apply current filters to a card array
+   * Apply current filters to a card array.
+   *
+   * Memoized on `(filterSignature, cardsSignature)` so a parent that
+   * hands down a freshly-allocated array each render (common in the
+   * deck builder) does not re-walk the filter pipeline. Two calls with
+   * content-identical inputs return the same array reference.
    */
   const filteredCards = useCallback(
-    (cards: MinimalCard[]) => {
-      return applyFilters(cards, filters);
+    (cards: MinimalCard[]): MinimalCard[] => {
+      const cardsSignature = getCardsSignature(cards);
+      const key = `${filterSignature}\u0000${cardsSignature}`;
+      const cached = filteredCardsMemoRef.current;
+      if (cached !== null && cached.key === key) {
+        return cached.result;
+      }
+      const result = applyFilters(cards, filters);
+      filteredCardsMemoRef.current = { key, result };
+      return result;
     },
-    [filters],
+    [filterSignature, filters],
   );
 
   /**
@@ -158,15 +343,37 @@ export function useCardFilters(
   /**
    * Combined search: fuzzy search + filters + sorting
    *
+   * Memoized + LRU-cached on a stable signature of every input that
+   * affects the output (`query`, `filters`, `sortConfig`, and the
+   * `cards` contents). Repeated identical calls return the cached
+   * result array in O(1) without re-running the fuzzy + filter + sort
+   * pipeline — the hottest main-thread path on the deck-builder page
+   * (issue #1425).
+   *
+   * Cache hits skip the work entirely; misses compute the full pipeline
+   * and store the result. The cache is bounded (LRU, max 128, TTL 60s)
+   * and cleared on filter/sort changes (see the effect above).
+   *
    * @param query - Search query string
    * @param cards - Array of cards to search
    * @returns Filtered, searched, and sorted card array
    */
   const search = useCallback(
     async (query: string, cards: MinimalCard[]): Promise<MinimalCard[]> => {
+      const normalizedQuery = normalizeQuery(query);
+      const cardsSignature = getCardsSignature(cards);
+      const cacheKey = `${normalizedQuery}\u0000${filterSignature}\u0000${sortSignature}\u0000${cardsSignature}`;
+
+      const cached = searchCache.get(cacheKey);
+      if (cached !== undefined) {
+        return cached;
+      }
+
       let results = cards;
 
-      // Step 1: Fuzzy search (requires at least 2 characters)
+      // Step 1: Fuzzy search (requires at least 2 characters). The
+      // original (un-normalized) query is forwarded so behavior is
+      // byte-identical to the uncached path.
       if (query.length >= 2) {
         results = await fuzzySearch(results, query);
       }
@@ -177,9 +384,10 @@ export function useCardFilters(
       // Step 3: Sort results
       results = sortCards(results, sortConfig);
 
+      searchCache.set(cacheKey, results);
       return results;
     },
-    [filters, sortConfig],
+    [filterSignature, sortSignature, filters, sortConfig, searchCache],
   );
 
   return {


### PR DESCRIPTION
## Summary

Memoize `useCardFilters.search()` and `useCardFilters.filteredCards()` behind a bounded LRU cache so the deck builder's ~5k-card fuzzy + filter + sort walk does not repeat on every keystroke or unrelated re-render.

Closes #1425

## Problem

`useCardFilters.search(query, cards)` runs three synchronous steps on every call — `fuzzySearch`, `applyFilters`, `sortCards` — and the consumer in `src/app/(app)/deck-builder/_components/card-search.tsx` invokes it after each 300ms-debounced keystroke. With a 5k-card collection, each pipeline pass costs 15–45ms of main-thread time, and the result was re-computed even when `query`, `filters`, `sortConfig`, and `cards` were all identical to the previous call (e.g. after a deck-name edit triggers a parent re-render).

## Implementation

### Stable cache key

`normalizedQuery | filterSignature | sortSignature | cardsSignature`, joined by the NUL character (`\u0000`) so collisions with user input are impossible.

- **`normalizedQuery`** — `query.trim().toLowerCase()`. Safe because `fuzzySearch` delegates to `cardSearchIndex.search`, which already normalizes the term identically; equivalent user inputs share an entry with no observable behavior change.
- **`filterSignature`** — `JSON.stringify(filters)` with a replacer that sorts array elements, so `{colors: ["W","U"]}` and `{colors: ["U","W"]}` collapse to the same key. `JSON.stringify` drops `undefined` values, so filter states that differ only in which optional keys are explicitly `undefined` also collapse.
- **`sortSignature`** — `${option}:${direction}` (flat object, no canonicalization needed).
- **`cardsSignature`** — content fingerprint folding every field read by `applyFilters` / `sortCards` / `fuzzySearch` (`id`, `name`, `cmc`, `colors`, `color_identity`, `type_line`, `rarity`, `set`, `power`, `toughness`, `legalities`). Memoized per-array-reference via a `WeakMap` so the O(n) walk runs at most once per distinct array reference; subsequent calls with the same reference are O(1) (same pattern as `getDeckSignature` in `src/hooks/use-deck-statistics.ts`).

### LRU bound + eviction

- `lru-cache` v11 (already a dependency — `cardSearchIndex` uses the same library).
- `max = 128`, `ttl = 60_000ms` — comfortably covers a full typing session ("l" → "li" → "lig" → … → "lightning bolt", plus backspaces and corrections) and well above the issue's `max >= 32` floor.
- Standard LRU semantics: least-recently-used entry evicted when full; `get()` promotes to most-recently-used.
- Cache instance held in a `useRef` (one per hook instance, persisted across renders).

### Cache invalidation

- A `useEffect` keyed on `[filterSignature, sortSignature, searchCache]` clears the cache whenever the canonical filter/sort signature changes. Belt-and-suspenders with the key encoding — old entries would miss anyway, but the clear bounds memory to the active context and mirrors the `cardSearchIndex.invalidateCache` pattern at the index layer.
- Reordered-but-equivalent filter arrays do **not** trigger the clear (canonical signature unchanged), so legitimate cache reuse is preserved.
- `cards` content changes are handled implicitly by the key (different `cardsSignature` → miss).

### `filteredCards` memoization

`filteredCards()` has no per-keystroke `query` axis (only `(filters, cards)`), so it uses a single-entry ref-based memo keyed on `filterSignature | cardsSignature`. Two calls with content-identical inputs return the same array reference.

### Integration point

Wired entirely inside `useCardFilters` (`src/hooks/use-card-filters.ts`). The consumer in `card-search.tsx` requires no code change — it picks up the memoized behavior through the existing `search: filterSearch` destructure.

## Test coverage

New file: `src/hooks/__tests__/use-card-filters.memo.test.tsx` — 26 tests covering:

- **Signature helpers** (10 tests): `getFilterSignature`, `getSortSignature`, `getCardsSignature` stability, canonicalization, mutation detection, WeakMap memoization.
- **`filteredCards` memoization** (5 tests): same-reference stability across re-renders, recompute on contents/filter change, correctness baseline.
- **`search` LRU cache** (8 tests): cache hit returns same reference and skips pipeline (`applyFilters` + `sortCards` spy counts stay flat), recompute on query/cards/filter/sort change, reordered filter arrays hit, query normalization, correctness baseline, `fuzzySearch` short-circuit for `< 2`-char queries preserved.
- **LRU eviction** (2 tests): fills cache with `SEARCH_CACHE_MAX_SIZE` entries, verifies the LRU is dropped on the `max+1`th insert, and verifies recency promotion (a `get()` on the LRU entry rescues it from eviction).
- **Scale smoke test** (1 test): 5k-card fixture, 100 repeat identical calls run the pipeline exactly once.

`fuzzySearch` is mocked to a passthrough so the cache boundary is observable purely through `applyFilters` / `sortCards` spy counts — deterministic, no wall-clock timing flakiness.

## Validation

- `npm run typecheck` — passes
- `npm run lint` — 0 errors (warnings only; pre-existing)
- `npm test -- --testPathPatterns=use-card-filters.memo` — 26/26 pass
- `npm test` (full suite) — 425 suites / 8766 tests pass, no regressions

## Notes

- Commit type is `fix:` rather than the issue prompt's suggested `perf:` because the repo's commitlint config (`@commitlint/config-conventional` overridden in `commitlint.config.cjs`) restricts allowed types to `feat fix docs style refactor test chore revert` — `perf` is rejected by the `commit-msg` hook.
