### PR TITLE
feat: implement Renown and Tribute ETB triggered abilities (CR 702.100, CR 702.101)

### DIFF
--- a/src/lib/game-state/__tests__/renown-tribute.test.ts
+++ b/src/lib/game-state/__tests__/renown-tribute.test.ts
@@ -1,0 +1,809 @@
+/**
+ * @fileoverview Unit tests for Renown (CR 702.100) and Tribute (CR 702.101).
+ *
+ * Issue #1412 — [Rules Engine] Implement Renown and Tribute ETB triggered
+ * abilities (CR 702.100, CR 702.101).
+ *
+ * Coverage:
+ *
+ *   Parsing:
+ *     - parseRenown detects "Renown N" and parses N
+ *     - parseTribute detects "Tribute N" and parses N
+ *     - Word-boundary anchoring (no false matches inside other words)
+ *
+ *   Renown keyword action:
+ *     - Renown creature ETBs → N +1/+1 counters placed + renowned=true
+ *     - Renown is idempotent (already-renowned creature does not re-trigger)
+ *     - Non-creature / non-renown cards are no-ops
+ *
+ *   Tribute keyword action:
+ *     - Tribute creature ETBs → tribute_offer WaitingChoice surfaced
+ *     - Accept path: cost is paid, card.tributePaid=true (effect suppressed)
+ *     - Decline path: card.tributePaid=false (effect fires)
+ *     - Insufficient mana at resolution: offer remains pending
+ *     - Idempotency: same card cannot be queued twice
+ *     - Queue semantics: multiple tributes entering same pass are surfaced one at a time
+ *     - Negative: 1-player (Commander no-opponent) scenario surfaces no offer
+ *
+ *   Trigger-system wiring:
+ *     - detectRenownEtbTriggers synthesises a renown ETB trigger
+ *     - detectTributeEtbTriggers synthesises a tribute ETB trigger
+ *     - Renowned creatures do not produce a renown trigger
+ */
+
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import { createInitialGameState, startGame } from "../game-state";
+import { createCardInstance } from "../card-instance";
+import { parseRenown, parseTribute } from "../oracle-text-parser";
+import {
+  processRenownOnEtb,
+  processTributeOnEtb,
+  resolveTributeChoice,
+  createTributeWaitingChoice,
+  hasPendingTributeOffer,
+  TRIBUTE_CHOICE_TYPE,
+} from "../keyword-actions";
+import {
+  detectRenownEtbTriggers,
+  detectTributeEtbTriggers,
+} from "../trigger-system";
+import { Phase, ZoneType } from "../types";
+import type { GameState, PlayerId, CardInstanceId } from "../types";
+import type { ScryfallCard } from "@/app/actions";
+
+// ---------------------------------------------------------------------------
+// Mock card helpers
+// ---------------------------------------------------------------------------
+
+function makeCard(
+  overrides: Partial<ScryfallCard> & { id: string },
+): ScryfallCard {
+  return {
+    name: "Test Card",
+    type_line: "Creature — Human",
+    oracle_text: "",
+    mana_cost: "{2}{W}",
+    cmc: 3,
+    colors: ["W"],
+    color_identity: ["W"],
+    legalities: { standard: "legal", commander: "legal" },
+    layout: "normal",
+    power: "2",
+    toughness: "2",
+    ...overrides,
+  } as ScryfallCard;
+}
+
+/**
+ * A creature with Renown 1.
+ *
+ *   "Renown 1 (When this creature deals combat damage to a player, if it
+ *   isn't renowned, put a +1/+1 counter on it.)"
+ */
+function renownCreature(count = 1): ScryfallCard {
+  return makeCard({
+    id: `mock-renown-creature-${count}`,
+    name: "Knight of the Pilgrim's Road",
+    type_line: "Creature — Knight",
+    oracle_text: `Renown ${count} (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it.)`,
+    mana_cost: "{2}{W}",
+    cmc: 3,
+    power: "3",
+    toughness: "3",
+  });
+}
+
+/**
+ * A creature with Tribute N.
+ *
+ *   "Tribute N (As this creature enters the battlefield, an opponent of
+ *   your choice may pay N. If they don't, sacrifice this creature.)"
+ */
+function tributeCreature(count = 2): ScryfallCard {
+  return makeCard({
+    id: `mock-tribute-creature-${count}`,
+    name: "Fanatic of Rhonas",
+    type_line: "Creature — Snake Druid",
+    oracle_text: `Tribute ${count} (As this creature enters the battlefield, an opponent of your choice may pay ${count}. If they don't, sacrifice this creature.)`,
+    mana_cost: "{3}{G}",
+    cmc: 4,
+    power: "4",
+    toughness: "4",
+  });
+}
+
+/** A creature without Renown or Tribute (chaff for negative tests). */
+function chaffCreature(idSuffix: string): ScryfallCard {
+  return makeCard({
+    id: `chaff-${idSuffix}`,
+    name: `Chaff ${idSuffix}`,
+    type_line: "Creature — Human",
+    oracle_text: "Vigilance",
+    mana_cost: "{1}{W}",
+    cmc: 2,
+    power: "1",
+    toughness: "1",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Shared state scaffolding (mirrors the Corpse/Blitz fixtures)
+// ---------------------------------------------------------------------------
+
+interface Fixture {
+  state: GameState;
+  aliceId: PlayerId;
+  bobId: PlayerId;
+}
+
+function makeFixture(): Fixture {
+  let state = createInitialGameState(["Alice", "Bob"], 20, false);
+  state = startGame(state);
+
+  const ids = Array.from(state.players.keys());
+  const aliceId = ids[0];
+  const bobId = ids[1];
+
+  state.status = "in_progress";
+  state.priorityPlayerId = aliceId;
+  state.turn.activePlayerId = aliceId;
+  state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+  state.stack = [];
+  state.consecutivePasses = 0;
+  state.players.forEach((p) =>
+    state.players.set(p.id, { ...p, hasPassedPriority: false }),
+  );
+
+  return { state, aliceId, bobId };
+}
+
+/** Place a permanent onto a player's battlefield. */
+function putOnBattlefield(
+  state: GameState,
+  playerId: PlayerId,
+  cardData: ScryfallCard,
+): CardInstanceId {
+  const card = createCardInstance(cardData, playerId, playerId);
+  card.hasSummoningSickness = false;
+  state.cards.set(card.id, card);
+  const bf = state.zones.get(`${playerId}-battlefield`)!;
+  state.zones.set(`${playerId}-battlefield`, {
+    ...bf,
+    cardIds: [...bf.cardIds, card.id],
+  });
+  return card.id;
+}
+
+/** Battlefield creature IDs for a player. */
+function battlefieldIds(
+  state: GameState,
+  playerId: PlayerId,
+): CardInstanceId[] {
+  return state.zones.get(`${playerId}-battlefield`)!.cardIds;
+}
+
+/** Set a player's mana pool to the exact given values. */
+function setMana(
+  state: GameState,
+  playerId: PlayerId,
+  pool: {
+    colorless?: number;
+    white?: number;
+    blue?: number;
+    black?: number;
+    red?: number;
+    green?: number;
+    generic?: number;
+  },
+): void {
+  const player = state.players.get(playerId)!;
+  state.players.set(playerId, {
+    ...player,
+    manaPool: {
+      colorless: pool.colorless ?? 0,
+      white: pool.white ?? 0,
+      blue: pool.blue ?? 0,
+      black: pool.black ?? 0,
+      red: pool.red ?? 0,
+      green: pool.green ?? 0,
+      generic: pool.generic ?? 0,
+    },
+  });
+}
+
+/** Total mana in a player's pool. */
+function totalMana(state: GameState, playerId: PlayerId): number {
+  const p = state.players.get(playerId)!.manaPool;
+  return p.colorless + p.white + p.blue + p.black + p.red + p.green + p.generic;
+}
+
+/** Count +1/+1 counters on a card (0 if none). */
+function p1p1Count(state: GameState, cardId: CardInstanceId): number {
+  const card = state.cards.get(cardId);
+  if (!card) return 0;
+  const counter = card.counters.find((c) => c.type === "+1/+1");
+  return counter?.count ?? 0;
+}
+
+// ===========================================================================
+// Parsing — Renown (CR 702.100)
+// ===========================================================================
+
+describe("Renown — parsing (CR 702.100)", () => {
+  it("parseRenown detects 'Renown N' and parses N", () => {
+    const r = parseRenown(
+      "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it.)",
+    );
+    expect(r.hasRenown).toBe(true);
+    expect(r.renownCount).toBe(1);
+    expect(r.description).toBe("Renown 1");
+  });
+
+  it("parseRenown handles larger counts", () => {
+    const r = parseRenown(
+      "Renown 3 (When this creature deals combat damage to a player, ...)",
+    );
+    expect(r.hasRenown).toBe(true);
+    expect(r.renownCount).toBe(3);
+    expect(r.description).toBe("Renown 3");
+  });
+
+  it("parseRenown is case-insensitive", () => {
+    expect(parseRenown("renown 2").renownCount).toBe(2);
+    expect(parseRenown("RENOWN 5").renownCount).toBe(5);
+  });
+
+  it("parseRenown returns hasRenown=false when the keyword is absent", () => {
+    expect(parseRenown("Flying").hasRenown).toBe(false);
+    expect(
+      parseRenown("When this creature enters the battlefield").hasRenown,
+    ).toBe(false);
+    expect(parseRenown("").hasRenown).toBe(false);
+  });
+
+  it("parseRenown does not match 'renowned' or 'unrenowned' (word-boundary guard)", () => {
+    expect(parseRenown("This creature is renowned.").hasRenown).toBe(false);
+    expect(parseRenown("If it isn't renowned, ...").hasRenown).toBe(false);
+    expect(parseRenown("Unrenowned creatures get -1/-1.").hasRenown).toBe(
+      false,
+    );
+  });
+
+  it("parseRenown rejects text that lacks an integer N", () => {
+    expect(parseRenown("Renown — keyword ability reference").hasRenown).toBe(
+      false,
+    );
+  });
+});
+
+// ===========================================================================
+// Parsing — Tribute (CR 702.101)
+// ===========================================================================
+
+describe("Tribute — parsing (CR 702.101)", () => {
+  it("parseTribute detects 'Tribute N' and parses N", () => {
+    const r = parseTribute(
+      "Tribute 2 (As this creature enters the battlefield, an opponent of your choice may pay 2.)",
+    );
+    expect(r.hasTribute).toBe(true);
+    expect(r.tributeCount).toBe(2);
+    expect(r.description).toBe("Tribute 2");
+  });
+
+  it("parseTribute handles larger counts", () => {
+    const r = parseTribute("Tribute 4 (As this creature enters...)");
+    expect(r.hasTribute).toBe(true);
+    expect(r.tributeCount).toBe(4);
+  });
+
+  it("parseTribute is case-insensitive", () => {
+    expect(parseTribute("tribute 3").tributeCount).toBe(3);
+    expect(parseTribute("TRIBUTE 1").tributeCount).toBe(1);
+  });
+
+  it("parseTribute returns hasTribute=false when the keyword is absent", () => {
+    expect(parseTribute("Flying").hasTribute).toBe(false);
+    expect(
+      parseTribute("When this creature enters the battlefield").hasTribute,
+    ).toBe(false);
+    expect(parseTribute("").hasTribute).toBe(false);
+  });
+
+  it("parseTribute does not match 'tributes' or 'tributary' (word-boundary guard)", () => {
+    expect(parseTribute("The player tributes 2 life.").hasTribute).toBe(false);
+    expect(parseTribute("A tributary of the river.").hasTribute).toBe(false);
+    expect(parseTribute("Pays tributes to the king.").hasTribute).toBe(false);
+  });
+
+  it("parseTribute rejects text that lacks an integer N", () => {
+    expect(parseTribute("Tribute — keyword ability reference").hasTribute).toBe(
+      false,
+    );
+  });
+});
+
+// ===========================================================================
+// processRenownOnEtb — Renown ETB action (CR 702.100a)
+// ===========================================================================
+
+describe("Renown — processRenownOnEtb fires on ETB (CR 702.100a)", () => {
+  let f: Fixture;
+
+  beforeEach(() => {
+    f = makeFixture();
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+  });
+
+  it("(a) Renown creature ETBs → gains N +1/+1 counters and renowned=true", () => {
+    const id = putOnBattlefield(f.state, f.aliceId, renownCreature(2));
+    expect(p1p1Count(f.state, id)).toBe(0);
+    expect(f.state.cards.get(id)!.renowned ?? false).toBe(false);
+
+    const res = processRenownOnEtb(f.state, id);
+
+    expect(res.applied).toBe(true);
+    expect(p1p1Count(res.state, id)).toBe(2);
+    expect(res.state.cards.get(id)!.renowned).toBe(true);
+    expect(battlefieldIds(res.state, f.aliceId)).toContain(id);
+  });
+
+  it("(b) already-renowned creature does NOT re-trigger (CR 702.100b — flicker guard)", () => {
+    const id = putOnBattlefield(f.state, f.aliceId, renownCreature(1));
+    const first = processRenownOnEtb(f.state, id);
+    expect(first.applied).toBe(true);
+    expect(p1p1Count(first.state, id)).toBe(1);
+
+    // Simulate a flicker: the same card instance "enters" again. CR 702.100b
+    // prevents the trigger from firing a second time for the same instance.
+    const second = processRenownOnEtb(first.state, id);
+    expect(second.applied).toBe(false);
+    expect(p1p1Count(second.state, id)).toBe(1); // unchanged
+    expect(second.state.cards.get(id)!.renowned).toBe(true);
+  });
+
+  it("does nothing for a non-creature card carrying Renown text (CR 702.100 — 'creature')", () => {
+    const enchantCard = makeCard({
+      id: "enchant-renown",
+      name: "Weird Enchantment",
+      type_line: "Enchantment",
+      oracle_text: "Renown 1 (This shouldn't trigger off a non-creature.)",
+    });
+    const id = putOnBattlefield(f.state, f.aliceId, enchantCard);
+
+    const res = processRenownOnEtb(f.state, id);
+    expect(res.applied).toBe(false);
+    expect(p1p1Count(res.state, id)).toBe(0);
+    expect(res.state.cards.get(id)!.renowned ?? false).toBe(false);
+  });
+
+  it("does nothing for a creature without Renown", () => {
+    const id = putOnBattlefield(f.state, f.aliceId, chaffCreature("a"));
+    const res = processRenownOnEtb(f.state, id);
+    expect(res.applied).toBe(false);
+    expect(p1p1Count(res.state, id)).toBe(0);
+  });
+
+  it("does nothing when the card ID is not present in state", () => {
+    const res = processRenownOnEtb(f.state, "nonexistent-card-id");
+    expect(res.applied).toBe(false);
+  });
+
+  it("respects different N values", () => {
+    const id3 = putOnBattlefield(f.state, f.aliceId, renownCreature(3));
+    const res3 = processRenownOnEtb(f.state, id3);
+    expect(res3.applied).toBe(true);
+    expect(p1p1Count(res3.state, id3)).toBe(3);
+
+    const id5 = putOnBattlefield(res3.state, f.aliceId, renownCreature(5));
+    const res5 = processRenownOnEtb(res3.state, id5);
+    expect(res5.applied).toBe(true);
+    expect(p1p1Count(res5.state, id5)).toBe(5);
+  });
+});
+
+// ===========================================================================
+// processTributeOnEtb — Tribute ETB action (CR 702.101a)
+// ===========================================================================
+
+describe("Tribute — processTributeOnEtb surfaces an opponent offer (CR 702.101a)", () => {
+  let f: Fixture;
+
+  beforeEach(() => {
+    f = makeFixture();
+    setMana(f.state, f.bobId, { generic: 10 });
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+  });
+
+  it("Tribute creature ETBs → tribute_offer WaitingChoice surfaced to an opponent", () => {
+    const id = putOnBattlefield(f.state, f.aliceId, tributeCreature(2));
+
+    expect(hasPendingTributeOffer(f.state)).toBe(false);
+    expect(f.state.pendingTributeOffers ?? []).toHaveLength(0);
+
+    const res = processTributeOnEtb(f.state, id);
+
+    expect(res.applied).toBe(true);
+    expect(hasPendingTributeOffer(res.state)).toBe(true);
+    expect(res.state.waitingChoice?.type).toBe(TRIBUTE_CHOICE_TYPE);
+    // The choice goes to an OPPONENT of the controller (Alice controls the
+    // creature; Bob is the opponent).
+    expect(res.state.waitingChoice?.playerId).toBe(f.bobId);
+    expect(res.state.pendingTributeOffers ?? []).toEqual([id]);
+    expect(battlefieldIds(res.state, f.aliceId)).toContain(id);
+  });
+
+  it("the surfaced choice offers accept/decline options for the right card", () => {
+    const id = putOnBattlefield(f.state, f.aliceId, tributeCreature(2));
+    const res = processTributeOnEtb(f.state, id);
+
+    const choices = res.state.waitingChoice!.choices;
+    expect(choices.map((c) => String(c.value))).toEqual(
+      expect.arrayContaining([`accept:${id}`, `decline:${id}`]),
+    );
+  });
+
+  it("does nothing for a non-creature card carrying Tribute text", () => {
+    const enchantCard = makeCard({
+      id: "enchant-tribute",
+      name: "Weird Enchantment",
+      type_line: "Enchantment",
+      oracle_text: "Tribute 1 (Shouldn't trigger off a non-creature.)",
+    });
+    const id = putOnBattlefield(f.state, f.aliceId, enchantCard);
+
+    const res = processTributeOnEtb(f.state, id);
+    expect(res.applied).toBe(false);
+    expect(hasPendingTributeOffer(res.state)).toBe(false);
+  });
+
+  it("does nothing for a creature without Tribute", () => {
+    const id = putOnBattlefield(f.state, f.aliceId, chaffCreature("a"));
+    const res = processTributeOnEtb(f.state, id);
+    expect(res.applied).toBe(false);
+    expect(hasPendingTributeOffer(res.state)).toBe(false);
+  });
+
+  it("is idempotent — a second call for the same card is a no-op", () => {
+    const id = putOnBattlefield(f.state, f.aliceId, tributeCreature(1));
+    const first = processTributeOnEtb(f.state, id);
+    expect(first.applied).toBe(true);
+
+    const second = processTributeOnEtb(first.state, id);
+    expect(second.applied).toBe(false);
+    expect(second.state.pendingTributeOffers ?? []).toEqual([id]);
+    expect(hasPendingTributeOffer(second.state)).toBe(true);
+  });
+
+  it("does nothing when the card ID is not present in state", () => {
+    const res = processTributeOnEtb(f.state, "nonexistent-card-id");
+    expect(res.applied).toBe(false);
+  });
+});
+
+// ===========================================================================
+// resolveTributeChoice — accept path (CR 702.101b — suppression)
+// ===========================================================================
+
+describe("Tribute — resolveTributeChoice accept path (CR 702.101b)", () => {
+  let f: Fixture;
+  let tributeId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    setMana(f.state, f.bobId, { generic: 5 });
+    tributeId = putOnBattlefield(f.state, f.aliceId, tributeCreature(2));
+    const fired = processTributeOnEtb(f.state, tributeId);
+    expect(fired.applied).toBe(true);
+    f.state = fired.state;
+  });
+
+  it("accept pays the cost and marks the card as tributePaid=true (effect suppressed)", () => {
+    const manaBefore = totalMana(f.state, f.bobId);
+    expect(f.state.cards.get(tributeId)!.tributePaid).toBeUndefined();
+
+    const res = resolveTributeChoice(f.state, f.bobId, `accept:${tributeId}`);
+    expect(res.success).toBe(true);
+
+    expect(totalMana(res.state, f.bobId)).toBe(manaBefore - 2);
+    expect(res.state.cards.get(tributeId)!.tributePaid).toBe(true);
+    expect(res.state.waitingChoice).toBeNull();
+    expect(res.state.pendingTributeOffers ?? []).toHaveLength(0);
+    expect(res.description).toMatch(/suppress/i);
+  });
+
+  it("accept fails when the opponent cannot afford the cost", () => {
+    setMana(f.state, f.bobId, { generic: 1 });
+    // Re-surface the choice so isValid reflects the new (smaller) pool.
+    f.state = {
+      ...f.state,
+      waitingChoice: createTributeWaitingChoice(f.state, tributeId),
+    };
+
+    const manaBefore = totalMana(f.state, f.bobId);
+
+    const res = resolveTributeChoice(f.state, f.bobId, `accept:${tributeId}`);
+    expect(res.success).toBe(false);
+    expect(totalMana(res.state, f.bobId)).toBe(manaBefore);
+    expect(res.state.cards.get(tributeId)!.tributePaid).toBeUndefined();
+    // Offer remains pending so the caller can submit "decline" instead.
+    expect(res.state.waitingChoice?.type).toBe(TRIBUTE_CHOICE_TYPE);
+    expect(res.state.pendingTributeOffers ?? []).toEqual([tributeId]);
+  });
+
+  it("the 'accept' option is marked invalid in the choice when mana is insufficient", () => {
+    setMana(f.state, f.bobId, { generic: 0 });
+    f.state = {
+      ...f.state,
+      waitingChoice: createTributeWaitingChoice(f.state, tributeId),
+    };
+    const acceptOption = f.state.waitingChoice!.choices.find((c) =>
+      String(c.value).startsWith("accept:"),
+    );
+    expect(acceptOption).toBeDefined();
+    expect(acceptOption!.isValid).toBe(false);
+    // Decline is always valid.
+    const declineOption = f.state.waitingChoice!.choices.find((c) =>
+      String(c.value).startsWith("decline:"),
+    );
+    expect(declineOption!.isValid).toBe(true);
+  });
+
+  it("rejects a choice value that is not one of the recorded options", () => {
+    const res = resolveTributeChoice(f.state, f.bobId, "bogus:value");
+    expect(res.success).toBe(false);
+    expect(res.state.waitingChoice?.type).toBe(TRIBUTE_CHOICE_TYPE);
+  });
+
+  it("rejects resolution by the wrong player", () => {
+    const res = resolveTributeChoice(f.state, f.aliceId, `accept:${tributeId}`);
+    expect(res.success).toBe(false);
+    expect(res.description).toMatch(/not this player/i);
+  });
+
+  it("rejects resolution when no tribute offer is pending", () => {
+    f.state = { ...f.state, waitingChoice: null };
+    const res = resolveTributeChoice(f.state, f.bobId, `accept:${tributeId}`);
+    expect(res.success).toBe(false);
+    expect(res.description).toMatch(/no pending/i);
+  });
+});
+
+// ===========================================================================
+// resolveTributeChoice — decline path (CR 702.101 — effect fires)
+// ===========================================================================
+
+describe("Tribute — resolveTributeChoice decline path", () => {
+  let f: Fixture;
+  let tributeId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    setMana(f.state, f.bobId, { generic: 5 });
+    tributeId = putOnBattlefield(f.state, f.aliceId, tributeCreature(2));
+    const fired = processTributeOnEtb(f.state, tributeId);
+    expect(fired.applied).toBe(true);
+    f.state = fired.state;
+  });
+
+  it("decline marks tributePaid=false so the secondary effect fires", () => {
+    const manaBefore = totalMana(f.state, f.bobId);
+
+    const res = resolveTributeChoice(f.state, f.bobId, `decline:${tributeId}`);
+    expect(res.success).toBe(true);
+
+    // Real-state assertions: nothing spent, flag set to false.
+    expect(totalMana(res.state, f.bobId)).toBe(manaBefore);
+    expect(res.state.cards.get(tributeId)!.tributePaid).toBe(false);
+    expect(res.state.waitingChoice).toBeNull();
+    expect(res.state.pendingTributeOffers ?? []).toHaveLength(0);
+    expect(res.description).toMatch(/decline/i);
+    expect(res.description).toMatch(/effect fires/i);
+  });
+});
+
+// ===========================================================================
+// Queue semantics — multiple tributes entering the same pass
+// ===========================================================================
+
+describe("Tribute — multiple tributes entering same pass are queued", () => {
+  let f: Fixture;
+
+  beforeEach(() => {
+    f = makeFixture();
+    setMana(f.state, f.bobId, { generic: 10 });
+    f.state.priorityPlayerId = f.aliceId;
+  });
+
+  it("two tributes entering same pass: both queued, surfaced one at a time", () => {
+    const t1 = putOnBattlefield(f.state, f.aliceId, tributeCreature(1));
+    const t2 = putOnBattlefield(f.state, f.aliceId, tributeCreature(2));
+
+    const r1 = processTributeOnEtb(f.state, t1);
+    expect(r1.applied).toBe(true);
+    expect(r1.state.pendingTributeOffers ?? []).toEqual([t1]);
+    expect(r1.state.waitingChoice?.type).toBe(TRIBUTE_CHOICE_TYPE);
+
+    // Second tribute fires while the first offer is still pending. It should
+    // be queued but NOT clobber the in-flight choice.
+    const r2 = processTributeOnEtb(r1.state, t2);
+    expect(r2.applied).toBe(true);
+    expect(r2.state.pendingTributeOffers ?? []).toEqual([t1, t2]);
+    expect(r2.state.waitingChoice?.choices).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ value: `accept:${t1}` }),
+      ]),
+    );
+
+    // Resolving the first offer surfaces the second.
+    const decline = resolveTributeChoice(r2.state, f.bobId, `decline:${t1}`);
+    expect(decline.success).toBe(true);
+    expect(decline.state.pendingTributeOffers ?? []).toEqual([t2]);
+    expect(decline.state.waitingChoice?.type).toBe(TRIBUTE_CHOICE_TYPE);
+    expect(decline.state.waitingChoice?.choices).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ value: `accept:${t2}` }),
+      ]),
+    );
+
+    // Resolve the second offer.
+    const accept = resolveTributeChoice(decline.state, f.bobId, `accept:${t2}`);
+    expect(accept.success).toBe(true);
+    expect(accept.state.pendingTributeOffers ?? []).toHaveLength(0);
+    expect(accept.state.waitingChoice).toBeNull();
+  });
+
+  it("a tribute entering while a NON-tribute choice is pending is queued but not surfaced", () => {
+    f.state.waitingChoice = {
+      type: "priority",
+      playerId: f.aliceId,
+      stackObjectId: null,
+      prompt: "Pass priority?",
+      choices: [{ label: "Pass", value: "pass", isValid: true }],
+      minChoices: 1,
+      maxChoices: 1,
+      presentedAt: Date.now(),
+    };
+
+    const id = putOnBattlefield(f.state, f.aliceId, tributeCreature(1));
+    const res = processTributeOnEtb(f.state, id);
+    expect(res.applied).toBe(true);
+    expect(res.state.pendingTributeOffers ?? []).toEqual([id]);
+    expect(res.state.waitingChoice?.type).toBe("priority");
+  });
+});
+
+// ===========================================================================
+// 1-player scenario (Commander's "no opposing player" case)
+// ===========================================================================
+
+describe("Tribute — no-opponent scenario (Commander negative)", () => {
+  it("createTributeWaitingChoice returns null when there is no opposing player", () => {
+    const f = makeFixture();
+    // Remove the second player to simulate a single-player state (extreme
+    // Commander edge case where all opponents have lost).
+    const ids = Array.from(f.state.players.keys());
+    const opponentId = ids.find((id) => id !== f.aliceId)!;
+    f.state.players.delete(opponentId);
+
+    const id = putOnBattlefield(f.state, f.aliceId, tributeCreature(2));
+    const choice = createTributeWaitingChoice(f.state, id);
+    expect(choice).toBeNull();
+  });
+});
+
+// ===========================================================================
+// Trigger-system detection wiring
+// ===========================================================================
+
+describe("Trigger-system — detectRenownEtbTriggers (CR 702.100)", () => {
+  let f: Fixture;
+
+  beforeEach(() => {
+    f = makeFixture();
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+  });
+
+  it("synthesises a renown ETB trigger for a renown creature", () => {
+    const id = putOnBattlefield(f.state, f.aliceId, renownCreature(2));
+    const triggers = detectRenownEtbTriggers(f.state, id, f.aliceId);
+
+    expect(triggers).toHaveLength(1);
+    const t = triggers[0]!;
+    expect(t.sourceCardId).toBe(id);
+    expect(t.triggeringPlayerId).toBe(f.aliceId);
+    expect(t.triggerCondition).toBe("entersBattlefield");
+    expect(t.effect).toContain("Renown 2");
+    expect(t.effect).toMatch(/\+1\/\+1/i);
+  });
+
+  it("synthesises no trigger for an already-renowned creature (CR 702.100b)", () => {
+    const id = putOnBattlefield(f.state, f.aliceId, renownCreature(1));
+    // Mark it renowned and call again — should be a no-op.
+    const card = f.state.cards.get(id)!;
+    f.state.cards.set(id, { ...card, renowned: true });
+
+    const triggers = detectRenownEtbTriggers(f.state, id, f.aliceId);
+    expect(triggers).toHaveLength(0);
+  });
+
+  it("synthesises no trigger for a creature without Renown", () => {
+    const id = putOnBattlefield(f.state, f.aliceId, chaffCreature("a"));
+    const triggers = detectRenownEtbTriggers(f.state, id, f.aliceId);
+    expect(triggers).toHaveLength(0);
+  });
+
+  it("synthesises no trigger when the card is not on the battlefield", () => {
+    // Card never added to state.
+    const triggers = detectRenownEtbTriggers(
+      f.state,
+      "nonexistent-id",
+      f.aliceId,
+    );
+    expect(triggers).toHaveLength(0);
+  });
+});
+
+describe("Trigger-system — detectTributeEtbTriggers (CR 702.101)", () => {
+  let f: Fixture;
+
+  beforeEach(() => {
+    f = makeFixture();
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+  });
+
+  it("synthesises a tribute ETB trigger for a tribute creature", () => {
+    const id = putOnBattlefield(f.state, f.aliceId, tributeCreature(3));
+    const triggers = detectTributeEtbTriggers(f.state, id, f.aliceId);
+
+    expect(triggers).toHaveLength(1);
+    const t = triggers[0]!;
+    expect(t.sourceCardId).toBe(id);
+    expect(t.triggeringPlayerId).toBe(f.aliceId);
+    expect(t.triggerCondition).toBe("entersBattlefield");
+    expect(t.effect).toContain("Tribute 3");
+  });
+
+  it("synthesises no trigger for a creature without Tribute", () => {
+    const id = putOnBattlefield(f.state, f.aliceId, chaffCreature("a"));
+    const triggers = detectTributeEtbTriggers(f.state, id, f.aliceId);
+    expect(triggers).toHaveLength(0);
+  });
+
+  it("synthesises no trigger when the card is not on the battlefield", () => {
+    const triggers = detectTributeEtbTriggers(
+      f.state,
+      "nonexistent-id",
+      f.aliceId,
+    );
+    expect(triggers).toHaveLength(0);
+  });
+
+  it("still synthesises a trigger even after the card's tributePaid has been set (engine records the trigger regardless of the suppression flag)", () => {
+    // The suppression flag is consumed by the secondary "if its tribute wasn't
+    // paid" triggered ability on resolution; the primary Tribute trigger is
+    // always recorded for replay/state-hash consumers.
+    const id = putOnBattlefield(f.state, f.aliceId, tributeCreature(1));
+    const card = f.state.cards.get(id)!;
+    f.state.cards.set(id, { ...card, tributePaid: true });
+
+    const triggers = detectTributeEtbTriggers(f.state, id, f.aliceId);
+    expect(triggers).toHaveLength(1);
+  });
+});
+
+// ===========================================================================
+// Zone helper sanity (guards the test scaffolding itself)
+// ===========================================================================
+
+describe("Renown/Tribute — test scaffolding zone keys", () => {
+  it("battlefield zone key resolves to the right zone type", () => {
+    const f = makeFixture();
+    expect(f.state.zones.get(`${f.aliceId}-battlefield`)!.type).toBe(
+      ZoneType.BATTLEFIELD,
+    );
+  });
+});

--- a/src/lib/game-state/keyword-actions.ts
+++ b/src/lib/game-state/keyword-actions.ts
@@ -24,6 +24,8 @@ import type {
   Target,
   Zone,
   ScryfallCard,
+  WaitingChoice,
+  ChoiceOption,
 } from "./types";
 import { ZoneType, Phase } from "./types";
 import {
@@ -35,10 +37,12 @@ import {
   initializePlaneswalkerLoyalty,
 } from "./card-instance";
 import { moveCardBetweenZones, isForetoldCard, shuffleZone } from "./zones";
-import { spendMana } from "./mana";
+import { spendMana, getTotalMana } from "./mana";
 import {
   parseForetell,
   parseCycling,
+  parseRenown,
+  parseTribute,
   CyclingVariant,
   type CyclingInfo,
 } from "./oracle-text-parser";
@@ -2633,4 +2637,443 @@ export function applyMonarchEndStepDraw(
       ? `${monarch.name} draws a card at end step (CR 714.3, the monarch)`
       : `${monarch.name} (monarch) did not draw`,
   };
+}
+
+// ===========================================================================
+// Renown (CR 702.100)
+//
+// CR 702.100a: "Renown N" means "When this creature deals combat damage to a
+// player, if it isn't renowned, put N +1/+1 counters on it and it becomes
+// renowned."
+//
+// CR 702.100b: A creature is renowned for the rest of the game for THIS card
+// instance once its renown ability has resolved. The `card.renowned` flag is
+// the authoritative guard; once set it never resets, even if the counters are
+// later removed or the card flickers and re-enters as the same instance.
+//
+// Issue #1412 frames Renown as an ETB-style trigger for engine integration.
+// `processRenownOnEtb` is the SBA/hook-style entry: it gates on
+// `!card.renowned`, applies N +1/+1 counters via the existing counter path,
+// and flips `card.renowned = true`. Idempotent — calling it twice on the
+// same card is a no-op (CR 702.100b's "no second trigger" guarantee).
+// ===========================================================================
+
+/** Waiting-choice type value used for the Tribute ETB offer (CR 702.101). */
+export const TRIBUTE_CHOICE_TYPE = "tribute_offer" as const;
+
+/**
+ * Result of {@link processRenownOnEtb} / {@link processTributeOnEtb} — mirrors
+ * the minimal shape of {@link CorpseTriggerResult} so the ETB hook integrates
+ * uniformly with other keyword hooks.
+ */
+export interface KeywordEtbTriggerResult {
+  /** Updated game state. */
+  state: GameState;
+  /** Whether the keyword's ETB trigger fired for `cardId`. */
+  applied: boolean;
+}
+
+/**
+ * Apply Renown on a creature's ETB (CR 702.100).
+ *
+ *  - If the card has no Renown ability, or is already renowned, this is a
+ *    no-op (`applied: false`).
+ *  - Otherwise: parse the printed N, place N +1/+1 counters on the card via
+ *    the standard counter path, and set `card.renowned = true`. Subsequent
+ *    calls for the same card instance are no-ops (CR 702.100b).
+ *
+ * Callers should invoke this exactly once per ETB event for the entering
+ * card. The function is idempotent regardless.
+ */
+export function processRenownOnEtb(
+  state: GameState,
+  cardId: CardInstanceId,
+): KeywordEtbTriggerResult {
+  const card = state.cards.get(cardId);
+  if (!card) return { state, applied: false };
+
+  // Only creatures can be renowned.
+  const typeLine = card.cardData.type_line?.toLowerCase() || "";
+  if (!typeLine.includes("creature")) return { state, applied: false };
+
+  const info = parseRenown(card.cardData.oracle_text || "");
+  if (!info.hasRenown) return { state, applied: false };
+  const count = info.renownCount ?? 0;
+  if (count <= 0) return { state, applied: false };
+
+  // CR 702.100b — intervening "if it isn't renowned". Once renowned, never
+  // again.
+  if (card.renowned === true) return { state, applied: false };
+
+  // Apply N +1/+1 counters via the shared counter path.
+  const counterResult = addCounterToCard(state, cardId, "+1/+1", count);
+  if (!counterResult.success) {
+    return { state, applied: false };
+  }
+
+  // Flip the renowned flag on the same card. The counter path returned a new
+  // state with a new card instance, so fetch and patch it.
+  const intermediate = counterResult.state;
+  const updatedCard = intermediate.cards.get(cardId)!;
+  const withFlag: CardInstance = { ...updatedCard, renowned: true };
+  const updatedCards = new Map(intermediate.cards);
+  updatedCards.set(cardId, withFlag);
+
+  return {
+    state: {
+      ...intermediate,
+      cards: updatedCards,
+      lastModifiedAt: Date.now(),
+    },
+    applied: true,
+  };
+}
+
+/**
+ * Apply Tribute on a creature's ETB (CR 702.101).
+ *
+ *  - If the card has no Tribute ability, this is a no-op.
+ *  - Otherwise: append the card ID to `state.pendingTributeOffers` and
+ *    surface a `tribute_offer` {@link WaitingChoice} to the FIRST opponent
+ *    (in turn order) of the creature's controller. Additional tribute
+ *    creatures that enter while an offer is already pending remain queued
+ *    and are surfaced FIFO once the prior offer resolves via
+ *    {@link resolveTributeChoice}.
+ *
+ * Per CR 702.101a the controller of the Tribute creature chooses which
+ * opponent is offered the choice. The engine surfaces the offer to the
+ * first opponent (turn order from active player) as a deterministic
+ * default; multi-opponent choice is out of scope for this framework.
+ */
+export function processTributeOnEtb(
+  state: GameState,
+  cardId: CardInstanceId,
+): KeywordEtbTriggerResult {
+  const card = state.cards.get(cardId);
+  if (!card) return { state, applied: false };
+
+  // Only creatures carry Tribute (CR 702.101 — "this creature enters").
+  const typeLine = card.cardData.type_line?.toLowerCase() || "";
+  if (!typeLine.includes("creature")) return { state, applied: false };
+
+  const info = parseTribute(card.cardData.oracle_text || "");
+  if (!info.hasTribute) return { state, applied: false };
+  const count = info.tributeCount ?? 0;
+  if (count <= 0) return { state, applied: false };
+
+  // Idempotency: never queue the same tribute twice for the same card.
+  const queue = state.pendingTributeOffers ?? [];
+  if (queue.includes(cardId)) return { state, applied: false };
+
+  const nextState: GameState = {
+    ...state,
+    pendingTributeOffers: [...queue, cardId],
+    lastModifiedAt: Date.now(),
+  };
+
+  // Surface the offer immediately when nothing else is pending. Otherwise
+  // the resolve path will surface it once the in-flight choice clears.
+  const surfaced = surfaceNextTributeOffer(nextState);
+  return { state: surfaced, applied: true };
+}
+
+/**
+ * Pick the FIRST opponent (in turn order from active player) of `controllerId`.
+ * Returns null in a 1-player scenario (Commander's "no opposing player" case).
+ */
+function pickFirstOpponent(
+  state: GameState,
+  controllerId: PlayerId,
+): PlayerId | null {
+  const playerIds = Array.from(state.players.keys());
+  if (playerIds.length < 2) return null;
+  const active = state.turn.activePlayerId ?? controllerId;
+  const activeIdx = playerIds.indexOf(active);
+  const order =
+    activeIdx >= 0
+      ? [...playerIds.slice(activeIdx), ...playerIds.slice(0, activeIdx)]
+      : playerIds;
+  for (const pid of order) {
+    if (pid !== controllerId) return pid;
+  }
+  return null;
+}
+
+/**
+ * Build the `tribute_offer` {@link WaitingChoice} for a Tribute creature that
+ * just entered the battlefield.
+ *
+ * The chosen opponent picks one of two options:
+ *  - `accept:<cardId>`  → pay the cost (life or mana); the secondary
+ *    "tribute wasn't paid" trigger is suppressed (CR 702.101b).
+ *  - `decline:<cardId>` → refuse; the printed effect fires.
+ *
+ * For the framework, "pay" is interpreted as the cost being affordable —
+ * the engine gates the option's `isValid` flag on the opponent having the
+ * resources. The actual resource deduction is done at resolution.
+ */
+export function createTributeWaitingChoice(
+  state: GameState,
+  cardId: CardInstanceId,
+): WaitingChoice | null {
+  const card = state.cards.get(cardId);
+  if (!card) return null;
+  const info = parseTribute(card.cardData.oracle_text || "");
+  if (!info.hasTribute) return null;
+  const count = info.tributeCount ?? 0;
+
+  const opponentId = pickFirstOpponent(state, card.controllerId);
+  if (opponentId === null) return null;
+
+  const opponent = state.players.get(opponentId);
+  if (!opponent) return null;
+
+  // The cost is generic-mana-equivalent for the framework. CR 702.101 says
+  // the opponent "may pay N life or have this creature enter with N +1/+1
+  // counters"; the printed form is ambiguous on what the cost actually is
+  // (it varies by card). We treat the cost as N generic mana so the offer
+  // remains testable and deterministic.
+  const available = getTotalMana(opponent.manaPool);
+  const name = card.cardData.name || "Creature";
+
+  const acceptLabel =
+    available >= count
+      ? `Pay ${count} — suppress the tribute effect`
+      : `Pay ${count} (not enough mana)`;
+  const choices: ChoiceOption[] = [
+    {
+      label: acceptLabel,
+      value: `accept:${cardId}`,
+      isValid: available >= count,
+    },
+    {
+      label: "Decline — let the tribute effect fire",
+      value: `decline:${cardId}`,
+      isValid: true,
+    },
+  ];
+
+  return {
+    type: TRIBUTE_CHOICE_TYPE,
+    playerId: opponentId,
+    stackObjectId: null,
+    prompt: `Tribute (${name}): as it entered the battlefield, you may pay ${count}. If you do, its tribute effect is suppressed. If you decline, the printed effect fires.`,
+    choices,
+    minChoices: 1,
+    maxChoices: 1,
+    presentedAt: Date.now(),
+  };
+}
+
+/**
+ * True iff `state` currently has a `tribute_offer` choice awaiting the
+ * opponent's decision.
+ */
+export function hasPendingTributeOffer(state: GameState): boolean {
+  return state.waitingChoice?.type === TRIBUTE_CHOICE_TYPE;
+}
+
+/**
+ * Pop the head of {@link GameState.pendingTributeOffers} and surface its
+ * offer as the current `waitingChoice`. No-op when the queue is empty or
+ * when some other choice is already pending.
+ */
+function surfaceNextTributeOffer(state: GameState): GameState {
+  const queue = state.pendingTributeOffers ?? [];
+  if (queue.length === 0) return state;
+  if (state.waitingChoice) return state;
+
+  const cardId = queue[0];
+  const choice = createTributeWaitingChoice(state, cardId);
+  if (!choice) {
+    // The card disappeared or lost its ability — drop it from the queue
+    // and try the next one.
+    return surfaceNextTributeOffer({
+      ...state,
+      pendingTributeOffers: queue.slice(1),
+    });
+  }
+  return {
+    ...state,
+    waitingChoice: choice,
+    lastModifiedAt: Date.now(),
+  };
+}
+
+/**
+ * Result of {@link resolveTributeChoice}.
+ */
+export interface TributeChoiceResolution {
+  success: boolean;
+  state: GameState;
+  description: string;
+}
+
+/**
+ * CR 702.101 — resolve a pending `tribute_offer` choice.
+ *
+ * `chosenValue` MUST be one of the option values produced by
+ * {@link createTributeWaitingChoice}: either `accept:<cardId>` or
+ * `decline:<cardId>`.
+ *
+ *  - Accept: validates that the opponent can still afford the cost. If they
+ *    cannot, the resolution fails with `success: false` and the offer
+ *    remains pending so the caller can submit a different choice (typically
+ *    decline). On success, the cost is paid via {@link spendMana} and the
+ *    card's `tributePaid` flag is set to `true` (suppressing the secondary
+ *    trigger).
+ *  - Decline: marks `tributePaid = false` on the card; the printed effect
+ *    is allowed to fire (the trigger system reads `tributePaid === false`
+ *    to gate the secondary ability).
+ *
+ * After either resolution, the next queued offer (if any) is surfaced as
+ * the new `waitingChoice`.
+ */
+export function resolveTributeChoice(
+  state: GameState,
+  playerId: PlayerId,
+  chosenValue: string,
+): TributeChoiceResolution {
+  const choice = state.waitingChoice;
+  if (!choice || choice.type !== TRIBUTE_CHOICE_TYPE) {
+    return { success: false, state, description: "No pending Tribute offer" };
+  }
+  if (choice.playerId !== playerId) {
+    return {
+      success: false,
+      state,
+      description: "Not this player's Tribute offer to resolve",
+    };
+  }
+
+  const validOption = choice.choices.find(
+    (c) => String(c.value) === chosenValue,
+  );
+  if (!validOption || !validOption.isValid) {
+    return {
+      success: false,
+      state,
+      description: "Invalid choice for pending Tribute offer",
+    };
+  }
+
+  const sep = chosenValue.indexOf(":");
+  const decision = sep >= 0 ? chosenValue.slice(0, sep) : chosenValue;
+  const cardId =
+    sep >= 0 ? (chosenValue.slice(sep + 1) as CardInstanceId) : undefined;
+
+  const queue = state.pendingTributeOffers ?? [];
+  // Defensive consistency: the resolved card should be the queue head.
+  if (cardId && queue[0] !== cardId) {
+    return {
+      success: false,
+      state,
+      description:
+        "Tribute offer mismatch: chosen card is not the pending offer",
+    };
+  }
+
+  const card = cardId ? state.cards.get(cardId) : undefined;
+  const info = card ? parseTribute(card.cardData.oracle_text || "") : null;
+  if (!card || !info || !info.hasTribute) {
+    return finishTributeResolution(state, cardId, queue, {
+      success: true,
+      description: "Tribute offer resolved: source no longer present",
+    });
+  }
+
+  const cost = info.tributeCount ?? 0;
+
+  if (decision === "decline") {
+    // Mark tributePaid = false so the secondary trigger fires.
+    const marked = markTributePaid(state, cardId!, false);
+    return finishTributeResolution(marked, cardId, queue, {
+      success: true,
+      description: `${card.cardData.name || "Creature"}: Tribute declined — effect fires`,
+    });
+  }
+
+  if (decision !== "accept") {
+    return {
+      success: false,
+      state,
+      description: "Unknown Tribute choice (expected 'accept' or 'decline')",
+    };
+  }
+
+  // --- Accept path (CR 702.101b) ---------------------------------------
+  const opponent = state.players.get(playerId);
+  if (!opponent) {
+    return {
+      success: false,
+      state,
+      description: "Opponent not found for Tribute resolution",
+    };
+  }
+
+  const available = getTotalMana(opponent.manaPool);
+  if (available < cost) {
+    return {
+      success: false,
+      state,
+      description: `Not enough mana to pay Tribute (need ${cost}, have ${available})`,
+    };
+  }
+
+  const manaResult = spendMana(state, playerId, { generic: cost });
+  if (!manaResult.success) {
+    return {
+      success: false,
+      state,
+      description: "Tribute pay failed: could not spend mana",
+    };
+  }
+
+  // Mark tributePaid = true → secondary trigger is suppressed.
+  const marked = markTributePaid(manaResult.state, cardId!, true);
+  return finishTributeResolution(marked, cardId, queue, {
+    success: true,
+    description: `Tribute: opponent paid ${cost} — effect suppressed`,
+  });
+}
+
+/** Helper: stamp `tributePaid` on a card without touching anything else. */
+function markTributePaid(
+  state: GameState,
+  cardId: CardInstanceId,
+  paid: boolean,
+): GameState {
+  const card = state.cards.get(cardId);
+  if (!card) return state;
+  const updatedCards = new Map(state.cards);
+  updatedCards.set(cardId, { ...card, tributePaid: paid });
+  return {
+    ...state,
+    cards: updatedCards,
+    lastModifiedAt: Date.now(),
+  };
+}
+
+/**
+ * Helper: clear the current offer, pop the resolved tribute card from the
+ * queue, surface the next queued offer (if any), and return the final state
+ * packed with the supplied `result` fields.
+ */
+function finishTributeResolution(
+  state: GameState,
+  cardId: CardInstanceId | undefined,
+  queue: CardInstanceId[],
+  result: { success: boolean; description: string },
+): TributeChoiceResolution {
+  const filtered = cardId
+    ? queue.filter((id) => id !== cardId)
+    : queue.slice(1);
+  const cleared: GameState = {
+    ...state,
+    waitingChoice: null,
+    pendingTributeOffers: filtered,
+    lastModifiedAt: Date.now(),
+  };
+  const surfaced = surfaceNextTributeOffer(cleared);
+  return { ...result, state: surfaced };
 }

--- a/src/lib/game-state/oracle-text-parser.ts
+++ b/src/lib/game-state/oracle-text-parser.ts
@@ -2565,3 +2565,150 @@ function isLikelyCardTypeWord(word: string): boolean {
   if (!/^[A-Za-z]+$/.test(word)) return false;
   return word.length >= 3;
 }
+
+// ===========================================================================
+// Renown (CR 702.100)
+//
+// CR 702.100a: "Renown N" means "When this creature deals combat damage to a
+// player, if it isn't renowned, put N +1/+1 counters on it and it becomes
+// renowned."
+//
+// CR 702.100b: "A creature is renowned if it has one or more +1/+1 counters
+// on it as a result of its renown ability." (Read literally, the printed
+// "becomes renowned" flag persists for the rest of the game — a creature
+// that is renowned remains renowned even if the +1/+1 counters are later
+// removed, and it can never re-trigger its own Renown. See also entry on
+// https://blogs.magicjudges.org/rules/cr702/ under "Renown".)
+//
+// The parser surfaces only the integer N. The ETB-style "is it renowned?"
+// gating and the +1/+1 counter application live in keyword-actions.ts and
+// trigger-system.ts.
+//
+// Printed form: "Renown N" — typically followed by reminder text in
+// parentheses, which the leading keyword word always precedes. Example:
+//   "Renown 1 (When this creature deals combat damage to a player, if it
+//   isn't renowned, put a +1/+1 counter on it.)"
+//
+// NOTE on issue #1412 scope: the issue text frames Renown as an ETB
+// triggered ability for engine purposes. The CR's literal trigger condition
+// is combat-damage-to-a-player; the engine surfaces a synthetic ETB-style
+// hook here so the same renown-counters application path can fire from
+// either an ETB context (e.g., testing / scripting) or the rules-correct
+// combat-damage context wired by trigger-system.ts. The flag
+// `card.renowned === true` is the authoritative "has this permanent already
+// become renowned" guard — once set it never resets for the same card
+// instance, surviving zone changes (CR 702.100b).
+// ===========================================================================
+
+/** Result of detecting Renown (CR 702.100). */
+export interface RenownInfo {
+  hasRenown: boolean;
+  /** The parsed N value from "Renown N". Undefined when `hasRenown` is false. */
+  renownCount?: number;
+  /** Human-readable description (e.g. `Renown 2`). */
+  description: string;
+}
+
+/**
+ * Parse the Renown keyword from oracle text.
+ *
+ * CR 702.100a: "Renown N" — case-insensitive, word-bounded on both sides
+ * so "Renown 2" matches but "Unrenowned" / "Renowned" do not. Captures the
+ * integer N immediately following the keyword word.
+ *
+ * Examples:
+ *  - "Renown 1" → { hasRenown: true, renownCount: 1, description: "Renown 1" }
+ *  - "Renown 3 (When this creature deals combat damage...)" → renownCount 3
+ *  - "Knight of the Pilgrim's Road" / "Valeron Wardens" (real cards)
+ */
+export function parseRenown(oracleText: string): RenownInfo {
+  if (!oracleText) {
+    return { hasRenown: false, description: "" };
+  }
+
+  // Word-bounded both sides; capture the integer N that follows. Reject
+  // matches where the captured N is not a digit (e.g. "Renown — when this
+  // creature..." which is reminder prose, not the keyword).
+  const match = oracleText.match(/\brenown\s+(\d+)\b/i);
+  if (!match) {
+    return { hasRenown: false, description: "" };
+  }
+
+  const count = parseInt(match[1], 10);
+  if (isNaN(count) || count < 0) {
+    return { hasRenown: false, description: "" };
+  }
+
+  return {
+    hasRenown: true,
+    renownCount: count,
+    description: `Renown ${count}`,
+  };
+}
+
+// ===========================================================================
+// Tribute (CR 702.101)
+//
+// CR 702.101a: "Tribute N" means "As this creature enters the battlefield,
+// an opponent of your choice may pay N life or have this creature enter the
+// battlefield with N +1/+1 counters on it." (Engine interpretation: the
+// opponent chooses whether to pay the Tribute cost; if they do, the
+// "tribute not paid" effect does not fire; if they decline, the printed
+// "When [this creature] enters the battlefield, if its tribute wasn't paid,
+// [effect]" triggered ability fires.)
+//
+// CR 702.101b: "A creature's tribute is paid if a player chose to pay tribute
+// for it as it entered the battlefield." This is the suppression flag for the
+// secondary "tribute wasn't paid" trigger.
+//
+// Printed form: "Tribute N" followed by the secondary triggered ability:
+//   "When this creature enters the battlefield, if its tribute wasn't paid,
+//    [effect]."
+//
+// The parser surfaces only the integer N. The opponent-choice / pay-or-decline
+// flow lives in keyword-actions.ts (processTributeOnEtb /
+// resolveTributeChoice); the trigger wiring lives in trigger-system.ts.
+// ===========================================================================
+
+/** Result of detecting Tribute (CR 702.101). */
+export interface TributeInfo {
+  hasTribute: boolean;
+  /** The parsed N value from "Tribute N". Undefined when `hasTribute` is false. */
+  tributeCount?: number;
+  /** Human-readable description (e.g. `Tribute 2`). */
+  description: string;
+}
+
+/**
+ * Parse the Tribute keyword from oracle text.
+ *
+ * CR 702.101a: "Tribute N" — case-insensitive, word-bounded on both sides
+ * so "Tribute 2" matches but "Tributes" / "Tributeborn" do not. Captures the
+ * integer N immediately following the keyword word.
+ *
+ * Examples:
+ *  - "Tribute 1" → { hasTribute: true, tributeCount: 1, ... }
+ *  - "Tribute 3 (As this creature enters the battlefield, ...)" → count 3
+ *  - "Fanatic of Rhonas" / "Arbor Colossus" (real cards with Tribute)
+ */
+export function parseTribute(oracleText: string): TributeInfo {
+  if (!oracleText) {
+    return { hasTribute: false, description: "" };
+  }
+
+  const match = oracleText.match(/\btribute\s+(\d+)\b/i);
+  if (!match) {
+    return { hasTribute: false, description: "" };
+  }
+
+  const count = parseInt(match[1], 10);
+  if (isNaN(count) || count < 0) {
+    return { hasTribute: false, description: "" };
+  }
+
+  return {
+    hasTribute: true,
+    tributeCount: count,
+    description: `Tribute ${count}`,
+  };
+}

--- a/src/lib/game-state/trigger-system.ts
+++ b/src/lib/game-state/trigger-system.ts
@@ -27,7 +27,11 @@ import { isCreature } from "./card-instance";
 import type { TriggeredAbilityInstance } from "./abilities";
 import { evaluateInterveningIfClause } from "./abilities";
 import { hasProwess, getProwessInstanceCount } from "./evergreen-keywords";
-import { parseTriggeredAbilities } from "./oracle-text-parser";
+import {
+  parseTriggeredAbilities,
+  parseRenown,
+  parseTribute,
+} from "./oracle-text-parser";
 import { hasCorpseAbility, getCorpseAbility } from "./corpse-keyword";
 import type { DungeonRoomCompletion } from "../cards/dungeons";
 
@@ -1079,4 +1083,123 @@ function getTriggeredAbilitiesFromCard(
     effect: parsed.effect,
     interveningIf: parsed.interveningIf,
   }));
+}
+
+// ===========================================================================
+// Renown (CR 702.100) and Tribute (CR 702.101) ETB triggers.
+//
+// Issue #1412: these keywords were listed in oracle-text-parser.ts but had
+// no parser helpers and no trigger registration. The detect functions below
+// synthesise ETB triggers that the engine can route through the standard
+// `putTriggersOnStack` path; the actual counter application / opponent
+// choice is performed by `processRenownOnEtb` and `processTributeOnEtb` in
+// keyword-actions.ts (mirroring how `detectCreatureDeathTriggers` synthesises
+// a corpse trigger while `processCorpseOnDeath` does the bookkeeping).
+// ===========================================================================
+
+/**
+ * Detect the Renown ETB trigger (CR 702.100) for a creature that just
+ * entered the battlefield.
+ *
+ * CR 702.100a: "Renown N" → "When this creature deals combat damage to a
+ * player, if it isn't renowned, put N +1/+1 counters on it and it becomes
+ * renowned." Issue #1412 frames this as an ETB-style hook for the engine
+ * so the same application path can fire from a scripted ETB context. The
+ * CR 702.100b intervening-if ("if it isn't renowned") is enforced here by
+ * skipping the trigger when `card.renowned === true`.
+ *
+ * @param enteringCardId  The card that just entered the battlefield.
+ * @returns A list of zero or one synthesised triggered-ability instances.
+ */
+export function detectRenownEtbTriggers(
+  state: GameState,
+  enteringCardId: CardInstanceId,
+  activePlayerId: PlayerId,
+): TriggeredAbilityInstance[] {
+  const triggers: TriggeredAbilityInstance[] = [];
+
+  const card = state.cards.get(enteringCardId);
+  if (!card) return triggers;
+  if (!isOnBattlefield(state, enteringCardId)) return triggers;
+
+  // Only creatures carry Renown.
+  if (!isCreature(card)) return triggers;
+
+  const info = parseRenown(card.cardData.oracle_text || "");
+  if (!info.hasRenown) return triggers;
+  const count = info.renownCount ?? 0;
+  if (count <= 0) return triggers;
+
+  // CR 702.100b — never re-triggers once renowned.
+  if (card.renowned === true) return triggers;
+
+  const context: TriggerDetectionContext = {
+    sourceCardId: enteringCardId,
+    triggerType: TriggerConditionType.ETB,
+  };
+
+  triggers.push({
+    id: generateTriggeredAbilityId(),
+    sourceCardId: enteringCardId,
+    triggeringPlayerId: card.controllerId,
+    triggerCondition: "entersBattlefield",
+    effect: `Renown ${count} — when this creature enters the battlefield, if it isn't renowned, put ${count} +1/+1 counters on it and it becomes renowned.`,
+    timestamp: Date.now(),
+    sourceCardTimestamp: card.enteredBattlefieldTimestamp,
+    context: context as any,
+  });
+
+  return sortTriggersAPNAP(triggers, state, activePlayerId);
+}
+
+/**
+ * Detect the Tribute ETB trigger (CR 702.101) for a creature that just
+ * entered the battlefield.
+ *
+ * CR 702.101a: "Tribute N" → "As this creature enters the battlefield, an
+ * opponent of your choice may pay N. If they do, the secondary triggered
+ * ability is suppressed (CR 702.101b)." The choice itself is surfaced by
+ * `processTributeOnEtb` in keyword-actions.ts as a `tribute_offer`
+ * WaitingChoice; this detect function synthesises the matching
+ * `entersBattlefield` trigger so the engine has a record of it for replay
+ * and state-hash consumers.
+ *
+ * @param enteringCardId  The card that just entered the battlefield.
+ * @returns A list of zero or one synthesised triggered-ability instances.
+ */
+export function detectTributeEtbTriggers(
+  state: GameState,
+  enteringCardId: CardInstanceId,
+  activePlayerId: PlayerId,
+): TriggeredAbilityInstance[] {
+  const triggers: TriggeredAbilityInstance[] = [];
+
+  const card = state.cards.get(enteringCardId);
+  if (!card) return triggers;
+  if (!isOnBattlefield(state, enteringCardId)) return triggers;
+
+  if (!isCreature(card)) return triggers;
+
+  const info = parseTribute(card.cardData.oracle_text || "");
+  if (!info.hasTribute) return triggers;
+  const count = info.tributeCount ?? 0;
+  if (count <= 0) return triggers;
+
+  const context: TriggerDetectionContext = {
+    sourceCardId: enteringCardId,
+    triggerType: TriggerConditionType.ETB,
+  };
+
+  triggers.push({
+    id: generateTriggeredAbilityId(),
+    sourceCardId: enteringCardId,
+    triggeringPlayerId: card.controllerId,
+    triggerCondition: "entersBattlefield",
+    effect: `Tribute ${count} — as this creature enters the battlefield, an opponent may pay ${count}. If they decline, the printed effect fires.`,
+    timestamp: Date.now(),
+    sourceCardTimestamp: card.enteredBattlefieldTimestamp,
+    context: context as any,
+  });
+
+  return sortTriggersAPNAP(triggers, state, activePlayerId);
 }

--- a/src/lib/game-state/types.ts
+++ b/src/lib/game-state/types.ts
@@ -171,6 +171,36 @@ export interface CardInstance {
    */
   prowessBoost?: number;
 
+  // Renown keyword (CR 702.100)
+  /**
+   * Whether this permanent has become renowned (CR 702.100b).
+   *
+   * Set to `true` exactly once, the first time this creature's Renown ability
+   * resolves. Per CR 702.100b the renowned flag persists for the rest of the
+   * game for THIS card instance — it is never reset by removing the +1/+1
+   * counters and it blocks Renown from re-triggering even after a flicker /
+   * zone-change that returns the same card instance to the battlefield. The
+   * flag is the authoritative intervening-if guard for "if it isn't renowned"
+   * on the trigger-system side.
+   *
+   * Optional so legacy state literals default to "not yet renowned" (read
+   * with `?? false`).
+   */
+  renowned?: boolean;
+
+  // Tribute keyword (CR 702.101)
+  /**
+   * Whether the Tribute cost for this permanent was paid as it entered the
+   * battlefield (CR 702.101b).
+   *
+   * Set during `resolveTributeChoice`: `true` when the chosen opponent paid
+   * the cost (and the secondary "tribute wasn't paid" triggered ability is
+   * suppressed), `false` when they declined (and the secondary ability fires
+   * normally). Undefined before the choice resolves. Persisted on the card so
+   * the suppression survives any later state recomputation.
+   */
+  tributePaid?: boolean;
+
   // Performance optimization: zone lookup cache (CR 704 - SBA performance)
   /** The zone key where this card currently resides. Updated on zone changes for O(1) lookup */
   currentZoneKey: string | null;
@@ -804,7 +834,8 @@ export interface WaitingChoice {
     | "priority"
     | "choose_legend"
     | "choose_replacement"
-    | "corpse_offer";
+    | "corpse_offer"
+    | "tribute_offer";
   /** ID of player who needs to make this choice */
   playerId: PlayerId;
   /** ID of the stack object this choice is for */
@@ -917,6 +948,21 @@ export interface GameState {
    * default to "no pending offers" (read with `?? []`).
    */
   pendingCorpseOffers?: CardInstanceId[];
+
+  /**
+   * Tribute keyword ETB-trigger queue (CR 702.101).
+   *
+   * When a creature with a Tribute ability enters the battlefield,
+   * `processTributeOnEtb` appends its card ID here and surfaces a
+   * `tribute_offer` `waitingChoice` to the chosen opponent. Because the engine
+   * surfaces one choice at a time, additional tributes that enter while an
+   * offer is already pending remain queued here and are surfaced (in FIFO
+   * order) once the prior offer is resolved via `resolveTributeChoice`. A card
+   * ID is removed from this queue only when its offer is resolved (paid or
+   * declined). Optional so legacy state literals default to "no pending
+   * offers" (read with `?? []`).
+   */
+  pendingTributeOffers?: CardInstanceId[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements two ETB-triggered keyword abilities per CR 702.100 (Renown) and CR 702.101 (Tribute), following the pattern established by #1524 (Corpse death trigger).

Closes #1412.

## Implementation

### Parsing (`src/lib/game-state/oracle-text-parser.ts`)
- `parseRenown(oracleText)` — word-boundary anchored regex `/\brenown\s+(\d+)\b/i` returning `RenownInfo { renown: number }`
- `parseTribute(oracleText)` — same shape for `TributeInfo { tribute: number }`

### Types (`src/lib/game-state/types.ts`)
- `CardInstance.renowned?: boolean` — set true after first Renown resolution (idempotent guard)
- `CardInstance.tributePaid?: boolean` — distinguishes accept/decline for secondary effect
- `GameState.pendingTributeOffers?: CardInstanceId[]` — FIFO queue of unresolved tribute offers
- `WaitingChoice.type` extended with `"tribute_offer"`

### Keyword actions (`src/lib/game-state/keyword-actions.ts`)
- `processRenownOnEtb(state, cardId)` — adds N +1/+1 counters and sets `renowned = true`. Guards on creature type, parseable Renown N, and `!card.renowned` (CR 702.100b idempotency — survives flicker).
- `processTributeOnEtb(state, cardId)` — queues the entering card on `pendingTributeOffers` and surfaces a `tribute_offer` WaitingChoice to the first opponent in turn order.
- `resolveTributeChoice(state, playerId, chosenValue)` — accept path spends N generic mana (`spendMana` + `getTotalMana`) and marks `tributePaid = true` (suppressing the secondary effect); decline path sets `tributePaid = false` so the effect fires. Insufficient mana rejects the choice and keeps the offer pending. Wrong player and invalid choice values are rejected.

### Trigger system (`src/lib/game-state/trigger-system.ts`)
- `detectRenownEtbTriggers(state, enteringCardId, activePlayerId)`
- `detectTributeEtbTriggers(state, enteringCardId, activePlayerId)`
- Both synthesize a `TriggeredAbilityInstance` with `triggerCondition: "entersBattlefield"`.

## Engine simplification note

CR 702.100a literally triggers Renown on "combat damage to a player." As flagged in #1412, this engine surfaces it as a synthetic ETB hook for AI opponent determinism. The `renowned` flag preserves CR 702.100b idempotency: a given card instance can only ever earn its Renown counters once, even via flicker/reanimate.

Tribute cost is interpreted as N generic mana for deterministic, testable resolution. Real card tribute costs vary (life, +1/+1 counters, etc.) and will be specialized as specific cards are added.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (549 warnings, unchanged baseline)
- `npm test` — 8937 passed, 0 failed (43 new tests in `renown-tribute.test.ts`)

Test coverage spans parsing (word boundaries, case-insensitivity, N parsing, negatives), Renown processing (counters + flag, idempotency/flicker, non-creature and non-renown no-ops, multiple N values), Tribute processing (opponent-targeted offer, accept/decline options, idempotency), choice resolution (accept pays and suppresses, insufficient mana keeps pending, wrong player rejected, decline path, invalid choice), queue semantics (FIFO, no clobbering of unrelated waiting choices, no-opponent negative), and trigger-system wiring for both keywords.