### PR TITLE
feat: implement delve alternative cost in spell casting

### DIFF
--- a/src/lib/game-state/__tests__/delve.test.ts
+++ b/src/lib/game-state/__tests__/delve.test.ts
@@ -1,0 +1,723 @@
+/**
+ * @fileoverview Unit tests for the Delve keyword (CR 702.61).
+ *
+ * Issue #1407 — [Rules Engine] Implement Delve (CR 702.61)
+ * exile-graveyard-cards-to-pay alternative cost.
+ *
+ * Delve is a static ability that functions while the spell with delve is on
+ * the stack. "For each card you exile from your graveyard while casting this
+ * spell, you may pay {1} rather than pay that card's mana cost."
+ *
+ * CR 702.61a — each card exiled from the caster's graveyard reduces the
+ * GENERIC portion of the spell's cost by {1}. Delve CANNOT pay colored pips
+ * (this is the key difference from Convoke, CR 702.93).
+ *
+ * NOTE on issue text: the issue title says "colored-pips" but the ACTUAL CR
+ * 702.61a is generic-only. These tests assert the correct, CR-faithful
+ * generic-reduction behaviour and document the deviation in the PR body.
+ *
+ * Coverage: parsing, the alternative-cost switch branch in `castSpell`, the
+ * generic-cost-reduction semantics per CR 702.61a, validation rules (in
+ * graveyard, controller, no duplicates), the post-cast exile state
+ * (graveyard shrinks, exile grows, currentZoneKey updated), combinations
+ * with mana in the pool, the "not enough energy" fall-through, over-exiling
+ * (wasted cards), the colored-pips-still-required invariant, and the
+ * validation-service bypass for the printed-cost precheck.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { castSpell } from "../spell-casting";
+import { createInitialGameState, startGame } from "../game-state";
+import { createCardInstance } from "../card-instance";
+import { addMana } from "../mana";
+import { parseDelve } from "../oracle-text-parser";
+import { Phase } from "../types";
+import type {
+  GameState,
+  PlayerId,
+  CardInstanceId,
+  CardInstance,
+} from "../types";
+import type { ScryfallCard } from "@/app/actions";
+
+// ---------------------------------------------------------------------------
+// Mock card helpers
+// ---------------------------------------------------------------------------
+
+function makeCard(
+  overrides: Partial<ScryfallCard> & { id: string },
+): ScryfallCard {
+  return {
+    name: "Test Card",
+    type_line: "Instant",
+    oracle_text: "",
+    mana_cost: "{1}{U}",
+    cmc: 2,
+    colors: ["U"],
+    color_identity: ["U"],
+    legalities: { standard: "legal", commander: "legal" },
+    layout: "normal",
+    ...overrides,
+  } as ScryfallCard;
+}
+
+/**
+ * Treasure Cruise — the canonical delve card. {7}{U}{U} = 8 mana value, 6
+ * generic + 2 blue pips. With 6 cards in the graveyard, delve can reduce it
+ * to {U}{U}.
+ */
+function treasureCruise(): ScryfallCard {
+  return makeCard({
+    id: "mock-treasure-cruise",
+    name: "Treasure Cruise",
+    type_line: "Sorcery",
+    oracle_text: "Delve\nDraw three cards.",
+    mana_cost: "{7}{U}{U}",
+    cmc: 8,
+    colors: ["U"],
+    color_identity: ["U"],
+    keywords: ["delve"],
+  });
+}
+
+/** Same cost as Treasure Cruise but WITHOUT the Delve keyword. */
+function nonDelveSorcery(): ScryfallCard {
+  return makeCard({
+    id: "mock-non-delve",
+    name: "Big Draw",
+    type_line: "Sorcery",
+    oracle_text: "Draw three cards.",
+    mana_cost: "{7}{U}{U}",
+    cmc: 8,
+    colors: ["U"],
+    color_identity: ["U"],
+  });
+}
+
+/** A cheap delve spell with mixed generic + colored: {2}{U} (1 colored pip). */
+function cheapDelve(): ScryfallCard {
+  return makeCard({
+    id: "mock-logic-of-the-goblin",
+    name: "Cheap Delve",
+    type_line: "Instant",
+    oracle_text: "Delve\nDraw a card.",
+    mana_cost: "{2}{U}",
+    cmc: 3,
+    colors: ["U"],
+    color_identity: ["U"],
+    keywords: ["delve"],
+  });
+}
+
+/** A generic-only delve spell: {6}{B}{B}. */
+function murderousCut(): ScryfallCard {
+  return makeCard({
+    id: "mock-murderous-cut",
+    name: "Murderous Cut",
+    type_line: "Instant",
+    oracle_text: "Delve\nDestroy target creature.",
+    mana_cost: "{6}{B}{B}",
+    cmc: 8,
+    colors: ["B"],
+    color_identity: ["B"],
+    keywords: ["delve"],
+  });
+}
+
+/** A filler card to populate the graveyard (cheap instant). */
+function fillerCard(id: string): ScryfallCard {
+  return makeCard({
+    id,
+    name: `Filler ${id}`,
+    type_line: "Instant",
+    oracle_text: "Draw a card.",
+    mana_cost: "{U}",
+    cmc: 1,
+    colors: ["U"],
+    color_identity: ["U"],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Shared state scaffolding
+// ---------------------------------------------------------------------------
+
+interface Fixture {
+  state: GameState;
+  aliceId: PlayerId;
+  bobId: PlayerId;
+}
+
+function makeFixture(): Fixture {
+  let state = createInitialGameState(["Alice", "Bob"], 20, false);
+  state = startGame(state);
+
+  const ids = Array.from(state.players.keys());
+  const aliceId = ids[0];
+  const bobId = ids[1];
+
+  state.status = "in_progress";
+  state.priorityPlayerId = aliceId;
+  state.turn.activePlayerId = aliceId;
+  state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+  state.stack = [];
+  state.consecutivePasses = 0;
+  state.players.forEach((p) =>
+    state.players.set(p.id, { ...p, hasPassedPriority: false }),
+  );
+
+  return { state, aliceId, bobId };
+}
+
+/** Place a card into a player's hand. */
+function putInHand(
+  state: GameState,
+  playerId: PlayerId,
+  cardData: ScryfallCard,
+): CardInstanceId {
+  const card = createCardInstance(cardData, playerId, playerId);
+  card.currentZoneKey = `${playerId}-hand`;
+  state.cards.set(card.id, card);
+  const hand = state.zones.get(`${playerId}-hand`)!;
+  state.zones.set(`${playerId}-hand`, {
+    ...hand,
+    cardIds: [...hand.cardIds, card.id],
+  });
+  return card.id;
+}
+
+/** Place a card into a player's graveyard. */
+function putInGraveyard(
+  state: GameState,
+  playerId: PlayerId,
+  cardData: ScryfallCard,
+): CardInstance {
+  const card = createCardInstance(cardData, playerId, playerId);
+  card.currentZoneKey = `${playerId}-graveyard`;
+  state.cards.set(card.id, card);
+  const grave = state.zones.get(`${playerId}-graveyard`)!;
+  state.zones.set(`${playerId}-graveyard`, {
+    ...grave,
+    cardIds: [...grave.cardIds, card.id],
+  });
+  return card;
+}
+
+/** Read a player's mana pool total (for spent-mana assertions). */
+function manaTotal(state: GameState, playerId: PlayerId): number {
+  const p = state.players.get(playerId)!;
+  return (
+    p.manaPool.generic +
+    p.manaPool.colorless +
+    p.manaPool.white +
+    p.manaPool.blue +
+    p.manaPool.black +
+    p.manaPool.red +
+    p.manaPool.green
+  );
+}
+
+// ===========================================================================
+// Parsing (CR 702.61)
+// ===========================================================================
+
+describe("Delve — parsing (CR 702.61)", () => {
+  it("parseDelve detects the 'Delve' keyword", () => {
+    const r = parseDelve("Delve");
+    expect(r.hasDelve).toBe(true);
+    expect(r.description).toBe("Delve");
+  });
+
+  it("parseDelve detects 'Delve' alongside other rules text", () => {
+    expect(parseDelve("Delve\nDraw three cards.").hasDelve).toBe(true);
+  });
+
+  it("parseDelve is case-insensitive", () => {
+    expect(parseDelve("delve").hasDelve).toBe(true);
+    expect(parseDelve("DELVE").hasDelve).toBe(true);
+    expect(parseDelve("DeLvE").hasDelve).toBe(true);
+  });
+
+  it("parseDelve tolerates the reminder-text form", () => {
+    expect(
+      parseDelve(
+        "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)",
+      ).hasDelve,
+    ).toBe(true);
+  });
+
+  it("parseDelve returns false when the keyword is absent", () => {
+    expect(parseDelve("Flying").hasDelve).toBe(false);
+    expect(parseDelve("Flashback {2}{U}").hasDelve).toBe(false);
+    expect(parseDelve("Convoke").hasDelve).toBe(false);
+  });
+
+  it("parseDelve returns false for empty / nullish text", () => {
+    expect(parseDelve("").hasDelve).toBe(false);
+    expect(parseDelve("").description).toBe("");
+    expect(parseDelve(null as unknown as string).hasDelve).toBe(false);
+  });
+
+  it("parseDelve does not match 'delve' inside other words", () => {
+    // Word-boundary anchored: "delved" is its own word and should NOT match
+    // "delve". The word-boundary regex catches this.
+    expect(parseDelve("delved").hasDelve).toBe(false);
+    expect(parseDelve("nondelveing").hasDelve).toBe(false);
+  });
+});
+
+// ===========================================================================
+// castSpell — the alternative-cost switch branch (CR 702.61)
+// ===========================================================================
+
+describe("Delve — castSpell generic-cost reduction (CR 702.61a)", () => {
+  it("each exiled graveyard card reduces the generic cost by {1}", () => {
+    // Treasure Cruise {7}{U}{U}. Alice exiles 7 cards to cover all 7 generic
+    // pips; remaining {U}{U} paid from pool.
+    const f = makeFixture();
+    const aliceId = f.aliceId;
+    let state = f.state;
+    const spellId = putInHand(state, aliceId, treasureCruise());
+    const graveIds: CardInstanceId[] = [];
+    for (let i = 0; i < 7; i++) {
+      graveIds.push(putInGraveyard(state, aliceId, fillerCard(`g-${i}`)).id);
+    }
+    state = addMana(state, aliceId, { blue: 2 });
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: graveIds,
+    });
+
+    expect(result.success).toBe(true);
+    const after = result.state;
+    // Spell on the stack.
+    expect(after.zones.get("stack")!.cardIds).toContain(spellId);
+    // All 7 graveyard cards exiled.
+    const aliceGrave = after.zones.get(`${aliceId}-graveyard`)!;
+    const aliceExile = after.zones.get(`${aliceId}-exile`)!;
+    for (const gid of graveIds) {
+      expect(aliceGrave.cardIds).not.toContain(gid);
+      expect(aliceExile.cardIds).toContain(gid);
+    }
+    // alternativeCostsUsed recorded delve.
+    expect(after.stack[0].alternativeCostsUsed).toContain("delve");
+    // Mana pool: 2 blue spent on the {U}{U} pips → 0 blue.
+    expect(after.players.get(aliceId)!.manaPool.blue).toBe(0);
+  });
+
+  it("delve can reduce the entire generic portion with no mana in the pool", () => {
+    // Murderous Cut {6}{B}{B}. Alice exiles 6 cards to cover all generic
+    // pips, pays {B}{B} from pool. Generic pool contribution = 0.
+    const f = makeFixture();
+    const aliceId = f.aliceId;
+    let state = f.state;
+    const spellId = putInHand(state, aliceId, murderousCut());
+    const graveIds: CardInstanceId[] = [];
+    for (let i = 0; i < 6; i++) {
+      graveIds.push(putInGraveyard(state, aliceId, fillerCard(`g-${i}`)).id);
+    }
+    state = addMana(state, aliceId, { black: 2 });
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: graveIds,
+    });
+
+    expect(result.success).toBe(true);
+    // Generic pool untouched (was 0; delve covered all 6 generic).
+    expect(result.state.players.get(aliceId)!.manaPool.generic).toBe(0);
+    expect(result.state.players.get(aliceId)!.manaPool.black).toBe(0);
+  });
+
+  it("delve combines with mana already in the pool for the generic portion", () => {
+    // Treasure Cruise {7}{U}{U}. Alice exiles 4 cards (-4 generic), pays the
+    // remaining {3}{U}{U} from the pool.
+    const f = makeFixture();
+    const aliceId = f.aliceId;
+    let state = f.state;
+    const spellId = putInHand(state, aliceId, treasureCruise());
+    const graveIds: CardInstanceId[] = [];
+    for (let i = 0; i < 4; i++) {
+      graveIds.push(putInGraveyard(state, aliceId, fillerCard(`g-${i}`)).id);
+    }
+    state = addMana(state, aliceId, { blue: 2, generic: 3 });
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: graveIds,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.state.players.get(aliceId)!.manaPool.blue).toBe(0);
+    expect(result.state.players.get(aliceId)!.manaPool.generic).toBe(0);
+  });
+
+  it("delve with empty delveCards uses only the mana pool", () => {
+    // Same as casting without delve — full cost paid from pool.
+    const f = makeFixture();
+    const aliceId = f.aliceId;
+    let state = f.state;
+    const spellId = putInHand(state, aliceId, treasureCruise());
+    // 1 grave card available but not declared.
+    putInGraveyard(state, aliceId, fillerCard("g-0"));
+    state = addMana(state, aliceId, { blue: 2, generic: 7 });
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: [],
+    });
+
+    expect(result.success).toBe(true);
+    // The available (but undeclared) card stays in the graveyard.
+    const aliceGrave = result.state.zones.get(`${aliceId}-graveyard`)!;
+    expect(aliceGrave.cardIds.length).toBe(1);
+    // Full {7}{U}{U} paid from pool.
+    expect(result.state.players.get(aliceId)!.manaPool.blue).toBe(0);
+    expect(result.state.players.get(aliceId)!.manaPool.generic).toBe(0);
+    // alternativeCostsUsed still records delve (the branch pushed it) but
+    // no cards were exiled.
+    expect(result.state.stack[0].alternativeCostsUsed).toContain("delve");
+  });
+
+  it("spells WITHOUT the Delve keyword are not reduced even when delveCards is passed", () => {
+    // The delve switch branch only fires when parseDelve returns true.
+    // Otherwise the keyword is silently dropped (matches the engine's
+    // established convention inherited from convoke).
+    const f = makeFixture();
+    const aliceId = f.aliceId;
+    let state = f.state;
+    const spellId = putInHand(state, aliceId, nonDelveSorcery());
+    const g = putInGraveyard(state, aliceId, fillerCard("g-0"));
+    // Pool covers the FULL printed {7}{U}{U} cost — castSpell must NOT use
+    // the grave card since the spell lacks the Delve keyword.
+    state = addMana(state, aliceId, { blue: 2, generic: 7 });
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: [g.id],
+    });
+
+    // Cast succeeds because the pool covers the full printed cost — the
+    // grave card is NOT exiled.
+    expect(result.success).toBe(true);
+    expect(result.state.zones.get(`${aliceId}-graveyard`)!.cardIds).toContain(
+      g.id,
+    );
+    expect(result.state.zones.get(`${aliceId}-exile`)!.cardIds).not.toContain(
+      g.id,
+    );
+    expect(result.state.stack[0].alternativeCostsUsed).not.toContain("delve");
+  });
+});
+
+// ===========================================================================
+// castSpell — CR 702.61a "generic only" invariant (deviation from issue text)
+// ===========================================================================
+
+describe("Delve — colored pips are NOT payable by delve (CR 702.61a)", () => {
+  it("delve cannot pay colored pips — colored mana must come from the pool", () => {
+    // Treasure Cruise {7}{U}{U}. Alice exiles 7 cards but only has 1 blue in
+    // the pool (needs {U}{U}). Cast must FAIL on the second blue pip —
+    // delve cannot pay colored pips.
+    const f = makeFixture();
+    const aliceId = f.aliceId;
+    let state = f.state;
+    const spellId = putInHand(state, aliceId, treasureCruise());
+    const graveIds: CardInstanceId[] = [];
+    for (let i = 0; i < 7; i++) {
+      graveIds.push(putInGraveyard(state, aliceId, fillerCard(`g-${i}`)).id);
+    }
+    state = addMana(state, aliceId, { blue: 1 });
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: graveIds,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/energy/i);
+    // Failure: no state mutation. Graveyard intact.
+    for (const gid of graveIds) {
+      expect(result.state.zones.get(`${aliceId}-graveyard`)!.cardIds).toContain(
+        gid,
+      );
+    }
+  });
+
+  it("delve does not produce a negative generic cost (over-exile wastes cards but reduces nothing beyond 0)", () => {
+    // Cheap Delve {2}{U}. Alice exiles 5 cards but the generic portion is
+    // only 2. The cast should still succeed (all 5 exiled, generic reduced
+    // by exactly 2, {U} paid from pool). The 3 extra cards are wasted.
+    const f = makeFixture();
+    const aliceId = f.aliceId;
+    let state = f.state;
+    const spellId = putInHand(state, aliceId, cheapDelve());
+    const graveIds: CardInstanceId[] = [];
+    for (let i = 0; i < 5; i++) {
+      graveIds.push(putInGraveyard(state, aliceId, fillerCard(`g-${i}`)).id);
+    }
+    state = addMana(state, aliceId, { blue: 1 });
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: graveIds,
+    });
+
+    expect(result.success).toBe(true);
+    const after = result.state;
+    // ALL 5 cards exiled (over-exile is binding per CR 601.2h).
+    const aliceExile = after.zones.get(`${aliceId}-exile`)!;
+    for (const gid of graveIds) {
+      expect(aliceExile.cardIds).toContain(gid);
+    }
+    expect(aliceExile.cardIds.length).toBe(5);
+    // Blue pip paid from pool.
+    expect(after.players.get(aliceId)!.manaPool.blue).toBe(0);
+  });
+});
+
+// ===========================================================================
+// castSpell — affordability fall-through
+// ===========================================================================
+
+describe("Delve — affordability fall-through", () => {
+  it("insufficient delve + insufficient mana → 'Not enough energy'", () => {
+    // Treasure Cruise {7}{U}{U} = 9 pips. Alice exiles only 3 cards and has
+    // no mana. Remaining {4}{U}{U} cannot be paid.
+    const { state, aliceId } = makeFixture();
+    const spellId = putInHand(state, aliceId, treasureCruise());
+    const graveIds: CardInstanceId[] = [];
+    for (let i = 0; i < 3; i++) {
+      graveIds.push(putInGraveyard(state, aliceId, fillerCard(`g-${i}`)).id);
+    }
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: graveIds,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/energy/i);
+    // State returned unchanged on failure — graveyard intact, exile empty.
+    const aliceGrave = result.state.zones.get(`${aliceId}-graveyard`)!;
+    const aliceExile = result.state.zones.get(`${aliceId}-exile`)!;
+    for (const gid of graveIds) {
+      expect(aliceGrave.cardIds).toContain(gid);
+    }
+    expect(aliceExile.cardIds.length).toBe(0);
+  });
+
+  it("delve cannot pay colored pips — not-enough-colored-mana fails even with a full graveyard", () => {
+    // Treasure Cruise {7}{U}{U}. Alice exiles 7 cards but has NO blue mana.
+    // The {U}{U} pips cannot be paid by delve → failure.
+    const { state, aliceId } = makeFixture();
+    const spellId = putInHand(state, aliceId, treasureCruise());
+    const graveIds: CardInstanceId[] = [];
+    for (let i = 0; i < 7; i++) {
+      graveIds.push(putInGraveyard(state, aliceId, fillerCard(`g-${i}`)).id);
+    }
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: graveIds,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/energy/i);
+  });
+});
+
+// ===========================================================================
+// castSpell — validation rules (CR 702.61a)
+// ===========================================================================
+
+describe("Delve — validation rules (CR 702.61a)", () => {
+  it("rejects a duplicate graveyard card in the exile list", () => {
+    const { state, aliceId } = makeFixture();
+    const spellId = putInHand(state, aliceId, cheapDelve());
+    const g = putInGraveyard(state, aliceId, fillerCard("g-0"));
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: [g.id, g.id],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/more than once/i);
+  });
+
+  it("rejects a card that is not in the graveyard (in hand)", () => {
+    const { state, aliceId } = makeFixture();
+    const spellId = putInHand(state, aliceId, cheapDelve());
+    // A card in hand (not in graveyard).
+    const inHand = putInHand(state, aliceId, fillerCard("c-hand"));
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: [inHand],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/graveyard/i);
+  });
+
+  it("rejects a card in the opponent's graveyard", () => {
+    const { state, aliceId, bobId } = makeFixture();
+    const spellId = putInHand(state, aliceId, cheapDelve());
+    // Bob's graveyard card.
+    const bobs = putInGraveyard(state, bobId, fillerCard("bob-g-0"));
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: [bobs.id],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/graveyard|controller/i);
+  });
+
+  it("rejects a card id that does not exist", () => {
+    const { state, aliceId } = makeFixture();
+    const spellId = putInHand(state, aliceId, cheapDelve());
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: ["nonexistent-id" as CardInstanceId],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+  });
+});
+
+// ===========================================================================
+// castSpell — post-cast state invariants
+// ===========================================================================
+
+describe("Delve — post-cast state invariants", () => {
+  it("delved cards move graveyard → exile (CR 702.61a, permanent exile)", () => {
+    const f = makeFixture();
+    const aliceId = f.aliceId;
+    let state = f.state;
+    const spellId = putInHand(state, aliceId, treasureCruise());
+    const graveIds: CardInstanceId[] = [];
+    for (let i = 0; i < 7; i++) {
+      graveIds.push(putInGraveyard(state, aliceId, fillerCard(`g-${i}`)).id);
+    }
+    state = addMana(state, aliceId, { blue: 2 });
+
+    const beforeGrave = state.zones.get(`${aliceId}-graveyard`)!.cardIds.length;
+    const beforeExile = state.zones.get(`${aliceId}-exile`)!.cardIds.length;
+    expect(beforeGrave).toBe(7);
+    expect(beforeExile).toBe(0);
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: graveIds,
+    });
+
+    expect(result.success).toBe(true);
+    const after = result.state;
+    // Graveyard shrunk by 7.
+    expect(after.zones.get(`${aliceId}-graveyard`)!.cardIds.length).toBe(0);
+    // Exile grew by 7.
+    expect(after.zones.get(`${aliceId}-exile`)!.cardIds.length).toBe(7);
+    // Each card's currentZoneKey updated to exile.
+    for (const gid of graveIds) {
+      expect(after.cards.get(gid)!.currentZoneKey).toBe(`${aliceId}-exile`);
+    }
+  });
+
+  it("the spell stack object records 'delve' in alternativeCostsUsed", () => {
+    const f = makeFixture();
+    const aliceId = f.aliceId;
+    let state = f.state;
+    const spellId = putInHand(state, aliceId, cheapDelve());
+    const g1 = putInGraveyard(state, aliceId, fillerCard("g-1"));
+    const g2 = putInGraveyard(state, aliceId, fillerCard("g-2"));
+    state = addMana(state, aliceId, { blue: 1 });
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: [g1.id, g2.id],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.state.stack[0].alternativeCostsUsed).toContain("delve");
+  });
+
+  it("graveyard cards NOT in the delve list stay in the graveyard", () => {
+    const f = makeFixture();
+    const aliceId = f.aliceId;
+    let state = f.state;
+    const spellId = putInHand(state, aliceId, cheapDelve());
+    const exiled = putInGraveyard(state, aliceId, fillerCard("g-exiled"));
+    const idle = putInGraveyard(state, aliceId, fillerCard("g-idle"));
+    state = addMana(state, aliceId, { blue: 1, generic: 1 });
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: [exiled.id],
+    });
+
+    expect(result.success).toBe(true);
+    const after = result.state;
+    // The exiled card went to exile.
+    expect(after.zones.get(`${aliceId}-exile`)!.cardIds).toContain(exiled.id);
+    // The idle (undeclared) card stayed in the graveyard.
+    expect(after.zones.get(`${aliceId}-graveyard`)!.cardIds).toContain(idle.id);
+  });
+
+  it("a single delve card reduces exactly one generic pip", () => {
+    // Cheap Delve {2}{U}. Alice exiles 1 card (-1 generic), pays {1}{U} from
+    // the pool. Proves the per-card reduction is exactly 1 (not 0, not >1).
+    const f = makeFixture();
+    const aliceId = f.aliceId;
+    let state = f.state;
+    const spellId = putInHand(state, aliceId, cheapDelve());
+    const g = putInGraveyard(state, aliceId, fillerCard("g-0"));
+    state = addMana(state, aliceId, { blue: 1, generic: 1 });
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: [g.id],
+    });
+
+    expect(result.success).toBe(true);
+    // {1}{U} paid from pool → both 0.
+    expect(result.state.players.get(aliceId)!.manaPool.blue).toBe(0);
+    expect(result.state.players.get(aliceId)!.manaPool.generic).toBe(0);
+  });
+});
+
+// ===========================================================================
+// Validation service — printed-cost precheck bypass
+// ===========================================================================
+
+describe("Delve — validation-service bypass", () => {
+  it("the printed-cost precheck does NOT reject a legal delve cast", () => {
+    // The validation service's pre-check would normally reject a {7}{U}{U}
+    // cast when the player's pool only covers {U}{U}. For delve, the
+    // pre-check is bypassed so castSpell can do the authoritative math
+    // after applying delve reductions. If the bypass is missing, this test
+    // fails with a "Not enough mana" reason from the validation service.
+    const f = makeFixture();
+    const aliceId = f.aliceId;
+    let state = f.state;
+    const spellId = putInHand(state, aliceId, treasureCruise());
+    const graveIds: CardInstanceId[] = [];
+    for (let i = 0; i < 7; i++) {
+      graveIds.push(putInGraveyard(state, aliceId, fillerCard(`g-${i}`)).id);
+    }
+    state = addMana(state, aliceId, { blue: 2 });
+
+    const result = castSpell(state, aliceId, spellId, [], [], 0, false, {
+      type: "delve",
+      delveCards: graveIds,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/src/lib/game-state/oracle-text-parser.ts
+++ b/src/lib/game-state/oracle-text-parser.ts
@@ -1825,6 +1825,43 @@ export function parseConvoke(oracleText: string): ConvokeInfo {
 }
 
 /**
+ * Result of detecting Delve (CR 702.61).
+ */
+export interface DelveInfo {
+  hasDelve: boolean;
+  description: string;
+}
+
+/**
+ * Parse the Delve keyword from oracle text.
+ *
+ * CR 702.61a: "Delve" is a static ability that functions while the spell with
+ * delve is on the stack. "For each card you exile from your graveyard while
+ * casting this spell, you may pay {1} rather than pay that card's mana cost."
+ * Each exiled card reduces the GENERIC portion of the cost by {1} — delve
+ * cannot pay colored pips (unlike Convoke). Detection is a word-boundary
+ * anchored, case-insensitive match so "Delve" matches while a hypothetical
+ * "delvedout" would not.
+ *
+ * Example oracle text: "Delve" (e.g. Treasure Cruise, Tasigur, the Golden
+ * Fang, Murderous Cut, Temporal Trespass).
+ */
+export function parseDelve(oracleText: string): DelveInfo {
+  if (!oracleText) {
+    return { hasDelve: false, description: "" };
+  }
+
+  // Word-boundary anchored on both sides: "Delve" matches, but substrings
+  // inside other words do not. Case-insensitive to be tolerant of casing.
+  const hasDelve = /\bdelve\b/i.test(oracleText);
+
+  return {
+    hasDelve,
+    description: hasDelve ? "Delve" : "",
+  };
+}
+
+/**
  * Result of detecting Attraction mechanic
  */
 export interface AttractionInfo {

--- a/src/lib/game-state/spell-casting.ts
+++ b/src/lib/game-state/spell-casting.ts
@@ -31,6 +31,7 @@ import {
   parseBlitz,
   parseForetell,
   parseConvoke,
+  parseDelve,
   parseSplitSecond,
   parseStorm,
   isModalSpell,
@@ -255,7 +256,8 @@ export function castSpell(
       | "spectacle"
       | "blitz"
       | "foretell"
-      | "convoke";
+      | "convoke"
+      | "delve";
     buybackReturnToHand?: boolean;
     bestowTarget?: CardInstanceId;
     /**
@@ -267,6 +269,15 @@ export function castSpell(
      * does NOT restrict it (CR 302.6 only restricts {T}/{Q} activated costs).
      */
     convokeCreatures?: CardInstanceId[];
+    /**
+     * CR 702.61 - Delve: cards in the player's graveyard chosen to be exiled
+     * while casting this spell. Each exiled card reduces the GENERIC portion
+     * of the cost by {1} (CR 702.61a); delve cannot pay colored pips (unlike
+     * Convoke). The chosen cards are exiled as part of paying the spell's
+     * cost. Over-exiling (more cards than remaining generic pips) is allowed
+     * but the extras reduce nothing — they are still exiled (binding choice).
+     */
+    delveCards?: CardInstanceId[];
   },
   /**
    * CR 702.85 — number of times the kicker (or multikicker) cost was paid.
@@ -419,6 +430,11 @@ export function castSpell(
   // is applied AFTER mana is spent (see `applyConvokeTaps` below) so the
   // pre-cast state used for validation is not mutated.
   const convokeTappedCreatures: CardInstanceId[] = [];
+  // CR 702.61 - Delve: graveyard cards the player declared they would exile
+  // while casting. Validated inside the `case "delve":` branch; the actual
+  // exile is applied AFTER mana is spent (see the delve exile block below)
+  // so the pre-cast state used for validation is not mutated.
+  const delveExiledCards: CardInstanceId[] = [];
 
   if (alternativeCost) {
     switch (alternativeCost.type) {
@@ -621,6 +637,81 @@ export function castSpell(
         }
         break;
       }
+      case "delve": {
+        // CR 702.61 - Delve: "For each card you exile from your graveyard
+        // while casting this spell, you may pay {1} rather than pay that
+        // card's mana cost." Delve is a cost-reduction applied to the
+        // printed mana cost (not an alternative cost that replaces it);
+        // other additional costs/taxes (kicker, etc.) still apply on top.
+        //
+        // CR 702.61a: each exiled card reduces the GENERIC portion of the
+        // cost by {1}. Unlike Convoke, delve CANNOT pay colored pips —
+        // colored mana must still come from the mana pool.
+        //
+        // Validation per CR 702.61a: each declared card must be a card in
+        // the caster's graveyard. (Graveyard cards are always owned by the
+        // caster in whose graveyard they sit — CR 400.3 — so the owner
+        // check is structural.) Over-exiling is allowed (binding choice)
+        // but extra cards beyond the generic portion reduce nothing.
+        const delveInfo = parseDelve(card.cardData.oracle_text || "");
+        if (delveInfo.hasDelve) {
+          alternativeCostsUsed.push("delve");
+          const declaredCards = alternativeCost.delveCards ?? [];
+          const seen = new Set<CardInstanceId>();
+          for (const delveCardId of declaredCards) {
+            if (seen.has(delveCardId)) {
+              return {
+                success: false,
+                state,
+                error:
+                  "Delve: a graveyard card cannot be exiled more than once to pay for the same spell.",
+              };
+            }
+            seen.add(delveCardId);
+
+            const delveCard = state.cards.get(delveCardId);
+            if (!delveCard) {
+              return {
+                success: false,
+                state,
+                error: "Delve: card not found.",
+              };
+            }
+            // Must be in the caster's graveyard (CR 702.61a). The
+            // graveyard is keyed by controller/owner; a card there is
+            // owned by that player (CR 400.3).
+            const graveKey = `${playerId}-graveyard`;
+            const grave = state.zones.get(graveKey);
+            if (!grave || !grave.cardIds.includes(delveCardId)) {
+              return {
+                success: false,
+                state,
+                error: "Delve: exiled card must be in the caster's graveyard.",
+              };
+            }
+            // Controller must be the caster (defensive — graveyard
+            // membership already implies this, but the explicit check
+            // guards against state corruption).
+            if (delveCard.controllerId !== playerId) {
+              return {
+                success: false,
+                state,
+                error:
+                  "Delve: exiled card must be controlled by the spell's controller.",
+              };
+            }
+
+            // CR 702.61a: reduce the generic portion by {1} per exiled
+            // card. If no generic pip remains, the card is still exiled
+            // (over-exile — binding choice) but contributes nothing.
+            if (totalGeneric > 0) {
+              totalGeneric--;
+            }
+            delveExiledCards.push(delveCardId);
+          }
+        }
+        break;
+      }
     }
   }
 
@@ -687,6 +778,48 @@ export function castSpell(
       cards: updatedConvokeCards,
       lastModifiedAt: Date.now(),
     };
+  }
+
+  // CR 702.61 - Delve: now that mana is spent and the cast is committed,
+  // exile each declared graveyard card to the caster's exile zone. The
+  // generic-cost reduction was already applied in the `case "delve":`
+  // branch; this step performs the actual zone move (graveyard → exile)
+  // and updates each card's `currentZoneKey` so subsequent lookups find it
+  // in exile. Cards exiled for delve are gone for good (CR 702.61a: the
+  // exile is part of paying the cost, not a duration effect).
+  if (delveExiledCards.length > 0) {
+    const graveKey = `${playerId}-graveyard`;
+    const exileKey = `${playerId}-exile`;
+    const updatedZonesDelve = new Map(currentState.zones);
+    let updatedGraveDelve = updatedZonesDelve.get(graveKey);
+    let updatedExileDelve = updatedZonesDelve.get(exileKey);
+    const updatedCardsDelve = new Map(currentState.cards);
+    if (updatedGraveDelve && updatedExileDelve) {
+      for (const delveCardId of delveExiledCards) {
+        const moved = moveCardBetweenZones(
+          updatedGraveDelve,
+          updatedExileDelve,
+          delveCardId,
+        );
+        updatedGraveDelve = moved.from;
+        updatedExileDelve = moved.to;
+        const dc = updatedCardsDelve.get(delveCardId);
+        if (dc) {
+          updatedCardsDelve.set(delveCardId, {
+            ...dc,
+            currentZoneKey: exileKey,
+          });
+        }
+      }
+      updatedZonesDelve.set(graveKey, updatedGraveDelve);
+      updatedZonesDelve.set(exileKey, updatedExileDelve);
+      currentState = {
+        ...currentState,
+        zones: updatedZonesDelve,
+        cards: updatedCardsDelve,
+        lastModifiedAt: Date.now(),
+      };
+    }
   }
 
   // Create stack object with alternative cost info

--- a/src/lib/game-state/validation-service.ts
+++ b/src/lib/game-state/validation-service.ts
@@ -354,7 +354,18 @@ export class ValidationService {
     // authoritative affordability check happens in castSpell AFTER convoke
     // reductions are applied, so the printed-cost check here would falsely
     // reject legal convoke casts. Skip it (same rationale as foretell).
-    if (altType !== "foretell" && altType !== "convoke") {
+    //
+    // Delve (CR 702.61) is likewise a cost-REDUCTION applied to the printed
+    // mana cost: each exiled graveyard card reduces the generic portion by
+    // {1}. The authoritative affordability check happens in castSpell AFTER
+    // delve reductions are applied, so the printed-cost check here would
+    // falsely reject legal delve casts. Skip it (same rationale as
+    // foretell/convoke).
+    if (
+      altType !== "foretell" &&
+      altType !== "convoke" &&
+      altType !== "delve"
+    ) {
       const manaValidation = this.validateManaCost(state, player, card);
       if (!manaValidation.isValid) {
         return manaValidation;


### PR DESCRIPTION
## Summary

Implements the **Delve** keyword (CR 702.61) in the rules engine as an additive extension of the alternative-cost machinery introduced by Convoke (recently merged sibling PR). This is part of the spell-casting alternative-cost clique.

## Where Delve is wired

| File | Change |
| --- | --- |
| `src/lib/game-state/oracle-text-parser.ts` | New `parseDelve(oracleText)` returning `{ hasDelve, description }` — word-boundary anchored, case-insensitive (mirrors `parseConvoke`). |
| `src/lib/game-state/spell-casting.ts` | `alternativeCost.type` union extended with `"delve"` and a new `delveCards?: CardInstanceId[]` field. New `case "delve":` in the alternative-cost switch (validates each chosen graveyard card, applies generic reduction), plus a post-`spendMana` block that physically exiles the declared cards (graveyard → exile + `currentZoneKey` update). |
| `src/lib/game-state/validation-service.ts` | Printed-cost precheck now bypassed for `"delve"` (same rationale as foretell/convoke — the authoritative affordability math runs in `castSpell` after reductions). |
| `src/lib/game-state/__tests__/delve.test.ts` | New co-located test suite (parsing, switch branch, CR 702.61a generic-only invariant, affordability fall-through, validation rules, post-cast state invariants, validation-service bypass). |

## CR 702.61 semantics implemented

Per **CR 702.61a**, each card exiled from the caster's graveyard reduces the **generic** portion of the spell's mana cost by **{1}**. Colored pips are **not** payable by delve — colored mana must still come from the mana pool. This is the key difference from Convoke.

- Chosen graveyard cards are exiled as part of paying the cost (graveyard shrinks, exile grows, `currentZoneKey` updated).
- Over-exiling (more cards than remaining generic pips) is allowed and binding — extras are still exiled but reduce nothing.
- The exile happens **after** `spendMana` commits the cast, so a failed affordability check leaves the graveyard intact (no partial mutation).

### ⚠️ Deviation from issue text

The issue title and "Proposed approach" describe delve as exiling cards to pay **colored pips**. That contradicts the actual CR 702.61a, which is **generic-only**. This PR implements the CR-faithful behaviour (generic reduction). The test suite explicitly asserts that delve **cannot** pay colored pips (`"delve cannot pay colored pips — colored mana must come from the pool"` and `"delve cannot pay colored pips — not-enough-colored-mana fails even with a full graveyard"`). The issue's acceptance-criteria bullet about exiling "to satisfy colored cost" would violate CR and is intentionally not implemented.

## Validation rules

A declared `delveCards` entry is rejected when it:
- is a duplicate of an already-declared card (`/more than once/i`),
- refers to a non-existent card id (`/not found/i`),
- is not in the caster's graveyard (`/graveyard/i`),
- is not controlled by the caster (`/controller/i` — defensive; graveyard membership implies this).

On any rejection the cast returns `success: false` and the state is unchanged (no graveyard mutation).

## Test coverage

`src/lib/game-state/__tests__/delve.test.ts` — assertions on **real post-cast zone state** (graveyard contents, exile contents, `currentZoneKey`, mana pool, stack object `alternativeCostsUsed`):

- **Parsing (7):** keyword detection, case-insensitivity, reminder-text tolerance, word-boundary anchoring, empty/null handling.
- **Generic-cost reduction (5):** per-card {1} reduction, full-generic delve with empty pool, delve + mana-pool combination, empty `delveCards` fall-through, non-delve spell is not reduced.
- **CR 702.61a generic-only invariant (2):** colored pips still required; over-exile wastes extras without going negative.
- **Affordability fall-through (2):** insufficient delve + mana → unchanged state; colored-pip shortfall with full graveyard.
- **Validation rules (4):** duplicates, in-hand card, opponent's graveyard, nonexistent id.
- **Post-cast state invariants (4):** graveyard→exile move + `currentZoneKey`, `alternativeCostsUsed` records delve, undeclared graveyard cards stay, single-card reduction is exactly 1.
- **Validation-service bypass (1):** printed-cost precheck does not reject a legal delve cast.

## Validation results

- `npm run typecheck` — pass
- `npm run lint` — pass (0 errors; pre-existing warnings only)
- `npm test` (full suite) — **8893 tests, 0 failures** (was green on main; Convoke suite still passes)
- `scripts/qa-coverage-gate.js` — OK (0 `it.todo` in `qa-coverage-holes.test.ts`)

## Scope

Strictly additive and limited to Delve. Sibling spell-casting PRs (Spectacle, Escape, Mutate) in later waves each add their own `case` — this PR's additive union/switch extension eases their rebases.

Closes #1407