### PR TITLE
feat: wire Mutate merge into castSpell dispatch (CR 702.140)

### DIFF
--- a/src/lib/game-state/__tests__/mutate-cast.test.ts
+++ b/src/lib/game-state/__tests__/mutate-cast.test.ts
@@ -1,0 +1,629 @@
+/**
+ * @fileoverview Unit tests for the Mutate keyword cast dispatch (CR 702.140).
+ *
+ * Issue #1410 — [Rules Engine] Wire Mutate merge into castSpell dispatch
+ * (CR 702.140). This is the FINAL issue in the spell-casting clique.
+ *
+ * Mutate (CR 702.140):
+ * - 702.140a: "Mutate [cost]" is a static ability that functions while the
+ *   spell is on the stack. It offers an alternative cost: the spell's
+ *   controller may pay [cost] rather than the printed mana cost to merge it
+ *   with a target non-Human creature they control.
+ * - 702.140b: The resulting merged permanent uses the top card's
+ *   characteristics (P/T, color, type) and its text includes text from all
+ *   components, with the highest-CMC component's text taking priority.
+ * - 702.140f: If the target leaves the battlefield before the mutate spell
+ *   resolves, the mutator enters the battlefield alone as a normal creature
+ *   (the merge is abandoned).
+ *
+ * Unlike the other alternative-cost siblings (Convoke/Delve/Spectacle/
+ * Escape), Mutate ALSO changes how the spell resolves — instead of entering
+ * as an independent permanent, the mutator merges onto the target creature
+ * via `applyMutate` (mutate.ts). These tests verify the full wiring: target
+ * choice, cost replacement, applyMutate dispatch, resolution handling, the
+ * target-disappears fallback, and the non-Human restriction.
+ */
+
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import { castSpell, resolveTopOfStack } from "../spell-casting";
+import { createInitialGameState, startGame } from "../game-state";
+import { createCardInstance } from "../card-instance";
+import { addMana } from "../mana";
+import {
+  parseMutate,
+  parseAlternativeCost,
+  AlternativeCostType,
+} from "../oracle-text-parser";
+import { Phase } from "../types";
+import { ZoneType } from "../types";
+import type { GameState, PlayerId, CardInstanceId } from "../types";
+import type { ScryfallCard } from "@/app/actions";
+
+// ---------------------------------------------------------------------------
+// Mock card helpers
+// ---------------------------------------------------------------------------
+
+function makeCard(
+  overrides: Partial<ScryfallCard> & { id: string },
+): ScryfallCard {
+  return {
+    name: "Test Card",
+    type_line: "Creature — Elemental",
+    oracle_text: "",
+    mana_cost: "{2}{U}",
+    cmc: 3,
+    power: "2",
+    toughness: "2",
+    colors: ["U"],
+    color_identity: ["U"],
+    keywords: ["Mutate"],
+    legalities: { standard: "legal", commander: "legal" },
+    layout: "normal",
+    ...overrides,
+  } as ScryfallCard;
+}
+
+/**
+ * A canonical mutate creature. Printed mana cost {3}{U}{U} (mana value 5);
+ * mutate cost {1}{U}. Oracle text intentionally uses the "Mutate {cost}"
+ * keyword form that `parseMutate` recognises.
+ */
+function mutateCreature(): ScryfallCard {
+  return makeCard({
+    id: "mock-mutate-creature",
+    name: "Cloudpiercer",
+    type_line: "Creature — Elemental Dinosaur",
+    oracle_text:
+      "Mutate {1}{U}\nWhen this creature enters the battlefield, draw a card.",
+    mana_cost: "{3}{U}{U}",
+    cmc: 5,
+    power: "4",
+    toughness: "4",
+    colors: ["U"],
+    color_identity: ["U"],
+    keywords: ["Mutate"],
+  });
+}
+
+/** A non-Human target creature controlled by the caster. */
+function targetBeast(): ScryfallCard {
+  return makeCard({
+    id: "mock-target-beast",
+    name: "Grizzly Bears",
+    type_line: "Creature — Bear",
+    oracle_text: "",
+    mana_cost: "{1}{G}",
+    cmc: 2,
+    power: "2",
+    toughness: "2",
+    colors: ["G"],
+    color_identity: ["G"],
+    keywords: [],
+  });
+}
+
+/** A Human creature — an ILLEGAL mutate target per CR 702.140b. */
+function humanCreature(): ScryfallCard {
+  return makeCard({
+    id: "mock-human",
+    name: "Loyal Apprentice",
+    type_line: "Creature — Human Artificer",
+    oracle_text: "",
+    mana_cost: "{1}{W}",
+    cmc: 2,
+    power: "1",
+    toughness: "1",
+    colors: ["W"],
+    color_identity: ["W"],
+    keywords: [],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Shared state scaffolding
+// ---------------------------------------------------------------------------
+
+interface Fixture {
+  state: GameState;
+  aliceId: PlayerId;
+  bobId: PlayerId;
+}
+
+function makeFixture(): Fixture {
+  let state = createInitialGameState(["Alice", "Bob"], 20, false);
+  state = startGame(state);
+
+  const ids = Array.from(state.players.keys());
+  const aliceId = ids[0];
+  const bobId = ids[1];
+
+  state.status = "in_progress";
+  state.priorityPlayerId = aliceId;
+  state.turn.activePlayerId = aliceId;
+  state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+  state.stack = [];
+  state.consecutivePasses = 0;
+  state.players.forEach((p) =>
+    state.players.set(p.id, { ...p, hasPassedPriority: false }),
+  );
+
+  return { state, aliceId, bobId };
+}
+
+/** Place a card into a player's hand. */
+function putInHand(
+  state: GameState,
+  playerId: PlayerId,
+  cardData: ScryfallCard,
+): CardInstanceId {
+  const card = createCardInstance(cardData, playerId, playerId);
+  card.currentZoneKey = `${playerId}-hand`;
+  state.cards.set(card.id, card);
+  const hand = state.zones.get(`${playerId}-hand`)!;
+  state.zones.set(`${playerId}-hand`, {
+    ...hand,
+    cardIds: [...hand.cardIds, card.id],
+  });
+  return card.id;
+}
+
+/** Place a card onto a player's battlefield. */
+function putOnBattlefield(
+  state: GameState,
+  playerId: PlayerId,
+  cardData: ScryfallCard,
+): CardInstanceId {
+  const card = createCardInstance(cardData, playerId, playerId);
+  card.currentZoneKey = `${playerId}-battlefield`;
+  card.hasSummoningSickness = false;
+  state.cards.set(card.id, card);
+  const bf = state.zones.get(`${playerId}-battlefield`)!;
+  state.zones.set(`${playerId}-battlefield`, {
+    ...bf,
+    cardIds: [...bf.cardIds, card.id],
+  });
+  return card.id;
+}
+
+/** Remove a card from its controller's battlefield (simulates a destroy). */
+function removeFromBattlefield(
+  state: GameState,
+  playerId: PlayerId,
+  cardId: CardInstanceId,
+): void {
+  const bf = state.zones.get(`${playerId}-battlefield`)!;
+  state.zones.set(`${playerId}-battlefield`, {
+    ...bf,
+    cardIds: bf.cardIds.filter((id) => id !== cardId),
+  });
+  const card = state.cards.get(cardId);
+  if (card) {
+    card.currentZoneKey = `${playerId}-graveyard`;
+  }
+}
+
+// ===========================================================================
+// Parsing — parseMutate / parseAlternativeCost
+// ===========================================================================
+
+describe("Mutate — parsing (CR 702.140)", () => {
+  it("parseMutate detects 'Mutate {cost}'", () => {
+    const r = parseMutate("Mutate {1}{U}");
+    expect(r.hasMutate).toBe(true);
+    expect(r.mutateCost).not.toBeNull();
+    expect(r.mutateCost!.generic).toBe(1);
+    expect(r.mutateCost!.blue).toBe(1);
+    expect(r.description).toBe("Mutate {1}{U}");
+  });
+
+  it("parseMutate is case-insensitive", () => {
+    expect(parseMutate("mutate {2}{R}").hasMutate).toBe(true);
+    expect(parseMutate("MUTATE {3}").hasMutate).toBe(true);
+  });
+
+  it("parseMutate returns false when the keyword is absent", () => {
+    expect(parseMutate("Flying").hasMutate).toBe(false);
+    expect(parseMutate("Flashback {2}{R}").hasMutate).toBe(false);
+    expect(parseMutate("").hasMutate).toBe(false);
+    expect(parseMutate("").mutateCost).toBeNull();
+  });
+
+  it("parseAlternativeCost recognises mutate as an alternative cost", () => {
+    const r = parseAlternativeCost("Mutate {1}{U}");
+    expect(r.hasAlternativeCost).toBe(true);
+    expect(r.costType).toBe(AlternativeCostType.MUTATE);
+    expect(r.manaCost).not.toBeNull();
+    expect(r.manaCost!.blue).toBe(1);
+    expect(r.description).toContain("Mutate");
+  });
+});
+
+// ===========================================================================
+// castSpell — the alternative-cost switch branch (CR 702.140a/b)
+// ===========================================================================
+
+describe("Mutate — castSpell cost replacement + dispatch (CR 702.140a/b)", () => {
+  let f: Fixture;
+  let mutateCardId: CardInstanceId;
+  let targetId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    mutateCardId = putInHand(f.state, f.aliceId, mutateCreature());
+    targetId = putOnBattlefield(f.state, f.aliceId, targetBeast());
+    // Printed {3}{U}{U} = 3 generic + 2 blue; mutate {1}{U} = 1 generic + 1 blue.
+    // Give enough mana for either path.
+    f.state = addMana(f.state, f.aliceId, { blue: 4, generic: 8 });
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+    f.state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    f.state.stack = [];
+  });
+
+  it("castSpell with alternativeCost mutate succeeds and records the cost used", () => {
+    const result = castSpell(
+      f.state,
+      f.aliceId,
+      mutateCardId,
+      [],
+      [],
+      0,
+      false,
+      {
+        type: "mutate",
+        targetCreatureId: targetId,
+      },
+    );
+    expect(result.success).toBe(true);
+    expect(result.state.stack.length).toBe(1);
+    expect(result.state.stack[0].alternativeCostsUsed).toContain("mutate");
+  });
+
+  it("mutate cost REPLACES the printed mana cost (CR 702.140b)", () => {
+    // Printed {3}{U}{U} = 3 generic + 2 blue; mutate {1}{U} = 1 generic + 1 blue.
+    const before = f.state.players.get(f.aliceId)!.manaPool;
+    const result = castSpell(
+      f.state,
+      f.aliceId,
+      mutateCardId,
+      [],
+      [],
+      0,
+      false,
+      {
+        type: "mutate",
+        targetCreatureId: targetId,
+      },
+    );
+    expect(result.success).toBe(true);
+    const after = result.state.players.get(f.aliceId)!.manaPool;
+    // Spent exactly 1 generic + 1 blue (the mutate cost), NOT the printed cost.
+    expect(before.generic - after.generic).toBe(1);
+    expect(before.blue - after.blue).toBe(1);
+  });
+
+  it("leaves the spell's mana value (printed mana_cost / cmc) unchanged (CR 702.140b)", () => {
+    const result = castSpell(
+      f.state,
+      f.aliceId,
+      mutateCardId,
+      [],
+      [],
+      0,
+      false,
+      {
+        type: "mutate",
+        targetCreatureId: targetId,
+      },
+    );
+    expect(result.success).toBe(true);
+    // The StackObject keeps the printed mana_cost string, not the mutate cost.
+    expect(result.state.stack[0].manaCost).toBe("{3}{U}{U}");
+    const card = result.state.cards.get(mutateCardId)!;
+    expect(card.cardData.cmc).toBe(5);
+  });
+
+  it("stamps the target creature id on the StackObject for resolution", () => {
+    const result = castSpell(
+      f.state,
+      f.aliceId,
+      mutateCardId,
+      [],
+      [],
+      0,
+      false,
+      {
+        type: "mutate",
+        targetCreatureId: targetId,
+      },
+    );
+    expect(result.success).toBe(true);
+    expect(result.state.stack[0].mutateTargetCreatureId).toBe(targetId);
+  });
+
+  it("is rejected when no target creature is declared", () => {
+    const result = castSpell(
+      f.state,
+      f.aliceId,
+      mutateCardId,
+      [],
+      [],
+      0,
+      false,
+      {
+        type: "mutate",
+      },
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/target creature/i);
+  });
+
+  it("is rejected when the card has no mutate cost", () => {
+    const nonMutateId = putInHand(
+      f.state,
+      f.aliceId,
+      makeCard({
+        id: "mock-non-mutate",
+        name: "Plain Creature",
+        oracle_text: "Flying",
+        keywords: [],
+      }),
+    );
+    const result = castSpell(
+      f.state,
+      f.aliceId,
+      nonMutateId,
+      [],
+      [],
+      0,
+      false,
+      {
+        type: "mutate",
+        targetCreatureId: targetId,
+      },
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/mutate cost/i);
+  });
+});
+
+// ===========================================================================
+// Non-Human target restriction (CR 702.140b)
+// ===========================================================================
+
+describe("Mutate — non-Human target restriction (CR 702.140b)", () => {
+  let f: Fixture;
+  let mutateCardId: CardInstanceId;
+  let humanId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    mutateCardId = putInHand(f.state, f.aliceId, mutateCreature());
+    humanId = putOnBattlefield(f.state, f.aliceId, humanCreature());
+    f.state = addMana(f.state, f.aliceId, { blue: 4, generic: 8 });
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+    f.state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    f.state.stack = [];
+  });
+
+  it("rejects mutating onto a Human creature", () => {
+    const result = castSpell(
+      f.state,
+      f.aliceId,
+      mutateCardId,
+      [],
+      [],
+      0,
+      false,
+      {
+        type: "mutate",
+        targetCreatureId: humanId,
+      },
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/human/i);
+  });
+
+  it("rejects mutating onto a creature the caster does not control", () => {
+    const opponentBeastId = putOnBattlefield(f.state, f.bobId, targetBeast());
+    const result = castSpell(
+      f.state,
+      f.aliceId,
+      mutateCardId,
+      [],
+      [],
+      0,
+      false,
+      {
+        type: "mutate",
+        targetCreatureId: opponentBeastId,
+      },
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/control/i);
+  });
+});
+
+// ===========================================================================
+// Resolution — merge onto target (CR 702.140b) + target-disappears fallback
+// ===========================================================================
+
+describe("Mutate — resolution: merge onto target (CR 702.140b)", () => {
+  let f: Fixture;
+  let mutateCardId: CardInstanceId;
+  let targetId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    mutateCardId = putInHand(f.state, f.aliceId, mutateCreature());
+    targetId = putOnBattlefield(f.state, f.aliceId, targetBeast());
+    f.state = addMana(f.state, f.aliceId, { blue: 4, generic: 8 });
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+    f.state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    f.state.stack = [];
+  });
+
+  it("merges the mutator onto the target creature when the spell resolves", () => {
+    const castResult = castSpell(
+      f.state,
+      f.aliceId,
+      mutateCardId,
+      [],
+      [],
+      0,
+      false,
+      { type: "mutate", targetCreatureId: targetId },
+    );
+    expect(castResult.success).toBe(true);
+
+    const resolved = resolveTopOfStack(castResult.state);
+    // The merge relationship is established by applyMutate (CR 702.140b):
+    // the target now carries the mutator in its mutatedCardIds list, and the
+    // mutator records its mutateBaseId back to the target.
+    const targetAfter = resolved.cards.get(targetId)!;
+    expect(targetAfter.mutatedCardIds).toContain(mutateCardId);
+    expect(targetAfter.isMutated).toBe(true);
+
+    const mutatorAfter = resolved.cards.get(mutateCardId)!;
+    expect(mutatorAfter.mutateBaseId).toBe(targetId);
+    expect(mutatorAfter.isMutated).toBe(true);
+
+    // The stack is empty after resolution.
+    expect(resolved.stack.length).toBe(0);
+  });
+
+  it("records the highest-CMC component for merged-characteristics (CR 702.140b)", () => {
+    // Mutator cmc 5, target cmc 2 → mutator is the highest-CMC component.
+    const castResult = castSpell(
+      f.state,
+      f.aliceId,
+      mutateCardId,
+      [],
+      [],
+      0,
+      false,
+      { type: "mutate", targetCreatureId: targetId },
+    );
+    const resolved = resolveTopOfStack(castResult.state);
+    const targetAfter = resolved.cards.get(targetId)!;
+    expect(targetAfter.highestCmcComponentId).toBe(mutateCardId);
+  });
+
+  it("merged permanent carries combined text from both components (CR 702.140b)", () => {
+    const castResult = castSpell(
+      f.state,
+      f.aliceId,
+      mutateCardId,
+      [],
+      [],
+      0,
+      false,
+      { type: "mutate", targetCreatureId: targetId },
+    );
+    const resolved = resolveTopOfStack(castResult.state);
+    // getMutatedCreatureText combines text from all stack components, highest
+    // CMC first (mutate.ts:174-200). The mutator (cmc 5) wins priority.
+    // Import lazily to avoid a circular import at module load.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { getMutatedCreatureText } = require("../mutate");
+    const text = getMutatedCreatureText(resolved, targetId);
+    // The mutator's "draw a card" ETB text and any component text both appear.
+    expect(text).toContain("draw a card");
+  });
+});
+
+describe("Mutate — target-disappears fallback (CR 702.140f)", () => {
+  let f: Fixture;
+  let mutateCardId: CardInstanceId;
+  let targetId: CardInstanceId;
+
+  beforeEach(() => {
+    f = makeFixture();
+    mutateCardId = putInHand(f.state, f.aliceId, mutateCreature());
+    targetId = putOnBattlefield(f.state, f.aliceId, targetBeast());
+    f.state = addMana(f.state, f.aliceId, { blue: 4, generic: 8 });
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+    f.state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    f.state.stack = [];
+  });
+
+  it("enters as a normal creature when the target leaves the battlefield before resolution (CR 702.140f)", () => {
+    const castResult = castSpell(
+      f.state,
+      f.aliceId,
+      mutateCardId,
+      [],
+      [],
+      0,
+      false,
+      { type: "mutate", targetCreatureId: targetId },
+    );
+    expect(castResult.success).toBe(true);
+
+    // Simulate the target being destroyed in response (while the mutate spell
+    // is on the stack). The target leaves the battlefield; the mutator is now
+    // an illegal merge target.
+    removeFromBattlefield(castResult.state, f.aliceId, targetId);
+
+    const resolved = resolveTopOfStack(castResult.state);
+    // The mutator did NOT merge — it enters as a normal creature.
+    const mutatorAfter = resolved.cards.get(mutateCardId)!;
+    expect(mutatorAfter.mutateBaseId).toBeNull();
+    expect(mutatorAfter.isMutated).toBe(false);
+    // The target creature is not marked as mutated.
+    const targetAfter = resolved.cards.get(targetId)!;
+    expect(targetAfter.mutatedCardIds).not.toContain(mutateCardId);
+    // The mutator is on the battlefield (entered as a normal creature).
+    const bfZone = resolved.zones.get(`${f.aliceId}-battlefield`)!;
+    expect(bfZone.cardIds).toContain(mutateCardId);
+    expect(bfZone.type).toBe(ZoneType.BATTLEFIELD);
+    // The stack is empty after resolution.
+    expect(resolved.stack.length).toBe(0);
+  });
+});
+
+// ===========================================================================
+// Wiring: applyMutate is called from the casting flow
+// ===========================================================================
+
+describe("Mutate — applyMutate is wired into castSpell resolution", () => {
+  it("rg-verification: castSpell calls applyMutate during mutate resolution", () => {
+    // This is a structural assertion: the castSpell dispatch records the
+    // mutate alternative cost, and resolveTopOfStack dispatches applyMutate
+    // via the mutate alternative-cost branch in resolveSpellCompletion. The
+    // merge relationship (mutatedCardIds / mutateBaseId) can ONLY be set by
+    // applyMutate (mutate.ts:88-141), so observing it after resolution proves
+    // the wiring is live.
+    const f = makeFixture();
+    const mutateCardId = putInHand(f.state, f.aliceId, mutateCreature());
+    const targetId = putOnBattlefield(f.state, f.aliceId, targetBeast());
+    f.state = addMana(f.state, f.aliceId, { blue: 4, generic: 8 });
+    f.state.priorityPlayerId = f.aliceId;
+    f.state.turn.activePlayerId = f.aliceId;
+    f.state.turn.currentPhase = Phase.PRECOMBAT_MAIN;
+    f.state.stack = [];
+
+    const castResult = castSpell(
+      f.state,
+      f.aliceId,
+      mutateCardId,
+      [],
+      [],
+      0,
+      false,
+      { type: "mutate", targetCreatureId: targetId },
+    );
+    expect(castResult.success).toBe(true);
+    expect(castResult.state.stack[0].alternativeCostsUsed).toContain("mutate");
+
+    const resolved = resolveTopOfStack(castResult.state);
+    // If applyMutate were NOT wired, mutatedCardIds would be empty. The fact
+    // that it contains the mutator proves applyMutate was dispatched.
+    expect(resolved.cards.get(targetId)!.mutatedCardIds).toContain(
+      mutateCardId,
+    );
+  });
+});

--- a/src/lib/game-state/mutate.ts
+++ b/src/lib/game-state/mutate.ts
@@ -62,6 +62,13 @@ export function canCastWithMutate(
     return { canCast: false, reason: "Target is not a creature" };
   }
 
+  // CR 702.140b — Mutate cannot target a Human. "You can't mutate onto a
+  // Human." The restriction is on the type line (a "Creature — Human" or
+  // any creature with the Human subtype is an illegal mutate target).
+  if (typeLine.includes("human")) {
+    return { canCast: false, reason: "Cannot mutate onto a Human" };
+  }
+
   // Check if player controls the target creature
   if (targetCard.controllerId !== playerId) {
     return { canCast: false, reason: "You do not control this creature" };

--- a/src/lib/game-state/oracle-text-parser.ts
+++ b/src/lib/game-state/oracle-text-parser.ts
@@ -1979,6 +1979,7 @@ export enum AlternativeCostType {
   BLAZE = "blaze",
   BLITZ = "blitz",
   FORETELL = "foretell",
+  MUTATE = "mutate",
   OTHER = "other",
 }
 
@@ -2064,6 +2065,27 @@ export function parseAlternativeCost(oracleText: string): AlternativeCostInfo {
       additionalRequirement: "Becomes an Aura attached to target creature",
       isAvailable: true,
       description: `Bestow ${bestowMatch[1]}`,
+    };
+  }
+
+  // Check for Mutate (CR 702.140)
+  // Mutate [cost] — If you cast this spell for its mutate cost, it merges
+  // onto a target non-Human creature you control instead of entering as an
+  // independent permanent. The merged permanent uses the top card's
+  // characteristics with combined text (CR 702.140b). Mutate is an
+  // alternative cost that REPLACES the printed mana cost (same treatment as
+  // Blitz/Foretell/Spectacle/Escape).
+  const mutateMatch = oracleText.match(/mutate\s*(\{[^}]+\}(?:\{[^}]+\})*)/i);
+  if (mutateMatch) {
+    const manaCost = parseManaCost(mutateMatch[1]);
+    return {
+      hasAlternativeCost: true,
+      costType: AlternativeCostType.MUTATE,
+      manaCost,
+      additionalRequirement:
+        "Merges onto target non-Human creature you control",
+      isAvailable: true,
+      description: `Mutate ${mutateMatch[1]}`,
     };
   }
 
@@ -2269,6 +2291,45 @@ export function parseBestow(oracleText: string): {
     hasBestow: true,
     bestowCost,
     description: `Bestow ${bestowMatch[1]}`,
+  };
+}
+
+/**
+ * Parse the Mutate keyword from oracle text.
+ *
+ * CR 702.140: "Mutate [cost]" is a static ability that functions while the
+ * spell is on the stack. It offers an alternative cost: "You may cast this
+ * card for [cost] rather than its mana cost. If you do, it merges with a
+ * creature you control." The parsed cost is an alternative cost (CR
+ * 702.140b) — the spell's mana value is unchanged and other costs and taxes
+ * still apply. The merge mechanic itself (target selection, merged
+ * characteristics) is handled by the spell-casting dispatch and mutate.ts.
+ *
+ * Example oracle text: "Mutate {2}{U}" (e.g. Cloudpiercer). The reminder
+ * text ("If you cast this spell for its mutate cost, put it over or under
+ * target non-Human creature you control...") is not part of the cost.
+ */
+export function parseMutate(oracleText: string): {
+  hasMutate: boolean;
+  mutateCost: ParsedManaCost | null;
+  description: string;
+} {
+  if (!oracleText) {
+    return { hasMutate: false, mutateCost: null, description: "" };
+  }
+
+  const mutateMatch = oracleText.match(/mutate\s*(\{[^}]+\}(?:\{[^}]+\})*)/i);
+
+  if (!mutateMatch) {
+    return { hasMutate: false, mutateCost: null, description: "" };
+  }
+
+  const mutateCost = parseManaCost(mutateMatch[1]);
+
+  return {
+    hasMutate: true,
+    mutateCost,
+    description: `Mutate ${mutateMatch[1]}`,
   };
 }
 

--- a/src/lib/game-state/spell-casting.ts
+++ b/src/lib/game-state/spell-casting.ts
@@ -34,6 +34,7 @@ import {
   parseConvoke,
   parseDelve,
   parseEscape,
+  parseMutate,
   parseSplitSecond,
   parseStorm,
   isModalSpell,
@@ -62,6 +63,7 @@ import {
 import type { CardInstance, StackEffect } from "./types";
 import { canTargetKeyword, applyProwessBoost } from "./evergreen-keywords";
 import { applyWardResolution } from "./ward-system";
+import { applyMutate, canCastWithMutate } from "./mutate";
 
 /**
  * Generate a unique stack object ID
@@ -259,9 +261,19 @@ export function castSpell(
       | "blitz"
       | "foretell"
       | "convoke"
-      | "delve";
+      | "delve"
+      | "mutate";
     buybackReturnToHand?: boolean;
     bestowTarget?: CardInstanceId;
+    /**
+     * CR 702.140 - Mutate: the target non-Human creature owned and
+     * controlled by the spell's controller that the mutator will merge onto
+     * at resolution. The mutate cost REPLACES the printed mana cost; on
+     * resolution the spell merges onto this target via `applyMutate`
+     * (mutate.ts). If the target leaves the battlefield before resolution,
+     * the mutator enters as a normal creature (CR 702.140f fallback).
+     */
+    targetCreatureId?: CardInstanceId;
     /**
      * CR 702.93 - Convoke: untapped creatures the player chooses to tap while
      * casting this spell. Each colored creature pays for one mana of that
@@ -446,6 +458,12 @@ export function castSpell(
   // Handle alternative costs (Buyback, Flashback, Bestow, etc.)
   let buybackReturnZone: string | undefined = undefined;
   let bestowTarget: CardInstanceId | undefined = undefined;
+  // CR 702.140 - Mutate: the target non-Human creature the mutator will
+  // merge onto at resolution. Validated inside the `case "mutate":` branch;
+  // the actual merge is applied during resolution in
+  // `resolveSpellCompletion` (after the stack has had a chance to respond
+  // and the target may have left the battlefield).
+  let mutateTargetCreatureId: CardInstanceId | undefined = undefined;
   // CR 702.93 - Convoke: creatures the player declared they would tap while
   // casting. Validated inside the `case "convoke":` branch; the actual tap
   // is applied AFTER mana is spent (see `applyConvokeTaps` below) so the
@@ -508,6 +526,79 @@ export function castSpell(
           alternativeCostsUsed.push("bestow");
           bestowTarget = alternativeCost.bestowTarget;
         }
+        break;
+      }
+      case "mutate": {
+        // CR 702.140 - Mutate: an alternative cost that REPLACES the mana
+        // cost (not an additional cost). The spell's mana value is unchanged
+        // and other additional costs/taxes still apply on top. Subtract the
+        // printed mana-cost component and add the mutate-cost component so
+        // additional costs are preserved (same treatment as
+        // Blitz/Foretell/Spectacle/Escape).
+        //
+        // Unlike those siblings, mutate ALSO changes how the spell resolves:
+        // instead of entering the battlefield as an independent permanent,
+        // the mutator merges onto a target non-Human creature the controller
+        // owns. The merge itself is dispatched in `resolveSpellCompletion`
+        // via `applyMutate` (mutate.ts), so here we only (1) replace the
+        // cost, (2) validate the target up front so the cast fails
+        // atomically before mana is spent, and (3) record the target on the
+        // StackObject for resolution.
+        //
+        // CR 702.140f fallback: if the target leaves the battlefield before
+        // resolution, the mutator enters as a normal creature. That branch
+        // lives in `resolveSpellCompletion` (it needs the resolution-time
+        // state, not the cast-time state).
+        if (sourceZone !== `${playerId}-hand`) {
+          return {
+            success: false,
+            state,
+            error: "Mutate can only be used to cast a card from your hand.",
+          };
+        }
+        const mutateInfo = parseMutate(card.cardData.oracle_text || "");
+        if (!mutateInfo.hasMutate || !mutateInfo.mutateCost) {
+          return {
+            success: false,
+            state,
+            error: "Card does not have a mutate cost.",
+          };
+        }
+        const declaredTarget = alternativeCost.targetCreatureId;
+        if (declaredTarget === undefined) {
+          return {
+            success: false,
+            state,
+            error: "Mutate requires a target creature.",
+          };
+        }
+        // Authoritative target validation via the mutate module helper. This
+        // enforces: card has mutate, target exists, target is a creature,
+        // target is NOT a Human (CR 702.140b), target is controlled by the
+        // caster, and the caster has priority.
+        const mutateCheck = canCastWithMutate(
+          state,
+          playerId,
+          cardId,
+          declaredTarget,
+        );
+        if (!mutateCheck.canCast) {
+          return {
+            success: false,
+            state,
+            error: mutateCheck.reason || "Invalid mutate target.",
+          };
+        }
+        // Replace printed-cost pips with mutate-cost pips (same shape as
+        // Blitz/Foretell/Spectacle/Escape).
+        totalGeneric += mutateInfo.mutateCost.generic - manaCost.generic;
+        totalWhite += mutateInfo.mutateCost.white - manaCost.white;
+        totalBlue += mutateInfo.mutateCost.blue - manaCost.blue;
+        totalBlack += mutateInfo.mutateCost.black - manaCost.black;
+        totalRed += mutateInfo.mutateCost.red - manaCost.red;
+        totalGreen += mutateInfo.mutateCost.green - manaCost.green;
+        alternativeCostsUsed.push("mutate");
+        mutateTargetCreatureId = declaredTarget;
         break;
       }
       case "blitz": {
@@ -1088,6 +1179,7 @@ export function castSpell(
     timesKicked: kickerChargeCount,
     buybackReturnZone,
     bestowTarget,
+    mutateTargetCreatureId,
     // CR 702.60 - Split second: parsed from Oracle text and stamped onto the
     // spell's StackObject so the restriction can be enforced while it's on
     // the stack (see hasSplitSecondOnStack / ValidationService).
@@ -1678,6 +1770,51 @@ function resolveSpellCompletion(
               cards: updatedCards,
             };
           }
+        }
+
+        // CR 702.140 - Mutate: the spell was already moved onto the
+        // battlefield by the generic permanent-resolution path above (the
+        // mutator is a creature permanent, so destinationZone was the
+        // controller's battlefield). Now merge it onto the declared target.
+        // If the target is no longer on the battlefield, CR 702.140f says
+        // the mutator enters as a normal creature — which is exactly the
+        // state we are already in (mutator on battlefield, no merge), so the
+        // fallback is a no-op.
+        if (
+          stackObject.alternativeCostsUsed?.includes("mutate") &&
+          stackObject.mutateTargetCreatureId
+        ) {
+          const targetId = stackObject.mutateTargetCreatureId;
+          const targetCard = currentState.cards.get(targetId);
+          // Target must still be on the battlefield for the merge to happen.
+          const targetZoneKey = targetCard?.currentZoneKey;
+          const targetZone = targetZoneKey
+            ? currentState.zones.get(targetZoneKey)
+            : undefined;
+          const targetStillOnBattlefield =
+            targetCard !== undefined &&
+            targetZone !== undefined &&
+            targetZone.type === ZoneType.BATTLEFIELD &&
+            targetZone.cardIds.includes(targetId);
+          if (targetStillOnBattlefield) {
+            // Apply the merge. `applyMutate` records the merge relationship
+            // (mutatedCardIds / mutateBaseId / isMutated /
+            // highestCmcComponentId) per CR 702.140b — the top card's
+            // characteristics control P/T/type/color while lower components'
+            // text contributes.
+            const mergeResult = applyMutate(
+              currentState,
+              stackObject.sourceCardId!,
+              targetId,
+            );
+            if (mergeResult.success) {
+              currentState = mergeResult.state;
+            }
+          }
+          // else: CR 702.140f fallback — target gone. The mutator is
+          // already on the battlefield as a normal creature (the generic
+          // permanent-resolution path moved it there), which is exactly
+          // what CR 702.140f prescribes. No further action needed.
         }
 
         // CR 702.150 - Blitz: a creature cast for its blitz cost gains haste

--- a/src/lib/game-state/types.ts
+++ b/src/lib/game-state/types.ts
@@ -553,6 +553,15 @@ export interface StackObject {
   /** Bestow attachment target (if cast as aura) */
   bestowTarget?: CardInstanceId;
   /**
+   * Mutate merge target (CR 702.140). Set on a spell's StackObject when it
+   * is cast for its mutate cost. On resolution, the spell merges onto this
+   * target non-Human creature (handled by `applyMutate` in mutate.ts). If
+   * the target has left the battlefield by resolution time, the spell
+   * resolves as a normal creature entering the battlefield (CR 702.140f
+   * fallback).
+   */
+  mutateTargetCreatureId?: CardInstanceId;
+  /**
    * Target card IDs for which the ward cost (CR 702.21) has been paid by this
    * spell/ability's controller. On resolution, any warded opponent target NOT
    * in this list causes this spell/ability to be countered.

--- a/src/lib/game-state/validation-service.ts
+++ b/src/lib/game-state/validation-service.ts
@@ -382,12 +382,18 @@ export class ValidationService {
     // (an alternative cost). The authoritative affordability check happens in
     // castSpell after the escape cost is substituted. Skip it (same rationale
     // as foretell/convoke/delve/spectacle).
+    //
+    // Mutate (CR 702.140) REPLACES the printed mana cost with the mutate cost
+    // (an alternative cost). The authoritative affordability check happens in
+    // castSpell after the mutate cost is substituted. Skip it (same rationale
+    // as foretell/convoke/delve/spectacle/escape).
     if (
       altType !== "foretell" &&
       altType !== "convoke" &&
       altType !== "delve" &&
       altType !== "spectacle" &&
-      altType !== "escape"
+      altType !== "escape" &&
+      altType !== "mutate"
     ) {
       const manaValidation = this.validateManaCost(state, player, card);
       if (!manaValidation.isValid) {


### PR DESCRIPTION
Closes #1410

## Summary

Wires the Mutate keyword (CR 702.140) into the `castSpell` dispatch — the FINAL issue in the spell-casting clique. Mutate was previously a partial implementation (`mutate.ts` had `hasMutate`, `canCastWithMutate`, `applyMutate`) but none of it was ever called from the casting flow.

Unlike the four merged alt-cost siblings (#1406 Convoke, #1407 Delve, #1408 Spectacle, #1409 Escape), Mutate is not just a cost replacement — it changes how the card enters play (merges onto a target creature instead of entering independently), which is why it is the capstone issue.

## Changes

- **`oracle-text-parser.ts`**: Add `parseMutate()` (mirrors `parseBestow`), add `MUTATE` to the `AlternativeCostType` enum, and add a Mutate branch to `parseAlternativeCost`.
- **`types.ts`**: Add `mutateTargetCreatureId` to `StackObject` so the resolution path knows which creature to merge onto.
- **`spell-casting.ts`**:
  - Extend the `alternativeCost.type` union with `"mutate"` + `targetCreatureId` field.
  - Add `case "mutate":` to the alt-cost switch: validates source zone (hand), validates the card has a mutate cost, authoritatively validates the target via `canCastWithMutate` (creature, non-Human per CR 702.140b, controlled by caster, priority), then replaces the printed mana cost with the mutate cost (same subtract-printed/add-alt shape as Blitz/Foretell/Spectacle/Escape).
  - Add a Mutate resolution branch to `resolveSpellCompletion`: dispatches `applyMutate(state, mutateCardId, targetId)` after the permanent-resolution path moved the mutator onto the battlefield. If the target is no longer on the battlefield, the mutator enters as a normal creature (CR 702.140f fallback — a no-op since the generic path already placed it correctly).
- **`validation-service.ts`**: Add `"mutate"` to the alt-cost skip list for the printed-mana pre-check (mutate REPLACES the cost, same rationale as the other replace-cost siblings).
- **`mutate.ts`**: Add the non-Human restriction (CR 702.140b) to `canCastWithMutate` — mutate cannot target a Human.

## Tests

New file `src/lib/game-state/__tests__/mutate-cast.test.ts` (17 tests) covering all required cases:
- Happy path: cast Mutate spell → merges onto target creature (merge relationship via `applyMutate`).
- Target disappears before resolution → mutator enters as normal creature (CR 702.140f).
- Mutate cost replaces printed cost (mana-spend assertion; mana value unchanged).
- Merged permanent carries combined text per CR 702.140b (`getMutatedCreatureText`).
- Non-Human target requirement enforced; controller-only restriction enforced.
- `applyMutate` is dispatched from `castSpell` resolution (structural assertion: the merge relationship can only be set by `applyMutate`).
- Parsing: `parseMutate` + `parseAlternativeCost` recognise the Mutate keyword.

## Verification

- `npm run typecheck` — pass
- `npm run lint` — 0 errors (warnings only, which do not gate)
- `npm test` — **436 suites, 9049 tests passed**, 0 failures (baseline ~9007+)
- `rg "applyMutate" src/lib/game-state/spell-casting.ts` — import (L67) + call site (L1808)
- `rg 'case "mutate"' src/lib/game-state/spell-casting.ts` — matches (L534)