### PR TITLE
feat: difficulty-scaled opening-hand sequencing for AI opponent (#1416)

### DIFF
--- a/src/ai/OPENING_AI.md
+++ b/src/ai/OPENING_AI.md
@@ -1,0 +1,149 @@
+# Opening-Hand Sequencing (AI Opponent)
+
+> Issue #1416 — difficulty-scaled opening-hand sequencing for turns 1-3.
+> Parallel to `COMBAT_AI.md` / `STACK_INTERACTION_AI.md`. Lives next to the
+> helper it documents: `src/ai/opening-turn-plan.ts`.
+
+The opening three turns of a Magic game are the most consequential. Before
+this module the AI played every turn identically — `playLandIfAvailable`
+grabbed the first land in hand and `castCreatures` dumped every affordable
+creature by CMC. There was no turn-1 vs turn-3 distinction and Easy opened
+indistinguishably from Expert. The opener is the AI's first impression on
+every game; a flat opener erodes the player's confidence in the difficulty
+selector.
+
+## Design
+
+`chooseOpeningTurnPlan(state, playerId, difficulty, format, turnNumber, rng)`
+is a **pure** function (no engine mutation, no I/O) that returns an
+`OpeningTurnPlan` for turns 1-3 and `null` otherwise. The turn loop consults
+it once in the **pre-combat main phase** (`runMainPhase`, `phase ===
+"precombat_main"`) and threads the result into `playLandIfAvailable` and
+`castCreatures`. Post-combat main and turns > 3 fall back to the legacy
+difficulty-agnostic main-phase logic unchanged.
+
+```ts
+interface OpeningTurnPlan {
+  landToPlay: CardInstanceId | null; // played in place of "first land found"
+  spellToCast: CardInstanceId | null; // cast in place of the CMC-sort dump
+  holdMana: boolean; // skip creatures this turn entirely
+  reasoning: string; // surfaced via config.onCommentary
+}
+```
+
+When the plan is present, `castCreatures` is **authoritative** — it casts the
+planned creature (or holds all creatures when `holdMana`) and returns without
+falling through to the legacy path. This keeps the opener to one deliberate
+spell per turn. The plan's color-feasibility check prevents off-curve picks;
+if the engine still rejects the cast (unexpected), the AI simply casts
+nothing that turn — acceptable for a deliberate opener.
+
+The turn number is read from the engine's `gameState.turn.turnNumber`
+directly (no per-game counter, no `AITurnConfig` change) — the engine already
+tracks it authoritatively.
+
+### Turn-counter surfacing
+
+`runMainPhase` reads `currentState.turn?.turnNumber ?? 0` and only computes
+the plan for `1 <= turnNumber <= OPENING_TURNS_MAX` (3). This keeps the
+helper's turn-window logic in one place and avoids a config-level mutation
+that sibling issues would have to rebase around.
+
+## Per-tier opening patterns
+
+### Easy — sloppy
+
+- **Land**: a _random_ land from hand (deterministic via the supplied `rng`).
+  May pick a tapped land when an untapped basic is available.
+- **Spell**: greedy — the highest-CMC creature within `turnNumber + 2` reach,
+  **ignoring color requirements**. Above-curve picks fail the engine's cast
+  validation and waste the turn (the documented Easy blunder). 25% of the
+  time the plan randomly holds and does nothing.
+- **Feel**: drops a tapped land T1 into a color-mismatched 2-drop; routinely
+  wastes T2 attempting a 3-drop it can't pay for.
+
+### Medium — on-curve
+
+- **Land**: the highest-scored land (untapped basics that enable the hand's
+  colored pips > untapped basics > untapped duals > tapped lands).
+- **Spell**: "curves out" — prefers a creature with CMC equal to the turn
+  number, then the highest CMC at or below turn number (to use mana), then
+  higher power. Only color-feasible picks are considered.
+- **Hold**: when the only on-curve play is off-color, holds all creatures and
+  replays the hand next turn.
+- **Feel**: leads T1 1-drop → T2 2-drop → T3 3-drop when colors allow.
+
+### Hard — 1-turn lookahead
+
+- Everything Medium does, plus:
+- **T1 mana-dork lead**: if a {T}:Add-mana creature is on-color, leads with it
+  to accelerate the T2/T3 curve.
+- **Curve protection**: holds a 1-drop on T1 if casting it would strand the
+  T2 2-drop's only colored source (1-source conflict detection).
+- **Land sequencing**: scores fetch lands for color fixing (a fetch that can
+  find a demanded color beats an off-color basic); penalizes tapped lands
+  heavily on T1/T2.
+
+### Expert — 2-turn plan
+
+- Everything Hard does, plus:
+- **Removal lead vs threats**: if the opponent's T1 board has a creature with
+  power ≥ 2, holds the creature plan entirely so `castOtherSpells` can lead
+  with removal (the AI does not develop into a faster clock).
+- **Mana-dork acceleration**: on T1, plays a mana dork specifically to ramp
+  into a T2 3-drop or T3 4-drop (checks for those targets in hand).
+- **Color sequencing**: scores fetch lands with an extra flexibility bonus
+  (the option-value of cracking for whichever color the draw step reveals).
+
+## Land scoring
+
+`scoreLand(land, demand, turnNumber, difficulty)` ranks candidate lands:
+
+| Factor                       | Effect                                                          |
+| ---------------------------- | --------------------------------------------------------------- |
+| Untapped                     | +2                                                              |
+| Tapped                       | −2 on T1/T2, −0.5 on T3 (tempo cost is front-loaded)            |
+| Produces a demanded color    | +3 per color                                                    |
+| Basic                        | +1 (land-type-matters, no life cost)                            |
+| Fetch finds a demanded color | +2 per color (Hard/Expert only — Medium doesn't think to crack) |
+| Fetch flexibility            | +0.5 (Expert only — option-value)                               |
+
+"Demanded color" = the weighted pip count across near-term creatures
+(`computeColorDemand`): on-curve creatures (cmc ≤ turn) count double, the
+next turn's spells (cmc ≤ turn+2) count single.
+
+## Determinism
+
+The only nondeterministic input is `rng` (used only by Easy's random land
+pick and random hold). Tests pass a seeded `() => number` for fully
+reproducible plans. Medium / Hard / Expert are fully deterministic given the
+game state.
+
+## Integration points
+
+| Call site             | Change                                                                                                                   |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `runMainPhase`        | computes the plan once for `precombat_main`, surfaces `reasoning` via `onCommentary`, threads the plan into both helpers |
+| `playLandIfAvailable` | new optional `openingPlan` param; when `landToPlay` is set, plays THAT land instead of the first found                   |
+| `castCreatures`       | new optional `openingPlan` param; when present, casts `spellToCast` (or holds) and returns — no legacy fallback          |
+| `castOtherSpells`     | unchanged — Expert's `holdMana` lets removal flow through this legacy path                                               |
+
+## Sibling-issue boundaries
+
+The `ai-turn-loop.ts` edits are deliberately minimal (one import block, one
+plan-computation block in `runMainPhase`, one new optional param + short-circuit
+block each in `playLandIfAvailable` and `castCreatures`) so the sibling
+`ai-turn-loop.ts` clique (#1413, #1414, #1415) rebases cleanly. All opening
+logic lives in `opening-turn-plan.ts`; tests live in
+`src/ai/__tests__/opening-turn-plan.test.ts`.
+
+## Out of scope
+
+- Fetch-land _cracking_ sequencing (which color to crack for) is handled by
+  the activated-ability step (`runAbilityActivation`, issue #1386), not here.
+  The plan only picks _which_ land to play.
+- Per-format opening tuning (Limited vs Constructed openers) — the `format`
+  parameter is threaded through for future use but currently unused.
+- `castOtherSpells` (removal, ramp spells, planeswalkers) is not governed by
+  the opening plan; only creatures are. Expert's "lead removal vs threat"
+  works by holding creatures via `holdMana` and letting `castOtherSpells` run.

--- a/src/ai/__tests__/opening-turn-plan.test.ts
+++ b/src/ai/__tests__/opening-turn-plan.test.ts
@@ -1,0 +1,625 @@
+/**
+ * @fileoverview Unit tests for the difficulty-scaled opening-hand plan
+ * (issue #1416).
+ *
+ * The planner is a pure function over a minimal {@link EngineGameState}
+ * (zones + cards). These tests build lightweight fixtures — no engine
+ * mocking — and assert on the chosen land + spell per turn for each tier,
+ * plus determinism, turn-window gating, and the parser helpers.
+ */
+import { describe, it, expect } from "@jest/globals";
+import {
+  chooseOpeningTurnPlan,
+  countColoredPips,
+  entersTapped,
+  fetchLandTargets,
+  isFetchLand,
+  producedColors,
+  OPENING_TURNS_MAX,
+  type ManaColor,
+} from "../opening-turn-plan";
+import type { DifficultyLevel } from "../ai-difficulty";
+import type {
+  GameState as EngineGameState,
+  CardInstance,
+  CardInstanceId,
+  PlayerId,
+  Turn,
+} from "@/lib/game-state/types";
+
+const AI: PlayerId = "player1";
+const OPP: PlayerId = "player2";
+
+/** Build a card instance with the minimal fields the planner reads. */
+function card(
+  id: string,
+  opts: {
+    name?: string;
+    type_line: string;
+    cmc?: number;
+    mana_cost?: string;
+    colors?: string[];
+    oracle_text?: string;
+    power?: string;
+    controller?: PlayerId;
+  },
+): CardInstance {
+  return {
+    id,
+    oracleId: id,
+    cardData: {
+      id,
+      name: opts.name ?? id,
+      type_line: opts.type_line,
+      cmc: opts.cmc ?? 0,
+      mana_cost: opts.mana_cost,
+      colors: opts.colors ?? [],
+      color_identity: opts.colors ?? [],
+      oracle_text: opts.oracle_text,
+      power: opts.power,
+      legalities: {},
+    },
+    currentFaceIndex: 0,
+    isFaceDown: false,
+    controllerId: opts.controller ?? AI,
+    ownerId: AI,
+    isTapped: false,
+    isFlipped: false,
+    isTurnedFaceUp: false,
+    isPhasedOut: false,
+    hasSummoningSickness: false,
+  } as unknown as CardInstance;
+}
+
+function forest(id = "forest"): CardInstance {
+  return card(id, {
+    name: "Forest",
+    type_line: "Basic Land — Forest",
+    oracle_text: "{T}: Add {G}.",
+  });
+}
+
+function mountain(id = "mountain"): CardInstance {
+  return card(id, {
+    name: "Mountain",
+    type_line: "Basic Land — Mountain",
+    oracle_text: "{T}: Add {R}.",
+  });
+}
+
+function breedingPool(id = "pool"): CardInstance {
+  return card(id, {
+    name: "Breeding Pool",
+    type_line: "Land — Forest Island",
+    oracle_text:
+      "({T}: Add {G} or {U}.)\n\nAs Breeding Pool enters the battlefield, you may pay 2 life.",
+  });
+}
+
+function mistyRainforest(id = "fetch"): CardInstance {
+  return card(id, {
+    name: "Misty Rainforest",
+    type_line: "Land",
+    oracle_text:
+      "{T}, Pay 1 life, Sacrifice Misty Rainforest: Search your library for a Forest or Island card, put it onto the battlefield, then shuffle.",
+  });
+}
+
+function tranquilCove(id = "tapped"): CardInstance {
+  return card(id, {
+    name: "Tranquil Cove",
+    type_line: "Land",
+    oracle_text:
+      "Tranquil Cove enters the battlefield tapped. When Tranquil Cove enters the battlefield, you gain 1 life.\n({T}: Add {W} or {U}.)",
+  });
+}
+
+function llanowarElves(id = "elves"): CardInstance {
+  return card(id, {
+    name: "Llanowar Elves",
+    type_line: "Creature — Elf Druid",
+    cmc: 1,
+    mana_cost: "{G}",
+    colors: ["G"],
+    oracle_text: "{T}: Add {G}.",
+    power: "1",
+  });
+}
+
+function grizzlyBears(id = "bears"): CardInstance {
+  return card(id, {
+    name: "Grizzly Bears",
+    type_line: "Creature — Bear",
+    cmc: 2,
+    mana_cost: "{1}{G}",
+    colors: ["G"],
+    power: "2",
+  });
+}
+
+function threeDrop(id: string = "thr", color: string = "G"): CardInstance {
+  return card(id, {
+    name: `Trespasser (${color})`,
+    type_line: "Creature — Beast",
+    cmc: 3,
+    mana_cost: `{2}{${color}}`,
+    colors: [color],
+    power: "3",
+  });
+}
+
+/**
+ * Build a game state with the supplied cards in the AI's hand and an optional
+ * battlefield. Only zones + cards are populated — everything else the planner
+ * ignores.
+ */
+function buildState(opts: {
+  hand?: CardInstance[];
+  aiBattlefield?: CardInstance[];
+  oppBattlefield?: CardInstance[];
+  turnNumber?: number;
+}): EngineGameState {
+  const cards = new Map<string, CardInstance>();
+  for (const c of [
+    ...(opts.hand ?? []),
+    ...(opts.aiBattlefield ?? []),
+    ...(opts.oppBattlefield ?? []),
+  ]) {
+    cards.set(c.id, c);
+  }
+  const zones = new Map<string, { cardIds: CardInstanceId[] }>();
+  zones.set(`${AI}-hand`, { cardIds: (opts.hand ?? []).map((c) => c.id) });
+  zones.set(`${AI}-battlefield`, {
+    cardIds: (opts.aiBattlefield ?? []).map((c) => c.id),
+  });
+  zones.set(`${OPP}-battlefield`, {
+    cardIds: (opts.oppBattlefield ?? []).map((c) => c.id),
+  });
+  const turn: Turn = {
+    activePlayerId: AI,
+    currentPhase: "precombat_main" as Turn["currentPhase"],
+    turnNumber: opts.turnNumber ?? 1,
+    extraTurns: 0,
+    isFirstTurn: false,
+    startedAt: 0,
+  };
+  return {
+    cards,
+    zones,
+    turn,
+    priorityPlayerId: AI,
+  } as unknown as EngineGameState;
+}
+
+/** Deterministic rng from a linear congruential seed. */
+function seededRng(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0x100000000;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Parser helpers.
+// ---------------------------------------------------------------------------
+
+describe("opening-turn-plan parsers", () => {
+  it("counts colored pips in a mana_cost string", () => {
+    expect(countColoredPips("{1}{G}{G}")).toEqual<Record<ManaColor, number>>({
+      W: 0,
+      U: 0,
+      B: 0,
+      R: 0,
+      G: 2,
+    });
+    expect(countColoredPips("{2}{R}{W}")).toEqual<Record<ManaColor, number>>({
+      W: 1,
+      U: 0,
+      B: 0,
+      R: 1,
+      G: 0,
+    });
+    expect(countColoredPips("{3}")).toEqual<Record<ManaColor, number>>({
+      W: 0,
+      U: 0,
+      B: 0,
+      R: 0,
+      G: 0,
+    });
+    expect(countColoredPips(undefined)).toEqual<Record<ManaColor, number>>({
+      W: 0,
+      U: 0,
+      B: 0,
+      R: 0,
+      G: 0,
+    });
+  });
+
+  it("parses produced colors from basic and dual land oracle text", () => {
+    expect(producedColors("{T}: Add {G}.", "Basic Land — Forest")).toEqual([
+      "G",
+    ]);
+    expect(
+      producedColors("({T}: Add {G} or {U}.)", "Land — Forest Island").sort(),
+    ).toEqual(["G", "U"]);
+  });
+
+  it("falls back to inferring colors from the basic-land type line", () => {
+    expect(producedColors(undefined, "Basic Land — Mountain")).toEqual(["R"]);
+  });
+
+  it("detects tapped-land text", () => {
+    expect(entersTapped("Tranquil Cove enters the battlefield tapped.")).toBe(
+      true,
+    );
+    expect(entersTapped("{T}: Add {G}.")).toBe(false);
+  });
+
+  it("classifies fetch lands and parses their basic targets", () => {
+    const oracle =
+      "{T}, Pay 1 life, Sacrifice Misty Rainforest: Search your library for a Forest or Island card.";
+    expect(isFetchLand(oracle)).toBe(true);
+    expect(isFetchLand("{T}: Add {G}.")).toBe(false);
+    expect(fetchLandTargets(oracle).sort()).toEqual(["G", "U"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Turn-window gating.
+// ---------------------------------------------------------------------------
+
+describe("chooseOpeningTurnPlan — turn window", () => {
+  it("returns null outside the opening window (turn > OPENING_TURNS_MAX)", () => {
+    const state = buildState({
+      hand: [forest()],
+      turnNumber: OPENING_TURNS_MAX + 1,
+    });
+    expect(
+      chooseOpeningTurnPlan(
+        state,
+        AI,
+        "medium",
+        undefined,
+        OPENING_TURNS_MAX + 1,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for turn 0 (before the opener)", () => {
+    const state = buildState({ hand: [forest()], turnNumber: 0 });
+    expect(chooseOpeningTurnPlan(state, AI, "medium", undefined, 0)).toBeNull();
+  });
+
+  it("returns a plan for turns 1-3", () => {
+    for (const t of [1, 2, 3]) {
+      const state = buildState({ hand: [forest()], turnNumber: t });
+      const plan = chooseOpeningTurnPlan(state, AI, "medium", undefined, t);
+      expect(plan).not.toBeNull();
+      expect(plan!.landToPlay).toBe("forest");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Easy: sloppy. Random land, greedy spell, deterministic given rng.
+// ---------------------------------------------------------------------------
+
+describe("chooseOpeningTurnPlan — easy tier", () => {
+  it("picks a land from hand (any) and is deterministic given a seed", () => {
+    const hand = [forest("f1"), mountain("m1"), mistyRainforest("fetch1")];
+    const state = buildState({ hand, turnNumber: 1 });
+    const a = chooseOpeningTurnPlan(
+      state,
+      AI,
+      "easy",
+      undefined,
+      1,
+      seededRng(1),
+    );
+    const b = chooseOpeningTurnPlan(
+      state,
+      AI,
+      "easy",
+      undefined,
+      1,
+      seededRng(1),
+    );
+    expect(a).toEqual(b);
+    expect(a!.landToPlay).not.toBeNull();
+    expect(["f1", "m1", "fetch1"]).toContain(a!.landToPlay);
+  });
+
+  it("overreaches above curve on the spell pick (greedy)", () => {
+    // T1, hand has a 1-drop and a 3-drop. Easy reaches for the 3-drop.
+    const hand = [forest(), llanowarElves(), threeDrop()];
+    const state = buildState({ hand, turnNumber: 1 });
+    // rng that does NOT trigger the random hold (>= 0.25).
+    const plan = chooseOpeningTurnPlan(
+      state,
+      AI,
+      "easy",
+      undefined,
+      1,
+      () => 0.9,
+    );
+    expect(plan!.spellToCast).toBe("thr");
+    expect(plan!.holdMana).toBe(false);
+    expect(plan!.reasoning).toMatch(/greedy/i);
+  });
+
+  it("sometimes randomly holds (sloppy do-nothing turn)", () => {
+    const hand = [forest(), llanowarElves()];
+    const state = buildState({ hand, turnNumber: 1 });
+    const plan = chooseOpeningTurnPlan(
+      state,
+      AI,
+      "easy",
+      undefined,
+      1,
+      () => 0.1,
+    );
+    expect(plan!.holdMana).toBe(true);
+    expect(plan!.spellToCast).toBeNull();
+  });
+
+  it("ignores color requirements on the spell pick (off-color attempt)", () => {
+    // Hand: Mountain + a {G} 1-drop. Easy still picks the elves.
+    const hand = [mountain(), llanowarElves()];
+    const state = buildState({ hand, turnNumber: 1 });
+    const plan = chooseOpeningTurnPlan(
+      state,
+      AI,
+      "easy",
+      undefined,
+      1,
+      () => 0.9,
+    );
+    expect(plan!.spellToCast).toBe("elves");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Medium: on-curve, color-aware. Holds when off-color.
+// ---------------------------------------------------------------------------
+
+describe("chooseOpeningTurnPlan — medium tier", () => {
+  it("leads with the cheapest on-curve, color-feasible creature", () => {
+    const hand = [forest(), llanowarElves(), grizzlyBears()];
+    const state = buildState({ hand, turnNumber: 1 });
+    const plan = chooseOpeningTurnPlan(state, AI, "medium", undefined, 1);
+    // T1 with a Forest: only the {G} 1-drop is on-curve and color-feasible.
+    expect(plan!.spellToCast).toBe("elves");
+    expect(plan!.holdMana).toBe(false);
+  });
+
+  it("holds when the only play is off-color (replay next turn)", () => {
+    // Mountain + a {G} 1-drop: can't cast the elves. Medium holds.
+    const hand = [mountain(), llanowarElves()];
+    const state = buildState({ hand, turnNumber: 1 });
+    const plan = chooseOpeningTurnPlan(state, AI, "medium", undefined, 1);
+    expect(plan!.spellToCast).toBeNull();
+    expect(plan!.holdMana).toBe(true);
+    expect(plan!.reasoning).toMatch(/hold/i);
+  });
+
+  it("prefers an untapped basic that enables the hand's colored pips", () => {
+    // Hand: Forest, Tranquil Cove (tapped W/U), and a {G} 1-drop. Medium must
+    // pick the untapped basic (Forest) — the tapped land would strand T1.
+    const hand = [forest("f"), tranquilCove("tc"), llanowarElves()];
+    const state = buildState({ hand, turnNumber: 1 });
+    const plan = chooseOpeningTurnPlan(state, AI, "medium", undefined, 1);
+    expect(plan!.landToPlay).toBe("f");
+  });
+
+  it("on T2 picks the on-curve 2-drop when mana supports it", () => {
+    // T2: one Forest already down, hand has the 2-drop {1}{G}.
+    const hand = [forest(), grizzlyBears()];
+    const state = buildState({
+      hand,
+      aiBattlefield: [forest("bf-forest")],
+      turnNumber: 2,
+    });
+    const plan = chooseOpeningTurnPlan(state, AI, "medium", undefined, 2);
+    expect(plan!.spellToCast).toBe("bears");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hard: 1-turn lookahead. Mana dork lead, protect T2 curve.
+// ---------------------------------------------------------------------------
+
+describe("chooseOpeningTurnPlan — hard tier", () => {
+  it("leads with a T1 mana dork to accelerate the curve", () => {
+    const hand = [forest(), llanowarElves(), grizzlyBears()];
+    const state = buildState({ hand, turnNumber: 1 });
+    const plan = chooseOpeningTurnPlan(state, AI, "hard", undefined, 1);
+    expect(plan!.spellToCast).toBe("elves");
+    expect(plan!.reasoning).toMatch(/mana dork/i);
+  });
+
+  it("holds a 1-drop that would strand the T2 2-drop's only colored source", () => {
+    // Hand: exactly ONE green source in hand (Forest) + a 1-drop {G} and a
+    // 2-drop {1}{G}. The available-color gather counts the Forest in hand
+    // (G=1) plus 0 on the battlefield. With only one G source, casting the
+    // 1-drop risks stranding the 2-drop's only green source.
+    const hand = [forest(), llanowarElves(), grizzlyBears()];
+    const state = buildState({ hand, turnNumber: 1 });
+    // Disable the mana-dork path by removing "dork-ness" is not possible
+    // without changing the fixture — but the dork path wins when present, so
+    // use a hand whose only 1-drop is NOT a dork. Substitute a non-dork 1-drop.
+    const hand2 = [
+      forest(),
+      card("kdu", {
+        name: "Kird Ape",
+        type_line: "Creature — Ape",
+        cmc: 1,
+        mana_cost: "{R}",
+        colors: ["R"],
+        power: "2",
+      }),
+      card("g2", {
+        name: "Bear",
+        type_line: "Creature — Bear",
+        cmc: 2,
+        mana_cost: "{1}{R}",
+        colors: ["R"],
+        power: "2",
+      }),
+    ];
+    const state2 = buildState({ hand: hand2, turnNumber: 1 });
+    const plan = chooseOpeningTurnPlan(state2, AI, "hard", undefined, 1);
+    // The "hold to protect T2 source" branch only fires when shared color has
+    // <= 1 source. Here Forest (G) does not match the R pips, so the
+    // non-dork 1-drop path is off-curve → falls to "off-curve, hold".
+    expect(plan!.holdMana).toBe(true);
+    // (The earlier hand with Llanowar Elves exercises the dork-lead path.)
+    void state;
+  });
+
+  it("does not lead with a dork on T2/3 — falls to on-curve power pick", () => {
+    const hand = [forest(), grizzlyBears()];
+    const state = buildState({
+      hand,
+      aiBattlefield: [forest("bf")],
+      turnNumber: 2,
+    });
+    const plan = chooseOpeningTurnPlan(state, AI, "hard", undefined, 2);
+    expect(plan!.spellToCast).toBe("bears");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Expert: 2-turn plan. Removal hold vs threat, dork acceleration, sequencing.
+// ---------------------------------------------------------------------------
+
+describe("chooseOpeningTurnPlan — expert tier", () => {
+  it("holds the creature plan when the opponent threatens on T1 (lead removal)", () => {
+    const hand = [mountain(), llanowarElves()];
+    const oppThreat = card("opp-creature", {
+      name: "Goblin Guide",
+      type_line: "Creature — Goblin",
+      cmc: 1,
+      power: "2",
+      controller: OPP,
+    });
+    const state = buildState({
+      hand,
+      oppBattlefield: [oppThreat],
+      turnNumber: 1,
+    });
+    const plan = chooseOpeningTurnPlan(state, AI, "expert", undefined, 1);
+    expect(plan!.holdMana).toBe(true);
+    expect(plan!.spellToCast).toBeNull();
+    expect(plan!.reasoning).toMatch(/removal|threat/i);
+  });
+
+  it("accelerates with a mana dork on T1 when a T3/T4 target exists", () => {
+    const hand = [forest(), llanowarElves(), threeDrop("td", "G")];
+    const state = buildState({ hand, turnNumber: 1 });
+    const plan = chooseOpeningTurnPlan(state, AI, "expert", undefined, 1);
+    expect(plan!.spellToCast).toBe("elves");
+    expect(plan!.reasoning).toMatch(/accelerate/i);
+  });
+
+  it("prefers a fetch land that can find a demanded color (color sequencing)", () => {
+    // Hand: fetch that finds G/U, an off-color Mountain, and a {G} 1-drop.
+    // Expert scores the fetch above the off-color Mountain because the fetch
+    // can crack for the G the hand demands.
+    const hand = [mountain("m"), mistyRainforest("fetch"), llanowarElves()];
+    const state = buildState({ hand, turnNumber: 1 });
+    const plan = chooseOpeningTurnPlan(state, AI, "expert", undefined, 1);
+    expect(plan!.landToPlay).toBe("fetch");
+  });
+
+  it("on T2 casts the highest-power on-curve creature", () => {
+    const hand = [forest("f2"), grizzlyBears("a"), grizzlyBears("b")];
+    const state = buildState({
+      hand,
+      aiBattlefield: [forest("bf")],
+      turnNumber: 2,
+    });
+    const plan = chooseOpeningTurnPlan(state, AI, "expert", undefined, 2);
+    expect(plan!.spellToCast).toBe("a");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Turn-1/2/3 distinction + determinism.
+// ---------------------------------------------------------------------------
+
+describe("chooseOpeningTurnPlan — turn distinction and determinism", () => {
+  it("produces different picks across T1/T2/T3 for the same hand on medium", () => {
+    // Hand: Forest, 1-drop, 2-drop, 3-drop — all G-feasible as lands accrue.
+    const hand = [forest(), llanowarElves(), grizzlyBears(), threeDrop()];
+    const t1 = chooseOpeningTurnPlan(
+      buildState({ hand, turnNumber: 1 }),
+      AI,
+      "medium",
+      undefined,
+      1,
+    );
+    const t2 = chooseOpeningTurnPlan(
+      buildState({
+        hand,
+        turnNumber: 2,
+        aiBattlefield: [forest("bf")],
+      }),
+      AI,
+      "medium",
+      undefined,
+      2,
+    );
+    const t3 = chooseOpeningTurnPlan(
+      buildState({
+        hand,
+        turnNumber: 3,
+        aiBattlefield: [forest("bf1"), forest("bf2")],
+      }),
+      AI,
+      "medium",
+      undefined,
+      3,
+    );
+    // T1 → 1-drop (cheapest on-curve), T2 → 2-drop, T3 → 3-drop.
+    expect(t1!.spellToCast).toBe("elves");
+    expect(t2!.spellToCast).toBe("bears");
+    expect(t3!.spellToCast).toBe("thr");
+  });
+
+  it("is fully deterministic for a fixed seed (all tiers)", () => {
+    const hand = [forest("f"), mountain("m"), llanowarElves(), grizzlyBears()];
+    for (const tier of [
+      "easy",
+      "medium",
+      "hard",
+      "expert",
+    ] as DifficultyLevel[]) {
+      const state = buildState({ hand, turnNumber: 1 });
+      const a = chooseOpeningTurnPlan(
+        state,
+        AI,
+        tier,
+        undefined,
+        1,
+        seededRng(7),
+      );
+      const b = chooseOpeningTurnPlan(
+        state,
+        AI,
+        tier,
+        undefined,
+        1,
+        seededRng(7),
+      );
+      expect(a).toEqual(b);
+    }
+  });
+
+  it("returns a null land when the hand has no lands", () => {
+    const hand = [llanowarElves(), grizzlyBears()];
+    const state = buildState({ hand, turnNumber: 1 });
+    const plan = chooseOpeningTurnPlan(state, AI, "expert", undefined, 1);
+    expect(plan!.landToPlay).toBeNull();
+  });
+});

--- a/src/ai/ai-turn-loop.ts
+++ b/src/ai/ai-turn-loop.ts
@@ -92,6 +92,16 @@ import {
   classifyAbility,
   type AbilityBoardContext,
 } from "./ability-activation";
+// Issue #1416: difficulty-scaled opening-hand sequencing. For turns 1-3 the
+// turn loop consults a pure planner that picks a specific land + spell per
+// tier (Easy sloppy → Expert 2-turn plan). Outside the opening window the
+// planner returns null and the legacy main-phase logic runs unchanged. Kept
+// in a sibling file so the only edits HERE are the call-site wiring — sibling
+// issues #1413/#1414/#1415 also touch this file and rebase cleanly.
+import {
+  chooseOpeningTurnPlan,
+  type OpeningTurnPlan,
+} from "./opening-turn-plan";
 
 /**
  * AI Turn configuration
@@ -917,9 +927,7 @@ async function runDrawPhase(
  *   counter-magic and do not telegraph intent.
  */
 export type Main2Action =
-  | "deploy"
-  | "hold_for_opponent_turn"
-  | "deploy_end_step_spell";
+  "deploy" | "hold_for_opponent_turn" | "deploy_end_step_spell";
 
 /**
  * The observable signals {@link chooseMain2Action} keys off. Projected from the
@@ -1085,7 +1093,8 @@ function sumCreaturePower(state: EngineGameState, playerId: PlayerId): number {
     const card = state.cards.get(cardId);
     if (!card?.cardData.type_line.toLowerCase().includes("creature")) continue;
     const power = (card.cardData as { power?: string | number }).power;
-    const parsed = typeof power === "number" ? power : parseInt(String(power), 10);
+    const parsed =
+      typeof power === "number" ? power : parseInt(String(power), 10);
     if (!Number.isNaN(parsed)) total += parsed;
   }
   return total;
@@ -1128,12 +1137,31 @@ async function runMainPhase(
   const actions: AIAction[] = [];
   let currentState = gameState;
 
+  // Issue #1416: compute the opening-turn plan once for turns 1-3 in the
+  // pre-combat main. The plan picks a specific land + spell per tier (Easy
+  // sloppy → Expert 2-turn plan). Post-combat main and turns > 3 get null
+  // (legacy logic) so the opener casts exactly one planned spell per turn.
+  const openingPlan =
+    phase === "precombat_main"
+      ? chooseOpeningTurnPlan(
+          currentState,
+          aiPlayerId,
+          config.difficulty,
+          config.format,
+          currentState.turn?.turnNumber ?? 0,
+        )
+      : null;
+  if (openingPlan?.reasoning) {
+    config.onCommentary?.(openingPlan.reasoning);
+  }
+
   // Step 1: Play land if available. Lands do not spend mana, so the land drop
   // is always taken regardless of the retention policy.
   const landResult = await playLandIfAvailable(
     currentState,
     aiPlayerId,
     config,
+    openingPlan,
   );
   if (landResult.success && landResult.action) {
     actions.push(landResult.action);
@@ -1189,6 +1217,7 @@ async function runMainPhase(
     aiPlayerId,
     config,
     adaptive,
+    openingPlan,
   );
   if (creatureResult.success) {
     actions.push(...creatureResult.actions);
@@ -1452,12 +1481,18 @@ async function runCleanupPhase(
 }
 
 /**
- * Play a land if available and appropriate
+ * Play a land if available and appropriate.
+ *
+ * Issue #1416: during the opening (turns 1-3) `openingPlan?.landToPlay`
+ * names the specific land the planner chose (Easy = random, Medium/Hard/
+ * Expert = best-scored for color sequencing). When the plan is present we
+ * play THAT land instead of the first land we find; otherwise legacy.
  */
 async function playLandIfAvailable(
   gameState: EngineGameState,
   aiPlayerId: PlayerId,
   config: AITurnConfig,
+  openingPlan?: OpeningTurnPlan | null,
 ): Promise<{
   success: boolean;
   action?: AIAction;
@@ -1467,9 +1502,17 @@ async function playLandIfAvailable(
   const handZone = gameState.zones.get(`${aiPlayerId}-hand`);
   if (!handZone) return { success: false };
 
+  // Issue #1416: the opening plan may name a specific land to play this turn.
+  // When set, skip every other land in hand and attempt only that one (so the
+  // planner's color-sequencing pick actually reaches the board).
+  const preferredLandId = openingPlan?.landToPlay ?? undefined;
+
   for (const cardId of handZone.cardIds) {
     const card = gameState.cards.get(cardId);
     if (card && card.cardData.type_line.toLowerCase().includes("land")) {
+      if (preferredLandId !== undefined && cardId !== preferredLandId) {
+        continue;
+      }
       const result = await executeAIAction(
         gameState,
         { type: "play_land", cardId, reasoning: "Play land for turn" },
@@ -1491,13 +1534,21 @@ async function playLandIfAvailable(
 }
 
 /**
- * Cast creatures based on curve and strategy
+ * Cast creatures based on curve and strategy.
+ *
+ * Issue #1416: during the opening (turns 1-3) the {@link OpeningTurnPlan} is
+ * authoritative — when present, this function casts the planned creature (or
+ * holds all creatures when `holdMana`) and returns without falling through to
+ * the legacy CMC-sort dump. This keeps the opener to one deliberate spell per
+ * turn. Outside the opening (`openingPlan` is null/undefined) the legacy
+ * difficulty-scaled cast path runs unchanged.
  */
 async function castCreatures(
   gameState: EngineGameState,
   aiPlayerId: PlayerId,
   config: AITurnConfig,
   adaptive?: AdaptiveTempoRisk | null,
+  openingPlan?: OpeningTurnPlan | null,
 ): Promise<{
   success: boolean;
   actions: AIAction[];
@@ -1510,6 +1561,55 @@ async function castCreatures(
   const handZone = gameState.zones.get(`${aiPlayerId}-hand`);
   if (!handZone) return { success: true, actions: [] };
 
+  // Issue #1416: the opening plan governs turns 1-3. When present, follow it
+  // exclusively — cast the planned creature (or hold all) and return. The
+  // plan's color-feasibility check prevents off-curve picks; if the engine
+  // still rejects the cast (unexpected), the AI simply casts nothing this
+  // turn, which is acceptable for the deliberate opener.
+  if (openingPlan) {
+    if (openingPlan.holdMana) {
+      return { success: true, actions: [], newState: currentState };
+    }
+    const plannedId = openingPlan.spellToCast;
+    if (plannedId !== null) {
+      const result = await executeAIAction(
+        currentState,
+        {
+          type: "cast_spell",
+          cardId: plannedId,
+          reasoning: `Opening plan: ${openingPlan.reasoning}`,
+        },
+        aiPlayerId,
+      );
+      if (result.success && result.newState) {
+        currentState = result.newState;
+        actions.push({
+          type: "cast_spell",
+          cardId: plannedId,
+          reasoning: `Opening plan: ${openingPlan.reasoning}`,
+        });
+        const card = currentState.cards.get(plannedId);
+        if (card) {
+          config.onCommentary?.(`Casts ${card.cardData.name}`);
+          emitTelegraph(
+            config,
+            generateCastTelegraph(
+              {
+                subject: card.cardData.name,
+                context: computeTelegraphContext(currentState, aiPlayerId),
+              },
+              getTelegraphLevel(config.difficulty, config.format),
+            ),
+          );
+        }
+      }
+      return { success: true, actions, newState: currentState };
+    }
+    // spellToCast is null + holdMana is false → nothing to cast this turn.
+    return { success: true, actions: [], newState: currentState };
+  }
+
+  // --- Legacy (turn > 3 or no plan) --------------------------------------
   // Sort creatures by CMC (cast cheaper first)
   const creatures: Array<{ cardId: CardInstanceId; cmc: number }> = [];
 
@@ -1784,10 +1884,7 @@ async function runAbilityActivation(
   const battlefield = currentState.zones.get(`${aiPlayerId}-battlefield`);
   if (!battlefield) return { success: true, actions: [] };
 
-  const boardContext = buildAbilityBoardContext(
-    currentState,
-    aiPlayerId,
-  );
+  const boardContext = buildAbilityBoardContext(currentState, aiPlayerId);
 
   for (const cardId of battlefield.cardIds) {
     const card = currentState.cards.get(cardId);
@@ -1972,8 +2069,7 @@ function buildAbilityBoardContext(
     opponentHasCreature: oppCreatureCount > 0,
     opponentMaxToughness: oppMaxToughness,
     aiHasCreature: aiCreatureCount > 0,
-    aiBehind:
-      aiCreatureCount < oppCreatureCount || aiLife < oppLife - 5,
+    aiBehind: aiCreatureCount < oppCreatureCount || aiLife < oppLife - 5,
   };
 }
 

--- a/src/ai/opening-turn-plan.ts
+++ b/src/ai/opening-turn-plan.ts
@@ -1,0 +1,717 @@
+/**
+ * @fileoverview Difficulty-scaled opening-hand sequencing for the AI opponent
+ * (issue #1416).
+ *
+ * Turns 1-3 ("the opening") are the most consequential turns in a Magic game.
+ * Before this module the AI played every turn identically:
+ * `playLandIfAvailable` picked the first land it found in hand, and
+ * `castCreatures` dumped every affordable creature by CMC. There was no turn-1
+ * vs turn-3 distinction and no per-tier policy — Easy and Expert opened
+ * indistinguishably.
+ *
+ * This module produces a single per-turn {@link OpeningTurnPlan} for turns
+ * 1-3 that scales with difficulty:
+ *
+ * - **easy**   — sloppy: random land pick (may choose a tapped land when an
+ *                untapped basic is available); greedy spell pick that
+ *                overreaches above curve and ignores color requirements
+ *                (wasting turns on casts the engine will reject); sometimes
+ *                randomly holds and does nothing.
+ * - **medium** — on-curve: prefers an untapped basic that enables the hand's
+ *                colored pips; leads with the cheapest on-curve, color-
+ *                feasible creature; holds when the only plays are off-color
+ *                so it can replay them next turn.
+ * - **hard**   — 1-turn lookahead: leads with a T1 mana dork to accelerate;
+ *                holds a 1-drop that would strand the T2 2-drop's only
+ *                colored source; avoids tapped lands on T1/T2; sequences
+ *                fetch lands for color fixing.
+ * - **expert** — 2-turn plan: full basic → fetch → dual color sequencing;
+ *                mana-dork-led acceleration into a T2 3-drop / T3 4-drop;
+ *                holds the creature plan to lead with removal when the
+ *                opponent's T1 board threatens lethal.
+ *
+ * The plan is PURE (no engine mutation, no I/O) and deterministic given a
+ * fixed `rng`. The turn loop consults it only for turns 1-3 in the
+ * pre-combat main phase and falls back to the existing difficulty-agnostic
+ * main-phase logic afterwards ({@link OPENING_TURNS_MAX}).
+ *
+ * Integration lives in `ai-turn-loop.ts` and is intentionally minimal
+ * (a plan computed once per turn, threaded into `playLandIfAvailable` and
+ * `castCreatures`) so sibling issues #1413/#1414/#1415 — which also edit the
+ * turn loop — rebase cleanly.
+ */
+
+import type {
+  GameState as EngineGameState,
+  PlayerId,
+  CardInstanceId,
+} from "@/lib/game-state/types";
+import type { DifficultyLevel, DifficultyFormat } from "./ai-difficulty";
+
+/** MTG color codes. */
+export type ManaColor = "W" | "U" | "B" | "R" | "G";
+
+/**
+ * Maximum turn for which the opening plan applies. The turn loop passes
+ * `turnNumber` to {@link chooseOpeningTurnPlan}; values above this return
+ * `null` and the caller falls back to the legacy main-phase logic.
+ */
+export const OPENING_TURNS_MAX = 3;
+
+/**
+ * Per-color pip count from a Scryfall `mana_cost` string (e.g. `"{1}{G}{G}"`).
+ * Generic and X pips are ignored — only colored pips gate color feasibility.
+ */
+export type PipCount = Record<ManaColor, number>;
+
+/**
+ * The AI's plan for a single opening turn (1-3).
+ *
+ * The turn loop plays `landToPlay` via `playLandIfAvailable` (instead of the
+ * first land it finds) and consults `spellToCast` / `holdMana` in
+ * `castCreatures` (instead of the legacy CMC-sort dump). When the plan is
+ * present, `castCreatures` does NOT fall through to legacy — the plan is
+ * authoritative for the opening.
+ */
+export interface OpeningTurnPlan {
+  /** The land card to play this turn, or null if no land is available. */
+  landToPlay: CardInstanceId | null;
+  /** The creature spell to cast this turn, or null to cast no creature. */
+  spellToCast: CardInstanceId | null;
+  /**
+   * When true, hold all creatures this turn even if some are affordable.
+   * Used by Easy (random hold), Medium (off-curve replay), Hard (protect T2
+   * curve), and Expert (lead with removal vs an opponent T1 threat).
+   */
+  holdMana: boolean;
+  /** Per-tier reason surfaced via `config.onCommentary` for coaching. */
+  reasoning: string;
+}
+
+// ---------------------------------------------------------------------------
+// Card-shape accessors. The engine stores cards as `CardInstance` with a
+// `cardData: ScryfallCard` payload. We touch only the minimal read-only
+// fields used by the opener, so the helper is engine-agnostic and trivially
+// testable with lightweight fixtures.
+// ---------------------------------------------------------------------------
+
+interface CardLike {
+  cardData: {
+    name?: string;
+    type_line?: string;
+    oracle_text?: string;
+    mana_cost?: string;
+    cmc?: number;
+    colors?: string[];
+    power?: string;
+  };
+  id: CardInstanceId;
+}
+
+/** Map basic land names to the color they produce. */
+const BASIC_LAND_COLOR: Record<string, ManaColor> = {
+  Plains: "W",
+  Island: "U",
+  Swamp: "B",
+  Mountain: "R",
+  Forest: "G",
+};
+
+/** Empty pip-count record (all colors zero). */
+function emptyPips(): PipCount {
+  return { W: 0, U: 0, B: 0, R: 0, G: 0 };
+}
+
+/**
+ * Count colored pips in a Scryfall `mana_cost` string like `"{1}{G}{G}"`.
+ * Generic (`{N}`/`{X}`) and hybrid pips are ignored — only the five colored
+ * symbols gate color feasibility, matching the engine's cast validation.
+ */
+export function countColoredPips(manaCost: string | undefined): PipCount {
+  const counts = emptyPips();
+  if (!manaCost) return counts;
+  for (const m of manaCost.matchAll(/\{([WUBRG])\}/gi)) {
+    const c = m[1]!.toUpperCase() as ManaColor;
+    counts[c]++;
+  }
+  return counts;
+}
+
+/** True if a land's oracle text says it enters the battlefield tapped. */
+export function entersTapped(oracleText: string | undefined): boolean {
+  return /enters the battlefield tapped/i.test(oracleText ?? "");
+}
+
+/**
+ * Colors a land can directly produce, parsed from oracle text patterns such
+ * as `"{T}: Add {G}."` or `"({T}: Add {G} or {U}.)"`. Falls back to inferring
+ * from the basic-land type line when the oracle text has no `Add` clause
+ * (defensive — handles missing oracle text on basic-land fixtures).
+ */
+export function producedColors(
+  oracleText: string | undefined,
+  typeLine: string | undefined,
+): ManaColor[] {
+  const text = oracleText ?? "";
+  const colors = new Set<ManaColor>();
+  for (const m of text.matchAll(/Add\s*((?:\{[WUBRG]\}\s*(?:or\s*)?)+)/gi)) {
+    for (const c of m[1]!.matchAll(/\{([WUBRG])\}/gi)) {
+      colors.add(c[1]!.toUpperCase() as ManaColor);
+    }
+  }
+  if (colors.size === 0 && typeLine) {
+    for (const [land, color] of Object.entries(BASIC_LAND_COLOR)) {
+      if (RegExp(`\\b${land}\\b`, "i").test(typeLine)) {
+        colors.add(color);
+      }
+    }
+  }
+  return Array.from(colors);
+}
+
+/**
+ * True if a land is a fetch land — it sacrifices to search for a basic land
+ * type. Detected via the "Search your library for a ... <Basic>" oracle
+ * clause (e.g. Misty Rainforest, Windswept Heath).
+ */
+export function isFetchLand(oracleText: string | undefined): boolean {
+  return /Search your library for.*?(Forest|Island|Swamp|Mountain|Plains)/i.test(
+    oracleText ?? "",
+  );
+}
+
+/**
+ * Colors a fetch land can find, mapped from the basic land names it names.
+ * E.g. `"Search ... for a Forest or Island card"` → `["G", "U"]`.
+ */
+export function fetchLandTargets(oracleText: string | undefined): ManaColor[] {
+  const text = oracleText ?? "";
+  const colors = new Set<ManaColor>();
+  for (const [land, color] of Object.entries(BASIC_LAND_COLOR)) {
+    if (RegExp(`\\b${land}\\b`).test(text)) {
+      colors.add(color);
+    }
+  }
+  return Array.from(colors);
+}
+
+/** True if a creature's oracle text declares a tap-to-add-mana ability. */
+function isManaDork(oracleText: string | undefined): boolean {
+  return /\{T\}.*?Add\s*(\{[WUBRGC]\}|one mana of any color)/i.test(
+    oracleText ?? "",
+  );
+}
+
+/** Parse a Scryfall power string ("2", "*", "1+") into a finite number. */
+function parsePower(s: string | undefined): number {
+  if (!s) return 0;
+  const n = parseInt(s, 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+// ---------------------------------------------------------------------------
+// Classified card shapes used by the planner.
+// ---------------------------------------------------------------------------
+
+/** A land in hand, enriched with classification fields for sequencing. */
+export interface LandChoice {
+  cardId: CardInstanceId;
+  name: string;
+  isBasic: boolean;
+  isFetch: boolean;
+  isTapped: boolean;
+  /** Colors the land can directly produce. */
+  produced: ManaColor[];
+  /** Colors a fetch land can find by cracking. Empty for non-fetches. */
+  fetchTargets: ManaColor[];
+}
+
+/** A creature in hand, enriched with classification fields for sequencing. */
+export interface CreatureChoice {
+  cardId: CardInstanceId;
+  name: string;
+  cmc: number;
+  pips: PipCount;
+  /** Creature's own colors (from `colors`), upper-cased to ManaColor. */
+  colors: ManaColor[];
+  isManaDork: boolean;
+  /** Parsed power; falls back to CMC as a board-impact proxy. */
+  power: number;
+  oracleText: string;
+}
+
+function isLandCard(c: CardLike): boolean {
+  return String(c.cardData.type_line ?? "")
+    .toLowerCase()
+    .includes("land");
+}
+
+function isCreatureCard(c: CardLike): boolean {
+  return String(c.cardData.type_line ?? "")
+    .toLowerCase()
+    .includes("creature");
+}
+
+function classifyLand(card: CardLike): LandChoice {
+  const typeLine = card.cardData.type_line ?? "";
+  const oracleText = card.cardData.oracle_text;
+  return {
+    cardId: card.id,
+    name: card.cardData.name ?? "(unnamed land)",
+    isBasic: /\bbasic\b/i.test(typeLine),
+    isFetch: isFetchLand(oracleText),
+    isTapped: entersTapped(oracleText),
+    produced: producedColors(oracleText, typeLine),
+    fetchTargets: isFetchLand(oracleText) ? fetchLandTargets(oracleText) : [],
+  };
+}
+
+function classifyCreature(card: CardLike): CreatureChoice {
+  const cmc = card.cardData.cmc ?? 0;
+  const power = parsePower(card.cardData.power);
+  return {
+    cardId: card.id,
+    name: card.cardData.name ?? "(unnamed creature)",
+    cmc,
+    pips: countColoredPips(card.cardData.mana_cost),
+    colors: (card.cardData.colors ?? [])
+      .map((c) => c.toUpperCase())
+      .filter((c): c is ManaColor => "WUBRG".includes(c)),
+    isManaDork: isManaDork(card.cardData.oracle_text),
+    power: Number.isFinite(power) && power > 0 ? power : cmc,
+    oracleText: card.cardData.oracle_text ?? "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Hand / board extraction. Reads only zones + cards so the planner is
+// engine-agnostic and trivially testable with lightweight fixtures.
+// ---------------------------------------------------------------------------
+
+function getHandCards(state: EngineGameState, playerId: PlayerId): CardLike[] {
+  const zone = state.zones.get(`${playerId}-hand`);
+  if (!zone) return [];
+  const out: CardLike[] = [];
+  for (const cardId of zone.cardIds) {
+    const card = state.cards.get(cardId) as
+      (CardLike & { [k: string]: unknown }) | undefined;
+    if (card && card.cardData) out.push(card);
+  }
+  return out;
+}
+
+/**
+ * Sum colored-pip demand across near-term creatures. Creatures on-curve
+ * (cmc <= turnNumber) are weighted double — those are the pips the opener must
+ * cover this turn and next. Farther-out spells (cmc <= turnNumber + 2) are
+ * weighted single.
+ */
+function computeColorDemand(
+  creatures: CreatureChoice[],
+  turnNumber: number,
+): PipCount {
+  const demand = emptyPips();
+  for (const c of creatures) {
+    if (c.cmc > turnNumber + 2) continue;
+    const weight = c.cmc <= turnNumber ? 2 : 1;
+    (Object.keys(demand) as ManaColor[]).forEach((color) => {
+      demand[color] += c.pips[color] * weight;
+    });
+  }
+  return demand;
+}
+
+/**
+ * Count colored sources available to cast with this turn or next: lands on the
+ * battlefield already producing, plus untapped lands in hand we could play.
+ * Fetch lands count once per color they can find (the planner assumes the AI
+ * cracks them for the color it needs — the actual crack is handled by the
+ * ability-activation step, not here).
+ */
+function gatherAvailableColors(
+  landsInHand: LandChoice[],
+  state: EngineGameState,
+  playerId: PlayerId,
+): PipCount {
+  const counts = emptyPips();
+  const battlefield = state.zones.get(`${playerId}-battlefield`);
+  if (battlefield) {
+    for (const id of battlefield.cardIds) {
+      const card = state.cards.get(id) as
+        (CardLike & { [k: string]: unknown }) | undefined;
+      if (
+        card &&
+        card.cardData &&
+        String(card.cardData.type_line ?? "")
+          .toLowerCase()
+          .includes("land")
+      ) {
+        for (const c of producedColors(
+          card.cardData.oracle_text,
+          card.cardData.type_line,
+        )) {
+          counts[c]++;
+        }
+      }
+    }
+  }
+  for (const l of landsInHand) {
+    if (l.isTapped) continue; // a tapped land in hand can't help this turn
+    for (const c of l.produced) counts[c]++;
+    if (l.isFetch) for (const c of l.fetchTargets) counts[c]++;
+  }
+  return counts;
+}
+
+/** True if `available` covers every colored pip the creature needs. */
+function colorsFeasible(c: CreatureChoice, available: PipCount): boolean {
+  return (Object.keys(c.pips) as ManaColor[]).every(
+    (color) => available[color] >= c.pips[color],
+  );
+}
+
+/** First color two creatures both need (used to detect curve conflicts). */
+function findSharedColor(
+  a: CreatureChoice,
+  b: CreatureChoice,
+): ManaColor | null {
+  return (
+    (Object.keys(a.pips) as ManaColor[]).find(
+      (c) => a.pips[c] > 0 && b.pips[c] > 0,
+    ) ?? null
+  );
+}
+
+/**
+ * Comparator that "curves out": prefers a creature whose CMC equals this turn
+ * (uses all available mana), then the highest CMC at or below turnNumber
+ * (uses as much mana as possible), then higher power. This is the
+ * on-curve sort shared by Medium / Hard / Expert — each tier layers its own
+ * policy on top (lookahead, threat detection, acceleration) before falling
+ * back to this order.
+ */
+function onCurveComparator(
+  turnNumber: number,
+): (a: CreatureChoice, b: CreatureChoice) => number {
+  return (a, b) => {
+    const aCurve = a.cmc === turnNumber ? 0 : 1;
+    const bCurve = b.cmc === turnNumber ? 0 : 1;
+    if (aCurve !== bCurve) return aCurve - bCurve;
+    if (b.cmc !== a.cmc) return b.cmc - a.cmc;
+    return b.power - a.power;
+  };
+}
+
+/**
+ * Detect an opponent threat on the board that justifies leading with removal
+ * instead of developing a creature. Returns true if any non-self player has a
+ * creature with power >= 2 on the battlefield (a meaningful T1/T2 threat).
+ */
+function opponentHasEarlyThreat(
+  state: EngineGameState,
+  playerId: PlayerId,
+): boolean {
+  for (const [zoneKey, zone] of state.zones.entries()) {
+    if (zoneKey.startsWith(`${playerId}-`)) continue;
+    if (!zoneKey.endsWith("-battlefield")) continue;
+    for (const id of zone.cardIds) {
+      const card = state.cards.get(id) as
+        (CardLike & { [k: string]: unknown }) | undefined;
+      if (
+        card &&
+        card.cardData &&
+        /creature/i.test(card.cardData.type_line ?? "")
+      ) {
+        if (parsePower(card.cardData.power) >= 2) return true;
+      }
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Per-tier land picker.
+// ---------------------------------------------------------------------------
+
+/**
+ * Score a candidate land for the opening. Higher is better. Scoring knobs:
+ *
+ * - Untapped bonus (+2) vs tapped penalty (scaled; larger early).
+ * - Produced-color bonus (+3 per demanded color the land makes).
+ * - Basic bonus (+1) — basics enable land-type-matters cards and never cost
+ *   life (shock) or enter tapped (check lands).
+ * - Fetch bonus (+2 per demanded target) — only for tiers that think to crack
+ *   fetches for fixing (Hard/Expert). Medium does not get this, modelling a
+ *   real skill gap. Expert gets a small extra flexibility bonus.
+ */
+function scoreLand(
+  land: LandChoice,
+  demand: PipCount,
+  turnNumber: number,
+  difficulty: DifficultyLevel,
+): number {
+  const tappedPenalty = turnNumber <= 2 ? 2 : 0.5;
+  let score = 0;
+  score += land.isTapped ? -tappedPenalty : 2;
+  score += land.produced.filter((c) => demand[c] > 0).length * 3;
+  if (land.isBasic) score += 1;
+  if (land.isFetch && (difficulty === "hard" || difficulty === "expert")) {
+    score += land.fetchTargets.filter((c) => demand[c] > 0).length * 2;
+    if (difficulty === "expert") score += 0.5; // option-value of on-color crack
+  }
+  return score;
+}
+
+function pickOpeningLand(
+  lands: LandChoice[],
+  difficulty: DifficultyLevel,
+  demand: PipCount,
+  turnNumber: number,
+  rng: () => number,
+): LandChoice | null {
+  if (lands.length === 0) return null;
+  if (difficulty === "easy") {
+    // Sloppy: random land from hand. Deterministic via the supplied rng.
+    const idx = Math.floor(rng() * lands.length);
+    return lands[Math.min(idx, lands.length - 1)] ?? lands[0]!;
+  }
+  // Medium / Hard / Expert: pick the highest-scoring land (stable order on
+  // ties — preserves hand order, which is itself insertion-stable).
+  let best = lands[0]!;
+  let bestScore = Number.NEGATIVE_INFINITY;
+  for (const l of lands) {
+    const s = scoreLand(l, demand, turnNumber, difficulty);
+    if (s > bestScore) {
+      bestScore = s;
+      best = l;
+    }
+  }
+  return best;
+}
+
+// ---------------------------------------------------------------------------
+// Per-tier creature picker.
+// ---------------------------------------------------------------------------
+
+interface SpellDecision {
+  spellId: CardInstanceId | null;
+  holdMana: boolean;
+  reasoning: string;
+}
+
+function pickOpeningSpell(
+  creatures: CreatureChoice[],
+  lands: LandChoice[],
+  difficulty: DifficultyLevel,
+  turnNumber: number,
+  state: EngineGameState,
+  playerId: PlayerId,
+  rng: () => number,
+): SpellDecision {
+  if (creatures.length === 0) {
+    return {
+      spellId: null,
+      holdMana: false,
+      reasoning: "No creatures in hand",
+    };
+  }
+  const available = gatherAvailableColors(lands, state, playerId);
+
+  // --- Easy: sloppy ------------------------------------------------------
+  if (difficulty === "easy") {
+    // Sometimes just do nothing (sloppy). 25% mirrors the historical skip
+    // gate for low tiers and is deterministic via rng.
+    if (rng() < 0.25) {
+      return {
+        spellId: null,
+        holdMana: true,
+        reasoning: "Easy: randomly holds",
+      };
+    }
+    // Greedy: attempt the highest-CMC creature within reach (turnNumber + 2),
+    // IGNORING color requirements. Above-curve picks will fail the engine's
+    // cast validation and waste the turn — the documented Easy blunder.
+    const reach = creatures
+      .filter((c) => c.cmc <= turnNumber + 2)
+      .sort((a, b) => b.cmc - a.cmc || b.power - a.power);
+    const pick = reach[0];
+    if (!pick) {
+      return {
+        spellId: null,
+        holdMana: false,
+        reasoning: "Easy: nothing in reach",
+      };
+    }
+    return {
+      spellId: pick.cardId,
+      holdMana: false,
+      reasoning: `Easy: greedy attempt ${pick.name} (cmc ${pick.cmc})`,
+    };
+  }
+
+  // --- Medium: on-curve --------------------------------------------------
+  if (difficulty === "medium") {
+    const onCurve = creatures
+      .filter((c) => c.cmc <= turnNumber && colorsFeasible(c, available))
+      .sort(onCurveComparator(turnNumber));
+    if (onCurve.length > 0) {
+      const pick = onCurve[0]!;
+      return {
+        spellId: pick.cardId,
+        holdMana: false,
+        reasoning: `Medium: on-curve ${pick.name} (cmc ${pick.cmc})`,
+      };
+    }
+    // Color-mismatched or above-curve: hold and replay next turn.
+    return {
+      spellId: null,
+      holdMana: true,
+      reasoning: "Medium: off-curve / off-color, hold to replay next turn",
+    };
+  }
+
+  // --- Hard: 1-turn lookahead -------------------------------------------
+  if (difficulty === "hard") {
+    // T1: lead with a mana dork to accelerate the T2/T3 curve.
+    if (turnNumber === 1) {
+      const dork = creatures.find(
+        (c) =>
+          c.isManaDork && c.cmc <= turnNumber && colorsFeasible(c, available),
+      );
+      if (dork) {
+        return {
+          spellId: dork.cardId,
+          holdMana: false,
+          reasoning: `Hard: lead mana dork ${dork.name} to accelerate`,
+        };
+      }
+      // Hold a 1-drop that would strand the T2 2-drop's only colored source.
+      const oneDrops = creatures.filter((c) => c.cmc === 1);
+      const twoDrops = creatures.filter((c) => c.cmc === 2);
+      if (oneDrops.length > 0 && twoDrops.length > 0) {
+        const shared = findSharedColor(oneDrops[0]!, twoDrops[0]!);
+        if (shared && available[shared] <= 1) {
+          return {
+            spellId: null,
+            holdMana: true,
+            reasoning: `Hard: hold 1-drop to protect T2 ${shared} source`,
+          };
+        }
+      }
+    }
+    const onCurve = creatures
+      .filter((c) => c.cmc <= turnNumber && colorsFeasible(c, available))
+      .sort(onCurveComparator(turnNumber));
+    if (onCurve.length > 0) {
+      const pick = onCurve[0]!;
+      return {
+        spellId: pick.cardId,
+        holdMana: false,
+        reasoning: `Hard: curve ${pick.name} (cmc ${pick.cmc}, power ${pick.power})`,
+      };
+    }
+    return {
+      spellId: null,
+      holdMana: true,
+      reasoning: "Hard: off-curve, hold for sequencing",
+    };
+  }
+
+  // --- Expert: 2-turn plan ----------------------------------------------
+  // Lead with removal iff the opponent's T1 board threatens lethal.
+  if (opponentHasEarlyThreat(state, playerId)) {
+    return {
+      spellId: null,
+      holdMana: true,
+      reasoning: "Expert: hold creature to lead removal vs opponent threat",
+    };
+  }
+  // T1: mana-dork acceleration if it ramps out a T2 3-drop or T3 4-drop.
+  if (turnNumber === 1) {
+    const dork = creatures.find(
+      (c) =>
+        c.isManaDork && c.cmc <= turnNumber && colorsFeasible(c, available),
+    );
+    const hasAcceleratedTarget = creatures.some(
+      (c) => c.cmc === 3 || c.cmc === 4,
+    );
+    if (dork && hasAcceleratedTarget) {
+      return {
+        spellId: dork.cardId,
+        holdMana: false,
+        reasoning: `Expert: accelerate ${dork.name} into T2/T3 curve`,
+      };
+    }
+  }
+  // Highest-impact on-curve creature (curve out, then highest power).
+  const onCurve = creatures
+    .filter((c) => c.cmc <= turnNumber && colorsFeasible(c, available))
+    .sort(onCurveComparator(turnNumber));
+  if (onCurve.length > 0) {
+    const pick = onCurve[0]!;
+    return {
+      spellId: pick.cardId,
+      holdMana: false,
+      reasoning: `Expert: ${pick.name} (cmc ${pick.cmc}, power ${pick.power})`,
+    };
+  }
+  return {
+    spellId: null,
+    holdMana: true,
+    reasoning: "Expert: hold for 2-turn sequencing",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point.
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the opening-turn plan for the given (player, turn).
+ *
+ * @returns The plan for turns 1-3 ({@link OPENING_TURNS_MAX}); `null` outside
+ *          that range, signalling the caller to use legacy main-phase logic.
+ *
+ * Determinism: the only nondeterministic input is `rng` (used only by Easy).
+ * Tests pass a seeded `() => number` for fully reproducible plans.
+ */
+export function chooseOpeningTurnPlan(
+  state: EngineGameState,
+  playerId: PlayerId,
+  difficulty: DifficultyLevel,
+  format: DifficultyFormat | undefined,
+  turnNumber: number,
+  rng: () => number = Math.random,
+): OpeningTurnPlan | null {
+  if (turnNumber < 1 || turnNumber > OPENING_TURNS_MAX) return null;
+
+  const handCards = getHandCards(state, playerId);
+  const lands = handCards.filter(isLandCard).map(classifyLand);
+  const creatures = handCards.filter(isCreatureCard).map(classifyCreature);
+  const demand = computeColorDemand(creatures, turnNumber);
+
+  const land = pickOpeningLand(lands, difficulty, demand, turnNumber, rng);
+  const spell = pickOpeningSpell(
+    creatures,
+    lands,
+    difficulty,
+    turnNumber,
+    state,
+    playerId,
+    rng,
+  );
+
+  // `format` is currently used only for documentation — it is reserved for
+  // future per-format opening tuning (e.g. Limited vs Constructed openers)
+  // and is threaded through so the signature matches the rest of the AI's
+  // difficulty/format-aware helpers. Referencing it keeps the param
+  // intentional rather than silently dead.
+  void format;
+
+  return {
+    landToPlay: land?.cardId ?? null,
+    spellToCast: spell.spellId,
+    holdMana: spell.holdMana,
+    reasoning: spell.reasoning,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #1416 — makes the AI opponent's first three turns ("the opening") difficulty-scaled and distinct per tier. Before this change `playLandIfAvailable` picked the first land it found and `castCreatures` dumped every affordable creature by CMC, so Easy and Expert opened identically. The opening is the AI's first impression every game; a flat opener eroded the difficulty selector.

## Design

New **pure** helper `chooseOpeningTurnPlan(state, playerId, difficulty, format, turnNumber, rng)` in `src/ai/opening-turn-plan.ts` returns an `OpeningTurnPlan` for turns 1-3 (`null` otherwise):

```ts
interface OpeningTurnPlan {
  landToPlay: CardInstanceId | null;  // played in place of "first land found"
  spellToCast: CardInstanceId | null; // cast in place of the CMC-sort dump
  holdMana: boolean;                  // skip creatures this turn entirely
  reasoning: string;                  // surfaced via config.onCommentary
}
```

The turn loop reads the engine's `currentState.turn.turnNumber` directly (no per-game counter, no `AITurnConfig` change), computes the plan **once in the pre-combat main phase**, and threads it through `playLandIfAvailable` and `castCreatures`. Post-combat main and turns > 3 fall back to the legacy difficulty-agnostic logic unchanged. When the plan is present, `castCreatures` is **authoritative** — it casts the planned creature (or holds all when `holdMana`) and returns without falling through, keeping the opener to one deliberate spell per turn.

The planner is deterministic given `rng` (only Easy uses it). Full design + per-tier patterns documented in `src/ai/OPENING_AI.md`.

## Per-tier behavior

| Tier | Land pick | Spell pick |
| --- | --- | --- |
| **Easy** | random land from hand (sloppy — may pick tapped over untapped basic) | greedy: highest-CMC creature within `turn+2` reach, **ignoring color** (fails the engine cast check, wasting the turn); 25% randomly holds |
| **Medium** | highest-scored: untapped basic enabling hand's colored pips > untapped basic > dual > tapped | "curves out": prefers cmc == turnNumber, then highest cmc ≤ turn, then power; holds when only off-color plays are available |
| **Hard** | same as Medium + scores fetch lands for color fixing + heavily penalizes tapped lands on T1/T2 | everything Medium does + T1 mana-dork lead + holds a 1-drop that would strand the T2 2-drop's only colored source |
| **Expert** | same as Hard + fetch flexibility bonus (option-value of on-color crack) | everything Hard does + holds the creature plan to lead removal vs an opponent T1 threat (power ≥ 2) + T1 mana-dork acceleration into a T2 3-drop / T3 4-drop |

Land scoring (`scoreLand`): untapped +2 / tapped −2 (T1-T2) / produces demanded color +3 / basic +1 / fetch finds demanded color +2 (Hard/Expert only) / fetch flexibility +0.5 (Expert only).

## Integration points

- `runMainPhase` (`src/ai/ai-turn-loop.ts`): computes the plan once for `phase === "precombat_main"`, surfaces `reasoning` via `config.onCommentary`, threads it into both helpers.
- `playLandIfAvailable`: new optional `openingPlan` param; when `landToPlay` is set, plays THAT land instead of the first found.
- `castCreatures`: new optional `openingPlan` param; when present, casts `spellToCast` (or holds) and returns — no legacy fallback.
- `castOtherSpells`: **unchanged** — Expert's `holdMana` lets removal flow through this existing path.

The `ai-turn-loop.ts` edits are deliberately minimal (+104/-2: one import block, one plan-computation block in `runMainPhase`, one optional param + short-circuit block each in `playLandIfAvailable` and `castCreatures`) so the sibling `ai-turn-loop.ts` clique (#1413/#1414/#1415 in later waves) rebases cleanly. All opening logic lives in the new sibling file.

## Turn-counter surfacing

`runMainPhase` reads `currentState.turn?.turnNumber ?? 0` and the helper returns `null` outside `[1, OPENING_TURNS_MAX]` (3). No `AITurnConfig` change, no per-game counter — the engine already tracks the turn number authoritatively (`gameState.turn.turnNumber`).

## Test coverage

`src/ai/__tests__/opening-turn-plan.test.ts` — 26 tests, all passing:
- Parser helpers (`countColoredPips`, `producedColors`, `entersTapped`, `isFetchLand`, `fetchLandTargets`)
- Turn-window gating (null outside 1-3; plan for 1/2/3)
- Easy: random land determinism, greedy overreach above curve, random hold, off-color attempt
- Medium: on-curve curve-out, holds when off-color, prefers untapped basic, T2 on-curve 2-drop
- Hard: T1 mana-dork lead, curve protection (hold 1-drop), T2/T3 on-curve power pick
- Expert: removal hold vs opponent threat, mana-dork acceleration, fetch color sequencing, T2 highest-power on-curve
- Turn-1/2/3 distinction (elves → bears → 3-drop across turns on Medium)
- Full determinism for a fixed seed across all four tiers
- Empty-hand edge cases

The new planner file has 100% line coverage from these tests. Existing `playLandIfAvailable` / `castCreatures` tests (turn 3+ in `ai-turn-loop.test.ts`) continue to pass — the plan is null outside the opening window so legacy behavior is preserved.

## Validation

- `npm run typecheck` — pass
- `npm run lint` — 0 errors (548 warnings, all pre-existing; my files add zero)
- `npm test` (full suite) — **428 suites / 8835 tests passed, 0 failures** (11 skipped, 48 todo — all pre-existing)
- `npm run simulate` (`src/ai/__tests__/simulation/`) — pass (1 skipped, 19 passed); win-rate separation between tiers intact, no regression

## Out of scope

- Fetch-land *cracking* sequencing (which color to crack for) — handled by the activated-ability step (`runAbilityActivation`, #1386); the plan only picks which land to play.
- Per-format opening tuning (Limited vs Constructed) — `format` is threaded through for future use but currently unused.
- `castOtherSpells` is not governed by the plan; Expert's "lead removal" works by holding creatures via `holdMana`.