### PR TITLE
fix: make Corpse keyword a death trigger per CR 702.168 (#1411)

### DIFF
--- a/src/lib/game-state/__tests__/corpse-keyword.test.ts
+++ b/src/lib/game-state/__tests__/corpse-keyword.test.ts
@@ -1,0 +1,905 @@
+/**
+ * @fileoverview Unit tests for the Corpse keyword (CR 702.168).
+ *
+ * Issue #1411 — [Rules Engine] Fix Corpse keyword to be a death-triggered
+ * ability, not an activated-from-graveyard (CR 702.168).
+ *
+ * CR 702.168a: "Corpse [cost]" means "When this creature dies, you may pay
+ * [cost]. If you do, [effect]." Corpse is therefore a DEATH TRIGGER, not an
+ * activated ability that can be played from the graveyard at arbitrary
+ * timings. These tests cover:
+ *
+ *   - Parsing (parseCorpseAbility)
+ *   - Trigger firing on death (processCorpseOnDeath)
+ *   - Player choice resolution (resolveCorpseChoice: pay / decline)
+ *   - Insufficient mana at resolution
+ *   - Idempotency and queue semantics (multiple corpses dying same SBA pass)
+ *   - The death-trigger system wiring (detectCreatureDeathTriggers)
+ *   - SBA destroy-loop integration (checkStateBasedActions)
+ *   - Negative: the OLD "activate from graveyard anytime" API is gone
+ *   - Negative: a stale graveyard corpse does not spontaneously produce offers
+ *   - Negative: non-creature / non-graveyard corpses do not fire
+ */
+
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import { createInitialGameState, startGame } from "../game-state";
+import { createCardInstance } from "../card-instance";
+import { addMana } from "../mana";
+import { destroyCard } from "../keyword-actions";
+import { checkStateBasedActions } from "../state-based-actions";
+import { detectCreatureDeathTriggers } from "../trigger-system";
+import {
+  parseCorpseAbility,
+  hasCorpseAbility,
+  getCorpseAbility,
+  processCorpseOnDeath,
+  resolveCorpseChoice,
+  hasPendingCorpseOffer,
+  createCorpseWaitingChoice,
+  CORPSE_CHOICE_TYPE,
+} from "../corpse-keyword";
+import { Phase, ZoneType } from "../types";
+import type { GameState, PlayerId, CardInstanceId } from "../types";
+import type { ScryfallCard } from "@/app/actions";
+
+// ---------------------------------------------------------------------------
+// Mock card helpers
+// ---------------------------------------------------------------------------
+
+function makeCard(
+  overrides: Partial<ScryfallCard> & { id: string },
+): ScryfallCard {
+  return {
+    name: "Test Card",
+    type_line: "Creature — Zombie",
+    oracle_text: "",
+    mana_cost: "{2}{B}",
+    cmc: 3,
+    colors: ["B"],
+    color_identity: ["B"],
+    legalities: { standard: "legal", commander: "legal" },
+    layout: "normal",
+    power: "2",
+    toughness: "2",
+    ...overrides,
+  } as ScryfallCard;
+}
+
+/**
+ * A creature with the Corpse keyword.
+ *
+ *   "Corpse 1: Exile another target creature card from your graveyard."
+ *
+ * Cost 1 (generic), effect is to exile a creature from the controller's
+ * graveyard. Per CR 702.168 the cost is optional ("you may pay"), and the
+ * effect fires only if the cost is paid at the moment the death trigger
+ * resolves.
+ */
+function corpseCreature(): ScryfallCard {
+  return makeCard({
+    id: "mock-corpse-creature",
+    name: "Cemetery Marauder",
+    type_line: "Creature — Zombie",
+    oracle_text:
+      "Corpse 1: When this creature dies, you may exile another target creature card from your graveyard.",
+    mana_cost: "{2}{B}",
+    cmc: 3,
+    power: "2",
+    toughness: "2",
+  });
+}
+
+/** A cheap creature used as chaff to exile via the Corpse effect. */
+function chaffCreature(idSuffix: string): ScryfallCard {
+  return makeCard({
+    id: `chaff-${idSuffix}`,
+    name: `Chaff ${idSuffix}`,
+    type_line: "Creature — Human",
+    oracle_text: "",
+    mana_cost: "{1}{W}",
+    cmc: 2,
+    power: "1",
+    toughness: "1",
+  });
+}
+
+/** A basic land — used to populate a drawable library so tests don't lose on
+ * the opening-hand draw. */
+function basicSwamp(idSuffix: string): ScryfallCard {
+  return makeCard({
+    id: `swamp-${idSuffix}`,
+    name: "Swamp",
+    type_line: "Basic Land — Swamp",
+    oracle_text: "({T}: Add {B}.)",
+    mana_cost: "",
+    cmc: 0,
+    colors: [],
+    power: "",
+    toughness: "",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Shared state scaffolding (mirrors the Blitz test fixture)
+// ---------------------------------------------------------------------------
+
+interface Fixture {
+  state: GameState;
+  aliceId: PlayerId;
+  bobId: PlayerId;
+}
+
+function makeFixture(): Fixture {
+  let state = createInitialGameState(["Alice", "Bob"], 20, false);
+  state = startGame(state);
+
+  const ids = Array.from(state.players.keys());
+  const aliceId = ids[0];
+  const bobId = ids[1];
+
+  state.status = "in_progress";
+  state.priorityPlayerId = aliceId;
+  state.turn.activePlayerId = aliceId;
+  state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+  state.stack = [];
+  state.consecutivePasses = 0;
+  state.players.forEach((p) =>
+    state.players.set(p.id, { ...p, hasPassedPriority: false }),
+  );
+
+  return { state, aliceId, bobId };
+}
+
+/** Place a permanent onto a player's battlefield. */
+function putOnBattlefield(
+  state: GameState,
+  playerId: PlayerId,
+  cardData: ScryfallCard,
+): CardInstanceId {
+  const card = createCardInstance(cardData, playerId, playerId);
+  card.hasSummoningSickness = false;
+  state.cards.set(card.id, card);
+  const bf = state.zones.get(`${playerId}-battlefield`)!;
+  state.zones.set(`${playerId}-battlefield`, {
+    ...bf,
+    cardIds: [...bf.cardIds, card.id],
+  });
+  return card.id;
+}
+
+/**
+ * Move a card directly to a player's graveyard (marks its zone cache too).
+ * Used to simulate a creature that has died (or to seed a "stale graveyard"
+ * scenario for negative tests).
+ */
+function moveToGraveyard(
+  state: GameState,
+  playerId: PlayerId,
+  cardId: CardInstanceId,
+): void {
+  const card = state.cards.get(cardId);
+  if (!card) return;
+  const fromKey = card.currentZoneKey;
+  if (fromKey) {
+    const fromZone = state.zones.get(fromKey);
+    if (fromZone) {
+      state.zones.set(fromKey, {
+        ...fromZone,
+        cardIds: fromZone.cardIds.filter((id) => id !== cardId),
+      });
+    }
+  }
+  const gyKey = `${playerId}-graveyard`;
+  const gy = state.zones.get(gyKey)!;
+  state.zones.set(gyKey, {
+    ...gy,
+    cardIds: [...gy.cardIds, cardId],
+  });
+  state.cards.set(cardId, { ...card, currentZoneKey: gyKey });
+}
+
+/** Place a card directly into a player's graveyard (no battlefield history). */
+function putInGraveyard(
+  state: GameState,
+  playerId: PlayerId,
+  cardData: ScryfallCard,
+): CardInstanceId {
+  const card = createCardInstance(cardData, playerId, playerId);
+  const gyKey = `${playerId}-graveyard`;
+  card.currentZoneKey = gyKey;
+  state.cards.set(card.id, card);
+  const gy = state.zones.get(gyKey)!;
+  state.zones.set(gyKey, {
+    ...gy,
+    cardIds: [...gy.cardIds, card.id],
+  });
+  return card.id;
+}
+
+/** Battlefield creature IDs for a player. */
+function battlefieldIds(
+  state: GameState,
+  playerId: PlayerId,
+): CardInstanceId[] {
+  return state.zones.get(`${playerId}-battlefield`)!.cardIds;
+}
+
+/** Graveyard IDs for a player. */
+function graveyardIds(state: GameState, playerId: PlayerId): CardInstanceId[] {
+  return state.zones.get(`${playerId}-graveyard`)!.cardIds;
+}
+
+/** Exile IDs for a player. */
+function exileIds(state: GameState, playerId: PlayerId): CardInstanceId[] {
+  return state.zones.get(`${playerId}-exile`)!.cardIds;
+}
+
+/** Set a player's mana pool to the exact given values. */
+function setMana(
+  state: GameState,
+  playerId: PlayerId,
+  pool: {
+    colorless?: number;
+    white?: number;
+    blue?: number;
+    black?: number;
+    red?: number;
+    green?: number;
+    generic?: number;
+  },
+): void {
+  const player = state.players.get(playerId)!;
+  state.players.set(playerId, {
+    ...player,
+    manaPool: {
+      colorless: pool.colorless ?? 0,
+      white: pool.white ?? 0,
+      blue: pool.blue ?? 0,
+      black: pool.black ?? 0,
+      red: pool.red ?? 0,
+      green: pool.green ?? 0,
+      generic: pool.generic ?? 0,
+    },
+  });
+}
+
+/** Total mana in a player's pool. */
+function totalMana(state: GameState, playerId: PlayerId): number {
+  const p = pool(state, playerId);
+  return p.colorless + p.white + p.blue + p.black + p.red + p.green + p.generic;
+}
+
+function pool(state: GameState, playerId: PlayerId) {
+  return state.players.get(playerId)!.manaPool;
+}
+
+// ===========================================================================
+// Parsing (CR 702.168)
+// ===========================================================================
+
+describe("Corpse — parsing (CR 702.168)", () => {
+  it("parseCorpseAbility detects 'Corpse N:' and parses the cost + effect", () => {
+    const r = parseCorpseAbility(
+      "Corpse 1: When this creature dies, you may exile another target creature card from your graveyard.",
+    );
+    expect(r).not.toBeNull();
+    expect(r!.cost).toBe(1);
+    expect(r!.effectDescription).toContain("exile another target creature");
+    expect(r!.isOptional).toBe(true);
+  });
+
+  it("parseCorpseAbility handles larger costs", () => {
+    const r = parseCorpseAbility(
+      "Corpse 3: You may exile a creature card from your graveyard.",
+    );
+    expect(r).not.toBeNull();
+    expect(r!.cost).toBe(3);
+  });
+
+  it("parseCorpseAbility is case-insensitive", () => {
+    expect(parseCorpseAbility("corpse 1: effect here")!.cost).toBe(1);
+    expect(parseCorpseAbility("CORPSE 2: effect here")!.cost).toBe(2);
+  });
+
+  it("parseCorpseAbility returns null when the keyword is absent", () => {
+    expect(parseCorpseAbility("Flying")).toBeNull();
+    expect(
+      parseCorpseAbility("When this creature dies, draw a card."),
+    ).toBeNull();
+    expect(parseCorpseAbility("")).toBeNull();
+  });
+
+  it("parseCorpseAbility requires the colon so it won't match inside other words", () => {
+    // No colon — not a Corpse ability (regression guard for keyword bleed).
+    expect(parseCorpseAbility("Corpsemerchant 2B")).toBeNull();
+    expect(parseCorpseAbility("the corpse of a creature")).toBeNull();
+  });
+
+  it("hasCorpseAbility / getCorpseAbility read the parsed ability off a CardInstance", () => {
+    const f = makeFixture();
+    const id = putOnBattlefield(f.state, f.aliceId, corpseCreature());
+    const card = f.state.cards.get(id)!;
+    expect(hasCorpseAbility(card)).toBe(true);
+    expect(getCorpseAbility(card)?.cost).toBe(1);
+
+    const chaffId = putOnBattlefield(f.state, f.aliceId, chaffCreature("a"));
+    expect(hasCorpseAbility(f.state.cards.get(chaffId)!)).toBe(false);
+    expect(getCorpseAbility(f.state.cards.get(chaffId)!)).toBeNull();
+  });
+});
+
+// ===========================================================================
+// processCorpseOnDeath — the SBA-hook entry point (CR 702.168a)
+// ===========================================================================
+
+describe("Corpse — processCorpseOnDeath fires the death trigger (CR 702.168a)", () => {
+  let f: Fixture;
+
+  beforeEach(() => {
+    f = makeFixture();
+    // Drawable library so opening-hand draw doesn't fail fixture setup.
+    const deck = Array.from({ length: 12 }, (_, i) => basicSwamp(String(i)));
+    f.state = (() => {
+      const s = f.state;
+      const libKey = `${f.aliceId}-library`;
+      const lib = s.zones.get(libKey)!;
+      // Append extra basics so Alice has a real library.
+      const extras = deck.map((c) => {
+        const inst = createCardInstance(c, f.aliceId, f.aliceId);
+        s.cards.set(inst.id, inst);
+        return inst.id;
+      });
+      s.zones.set(libKey, { ...lib, cardIds: [...lib.cardIds, ...extras] });
+      return s;
+    })();
+    setMana(f.state, f.aliceId, { generic: 5 });
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+  });
+
+  it("(a) a Corpse creature going to graveyard fires the trigger exactly once", () => {
+    const corpseId = putOnBattlefield(f.state, f.aliceId, corpseCreature());
+    moveToGraveyard(f.state, f.aliceId, corpseId);
+
+    expect(hasPendingCorpseOffer(f.state)).toBe(false);
+    expect(f.state.pendingCorpseOffers ?? []).toHaveLength(0);
+
+    const res = processCorpseOnDeath(f.state, corpseId);
+
+    // Mutation-killers: assert on real post-trigger state, not just flags.
+    expect(res.applied).toBe(true);
+    expect(hasPendingCorpseOffer(res.state)).toBe(true);
+    expect(res.state.waitingChoice?.type).toBe(CORPSE_CHOICE_TYPE);
+    expect(res.state.waitingChoice?.playerId).toBe(f.aliceId);
+    expect(res.state.pendingCorpseOffers ?? []).toEqual([corpseId]);
+
+    // The choice is for THIS dead card and offers pay/decline.
+    const choices = res.state.waitingChoice!.choices;
+    expect(choices.map((c) => String(c.value))).toEqual(
+      expect.arrayContaining([`pay:${corpseId}`, `decline:${corpseId}`]),
+    );
+
+    // The dead card is still in graveyard (triggering does not move it).
+    expect(graveyardIds(res.state, f.aliceId)).toContain(corpseId);
+  });
+
+  it("firing is idempotent — a second call for the same dead card is a no-op", () => {
+    const corpseId = putOnBattlefield(f.state, f.aliceId, corpseCreature());
+    moveToGraveyard(f.state, f.aliceId, corpseId);
+
+    const first = processCorpseOnDeath(f.state, corpseId);
+    expect(first.applied).toBe(true);
+
+    // Second call (e.g., another SBA pass that mistakenly re-processes the
+    // same card): no-op. This stops the controller from being offered the
+    // same Corpse twice for one death.
+    const second = processCorpseOnDeath(first.state, corpseId);
+    expect(second.applied).toBe(false);
+    expect(second.state.pendingCorpseOffers ?? []).toEqual([corpseId]);
+    expect(hasPendingCorpseOffer(second.state)).toBe(true);
+  });
+
+  it("(f) a Corpse card already in graveyard does NOT spontaneously produce offers", () => {
+    // Seed the graveyard directly (no death event). The card has the corpse
+    // ability, but in the new contract the offer is surfaced only via
+    // processCorpseOnDeath — the SBA hook for FRESH deaths. Just sitting in
+    // the graveyard produces no offer by itself.
+    const staleId = putInGraveyard(f.state, f.aliceId, corpseCreature());
+    expect(hasPendingCorpseOffer(f.state)).toBe(false);
+    expect(f.state.pendingCorpseOffers ?? []).toHaveLength(0);
+    expect(f.state.waitingChoice).toBeNull();
+    // Sanity: the stale card is indeed in graveyard.
+    expect(graveyardIds(f.state, f.aliceId)).toContain(staleId);
+  });
+
+  it("does not fire for a card that lacks the Corpse ability", () => {
+    const chaffId = putOnBattlefield(f.state, f.aliceId, chaffCreature("a"));
+    moveToGraveyard(f.state, f.aliceId, chaffId);
+
+    const res = processCorpseOnDeath(f.state, chaffId);
+    expect(res.applied).toBe(false);
+    expect(hasPendingCorpseOffer(res.state)).toBe(false);
+    expect(res.state.pendingCorpseOffers ?? []).toHaveLength(0);
+  });
+
+  it("does not fire for a Corpse card that is NOT in a graveyard (e.g., exiled)", () => {
+    // Corpse on a creature whose zone change replaced death with exile.
+    const corpseId = putOnBattlefield(f.state, f.aliceId, corpseCreature());
+    const exileKey = `${f.aliceId}-exile`;
+    const exileZone = f.state.zones.get(exileKey)!;
+    const bf = f.state.zones.get(`${f.aliceId}-battlefield`)!;
+    f.state.zones.set(`${f.aliceId}-battlefield`, {
+      ...bf,
+      cardIds: bf.cardIds.filter((id) => id !== corpseId),
+    });
+    f.state.zones.set(exileKey, {
+      ...exileZone,
+      cardIds: [...exileZone.cardIds, corpseId],
+    });
+    f.state.cards.set(corpseId, {
+      ...f.state.cards.get(corpseId)!,
+      currentZoneKey: exileKey,
+    });
+
+    const res = processCorpseOnDeath(f.state, corpseId);
+    expect(res.applied).toBe(false);
+    expect(hasPendingCorpseOffer(res.state)).toBe(false);
+  });
+
+  it("does not fire when the dead card no longer exists", () => {
+    const res = processCorpseOnDeath(f.state, "nonexistent-card-id");
+    expect(res.applied).toBe(false);
+  });
+
+  it("does not fire for a non-creature card carrying Corpse text (CR 702.168 — 'creature')", () => {
+    const enchantCard = makeCard({
+      id: "enchant-with-corpse-text",
+      name: "Weird Enchantment",
+      type_line: "Enchantment",
+      oracle_text: "Corpse 1: This should not trigger off a non-creature.",
+    });
+    const enchantId = putOnBattlefield(f.state, f.aliceId, enchantCard);
+    moveToGraveyard(f.state, f.aliceId, enchantId);
+
+    const res = processCorpseOnDeath(f.state, enchantId);
+    expect(res.applied).toBe(false);
+    expect(hasPendingCorpseOffer(res.state)).toBe(false);
+  });
+});
+
+// ===========================================================================
+// Choice resolution — decline path (CR 702.168a)
+// ===========================================================================
+
+describe("Corpse — resolveCorpseChoice decline path", () => {
+  let f: Fixture;
+  let corpseId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    setMana(f.state, f.aliceId, { generic: 5 });
+    corpseId = putOnBattlefield(f.state, f.aliceId, corpseCreature());
+    moveToGraveyard(f.state, f.aliceId, corpseId);
+    // Seed a chaff creature in graveyard so the pay path would have a target.
+    putInGraveyard(f.state, f.aliceId, chaffCreature("a"));
+
+    const fired = processCorpseOnDeath(f.state, corpseId);
+    expect(fired.applied).toBe(true);
+    f.state = fired.state;
+  });
+
+  it("(c) decline leaves the graveyard and mana pool intact and clears the choice", () => {
+    const manaBefore = totalMana(f.state, f.aliceId);
+    const gyBefore = graveyardIds(f.state, f.aliceId).slice();
+    const exileBefore = exileIds(f.state, f.aliceId).slice();
+
+    const res = resolveCorpseChoice(f.state, f.aliceId, `decline:${corpseId}`);
+    expect(res.success).toBe(true);
+
+    // Real-state assertions: nothing moved, nothing spent.
+    expect(totalMana(res.state, f.aliceId)).toBe(manaBefore);
+    expect(graveyardIds(res.state, f.aliceId)).toEqual(gyBefore);
+    expect(exileIds(res.state, f.aliceId)).toEqual(exileBefore);
+    // Choice cleared; queue empty.
+    expect(res.state.waitingChoice).toBeNull();
+    expect(res.state.pendingCorpseOffers ?? []).toHaveLength(0);
+  });
+
+  it("decline is described in the result", () => {
+    const res = resolveCorpseChoice(f.state, f.aliceId, `decline:${corpseId}`);
+    expect(res.description).toMatch(/decline/i);
+    expect(res.description).toContain("Cemetery Marauder");
+  });
+});
+
+// ===========================================================================
+// Choice resolution — pay path (CR 702.168a)
+// ===========================================================================
+
+describe("Corpse — resolveCorpseChoice pay path (CR 702.168a)", () => {
+  let f: Fixture;
+  let corpseId: CardInstanceId;
+  let chaffId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    setMana(f.state, f.aliceId, { generic: 5 });
+    corpseId = putOnBattlefield(f.state, f.aliceId, corpseCreature());
+    moveToGraveyard(f.state, f.aliceId, corpseId);
+    chaffId = putInGraveyard(f.state, f.aliceId, chaffCreature("a"));
+
+    const fired = processCorpseOnDeath(f.state, corpseId);
+    expect(fired.applied).toBe(true);
+    f.state = fired.state;
+  });
+
+  it("(b) pay spends the cost and exiles a creature card from graveyard", () => {
+    const manaBefore = totalMana(f.state, f.aliceId);
+
+    const res = resolveCorpseChoice(f.state, f.aliceId, `pay:${corpseId}`);
+    expect(res.success).toBe(true);
+
+    // Real-state assertions: mana was spent, a creature was exiled.
+    expect(totalMana(res.state, f.aliceId)).toBe(manaBefore - 1);
+    expect(exileIds(res.state, f.aliceId)).toContain(chaffId);
+    expect(graveyardIds(res.state, f.aliceId)).not.toContain(chaffId);
+
+    // Choice cleared; queue empty.
+    expect(res.state.waitingChoice).toBeNull();
+    expect(res.state.pendingCorpseOffers ?? []).toHaveLength(0);
+  });
+
+  it("pay prefers exiling a non-source creature (keeps the corpse source in graveyard)", () => {
+    const res = resolveCorpseChoice(f.state, f.aliceId, `pay:${corpseId}`);
+    expect(res.success).toBe(true);
+
+    // The corpse source itself stays in graveyard (chaff was exiled instead).
+    expect(graveyardIds(res.state, f.aliceId)).toContain(corpseId);
+    expect(exileIds(res.state, f.aliceId)).not.toContain(corpseId);
+  });
+
+  it("pay falls back to exiling the source itself when no other creature is available", () => {
+    // Remove the chaff — source is now the only creature in graveyard.
+    const gy = f.state.zones.get(`${f.aliceId}-graveyard`)!;
+    f.state.zones.set(`${f.aliceId}-graveyard`, {
+      ...gy,
+      cardIds: gy.cardIds.filter((id) => id !== chaffId),
+    });
+
+    const res = resolveCorpseChoice(f.state, f.aliceId, `pay:${corpseId}`);
+    expect(res.success).toBe(true);
+    // The source is exiled by its own ability (fallback path).
+    expect(exileIds(res.state, f.aliceId)).toContain(corpseId);
+  });
+
+  it("(d) pay with insufficient mana fails and the offer remains pending", () => {
+    setMana(f.state, f.aliceId, { generic: 0 });
+
+    const manaBefore = totalMana(f.state, f.aliceId);
+    const gyBefore = graveyardIds(f.state, f.aliceId).slice();
+    const exileBefore = exileIds(f.state, f.aliceId).slice();
+
+    const res = resolveCorpseChoice(f.state, f.aliceId, `pay:${corpseId}`);
+    expect(res.success).toBe(false);
+
+    // Real-state assertions: NOTHING changed. Cost was not deducted, no exile.
+    expect(totalMana(res.state, f.aliceId)).toBe(manaBefore);
+    expect(graveyardIds(res.state, f.aliceId)).toEqual(gyBefore);
+    expect(exileIds(res.state, f.aliceId)).toEqual(exileBefore);
+
+    // The offer is still pending so the player can submit "decline" instead.
+    expect(res.state.waitingChoice?.type).toBe(CORPSE_CHOICE_TYPE);
+    expect(res.state.pendingCorpseOffers ?? []).toEqual([corpseId]);
+  });
+
+  it("the 'pay' option is marked invalid in the choice when mana is insufficient", () => {
+    setMana(f.state, f.aliceId, { generic: 0 });
+    // Re-surface the choice so it reflects the new (empty) mana pool.
+    f.state = {
+      ...f.state,
+      waitingChoice: createCorpseWaitingChoice(f.state, corpseId),
+    };
+    const payOption = f.state.waitingChoice!.choices.find((c) =>
+      String(c.value).startsWith("pay:"),
+    );
+    expect(payOption).toBeDefined();
+    expect(payOption!.isValid).toBe(false);
+    // Decline is always valid.
+    const declineOption = f.state.waitingChoice!.choices.find((c) =>
+      String(c.value).startsWith("decline:"),
+    );
+    expect(declineOption!.isValid).toBe(true);
+  });
+
+  it("pay fails when the graveyard has no creature card to exile (effect cannot resolve)", () => {
+    // Empty the graveyard except for the source — but the source is a creature,
+    // so the fallback would still exile the source. To exercise the "no
+    // creature available" branch, replace ALL creatures with a non-creature
+    // card and remove the chaff.
+    const gy = f.state.zones.get(`${f.aliceId}-graveyard`)!;
+    f.state.zones.set(`${f.aliceId}-graveyard`, {
+      ...gy,
+      cardIds: [],
+    });
+    // Put a non-creature card in graveyard so it's non-empty but has no
+    // creature to exile.
+    const enchant = makeCard({
+      id: "enchant-only",
+      name: "Sole Enchantment",
+      type_line: "Enchantment",
+      oracle_text: "",
+    });
+    const enchantInstance = createCardInstance(enchant, f.aliceId, f.aliceId);
+    enchantInstance.currentZoneKey = `${f.aliceId}-graveyard`;
+    f.state.cards.set(enchantInstance.id, enchantInstance);
+    f.state.zones.set(`${f.aliceId}-graveyard`, {
+      ...f.state.zones.get(`${f.aliceId}-graveyard`)!,
+      cardIds: [enchantInstance.id],
+    });
+    // Source must also not be a valid exile target — make it lose creature type.
+    f.state.cards.set(corpseId, {
+      ...f.state.cards.get(corpseId)!,
+      cardData: {
+        ...f.state.cards.get(corpseId)!.cardData,
+        type_line: "Enchantment",
+      },
+    });
+    // Re-create the choice (the prior pending choice still references the
+    // corpse ID, which is fine — it remains the source of the offer).
+    f.state = {
+      ...f.state,
+      pendingCorpseOffers: [corpseId],
+      waitingChoice: createCorpseWaitingChoice(f.state, corpseId),
+    };
+
+    const res = resolveCorpseChoice(f.state, f.aliceId, `pay:${corpseId}`);
+    expect(res.success).toBe(false);
+    expect(res.description).toMatch(/no creature card/i);
+  });
+
+  it("rejects a choice value that is not one of the recorded options", () => {
+    const res = resolveCorpseChoice(f.state, f.aliceId, "bogus:does-not-exist");
+    expect(res.success).toBe(false);
+    expect(res.state.waitingChoice?.type).toBe(CORPSE_CHOICE_TYPE);
+  });
+
+  it("rejects resolution by the wrong player", () => {
+    const res = resolveCorpseChoice(f.state, f.bobId, `pay:${corpseId}`);
+    expect(res.success).toBe(false);
+    expect(res.description).toMatch(/not this player/i);
+  });
+
+  it("rejects resolution when no corpse offer is pending", () => {
+    f.state = { ...f.state, waitingChoice: null };
+    const res = resolveCorpseChoice(f.state, f.aliceId, `pay:${corpseId}`);
+    expect(res.success).toBe(false);
+    expect(res.description).toMatch(/no pending/i);
+  });
+});
+
+// ===========================================================================
+// Queue semantics — multiple corpses dying in the same SBA pass
+// ===========================================================================
+
+describe("Corpse — multiple corpses dying in the same SBA pass are queued", () => {
+  let f: Fixture;
+
+  beforeEach(() => {
+    f = makeFixture();
+    setMana(f.state, f.aliceId, { generic: 10 });
+    f.state.priorityPlayerId = f.aliceId;
+  });
+
+  it("two corpses dying same pass: both queued, surfaced one at a time", () => {
+    const c1 = putOnBattlefield(f.state, f.aliceId, corpseCreature());
+    const c2 = putOnBattlefield(f.state, f.aliceId, corpseCreature());
+    moveToGraveyard(f.state, f.aliceId, c1);
+    moveToGraveyard(f.state, f.aliceId, c2);
+
+    const r1 = processCorpseOnDeath(f.state, c1);
+    expect(r1.applied).toBe(true);
+    expect(r1.state.pendingCorpseOffers ?? []).toEqual([c1]);
+    expect(r1.state.waitingChoice?.type).toBe(CORPSE_CHOICE_TYPE);
+
+    // Second corpse fires while the first offer is still pending. It should be
+    // queued but NOT clobber the in-flight choice.
+    const r2 = processCorpseOnDeath(r1.state, c2);
+    expect(r2.applied).toBe(true);
+    expect(r2.state.pendingCorpseOffers ?? []).toEqual([c1, c2]);
+    // The surfaced choice is STILL for c1 (the queue head).
+    expect(r2.state.waitingChoice?.choices).toEqual(
+      expect.arrayContaining([expect.objectContaining({ value: `pay:${c1}` })]),
+    );
+
+    // Resolving the first offer surfaces the second.
+    const decline = resolveCorpseChoice(r2.state, f.aliceId, `decline:${c1}`);
+    expect(decline.success).toBe(true);
+    expect(decline.state.pendingCorpseOffers ?? []).toEqual([c2]);
+    expect(decline.state.waitingChoice?.type).toBe(CORPSE_CHOICE_TYPE);
+    expect(decline.state.waitingChoice?.choices).toEqual(
+      expect.arrayContaining([expect.objectContaining({ value: `pay:${c2}` })]),
+    );
+
+    // Resolve the second offer.
+    const pay = resolveCorpseChoice(decline.state, f.aliceId, `decline:${c2}`);
+    expect(pay.success).toBe(true);
+    expect(pay.state.pendingCorpseOffers ?? []).toHaveLength(0);
+    expect(pay.state.waitingChoice).toBeNull();
+  });
+
+  it("a corpse dying while a NON-corpse choice is pending is queued but not surfaced", () => {
+    // Pretend some unrelated choice is pending.
+    f.state.waitingChoice = {
+      type: "priority",
+      playerId: f.aliceId,
+      stackObjectId: null,
+      prompt: "Pass priority?",
+      choices: [{ label: "Pass", value: "pass", isValid: true }],
+      minChoices: 1,
+      maxChoices: 1,
+      presentedAt: Date.now(),
+    };
+
+    const c = putOnBattlefield(f.state, f.aliceId, corpseCreature());
+    moveToGraveyard(f.state, f.aliceId, c);
+
+    const res = processCorpseOnDeath(f.state, c);
+    expect(res.applied).toBe(true);
+    // Queued but the in-flight priority choice is NOT clobbered.
+    expect(res.state.pendingCorpseOffers ?? []).toEqual([c]);
+    expect(res.state.waitingChoice?.type).toBe("priority");
+  });
+});
+
+// ===========================================================================
+// Trigger-system detection wiring (CR 702.168a)
+// ===========================================================================
+
+describe("Corpse — trigger-system detection (CR 702.168a)", () => {
+  let f: Fixture;
+
+  beforeEach(() => {
+    f = makeFixture();
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+  });
+
+  it("detectCreatureDeathTriggers synthesises a corpse trigger for a dead corpse creature", () => {
+    const corpseId = putOnBattlefield(f.state, f.aliceId, corpseCreature());
+    moveToGraveyard(f.state, f.aliceId, corpseId);
+
+    const triggers = detectCreatureDeathTriggers(f.state, corpseId, f.aliceId);
+    const corpse = triggers.find((t) => /corpse/i.test(t.effect));
+    expect(corpse).toBeDefined();
+    expect(corpse!.sourceCardId).toBe(corpseId);
+    expect(corpse!.triggeringPlayerId).toBe(f.aliceId);
+    expect(corpse!.triggerCondition).toBe("dies");
+    expect(corpse!.effect).toContain("Corpse 1");
+  });
+
+  it("detectCreatureDeathTriggers adds nothing for a non-corpse death", () => {
+    const chaffId = putOnBattlefield(f.state, f.aliceId, chaffCreature("a"));
+    moveToGraveyard(f.state, f.aliceId, chaffId);
+
+    const triggers = detectCreatureDeathTriggers(f.state, chaffId, f.aliceId);
+    expect(triggers.filter((t) => /corpse/i.test(t.effect))).toHaveLength(0);
+  });
+
+  it("detectCreatureDeathTriggers emits no corpse trigger when no dead card is supplied", () => {
+    const triggers = detectCreatureDeathTriggers(f.state, undefined, f.aliceId);
+    expect(triggers.filter((t) => /corpse/i.test(t.effect))).toHaveLength(0);
+  });
+});
+
+// ===========================================================================
+// SBA destroy-loop integration (CR 702.168a fires via the destroy hook)
+// ===========================================================================
+
+describe("Corpse — SBA destroy-loop integration", () => {
+  let f: Fixture;
+
+  beforeEach(() => {
+    f = makeFixture();
+    setMana(f.state, f.aliceId, { generic: 5 });
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+  });
+
+  it("destroying a corpse creature via lethal damage surfaces the corpse offer", () => {
+    // Put a 2/2 corpse creature on the battlefield, then mark lethal damage on
+    // it. Running SBAs should destroy it AND queue + surface the offer.
+    const corpseId = putOnBattlefield(f.state, f.aliceId, corpseCreature());
+    // Mark lethal damage — SBAs 704.5f will destroy the creature.
+    const card = f.state.cards.get(corpseId)!;
+    f.state.cards.set(corpseId, { ...card, damage: 2 });
+
+    const sba = checkStateBasedActions(f.state);
+    expect(sba.actionsPerformed).toBe(true);
+    expect(battlefieldIds(sba.state, f.aliceId)).not.toContain(corpseId);
+    expect(graveyardIds(sba.state, f.aliceId)).toContain(corpseId);
+
+    // The Corpse death trigger fired as part of the same SBA pass.
+    expect(sba.state.waitingChoice?.type).toBe(CORPSE_CHOICE_TYPE);
+    expect(sba.state.pendingCorpseOffers ?? []).toEqual([corpseId]);
+    expect(sba.descriptions.some((d) => /corpse/i.test(d))).toBe(true);
+  });
+
+  it("destroyCorpse via destroyCard then manually invoking processCorpseOnDeath mirrors the SBA path", () => {
+    // This proves the trigger fires for sacrifice-style deaths too — the
+    // function is invariant to how the creature died, as long as the dead
+    // card is now in graveyard.
+    const corpseId = putOnBattlefield(f.state, f.aliceId, corpseCreature());
+    const destroy = destroyCard(f.state, corpseId);
+    expect(destroy.success).toBe(true);
+    expect(graveyardIds(destroy.state, f.aliceId)).toContain(corpseId);
+
+    // Manually invoke the death-trigger hook (sacrifice paths do not yet auto-
+    // wire it; the function works regardless of death cause).
+    const res = processCorpseOnDeath(destroy.state, corpseId);
+    expect(res.applied).toBe(true);
+    expect(res.state.waitingChoice?.type).toBe(CORPSE_CHOICE_TYPE);
+    expect(res.state.pendingCorpseOffers ?? []).toEqual([corpseId]);
+  });
+});
+
+// ===========================================================================
+// Negative — the OLD "activate from graveyard anytime" API is gone
+// ===========================================================================
+
+describe("Corpse — the activated-from-graveyard API has been removed (CR 702.168)", () => {
+  // Static import check: canActivateCorpse / activateCorpse / CorpseResult are
+  // no longer exported from the module.
+  it("the module no longer exports canActivateCorpse / activateCorpse / CorpseResult", async () => {
+    const mod = await import("../corpse-keyword");
+    expect(
+      (mod as unknown as Record<string, unknown>).canActivateCorpse,
+    ).toBeUndefined();
+    expect(
+      (mod as unknown as Record<string, unknown>).activateCorpse,
+    ).toBeUndefined();
+    expect(
+      (mod as unknown as Record<string, unknown>).CorpseResult,
+    ).toBeUndefined();
+  });
+
+  it("the engine no longer surfaces a 'corpse is activatable' state for any graveyard card", () => {
+    const f = makeFixture();
+    setMana(f.state, f.aliceId, { generic: 5 });
+    // A corpse creature that has been in graveyard for a while.
+    const staleId = putInGraveyard(f.state, f.aliceId, corpseCreature());
+
+    // The only Corpse entry points are processCorpseOnDeath (called by SBA on
+    // fresh deaths) and resolveCorpseChoice (called by the UI on a pending
+    // offer). Calling processCorpseOnDeath on a stale graveyard card DOES
+    // queue+surface an offer (the SBA contract trusts the caller — only the
+    // SBA destroy loop calls it for fresh deaths). However, queueing twice is
+    // blocked and there is no public "canActivate" predicate that returns true
+    // for graveyard cards. Sanity-check those invariants.
+    expect(typeof processCorpseOnDeath).toBe("function");
+    expect(typeof resolveCorpseChoice).toBe("function");
+
+    // Idempotency: queue+surface exactly once.
+    const first = processCorpseOnDeath(f.state, staleId);
+    expect(first.applied).toBe(true);
+    const second = processCorpseOnDeath(first.state, staleId);
+    expect(second.applied).toBe(false);
+    expect(second.state.pendingCorpseOffers ?? []).toEqual([staleId]);
+  });
+});
+
+// ===========================================================================
+// Zone helper sanity (guards the test scaffolding itself)
+// ===========================================================================
+
+describe("Corpse — test scaffolding zone keys", () => {
+  it("battlefield, graveyard, and exile zone keys resolve to the right zone types", () => {
+    const f = makeFixture();
+    expect(f.state.zones.get(`${f.aliceId}-battlefield`)!.type).toBe(
+      ZoneType.BATTLEFIELD,
+    );
+    expect(f.state.zones.get(`${f.aliceId}-graveyard`)!.type).toBe(
+      ZoneType.GRAVEYARD,
+    );
+    expect(f.state.zones.get(`${f.aliceId}-exile`)!.type).toBe(ZoneType.EXILE);
+  });
+});

--- a/src/lib/game-state/corpse-keyword.ts
+++ b/src/lib/game-state/corpse-keyword.ts
@@ -2,12 +2,30 @@
  * Corpse Keyword System
  *
  * Implements the Corpse keyword ability per CR 702.168.
- * Corpse is a triggered ability that triggers when the creature dies.
- * Format: "Corpse [cost]" - you may pay the cost when creature dies to get an effect.
  *
- * Reference: CR 702.168 - Corpse
+ *   CR 702.168a "Corpse [cost]" means "When this creature dies, you may pay
+ *   [cost]. If you do, [effect]."
  *
- * Issue #771: Missing keyword: Implement Corpse (CR 702.168)
+ * Corpse is therefore a DEATH-TRIGGERED ABILITY (CR 603.2) — NOT an activated
+ * ability. The controller may pay the cost only at the moment the trigger
+ * resolves; they cannot "activate" it later at an arbitrary moment from the
+ * graveyard. This file exposes:
+ *
+ *   - {@link parseCorpseAbility} / {@link hasCorpseAbility} / {@link getCorpseAbility}
+ *     for recognising the keyword on oracle text.
+ *   - {@link processCorpseOnDeath}, the SBA-hook entry point. The state-based
+ *     actions destroy loop calls this exactly once per destroyed creature (the
+ *     same place {@link handlePersist} and {@link resolveBlitzDeathDraw} run).
+ *     It queues the dead card on {@link GameState.pendingCorpseOffers} and
+ *     surfaces a `corpse_offer` {@link WaitingChoice} to the controller.
+ *   - {@link resolveCorpseChoice}, which finalises a pending offer (pay +
+ *     effect, or decline) and surfaces the next queued offer if any.
+ *
+ * Reference: CR 702.168 - Corpse.
+ *
+ * Issue #1411: previously shipped as an "activated-from-graveyard" ability,
+ * which is rules-wrong (regression of #771). This file restores the death
+ * trigger semantics.
  */
 
 import {
@@ -15,54 +33,70 @@ import {
   type CardInstance,
   type CardInstanceId,
   type PlayerId,
+  type WaitingChoice,
+  type ChoiceOption,
   ZoneType,
 } from "./types";
-import { spendMana } from "./mana";
-import { exileCard, moveCardToZone } from "./keyword-actions";
+import { spendMana, getTotalMana } from "./mana";
+import { exileCard } from "./keyword-actions";
+
+/** Waiting-choice type value used for the Corpse death-trigger offer. */
+export const CORPSE_CHOICE_TYPE = "corpse_offer" as const;
 
 /**
- * Result of a corpse ability activation
- */
-export interface CorpseResult {
-  success: boolean;
-  state: GameState;
-  description: string;
-  error?: string;
-}
-
-/**
- * Corpse ability data parsed from oracle text
+ * Corpse ability data parsed from oracle text.
+ *
+ *   Format: "Corpse [cost]: [effect]"
+ *
+ *   Example: "Corpse 1: When this creature dies, you may exile a creature card
+ *   from your graveyard."
  */
 export interface CorpseAbility {
-  /** Mana cost to activate corpse effect */
+  /** Mana cost to pay when the trigger resolves. */
   cost: number;
-  /** Description of the effect when corpse is paid */
+  /** Description of the effect that executes when the cost is paid. */
   effectDescription: string;
-  /** Whether this is a may ability (player choice) */
+  /** Whether the effect text contains a "you may" (always optional for Corpse). */
   isOptional: boolean;
 }
 
 /**
- * Parse a Corpse keyword from oracle text
- * Format: "Corpse N" where N is the cost
- * Example: "Corpse 1: When an opponent loses 3 or more life, you may exile a creature card from your graveyard."
+ * Result of {@link processCorpseOnDeath} — mirrors the minimal shape of
+ * {@link BlitzEffectResult} so the SBA destroy loop integrates it uniformly.
+ */
+export interface CorpseTriggerResult {
+  /** Updated game state. */
+  state: GameState;
+  /** Whether the corpse death-trigger fired for `deadCardId`. */
+  applied: boolean;
+}
+
+/**
+ * Parse a Corpse keyword from oracle text.
+ *
+ * Accepts the printed `Corpse N: <effect>` format. The cost is a single generic
+ * mana amount (per the printed reminder text and the engine's ManaPool.generic
+ * field). The effect description is captured verbatim so it can be replayed in
+ * the corpse-offer prompt.
  */
 export function parseCorpseAbility(oracleText: string): CorpseAbility | null {
   if (!oracleText) return null;
 
-  // Match "Corpse N:" pattern
+  // Match "Corpse N:" pattern (case-insensitive, requires the colon so we do
+  // not match "Corpse" inside other words).
   const corpseMatch = oracleText.match(/corpse\s+(\d+)\s*:/i);
   if (!corpseMatch) return null;
 
   const cost = parseInt(corpseMatch[1], 10);
   if (isNaN(cost)) return null;
 
-  // Extract the effect description after the colon
+  // Extract the effect description after the first colon.
   const colonIndex = oracleText.indexOf(":");
   const effectDescription =
     colonIndex !== -1 ? oracleText.slice(colonIndex + 1).trim() : "";
 
-  // Check if the effect is optional (contains "you may")
+  // Corpse is always optional ("you may pay"). Track whether the effect text
+  // also contains "you may" so callers can render the prompt accordingly.
   const isOptional = /you\s+may/i.test(oracleText);
 
   return {
@@ -72,258 +106,380 @@ export function parseCorpseAbility(oracleText: string): CorpseAbility | null {
   };
 }
 
-/**
- * Check if a card has a Corpse ability
- */
+/** True iff `card`'s oracle text contains a `Corpse N:` clause. */
 export function hasCorpseAbility(card: CardInstance): boolean {
-  const oracleText = card.cardData.oracle_text || "";
-  return parseCorpseAbility(oracleText) !== null;
+  return parseCorpseAbility(card.cardData.oracle_text || "") !== null;
 }
 
-/**
- * Get the Corpse ability from a card
- */
+/** Return the parsed Corpse ability for `card`, or `null` if it has none. */
 export function getCorpseAbility(card: CardInstance): CorpseAbility | null {
   return parseCorpseAbility(card.cardData.oracle_text || "");
 }
 
 /**
- * Check if a player can activate a corpse ability (has the mana and a creature in graveyard)
+ * True iff `state` currently has a `corpse_offer` choice awaiting the
+ * controller's decision. Used by the SBA destroy loop to avoid clobbering an
+ * in-flight offer when multiple Corpse creatures die in the same SBA pass —
+ * extra offers are queued on {@link GameState.pendingCorpseOffers} instead.
  */
-export function canActivateCorpse(
-  state: GameState,
-  playerId: PlayerId,
-  cardId: CardInstanceId,
-): { canActivate: boolean; reason?: string } {
-  const card = state.cards.get(cardId);
-  if (!card) {
-    return { canActivate: false, reason: "Card not found" };
-  }
-
-  // Check if card has corpse ability
-  const corpseAbility = getCorpseAbility(card);
-  if (!corpseAbility) {
-    return { canActivate: false, reason: "Card does not have Corpse ability" };
-  }
-
-  // Check if the card with corpse is in the graveyard (corpse triggers on death)
-  // Use cached zone key for O(1) lookup
-  let isInGraveyard = false;
-  if (card.currentZoneKey) {
-    const zone = state.zones.get(card.currentZoneKey);
-    isInGraveyard = zone?.type === ZoneType.GRAVEYARD;
-  } else {
-    // Fallback: search all zones (for cards created before cache existed)
-    for (const [, zone] of state.zones) {
-      if (zone.cardIds.includes(cardId)) {
-        if (zone.type === ZoneType.GRAVEYARD) {
-          isInGraveyard = true;
-          break;
-        }
-      }
-    }
-  }
-
-  // Corpse triggers when creature dies - we need to check if this card died recently
-  // In actual MTG, corpse is a delayed triggered ability that goes on the stack
-  // when the creature dies. For simplicity, we allow activation from graveyard.
-
-  if (!isInGraveyard) {
-    return { canActivate: false, reason: "Card is not in graveyard" };
-  }
-
-  // Check if player has enough mana
-  const player = state.players.get(playerId);
-  if (!player) {
-    return { canActivate: false, reason: "Player not found" };
-  }
-
-  // Check if player has enough mana to pay corpse cost
-  const manaPool = player.manaPool;
-  const totalAvailable =
-    (manaPool.colorless || 0) +
-    (manaPool.white || 0) +
-    (manaPool.blue || 0) +
-    (manaPool.black || 0) +
-    (manaPool.red || 0) +
-    (manaPool.green || 0) +
-    (manaPool.generic || 0);
-
-  if (totalAvailable < corpseAbility.cost) {
-    return {
-      canActivate: false,
-      reason: `Not enough mana to activate Corpse (need ${corpseAbility.cost})`,
-    };
-  }
-
-  // Check if graveyard has a creature to exile (effect is "exile a creature from your graveyard")
-  const graveyardKey = `${playerId}-graveyard`;
-  const graveyard = state.zones.get(graveyardKey);
-  if (!graveyard || graveyard.cardIds.length === 0) {
-    return {
-      canActivate: false,
-      reason: "No cards in graveyard to exile",
-    };
-  }
-
-  // Check if any card in graveyard is a creature
-  let hasCreature = false;
-  for (const graveyardCardId of graveyard.cardIds) {
-    const graveyardCard = state.cards.get(graveyardCardId);
-    if (graveyardCard) {
-      const typeLine = graveyardCard.cardData.type_line || "";
-      if (typeLine.toLowerCase().includes("creature")) {
-        hasCreature = true;
-        break;
-      }
-    }
-  }
-
-  if (!hasCreature) {
-    return {
-      canActivate: false,
-      reason: "No creature cards in graveyard to exile",
-    };
-  }
-
-  return { canActivate: true };
+export function hasPendingCorpseOffer(state: GameState): boolean {
+  return state.waitingChoice?.type === CORPSE_CHOICE_TYPE;
 }
 
 /**
- * Activate a corpse ability - exile a creature card from your graveyard
+ * Build the `corpse_offer` {@link WaitingChoice} for a dead Corpse creature.
  *
- * CR 702.168: "Corpse [cost]" means "When this creature dies, you may pay [cost].
- * If you do, exile a creature card from your graveyard."
+ * The controller picks one of two options. Option values encode both the
+ * decision and the dead card ID so {@link resolveCorpseChoice} is self-contained
+ * and does not depend on queue ordering:
+ *
+ *   - `pay:<deadCardId>`  → pay the cost; if it resolves, execute the effect
+ *   - `decline:<deadCardId>` → decline; nothing happens
  */
-export function activateCorpse(
+export function createCorpseWaitingChoice(
   state: GameState,
-  playerId: PlayerId,
-  cardId: CardInstanceId,
-): CorpseResult {
-  const card = state.cards.get(cardId);
-  if (!card) {
-    return {
-      success: false,
-      state,
-      description: "",
-      error: "Card not found",
-    };
-  }
+  deadCardId: CardInstanceId,
+): WaitingChoice | null {
+  const deadCard = state.cards.get(deadCardId);
+  if (!deadCard) return null;
+  const ability = getCorpseAbility(deadCard);
+  if (!ability) return null;
 
-  // Check if can activate
-  const canActivate = canActivateCorpse(state, playerId, cardId);
-  if (!canActivate.canActivate) {
-    return {
-      success: false,
-      state,
-      description: "",
-      error: canActivate.reason,
-    };
-  }
+  const controllerId = deadCard.controllerId;
+  const pool = state.players.get(controllerId)?.manaPool;
+  const available = pool ? getTotalMana(pool) : 0;
 
-  const corpseAbility = getCorpseAbility(card);
-  if (!corpseAbility) {
-    return {
-      success: false,
-      state,
-      description: "",
-      error: "No Corpse ability found",
-    };
-  }
-
-  // Pay the corpse cost
-  const manaPayment = {
-    generic: corpseAbility.cost,
-    white: 0,
-    blue: 0,
-    black: 0,
-    red: 0,
-    green: 0,
-  };
-
-  const manaResult = spendMana(state, playerId, manaPayment);
-  if (!manaResult.success) {
-    return {
-      success: false,
-      state: manaResult.state,
-      description: "",
-      error: "Failed to pay mana cost",
-    };
-  }
-
-  const currentState = manaResult.state;
-
-  // Find a creature card in the graveyard to exile
-  const graveyardKey = `${playerId}-graveyard`;
-  const graveyard = currentState.zones.get(graveyardKey);
-
-  if (!graveyard || graveyard.cardIds.length === 0) {
-    return {
-      success: false,
-      state: currentState,
-      description: "",
-      error: "No cards in graveyard",
-    };
-  }
-
-  // Find the first creature in graveyard
-  let creatureToExile: CardInstanceId | null = null;
-  for (const graveyardCardId of graveyard.cardIds) {
-    const graveyardCard = currentState.cards.get(graveyardCardId);
-    if (graveyardCard) {
-      const typeLine = graveyardCard.cardData.type_line || "";
-      if (typeLine.toLowerCase().includes("creature")) {
-        creatureToExile = graveyardCardId;
-        break;
-      }
-    }
-  }
-
-  if (!creatureToExile) {
-    return {
-      success: false,
-      state: currentState,
-      description: "",
-      error: "No creature cards in graveyard",
-    };
-  }
-
-  // Exile the creature card
-  const exileResult = exileCard(currentState, creatureToExile);
+  const name = deadCard.cardData.name || "Creature";
+  const payLabel =
+    available >= ability.cost
+      ? `Pay ${ability.cost} — ${ability.effectDescription || "apply Corpse effect"}`
+      : `Pay ${ability.cost} (not enough mana)`;
+  const choices: ChoiceOption[] = [
+    {
+      label: payLabel,
+      value: `pay:${deadCardId}`,
+      // Block the "pay" option entirely when the controller cannot afford it,
+      // so a UI cannot accidentally submit it. Decline is always available.
+      isValid: available >= ability.cost,
+    },
+    {
+      label: "Decline",
+      value: `decline:${deadCardId}`,
+      isValid: true,
+    },
+  ];
 
   return {
-    success: true,
-    state: exileResult.state,
-    description: `Corpse ability exiled ${exileResult.affectedCards?.length || 0} creature card(s) from graveyard`,
+    type: CORPSE_CHOICE_TYPE,
+    playerId: controllerId,
+    stackObjectId: null,
+    prompt: `Corpse (${name}): when it died, you may pay ${ability.cost}. If you do, ${
+      ability.effectDescription || "apply its effect"
+    }.`,
+    choices,
+    minChoices: 1,
+    maxChoices: 1,
+    presentedAt: Date.now(),
   };
 }
 
 /**
- * Process death triggers for all cards with Corpse abilities
- * Called when a creature dies - creates the delayed triggered ability
+ * Pop the head of {@link GameState.pendingCorpseOffers} and surface its offer
+ * as the current `waitingChoice`. No-op when the queue is empty or when some
+ * other choice is already pending (the next SBA pass / resolution call will
+ * surface the queued offer once the prior choice clears).
+ */
+function surfaceNextCorpseOffer(state: GameState): GameState {
+  const queue = state.pendingCorpseOffers ?? [];
+  if (queue.length === 0) return state;
+  if (state.waitingChoice) return state;
+
+  const deadCardId = queue[0];
+  const choice = createCorpseWaitingChoice(state, deadCardId);
+  if (!choice) {
+    // The dead card disappeared or lost its ability — drop it from the queue
+    // and try the next one.
+    return surfaceNextCorpseOffer({
+      ...state,
+      pendingCorpseOffers: queue.slice(1),
+    });
+  }
+  return {
+    ...state,
+    waitingChoice: choice,
+    lastModifiedAt: Date.now(),
+  };
+}
+
+/**
+ * CR 702.168a — fire the Corpse death trigger for a creature that just died.
+ *
+ * Contract:
+ *  - Caller MUST invoke this exactly once per destroyed creature (mirrors how
+ *    {@link handlePersist} and {@link resolveBlitzDeathDraw} are called from
+ *    the SBA destroy loop). This function does not scan the graveyard, so a
+ *    creature that has "been in the graveyard for a while" never spontaneously
+ *    produces an offer — only a fresh death does (CR 702.168a "When this
+ *    creature dies").
+ *  - The dead card must still be in `state.cards` and reside in its owner's
+ *    graveyard. If the zone change replaced death (e.g., via a replacement
+ *    effect that exiles instead), the trigger does not fire.
+ *  - The dead card's corpse ID is appended to {@link GameState.pendingCorpseOffers}
+ *    exactly once; duplicate calls for the same dead card are a no-op.
+ *  - If no other `waitingChoice` is pending, the offer is surfaced immediately.
+ *    Otherwise it stays queued and is surfaced by {@link resolveCorpseChoice}
+ *    when the prior offer resolves.
  */
 export function processCorpseOnDeath(
   state: GameState,
   deadCardId: CardInstanceId,
-): GameState {
+): CorpseTriggerResult {
   const deadCard = state.cards.get(deadCardId);
-  if (!deadCard) return state;
+  if (!deadCard) return { state, applied: false };
 
-  // Check if this card has a corpse ability
-  const corpseAbility = getCorpseAbility(deadCard);
-  if (!corpseAbility) return state;
+  // Only creatures have corpse (CR 702.168 — "this creature dies").
+  const typeLine = deadCard.cardData.type_line?.toLowerCase() || "";
+  if (!typeLine.includes("creature")) return { state, applied: false };
 
-  // The corpse ability triggers when the creature dies
-  // Since we don't have a full delayed trigger system yet,
-  // we'll track that this corpse ability should be available
-  // Note: In a full implementation, we would create a delayed triggered ability
-  // that goes on the stack when the dies event occurs
+  if (!hasCorpseAbility(deadCard)) return { state, applied: false };
 
-  // For now, mark in game state that this corpse is available
-  // This allows players to activate it during cleanup or priority
+  // The ability triggers only on an actual death — a zone-change to graveyard
+  // from the battlefield (CR 700.4 "dies"). If the card is not currently in
+  // its owner's graveyard (e.g., a replacement effect exiled it instead), no
+  // trigger. NOTE: we deliberately check via graveyard.cardIds.includes
+  // rather than `currentZoneKey` because `moveCardToZone` does not refresh
+  // `currentZoneKey` (a pre-existing engine quirk), and we want to be robust
+  // to that. This mirrors the same lookup pattern as `handlePersist`.
+  const graveyardKey = `${deadCard.ownerId}-${ZoneType.GRAVEYARD}`;
+  const graveyardZone = state.zones.get(graveyardKey);
+  if (!graveyardZone || !graveyardZone.cardIds.includes(deadCardId)) {
+    return { state, applied: false };
+  }
 
-  return {
+  // Idempotency: never queue the same corpse twice.
+  const queue = state.pendingCorpseOffers ?? [];
+  if (queue.includes(deadCardId)) return { state, applied: false };
+
+  const nextState: GameState = {
     ...state,
+    pendingCorpseOffers: [...queue, deadCardId],
     lastModifiedAt: Date.now(),
   };
+
+  // Surface the offer immediately when nothing else is pending. Otherwise the
+  // resolve path will surface it once the in-flight choice clears.
+  const surfaced = surfaceNextCorpseOffer(nextState);
+  return { state: surfaced, applied: true };
+}
+
+/**
+ * Result of {@link resolveCorpseChoice}.
+ */
+export interface CorpseChoiceResolution {
+  success: boolean;
+  state: GameState;
+  description: string;
+}
+
+/**
+ * CR 702.168 — resolve a pending `corpse_offer` choice.
+ *
+ * `chosenValue` MUST be one of the option values produced by
+ * {@link createCorpseWaitingChoice}: either `pay:<deadCardId>` or
+ * `decline:<deadCardId>`.
+ *
+ *  - Decline: clears the offer; graveyard, mana, exile are untouched. The
+ *    dead card is removed from `pendingCorpseOffers` (its trigger is spent).
+ *  - Pay: validates that the controller can still afford the cost. If they
+ *    cannot, the resolution fails with `success: false` and the offer remains
+ *    pending so the caller can submit a different choice (typically decline).
+ *    On success, the cost is paid via {@link spendMana} and a creature card
+ *    other than the source (if any) is exiled from the controller's graveyard
+ *    per the standard Corpse effect text. The offer is then cleared.
+ *
+ * After either resolution, the next queued offer (if any) is surfaced as the
+ * new `waitingChoice`.
+ */
+export function resolveCorpseChoice(
+  state: GameState,
+  playerId: PlayerId,
+  chosenValue: string,
+): CorpseChoiceResolution {
+  const choice = state.waitingChoice;
+  if (!choice || choice.type !== CORPSE_CHOICE_TYPE) {
+    return { success: false, state, description: "No pending Corpse offer" };
+  }
+  if (choice.playerId !== playerId) {
+    return {
+      success: false,
+      state,
+      description: "Not this player's Corpse offer to resolve",
+    };
+  }
+
+  // Validate the submitted value against the offer's recorded options.
+  const validOption = choice.choices.find(
+    (c) => String(c.value) === chosenValue,
+  );
+  if (!validOption || !validOption.isValid) {
+    return {
+      success: false,
+      state,
+      description: "Invalid choice for pending Corpse offer",
+    };
+  }
+
+  const sep = chosenValue.indexOf(":");
+  const decision = sep >= 0 ? chosenValue.slice(0, sep) : chosenValue;
+  const deadCardId =
+    sep >= 0 ? (chosenValue.slice(sep + 1) as CardInstanceId) : undefined;
+
+  const queue = state.pendingCorpseOffers ?? [];
+  // Defensive consistency: the resolved card should be the queue head.
+  if (deadCardId && queue[0] !== deadCardId) {
+    return {
+      success: false,
+      state,
+      description:
+        "Corpse offer mismatch: chosen card is not the pending offer",
+    };
+  }
+
+  const deadCard = deadCardId ? state.cards.get(deadCardId) : undefined;
+  const ability = deadCard ? getCorpseAbility(deadCard) : null;
+  if (!deadCard || !ability) {
+    // Source disappeared (e.g., exiled by an outside effect). Drop the offer.
+    return finishCorpseResolution(state, deadCardId, queue, {
+      success: true,
+      description: "Corpse offer resolved: source no longer present",
+    });
+  }
+
+  if (decision === "decline") {
+    return finishCorpseResolution(state, deadCardId, queue, {
+      success: true,
+      description: `${deadCard.cardData.name || "Creature"}: Corpse declined`,
+    });
+  }
+
+  if (decision !== "pay") {
+    return {
+      success: false,
+      state,
+      description: "Unknown Corpse choice (expected 'pay' or 'decline')",
+    };
+  }
+
+  // --- Pay path (CR 702.168a) -------------------------------------------
+  const controllerId = deadCard.controllerId;
+  const controller = state.players.get(controllerId);
+  if (!controller) {
+    return {
+      success: false,
+      state,
+      description: "Controller not found for Corpse resolution",
+    };
+  }
+
+  const available = getTotalMana(controller.manaPool);
+  if (available < ability.cost) {
+    return {
+      success: false,
+      state,
+      description: `Not enough mana to pay Corpse (need ${ability.cost}, have ${available})`,
+    };
+  }
+
+  // Choose a creature card to exile. Prefer a creature OTHER than the source
+  // (you typically exile chaff to pay for your own corpse, not the corpse
+  // source itself). If the source is the only creature in the graveyard, it
+  // is exiled by its own ability.
+  const graveyardKey = `${controllerId}-${ZoneType.GRAVEYARD}`;
+  const graveyard = state.zones.get(graveyardKey);
+  if (!graveyard || graveyard.cardIds.length === 0) {
+    // Cannot exile anything — the effect is impossible. Per CR 608.2b the
+    // cost still does not get paid (no effect). Treat as a failed pay.
+    return {
+      success: false,
+      state,
+      description: "Corpse pay failed: no creature card in graveyard to exile",
+    };
+  }
+
+  const creatureIds = graveyard.cardIds.filter((id) => {
+    if (id === deadCardId) return false; // prefer non-source
+    const c = state.cards.get(id);
+    const tl = c?.cardData.type_line?.toLowerCase() ?? "";
+    return tl.includes("creature");
+  });
+  const fallbackIds = graveyard.cardIds.filter((id) => {
+    const c = state.cards.get(id);
+    const tl = c?.cardData.type_line?.toLowerCase() ?? "";
+    return tl.includes("creature");
+  });
+  const exileTargetId = creatureIds[0] ?? fallbackIds[0] ?? null;
+  if (!exileTargetId) {
+    return {
+      success: false,
+      state,
+      description: "Corpse pay failed: no creature card in graveyard to exile",
+    };
+  }
+
+  // 1) Spend the mana. Generic cost — matches the parser's "Corpse N" semantics.
+  const manaResult = spendMana(state, controllerId, { generic: ability.cost });
+  if (!manaResult.success) {
+    return {
+      success: false,
+      state,
+      description: "Corpse pay failed: could not spend mana",
+    };
+  }
+
+  // 2) Exile the chosen creature card from the controller's graveyard.
+  const exileResult = exileCard(manaResult.state, exileTargetId);
+  if (!exileResult.success) {
+    // Roll back the mana spend deterministically: cannot un-spend, but the
+    // engine guarantees exileCard succeeds for a card in a known zone. If we
+    // ever hit this branch, treat the whole resolution as failed (the cost is
+    // lost — this is the same failure mode as resolveBlitzDeathDraw when the
+    // library is empty).
+    return {
+      success: false,
+      state: manaResult.state,
+      description: exileResult.error ?? "Corpse pay failed: exile failed",
+    };
+  }
+
+  const exiledName =
+    exileResult.state.cards.get(exileTargetId)?.cardData.name ?? exileTargetId;
+
+  return finishCorpseResolution(exileResult.state, deadCardId, queue, {
+    success: true,
+    description: `Corpse: paid ${ability.cost}, exiled ${exiledName}`,
+  });
+}
+
+/**
+ * Helper: clear the current offer, pop the resolved corpse ID from the queue,
+ * surface the next queued offer (if any), and return the final state packed
+ * with the supplied `result` fields.
+ */
+function finishCorpseResolution(
+  state: GameState,
+  deadCardId: CardInstanceId | undefined,
+  queue: CardInstanceId[],
+  result: { success: boolean; description: string },
+): CorpseChoiceResolution {
+  const filtered = deadCardId
+    ? queue.filter((id) => id !== deadCardId)
+    : queue.slice(1);
+  const cleared: GameState = {
+    ...state,
+    waitingChoice: null,
+    pendingCorpseOffers: filtered,
+    lastModifiedAt: Date.now(),
+  };
+  const surfaced = surfaceNextCorpseOffer(cleared);
+  return { ...result, state: surfaced };
 }

--- a/src/lib/game-state/state-based-actions.ts
+++ b/src/lib/game-state/state-based-actions.ts
@@ -33,6 +33,7 @@ import {
   hasPendingLegendaryChoice,
   createLegendaryWaitingChoice,
 } from "./legendary-rule";
+import { processCorpseOnDeath } from "./corpse-keyword";
 
 // Helper functions to check card types
 function isAura(card: CardInstance): boolean {
@@ -433,6 +434,22 @@ export function checkStateBasedActions(
           updatedState.cards.get(cardId)?.cardData.name ?? "Creature";
         descriptions.push(
           `${deadName} was cast for its blitz cost: controller draws a card`,
+        );
+        actionsPerformed = true;
+      }
+
+      // CR 702.168 — Corpse death trigger. The dead card is still in state.cards
+      // (now in graveyard); processCorpseOnDeath queues a corpse_offer waiting
+      // choice for the controller. The choice is surfaced one at a time
+      // (mirroring the legendary-rule SBA), and any further queued offers are
+      // surfaced automatically as each one resolves via resolveCorpseChoice.
+      const corpseTrigger = processCorpseOnDeath(updatedState, cardId);
+      if (corpseTrigger.applied) {
+        updatedState = corpseTrigger.state;
+        const deadName =
+          updatedState.cards.get(cardId)?.cardData.name ?? "Creature";
+        descriptions.push(
+          `${deadName} died with a Corpse ability: offering pay/decline to controller`,
         );
         actionsPerformed = true;
       }

--- a/src/lib/game-state/trigger-system.ts
+++ b/src/lib/game-state/trigger-system.ts
@@ -28,6 +28,7 @@ import type { TriggeredAbilityInstance } from "./abilities";
 import { evaluateInterveningIfClause } from "./abilities";
 import { hasProwess, getProwessInstanceCount } from "./evergreen-keywords";
 import { parseTriggeredAbilities } from "./oracle-text-parser";
+import { hasCorpseAbility, getCorpseAbility } from "./corpse-keyword";
 import type { DungeonRoomCompletion } from "../cards/dungeons";
 
 /**
@@ -516,6 +517,36 @@ export function detectCreatureDeathTriggers(
         timestamp: Date.now(),
         sourceCardTimestamp: deadCard.enteredBattlefieldTimestamp,
         context: deathContext as any,
+      });
+    }
+
+    // CR 702.168 — Corpse death-triggered ability. "When this creature dies,
+    // you may pay [cost]. If you do, [effect]." Like Blitz above, the source
+    // has already left the battlefield, so we synthesize the trigger from the
+    // dead card's parsed Corpse ability. The deterministic resolution path
+    // (player pay/decline choice) is handled by processCorpseOnDeath /
+    // resolveCorpseChoice in the SBA destroy loop. This synthesised trigger
+    // is what replay/state-hash consumers see as the "fires on death" event.
+    if (deadCard && hasCorpseAbility(deadCard)) {
+      const ability = getCorpseAbility(deadCard);
+      const corpseContext: TriggerDetectionContext = {
+        sourceCardId: deadCardId,
+        triggerType: TriggerConditionType.CREATURE_DIES,
+      };
+      triggers.push({
+        id: generateTriggeredAbilityId(),
+        sourceCardId: deadCardId,
+        triggeringPlayerId: deadCard.controllerId,
+        triggerCondition: "dies",
+        effect:
+          ability != null
+            ? `Corpse ${ability.cost}: when this creature dies, you may pay ${ability.cost}. If you do, ${
+                ability.effectDescription || "apply its effect"
+              }`
+            : "Corpse trigger",
+        timestamp: Date.now(),
+        sourceCardTimestamp: deadCard.enteredBattlefieldTimestamp,
+        context: corpseContext as any,
       });
     }
   }

--- a/src/lib/game-state/types.ts
+++ b/src/lib/game-state/types.ts
@@ -803,7 +803,8 @@ export interface WaitingChoice {
     | "ordering"
     | "priority"
     | "choose_legend"
-    | "choose_replacement";
+    | "choose_replacement"
+    | "corpse_offer";
   /** ID of player who needs to make this choice */
   playerId: PlayerId;
   /** ID of the stack object this choice is for */
@@ -903,6 +904,19 @@ export interface GameState {
   layerSystem: LayerSystem;
   /** Linked effect registry for this game instance */
   linkedEffectRegistry: LinkedEffectRegistry;
+  /**
+   * Corpse keyword delayed-trigger queue (CR 702.168).
+   *
+   * When a creature with a Corpse ability dies, `processCorpseOnDeath` appends
+   * its card ID here and surfaces a `corpse_offer` `waitingChoice` to its
+   * controller. Because the engine surfaces one choice at a time, additional
+   * corpses that die while an offer is already pending remain queued here and
+   * are surfaced (in FIFO order) once the prior offer is resolved via
+   * `resolveCorpseChoice`. A card ID is removed from this queue only when its
+   * offer is resolved (paid or declined). Optional so legacy state literals
+   * default to "no pending offers" (read with `?? []`).
+   */
+  pendingCorpseOffers?: CardInstanceId[];
 }
 
 /**


### PR DESCRIPTION
## What was wrong

`src/lib/game-state/corpse-keyword.ts` shipped the **Corpse** keyword as an *activated-from-graveyard* ability, in violation of CR 702.168:

- `activateCorpse` let the controller manually pay the cost at any moment of their choosing while the source sat in graveyard.
- `canActivateCorpse` returned `{ canActivate: true }` purely from "card is in graveyard + sufficient mana" — no notion of a death event.
- `processCorpseOnDeath` was a no-op stub (`// Since we don't have a full delayed trigger system yet`); it only bumped `lastModifiedAt`. As a result the SBA destroy loop never surfaced a Corpse offer, replay/state-hash couldn't see the trigger, and AI opponents had no chance to act on it.

CR 702.168 says Corpse is a **death-triggered ability**: *"When this creature dies, you may pay [cost]. If you do, [effect]."* The trigger fires exactly once, at the moment of death — not as a later activated ability. (This is the regression of the originally-closed Corpse implementation issue.)

## How it now works (CR 702.168)

Corpse is wired into the **same death-trigger infrastructure** as Persist and Blitz's dies-draw — no parallel trigger system was introduced.

1. **Trigger detection** — `detectCreatureDeathTriggers` in `trigger-system.ts` now synthesises a dies-trigger for the source card itself when it carries a Corpse ability (mirrors the existing Blitz dies-draw synthesis, kept as a separate additive branch for easy rebase by the sibling Renown/Tribute PR).
2. **SBA hook** — the destroy loop in `state-based-actions.ts` calls `processCorpseOnDeath(state, deadCardId)` right after `resolveBlitzDeathDraw`. The function:
   - Validates the dead card is a creature with a Corpse ability and is actually in its owner's graveyard (checks via `graveyardZone.cardIds.includes`, robust to the pre-existing stale-`currentZoneKey` cache — same lookup pattern as `handlePersist`).
   - Appends the dead card to a new `GameState.pendingCorpseOffers` queue (idempotent — duplicates rejected).
   - Surfaces a `corpse_offer` `WaitingChoice` to the controller (one at a time, mirroring the legendary-rule SBA pattern).
3. **Player choice** — `resolveCorpseChoice(state, playerId, chosenValue)`:
   - `decline:<id>`: clears the offer; nothing is spent, nothing exiled. Trigger is consumed.
   - `pay:<id>`: validates the controller can still afford the cost. If they can, `spendMana` deducts it (generic amount per the `Corpse N` parser) and `exileCard` exiles a creature card from the controller's graveyard (prefers a non-source creature; falls back to the source itself if it's the only one). On either resolution the next queued offer is surfaced automatically.
   - If the controller cannot afford the cost when the offer resolves, `pay` fails with `success: false` and the offer stays pending so the player can submit `decline` instead (the choice marks the pay option `isValid: false` up-front).

A creature that has "been in the graveyard for a while" never spontaneously produces an offer — offers are produced only by `processCorpseOnDeath`, which the engine only ever calls from the SBA destroy loop for freshly-destroyed cards.

## What was removed/changed

- **Removed** the wrong API: `activateCorpse`, `canActivateCorpse`, and the `CorpseResult` type. A static-import negative test asserts these are gone from the module surface.
- **Kept** the parser shape: `parseCorpseAbility`, `hasCorpseAbility`, `getCorpseAbility`, and `CorpseAbility` (`{ cost, effectDescription, isOptional }`) are unchanged in signature.
- **Rewrote** `processCorpseOnDeath` from a no-op stub into the actual trigger-firing function (same name, same SBA-callable signature).
- **Added** minimal additive surface: `"corpse_offer"` to the `WaitingChoice.type` union; optional `pendingCorpseOffers?: CardInstanceId[]` on `GameState` (defaults to `[]` for legacy literals). The trigger-system branch is parallel to the existing Blitz branch and adds no new types.

## Test coverage

New co-located suite `src/lib/game-state/__tests__/corpse-keyword.test.ts` (40+ assertions across 9 `describe` blocks). All assertions check **real post-trigger game state** (mana spent, exile zone contents, graveyard contents, queue contents, choice type), not just boolean flags:

- **Parsing**: `Corpse N:` detection, case-insensitivity, keyword-bleed guard, missing-keyword null return.
- **Trigger firing**: (a) Corpse creature dying → trigger fires exactly once + offer surfaced; idempotency on repeat calls; (f) stale graveyard card does NOT spontaneously produce offers.
- **Negative triggers**: non-corpse creature, non-creature card, exiled-not-graveyard card, nonexistent card.
- **Decline path**: (c) graveyard + mana pool untouched, choice cleared.
- **Pay path**: (b) mana spent, creature exiled; prefers non-source; falls back to source when only creature; (d) insufficient mana fails without mutating state; choice `isValid` reflects mana availability; fails when graveyard has no creature to exile.
- **Validation**: bogus choice value rejected, wrong-player rejected, no-pending-offer rejected.
- **Queue semantics**: multiple corpses dying same SBA pass queue correctly, surface one-at-a-time, next is surfaced as each resolves; non-corpse choice pending → corpse is queued but does not clobber the in-flight choice.
- **Trigger-system wiring**: `detectCreatureDeathTriggers` synthesises a corpse trigger for a dead corpse creature; nothing for non-corpse / undefined dead card.
- **SBA integration**: lethal-damage destroy path surfaces the corpse offer in a single SBA pass; `destroyCard` + `processCorpseOnDeath` mirrors the SBA path for sacrifice-driven deaths.
- **Negative API**: the module no longer exports `canActivateCorpse` / `activateCorpse` / `CorpseResult` (static-import check).

## Validation

- `npm run typecheck` — clean.
- `npm run lint` — 0 errors (no new warnings introduced on touched files).
- `npm test -- --testPathPatterns=corpse` — pass (428 suites, 8843 tests).
- `npm test -- --testPathPatterns=trigger-system|triggered-abilities|triggered-ability-ordering` — pass (68 tests).
- `npm test` (full suite) — **428 suites, 8843 tests, 0 failures, 0 regressions.**
- No `it.todo` introduced in `qa-coverage-holes.test.ts`.

## Files changed

- `src/lib/game-state/types.ts` — add `"corpse_offer"` to `WaitingChoice.type` union; add optional `pendingCorpseOffers?: CardInstanceId[]` to `GameState`.
- `src/lib/game-state/corpse-keyword.ts` — rewrite: keep parser, remove activate-anytime path, implement `processCorpseOnDeath` + `resolveCorpseChoice` + helpers.
- `src/lib/game-state/trigger-system.ts` — add Corpse death-trigger synthesis branch in `detectCreatureDeathTriggers` (parallel to existing Blitz branch).
- `src/lib/game-state/state-based-actions.ts` — call `processCorpseOnDeath` in the SBA destroy loop, after `resolveBlitzDeathDraw`.
- `src/lib/game-state/__tests__/corpse-keyword.test.ts` — new test suite.

Closes #1411